### PR TITLE
Refactor TabbedMixin to be ParentMap instead of ParentList

### DIFF
--- a/src/mixins/createCachedRenderMixin.ts
+++ b/src/mixins/createCachedRenderMixin.ts
@@ -4,10 +4,9 @@ import createStateful, { State, Stateful, StatefulOptions } from 'dojo-compose/m
 import { assign } from 'dojo-core/lang';
 import Map from 'dojo-core/Map';
 import WeakMap from 'dojo-core/WeakMap';
-import { ParentListMixin } from './createParentListMixin';
 import createRenderable, { Renderable } from './createRenderable';
 import createVNodeEvented, { VNodeEvented } from './createVNodeEvented';
-import { Child } from './interfaces';
+import { Parent } from './interfaces';
 
 export type StylesHash = { [style: string]: string; };
 
@@ -33,7 +32,7 @@ export interface CachedRenderState extends State {
 	styles?: StylesHash;
 }
 
-export type CachedRenderParent = ParentListMixin<Child> & {
+export type CachedRenderParent = Parent & {
 	/**
 	 * Invalidate the widget so that it will recalculate on its next render
 	 */

--- a/src/mixins/createRenderableChildrenMixin.ts
+++ b/src/mixins/createRenderableChildrenMixin.ts
@@ -2,9 +2,7 @@ import { VNode } from 'maquette/maquette';
 import { List } from 'immutable/immutable';
 import compose, { ComposeFactory } from 'dojo-compose/compose';
 import { from as arrayFrom } from 'dojo-core/array';
-import { Child } from './interfaces';
-
-export type ChildEntry<C extends Child> = [ string | number, C ];
+import { Child, ChildEntry } from './interfaces';
 
 export interface RenderableChildrenOptions {
 	/**

--- a/src/mixins/interfaces.d.ts
+++ b/src/mixins/interfaces.d.ts
@@ -8,6 +8,8 @@ export interface ChildrenMap<C extends Child> {
 	[key: string]: C;
 }
 
+export type ChildEntry<C extends Child> = [ string | number, C ];
+
 export interface ChildListEvent<T, C extends Child> {
 	children: Map<string, C> | List<C>;
 	target: T;

--- a/tests/unit/mixins/createTabbedMixin.ts
+++ b/tests/unit/mixins/createTabbedMixin.ts
@@ -57,7 +57,7 @@ registerSuite({
 	'close child'() {
 		const foo = createPanel({ state: { closeable: true, id: 'foo', label: 'foo' }});
 		const tabbed = createTabbedMixin({ children: { foo } });
-		const [ tabBar ] = tabbed.render().children;
+		// const [ tabBar ] = tabbed.render().children;
 		/* TODO: Complete */
 	},
 	'activeTab': {

--- a/tests/unit/mixins/createTabbedMixin.ts
+++ b/tests/unit/mixins/createTabbedMixin.ts
@@ -2,18 +2,19 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createTabbedMixin from 'src/mixins/createTabbedMixin';
 import createPanel from 'src/createPanel';
+import { from as arrayFrom } from 'dojo-core/array';
 
 registerSuite({
 	name: 'mixins/ceateTabbedMixin',
 	'creation': {
 		'with closable tabs'() {
 			const tabbed = createTabbedMixin({
-				children: [
-					createPanel({ state: { closeable: true, id: 'foo', label: 'foo' }}),
-					createPanel({ state: { closeable: false, id: 'bar', label: 'bar' }}),
-					createPanel({ state: { closeable: true, id: 'baz', label: 'baz' }}),
-					createPanel({ state: { closeable: false, id: 'qat', label: 'qat' }})
-				],
+				children: {
+					foo: createPanel({ state: { closeable: true, id: 'foo', label: 'foo' }}),
+					bar: createPanel({ state: { closeable: false, id: 'bar', label: 'bar' }}),
+					baz: createPanel({ state: { closeable: true, id: 'baz', label: 'baz' }}),
+					qat: createPanel({ state: { closeable: false, id: 'qat', label: 'qat' }})
+				},
 				state: {
 					id: 'qux'
 				}
@@ -29,24 +30,88 @@ registerSuite({
 			assert.strictEqual(vnode.vnodeSelector, 'dojo-panel-mixin');
 			assert.strictEqual(vnode.children.length, 2, 'should have two children');
 
-			const tabBar = vnode.children[0];
+			const [ tabBar, panels ] = vnode.children;
 			assert.strictEqual(tabBar.vnodeSelector, 'ul');
 			assert.strictEqual(tabBar.children.length, 4);
 			tabBar.children.forEach((child) => assert.strictEqual(child.vnodeSelector, 'li'));
-			assert.strictEqual(tabBar.children[0].children[0].text, 'foo');
-			assert.strictEqual(tabBar.children[0].children.length, 2);
-			assert.strictEqual(tabBar.children[1].children[0].text, 'bar');
-			assert.strictEqual(tabBar.children[1].children.length, 1);
-			assert.strictEqual(tabBar.children[2].children[0].text, 'baz');
-			assert.strictEqual(tabBar.children[2].children.length, 2);
-			assert.strictEqual(tabBar.children[3].children[0].text, 'qat');
-			assert.strictEqual(tabBar.children[3].children.length, 1);
 
-			const panels = vnode.children[1];
+			const [ child1, child2, child3, child4 ] = tabBar.children;
+			assert.strictEqual(child1.children[0].text, 'foo');
+			assert.strictEqual(child1.children.length, 2);
+			assert.strictEqual(child2.children[0].text, 'bar');
+			assert.strictEqual(child2.children.length, 1);
+			assert.strictEqual(child3.children[0].text, 'baz');
+			assert.strictEqual(child3.children.length, 2);
+			assert.strictEqual(child4.children[0].text, 'qat');
+			assert.strictEqual(child4.children.length, 1);
+
 			assert.strictEqual(panels.vnodeSelector, 'div.panels');
 			assert.strictEqual(panels.children.length, 1);
 
 			assert.strictEqual(vnode, tabbed.render(), 'should cache results, if not invalidated');
+
+			tabbed.invalidate();
+			assert.notStrictEqual(vnode, tabbed.render(), 'but should provide fresh results on invalidation');
 		}
+	},
+	'close child'() {
+		const foo = createPanel({ state: { closeable: true, id: 'foo', label: 'foo' }});
+		const tabbed = createTabbedMixin({ children: { foo } });
+		const [ tabBar ] = tabbed.render().children;
+		/* TODO: Complete */
+	},
+	'activeTab': {
+		'get()'() {
+			const foo = createPanel({ state: { closeable: true, id: 'foo', label: 'foo' }});
+			const bar = createPanel({ state: { closeable: false, id: 'bar', label: 'bar', active: true }});
+			const tabbed = createTabbedMixin({
+				children: { foo, bar }
+			});
+			assert.strictEqual(tabbed.activeChild, bar);
+			foo.setState({ active: true });
+			assert.strictEqual(tabbed.activeChild, foo);
+			assert.isFalse(bar.state['active']);
+		},
+		'set()'() {
+			const foo = createPanel({ state: { closeable: true, id: 'foo', label: 'foo' }});
+			const bar = createPanel({ state: { closeable: false, id: 'bar', label: 'bar', active: true }});
+			const tabbed = createTabbedMixin({
+				children: { foo, bar }
+			});
+			assert.strictEqual(tabbed.activeChild, bar);
+			tabbed.activeChild = foo;
+			assert.strictEqual(tabbed.activeChild, foo);
+			assert.isTrue(foo.state['active']);
+			assert.isFalse(bar.state['active']);
+		},
+		'click'() {
+			let count = 0;
+			const foo = createPanel({ state: { closeable: true, id: 'foo', label: 'foo' }});
+			const bar = createPanel({ state: { closeable: false, id: 'bar', label: 'bar', active: true }});
+			const tabbed = createTabbedMixin({
+				children: { foo, bar }
+			});
+			const [ tabBar ] = tabbed.render().children;
+			tabBar.children[0].children[0].properties.onclick(<any> {
+				preventDefault() { count++; }
+			});
+			assert.strictEqual(tabbed.activeChild, foo);
+			assert.strictEqual(count, 1);
+		}
+	},
+	'children': {
+		'merge'() {
+			const foo = createPanel({ state: { closeable: true, id: 'foo', label: 'foo' }});
+			const bar = createPanel({ state: { closeable: false, id: 'bar', label: 'bar' }});
+			const baz = createPanel({ state: { closeable: true, id: 'baz', label: 'baz' }});
+			const qat = createPanel({ state: { closeable: false, id: 'qat', label: 'qat' }});
+			const tabbed = createTabbedMixin();
+			tabbed.merge({ foo, bar, baz, qat });
+			assert.deepEqual(arrayFrom(<any> tabbed.children.keys()), [ 'foo', 'bar', 'baz', 'qat' ]);
+		}
+	},
+	'destroy()'() {
+		const tabbed = createTabbedMixin();
+		return tabbed.destroy();
 	}
 });

--- a/tests/unit/mixins/createTabbedMixin.ts
+++ b/tests/unit/mixins/createTabbedMixin.ts
@@ -55,8 +55,8 @@ registerSuite({
 		}
 	},
 	'close child'() {
-		const foo = createPanel({ state: { closeable: true, id: 'foo', label: 'foo' }});
-		const tabbed = createTabbedMixin({ children: { foo } });
+		// const foo = createPanel({ state: { closeable: true, id: 'foo', label: 'foo' }});
+		// const tabbed = createTabbedMixin({ children: { foo } });
 		// const [ tabBar ] = tabbed.render().children;
 		/* TODO: Complete */
 	},


### PR DESCRIPTION
This PR refactors `TabbedMixin` to utilise the `ParentMap` mixin instead of the `ParentList` mixin.  This allows tabs to be referenced by name instead of by index, as well as there is ability to change the sort order of the tabs based on a custom sort function.