### PR TITLE
Add createChild() to createStatefulChildrenMixin

### DIFF
--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -2,9 +2,10 @@ import createMemoryStore from 'src/util/createMemoryStore';
 import createWidget from 'src/createWidget';
 import createPanel from 'src/createPanel';
 import createTabbedPanel from 'src/createTabbedPanel';
-import { Child } from 'src/mixins/interfaces';
+import { Child, RegistryProvider } from 'src/mixins/interfaces';
 import projector from 'src/projector';
 import Promise from 'dojo-shim/Promise';
+import { ComposeFactory } from 'dojo-compose/compose';
 
 /**
  * A memory store which handles the widget states
@@ -24,6 +25,9 @@ const widgetStore = createMemoryStore({
 	]
 });
 
+/**
+ * This is a mock of dojo/app
+ */
 const widgetRegistry = {
 	get(id: string | symbol): Promise<Child> {
 		let widget: Child;
@@ -60,10 +64,13 @@ const widgetRegistry = {
 			break;
 		}
 		return id;
+	},
+	create(factory: ComposeFactory<any, any>, options?: any): Promise<[ string, Child ]> {
+		return factory(options);
 	}
 };
 
-const registryProvider = {
+const registryProvider: RegistryProvider<any> = {
 	get(type: string) {
 		if (type === 'widgets') {
 			return widgetRegistry;

--- a/src/mixins/createStatefulChildrenMixin.ts
+++ b/src/mixins/createStatefulChildrenMixin.ts
@@ -1,6 +1,6 @@
 import compose, { ComposeFactory } from 'dojo-compose/compose';
 import createEvented from 'dojo-compose/mixins/createEvented';
-import createStateful, { Stateful, StatefulOptions, StateChangeEvent } from 'dojo-compose/mixins/createStateful';
+import createStateful, { Stateful, StatefulOptions, StateChangeEvent, State } from 'dojo-compose/mixins/createStateful';
 import Map from 'dojo-shim/Map';
 import Promise from 'dojo-shim/Promise';
 import WeakMap from 'dojo-shim/WeakMap';
@@ -22,6 +22,10 @@ export interface StatefulChildrenOptions<C extends Child, S extends StatefulChil
 	registryProvider?: RegistryProvider<C>;
 }
 
+export interface CreateChildrenMap<C extends Child> {
+	[label: string]: [ComposeFactory<C, StatefulOptions<State>>, StatefulOptions<State>];
+}
+
 export type StatefulChildren<C extends Child, S extends StatefulChildrenState> = Stateful<S> & {
 	/**
 	 * The children that are associated with this widget
@@ -31,8 +35,20 @@ export type StatefulChildren<C extends Child, S extends StatefulChildrenState> =
 	/**
 	 * Creates an instance based on the supplied factory and adds the child to this parent
 	 * returning a promise which resolves with the ID and the instace.
+	 *
+	 * @param factory The factory to use to create the child
+	 * @param options Any options that should be used when creating the child
 	 */
-	createChild<D extends C, O extends { id?: string }>(factory: ComposeFactory<D, O>, options?: O): Promise<[string, D]>;
+	createChild<D extends C, O extends StatefulOptions<S>, S extends State>(
+		factory: ComposeFactory<D, O>, options?: O): Promise<[string, D]>;
+
+	/**
+	 * Creates a set or map of instances based upon the supplied data
+	 *
+	 * @param children the set or map of children factories and options
+	 */
+	createChildren(children: [ComposeFactory<C, StatefulOptions<State>>, StatefulOptions<State>][]): Promise<[string, C][]>;
+	createChildren(children: CreateChildrenMap<C>): Promise<{ [label: string]: [string, C]}>
 
 	/**
 	 * The ID for this widget

--- a/src/mixins/createStatefulChildrenMixin.ts
+++ b/src/mixins/createStatefulChildrenMixin.ts
@@ -201,14 +201,12 @@ const createStatefulChildrenMixin = compose({
 					/* depending upon the construction lifecycle, the this.id may not have been properly set and will
 					 * auto-generate an ID, therefore we have copied the ID out of options, if it was present and will
 					 * use that as a base for autogenerating the child widget's ID */
-					options.id = id
-						? `${id}-child-${++management.childrenUID}`
-						: `${this.id}-child-${++management.childrenUID}`;
+					options.id = `${id || this.id}-child-${++management.childrenUID}`;
 				}
 				return registry.create(factory, options)
 					.then(([ id, child ]): [ string, C ] => {
-						/* This mixin doesn't understand how to directly append a child widget, so instead it will modify
-						 * the widget's state and append the id to the children state */
+						/* Because this mixin manages children in the state, we will append the child to the state
+						 * of the parent */
 						this.setState({ children: (this.state.children || []).concat([ id ]) });
 						return [ id, child ];
 					});

--- a/src/mixins/createStatefulChildrenMixin.ts
+++ b/src/mixins/createStatefulChildrenMixin.ts
@@ -207,7 +207,8 @@ const createStatefulChildrenMixin = compose({
 					.then(([ id, child ]): [ string, C ] => {
 						/* Because this mixin manages children in the state, we will append the child to the state
 						 * of the parent */
-						this.setState({ children: (this.state.children || []).concat([ id ]) });
+						const children = this.state.children ? [ ...this.state.children, id ] : [ id ];
+						this.setState({ children });
 						return [ id, child ];
 					});
 			}
@@ -227,7 +228,7 @@ const createStatefulChildrenMixin = compose({
 					registry,
 					generation: 0,
 					childrenUID: 0,
-					id: id
+					id
 				});
 
 				instance.own(instance.on('statechange', manageChildren));

--- a/src/mixins/interfaces.ts
+++ b/src/mixins/interfaces.ts
@@ -1,3 +1,4 @@
+import { ComposeFactory } from 'dojo-compose/compose';
 import { Handle } from 'dojo-core/interfaces';
 import Promise from 'dojo-shim/Promise';
 import { List, Map } from 'immutable';
@@ -46,6 +47,21 @@ export interface Registry<T> {
 }
 
 /**
+ * A special type of registry that allows realization of children on a parent
+ */
+export interface CreatableRegistry<T extends Child> extends Registry<T> {
+	/**
+	 * Realize a child of the specified parent, returning a promise which resolves with
+	 * a tuple that contains the ID and the realized instance.
+	 *
+	 * @param parent The parent where the realized child should be attached to
+	 * @param factory The factory that should be used to realize the child
+	 * @param options Any options that should be passed to the factory when realizing the child
+	 */
+	create<U extends T, O>(parent: { children: Map<string, Child> | List<Child>; }, factory: ComposeFactory<U, O>, options?: O): Promise<[ string | symbol, U ]>;
+}
+
+/**
  * Provides access to read-only registries.
  */
 export interface RegistryProvider<T> {
@@ -54,5 +70,7 @@ export interface RegistryProvider<T> {
 	 *
 	 * Implementations should throw if the given type is not supported.
 	 */
-	get(type: 'actions' | 'stores' | 'widgets'): Registry<T>;
+	get<U extends T & Child>(type: 'widgets'): CreatableRegistry<U>;
+	get(type: 'actions' | 'stores'): Registry<T>;
+	get(type: string): Registry<T>;
 }

--- a/src/mixins/interfaces.ts
+++ b/src/mixins/interfaces.ts
@@ -58,7 +58,7 @@ export interface CreatableRegistry<T extends Child> extends Registry<T> {
 	 * @param factory The factory that should be used to realize the child
 	 * @param options Any options that should be passed to the factory when realizing the child
 	 */
-	create<U extends T, O>(parent: { children: Map<string, Child> | List<Child>; }, factory: ComposeFactory<U, O>, options?: O): Promise<[ string | symbol, U ]>;
+	create<U extends T, O>(factory: ComposeFactory<U, O>, options?: O): Promise<[ string, U ]>;
 }
 
 /**

--- a/tests/unit/mixins/createStatefulChildrenMixin.ts
+++ b/tests/unit/mixins/createStatefulChildrenMixin.ts
@@ -35,7 +35,7 @@ const widgetRegistry = {
 			? 'widget3' : value === widget4
 			? 'widget4' : undefined;
 	},
-	create<C extends Renderable>(parent: any, factory: ComposeFactory<C, any>, options?: any): Promise<[string | symbol, C]> {;
+	create<C extends Renderable>(factory: ComposeFactory<C, any>, options?: any): Promise<[string | symbol, C]> {;
 		return Promise.resolve<[ string, C ]>([`widget${widgetUID++}`, factory(options)]);
 	}
 };
@@ -387,7 +387,7 @@ registerSuite({
 				assert.strictEqual(widget.render().vnodeSelector, 'div');
 			});
 		},
-		'non-registry rejects'() {
+		'non-registry rejects'(this: any) {
 			const dfd = this.async();
 			const stateful = createStatefulChildrenMixin();
 			stateful.createChild(createRenderable)

--- a/tests/unit/mixins/createStatefulChildrenMixin.ts
+++ b/tests/unit/mixins/createStatefulChildrenMixin.ts
@@ -364,7 +364,8 @@ registerSuite({
 			const createFoo = compose({})
 				.mixin({
 					mixin: createStatefulChildrenMixin,
-					initialize(instance) {
+					initialize(instance, options) {
+						instance.id = options && options.id;
 						p = instance.createChild(createRenderable, <RenderableOptions> {
 							render() {
 								return h('div');
@@ -373,6 +374,7 @@ registerSuite({
 					}
 				});
 			const foo = createFoo({
+				id: 'foo',
 				registryProvider: {
 					get(type: string) {
 						return type === 'widgets' ? registry : null;
@@ -383,7 +385,7 @@ registerSuite({
 			assert(p);
 			return p.then((result) => {
 				const [ id, widget ] = result;
-				assert.include(id, 'undefined-child');
+				assert.include(id, 'foo-child');
 				assert.strictEqual(widget.render().vnodeSelector, 'div');
 			});
 		},

--- a/tests/unit/mixins/createStatefulChildrenMixin.ts
+++ b/tests/unit/mixins/createStatefulChildrenMixin.ts
@@ -7,7 +7,7 @@ import { List, Map } from 'immutable';
 import { Child, RegistryProvider } from 'src/mixins/interfaces';
 import compose, { ComposeFactory } from 'dojo-compose/compose';
 import createDestroyable from 'dojo-compose/mixins/createDestroyable';
-import { h } from 'maquette/maquette';
+import { h } from 'maquette';
 
 const widget1 = createRenderable();
 const widget2 = createRenderable();

--- a/tests/unit/mixins/createStatefulListenersMixin.ts
+++ b/tests/unit/mixins/createStatefulListenersMixin.ts
@@ -58,7 +58,7 @@ const actionRegistry = {
 	}
 };
 
-const registryProvider: RegistryProvider<Action> = {
+const registryProvider: RegistryProvider<Action> = <any> {
 	get(type: string) {
 		return type === 'actions' ? actionRegistry : null;
 	}
@@ -217,7 +217,7 @@ registerSuite({
 
 		const dfd = this.async();
 
-		const widget = createStatefulListenersMixin({
+		const widget = createStatefulListenersMixin(<any> {
 			registryProvider: {
 				get(type: string) {
 					return type === 'actions' ? rejectingRegistry : null;
@@ -239,7 +239,7 @@ registerSuite({
 		const { get } = actionRegistry;
 		let registry = Object.create(actionRegistry);
 
-		const widget = createStatefulListenersMixin({
+		const widget = createStatefulListenersMixin(<any> {
 			registryProvider: {
 				get(type: string) {
 					return type === 'actions' ? registry : null;


### PR DESCRIPTION
This PR allows instances of `createStatefulChildrenMixin` to be able to create children that are intended to be managed externally (like via `dojo/app`).  Specifically it assumes that `widget` registries return not only contain `get` and `identify` but also `create()` with the signature of:

```typescript
export interface CreatableRegistry<T extends Child> extends Registry<T> {
	/**
	 * Realize a child of the specified parent, returning a promise which resolves with
	 * a tuple that contains the ID and the realized instance.
	 *
	 * @param parent The parent where the realized child should be attached to
	 * @param factory The factory that should be used to realize the child
	 * @param options Any options that should be passed to the factory when realizing the child
	 */
	create<U extends T, O>(parent: { children: Map<string, Child> | List<Child>; }, factory: ComposeFactory<U, O>, options?: O): Promise<[ string | symbol, U ]>;
}
```

It then add the method `createChild()` which has the following signature:

```typescript
export type StatefulChildren<C extends Child, S extends StatefulChildrenState> = Stateful<S> & {
	/**
	 * Creates an instance based on the supplied factory and adds the child to this parent
	 * returning a promise which resolves with the ID and the instace.
	 */
	createChild<D extends C, O>(factory: ComposeFactory<D, O>, options?: O): Promise<[string | symbol, D]>;
}
```

It is mainly indented to be used during construction when creating a widget parent which is tightly coupled to it's child widget but is being managed by something like `dojo/app`.  For example, the following can be done in an initalizer:

```typescript
{
	mixin: createStatefulChildrenMixin,
	initialize(instance) {
		instance.createChild(createRenderable, <RenderableOptions> {
			render() {
				return h('div');
			}
		});
	}
}
```
