### PR TITLE
Allow projector module to be loaded in non-browser environments

### DIFF
--- a/src/projector.ts
+++ b/src/projector.ts
@@ -1,17 +1,12 @@
-import './util/has!dom-requestanimationframe?:maquette/maquette-polyfills.min'; /* IE9/Node do not support RequestAnimationFrame */
 import { h, createProjector as createMaquetteProjector, Projector as MaquetteProjector, VNode, VNodeProperties } from 'maquette/maquette';
 import compose, { ComposeFactory } from 'dojo-compose/compose';
 import { EventedOptions } from 'dojo-compose/mixins/createEvented';
-import global from 'dojo-core/global';
 import { Handle } from 'dojo-core/interfaces';
 import { assign } from 'dojo-core/lang';
 import { queueTask } from 'dojo-core/queue';
 import WeakMap from 'dojo-core/WeakMap';
 import createVNodeEvented, { VNodeEvented } from './mixins/createVNodeEvented';
 import createParentMixin, { ParentMixin, ParentMixinOptions, Child } from './mixins/createParentMixin';
-
-/* maquette polyfills changed from 2.2 to 2.3 */
-global.requestAnimationFrame = global.requestAnimationFrame || global.window.requestAnimationFrame;
 
 export type AttachType = 'append' | 'merge' | 'replace';
 

--- a/src/projector.ts
+++ b/src/projector.ts
@@ -1,6 +1,7 @@
 import { h, createProjector as createMaquetteProjector, Projector as MaquetteProjector, VNode, VNodeProperties } from 'maquette/maquette';
 import compose, { ComposeFactory } from 'dojo-compose/compose';
 import { EventedOptions } from 'dojo-compose/mixins/createEvented';
+import global from 'dojo-core/global';
 import { Handle } from 'dojo-core/interfaces';
 import { assign } from 'dojo-core/lang';
 import { queueTask } from 'dojo-core/queue';
@@ -262,6 +263,6 @@ export const createProjector: ProjectorFactory = compose<ProjectorMixin, Project
 		}
 	});
 
-const defaultProjector: Projector = createProjector();
+const defaultProjector: Projector = typeof global.document === 'undefined' ? null : createProjector();
 
 export default defaultProjector;

--- a/tests/support/loadJsdom.ts
+++ b/tests/support/loadJsdom.ts
@@ -19,6 +19,11 @@ global.document = doc;
 /* Assign a global window as well */
 global.window = doc.defaultView;
 
+/* Polyfill requestAnimationFrame */
+global.requestAnimationFrame = (cb: (...args: any[]) => {}) => {
+	setImmediate(cb);
+};
+
 export default doc;
 
 console.log('Loaded JSDOM...');


### PR DESCRIPTION
See commits.

TL;DR this allows the projector to be required from Node.js runtimes that haven't polyfilled the `document` global, perhaps because they don't need the projector but cannot avoid requiring it.