### PR TITLE
Expect a registry provider to provide a registry

### DIFF
--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -63,6 +63,16 @@ const widgetRegistry = {
 	}
 };
 
+const registryProvider = {
+	get(type: string) {
+		if (type === 'widgets') {
+			return widgetRegistry;
+		}
+
+		throw new Error('No such registry');
+	}
+};
+
 const widgets: Child[] = [];
 
 /**
@@ -77,7 +87,7 @@ widgets.push(createWidget({
 const tabbedPanel = createTabbedPanel({
 	id: 'tabbed-panel',
 	stateFrom: widgetStore,
-	widgetRegistry,
+	registryProvider,
 	listeners: {
 		error(evt) {
 			console.log(evt);

--- a/src/mixins/interfaces.ts
+++ b/src/mixins/interfaces.ts
@@ -1,4 +1,5 @@
 import { Handle } from 'dojo-core/interfaces';
+import Promise from 'dojo-core/Promise';
 import { List, Map } from 'immutable';
 import { Renderable } from './createRenderable';
 
@@ -19,4 +20,39 @@ export interface ChildListEvent<T, C extends Child> {
 export interface Parent {
 	children: Map<string, Child> | List<Child>;
 	append(child: Child | Child[]): Handle;
+}
+
+/**
+ * Registry to (asynchronously) get instances by their ID.
+ */
+export interface Registry<T> {
+	/**
+	 * Asynchronously get an instance by its ID.
+	 *
+	 * @param id Identifier for the instance that is to be retrieved
+	 * @return A promise for the instance. The promise rejects if no instance was found.
+	 */
+	get(id: string | symbol): Promise<T>;
+
+	/**
+	 * Look up the identifier for which the given value has been registered.
+	 *
+	 * Throws if the value hasn't been registered.
+	 *
+	 * @param value The value
+	 * @return The identifier
+	 */
+	identify(value: T): string | symbol;
+}
+
+/**
+ * Provides access to read-only registries.
+ */
+export interface RegistryProvider<T> {
+	/**
+	 * Get a registry. Different widgets expect different types of registries.
+	 *
+	 * Implementations should throw if the given type is not supported.
+	 */
+	get(type: 'actions' | 'stores' | 'widgets'): Registry<T>;
 }

--- a/tests/unit/mixins/createStatefulChildrenMixin.ts
+++ b/tests/unit/mixins/createStatefulChildrenMixin.ts
@@ -4,7 +4,7 @@ import createStatefulChildrenMixin from 'src/mixins/createStatefulChildrenMixin'
 import createRenderable, { Renderable } from 'src/mixins/createRenderable';
 import Promise from 'dojo-core/Promise';
 import { List, Map } from 'immutable/immutable';
-import { Child } from 'src/mixins/interfaces';
+import { Child, RegistryProvider } from 'src/mixins/interfaces';
 
 const widget1 = createRenderable();
 const widget2 = createRenderable();
@@ -33,6 +33,12 @@ const widgetRegistry = {
 	}
 };
 
+const registryProvider: RegistryProvider<Child> = {
+	get(type: string) {
+		return type === 'widgets' ? widgetRegistry : null;
+	}
+};
+
 const createStatefulChildrenList = createStatefulChildrenMixin
 	.extend({
 		children: List<Child>()
@@ -56,7 +62,7 @@ registerSuite({
 		creation() {
 			const dfd = this.async();
 			const parent = createStatefulChildrenList({
-				widgetRegistry,
+				registryProvider,
 				state: {
 					children: [ 'widget1' ]
 				}
@@ -70,7 +76,7 @@ registerSuite({
 		setState() {
 			const dfd = this.async();
 			const parent = createStatefulChildrenList({
-				widgetRegistry
+				registryProvider
 			});
 
 			parent.setState({ children: [ 'widget2' ] });
@@ -83,7 +89,7 @@ registerSuite({
 		'caching widgets'() {
 			const dfd = this.async();
 			const parent = createStatefulChildrenList({
-				widgetRegistry
+				registryProvider
 			});
 
 			parent.setState({ children: [ 'widget1' ]});
@@ -104,7 +110,7 @@ registerSuite({
 			const dfd = this.async();
 
 			const parent = createStatefulChildrenList({
-				widgetRegistry
+				registryProvider
 			});
 
 			parent.emit({
@@ -130,7 +136,7 @@ registerSuite({
 		creation() {
 			const dfd = this.async();
 			const parent = createStatefulChildrenMap({
-				widgetRegistry,
+				registryProvider,
 				state: {
 					children: [ 'widget1' ]
 				}
@@ -144,7 +150,7 @@ registerSuite({
 		setState() {
 			const dfd = this.async();
 			const parent = createStatefulChildrenMap({
-				widgetRegistry
+				registryProvider
 			});
 
 			parent.setState({ children: [ 'widget2' ] });
@@ -157,7 +163,7 @@ registerSuite({
 		'caching widgets'() {
 			const dfd = this.async();
 			const parent = createStatefulChildrenMap({
-				widgetRegistry
+				registryProvider
 			});
 
 			parent.setState({ children: [ 'widget1' ]});
@@ -178,7 +184,7 @@ registerSuite({
 			const dfd = this.async();
 
 			const parent = createStatefulChildrenList({
-				widgetRegistry
+				registryProvider
 			});
 
 			parent.emit({
@@ -202,7 +208,7 @@ registerSuite({
 	},
 	'Avoids updating children if there are no changes'() {
 		const parent = createStatefulChildrenList({
-			widgetRegistry
+			registryProvider
 		});
 
 		let setCount = 0;
@@ -225,7 +231,7 @@ registerSuite({
 	},
 	'Avoids updating state if there are no changes'() {
 		const parent = createStatefulChildrenList({
-			widgetRegistry
+			registryProvider
 		});
 
 		let setCount = 0;
@@ -257,7 +263,7 @@ registerSuite({
 	},
 	destroy() {
 		const parent = createStatefulChildrenList({
-			widgetRegistry
+			registryProvider
 		});
 
 		return delay().then(() => {
@@ -274,7 +280,11 @@ registerSuite({
 		const dfd = this.async();
 
 		const parent = createStatefulChildrenList({
-			widgetRegistry: rejectingRegistry,
+			registryProvider: {
+				get(type: string) {
+					return type === 'widgets' ? rejectingRegistry : null;
+				}
+			},
 			state: {
 				children: ['widget1']
 			}
@@ -290,7 +300,11 @@ registerSuite({
 		let registry = Object.create(widgetRegistry);
 
 		const parent = createStatefulChildrenList({
-			widgetRegistry: registry,
+			registryProvider: {
+				get(type: string) {
+					return type === 'widgets' ? registry : null;
+				}
+			},
 			state: {
 				children: ['widget1']
 			}

--- a/tests/unit/mixins/createStatefulListenersMixin.ts
+++ b/tests/unit/mixins/createStatefulListenersMixin.ts
@@ -3,6 +3,7 @@ import * as assert from 'intern/chai!assert';
 import { Actionable, TargettedEventObject } from 'dojo-compose/mixins/createEvented';
 import Promise from 'dojo-core/Promise';
 import createStatefulListenersMixin from 'src/mixins/createStatefulListenersMixin';
+import { RegistryProvider } from 'src/mixins/interfaces';
 
 type Action = Actionable<TargettedEventObject>;
 
@@ -57,6 +58,12 @@ const actionRegistry = {
 	}
 };
 
+const registryProvider: RegistryProvider<Action> = {
+	get(type: string) {
+		return type === 'actions' ? actionRegistry : null;
+	}
+};
+
 function delay() {
 	return new Promise((resolve) => setTimeout(resolve, 50));
 }
@@ -73,7 +80,7 @@ registerSuite({
 	creation: {
 		'with registry'() {
 			const widget = createStatefulListenersMixin({
-				actionRegistry,
+				registryProvider,
 				state: {
 					listeners: {
 						foo: 'action1',
@@ -112,7 +119,7 @@ registerSuite({
 	},
 	setState() {
 		const widget = createStatefulListenersMixin({
-			actionRegistry,
+			registryProvider,
 			state: {
 				listeners: {
 					foo: 'action1'
@@ -166,7 +173,7 @@ registerSuite({
 	},
 	'caches actions'() {
 		const widget = createStatefulListenersMixin({
-			actionRegistry,
+			registryProvider,
 			state: {
 				listeners: {
 					foo: 'action1'
@@ -189,7 +196,7 @@ registerSuite({
 	},
 	destroy() {
 		const widget = createStatefulListenersMixin({
-			actionRegistry,
+			registryProvider,
 			state: {
 				listeners: {
 					foo: 'action1'
@@ -211,7 +218,11 @@ registerSuite({
 		const dfd = this.async();
 
 		const widget = createStatefulListenersMixin({
-			actionRegistry: rejectingRegistry,
+			registryProvider: {
+				get(type: string) {
+					return type === 'actions' ? rejectingRegistry : null;
+				}
+			},
 			state: {
 				listeners: {
 					foo: 'action1'
@@ -229,7 +240,11 @@ registerSuite({
 		let registry = Object.create(actionRegistry);
 
 		const widget = createStatefulListenersMixin({
-			actionRegistry: registry,
+			registryProvider: {
+				get(type: string) {
+					return type === 'actions' ? registry : null;
+				}
+			},
 			state: {
 				listeners: {
 					foo: 'action1'


### PR DESCRIPTION
Rather than creating widgets with a particular registry, expect a registry provider to be passed. Widgets can access the required registry via this provider.

See also <https://github.com/dojo/app/pull/18>.

