### PR TITLE
MemoryStore patch with missing ID adds instead of rejects

### DIFF
--- a/src/util/createMemoryStore.ts
+++ b/src/util/createMemoryStore.ts
@@ -290,14 +290,9 @@ const createMemoryStore = compose<MemoryStoreMixin<Object>, MemoryStoreOptions<O
 				return wrapError(store, new Error(`Object ID must either be passed in "partial.${idProperty}" or "options.id"`));
 			}
 			return wrapResult(store, store.get(id).then((item) => {
-				if (item) {
-					options = options || {};
-					options.id = id;
-					return store.put(assign(item, partial), options);
-				}
-				else {
-					return wrapError(store, new Error(`Object with ID "${id}" not found, unable to patch.`));
-				}
+				options = options || {};
+				options.id = id;
+				return store.put(assign(item || {}, partial), options);
 			}));
 		},
 

--- a/tests/unit/util/createMemoryStore.ts
+++ b/tests/unit/util/createMemoryStore.ts
@@ -132,16 +132,16 @@ registerSuite({
 					assert.deepEqual(item, { id: 1, foo: 'qat', bar: 1 });
 				});
 		},
-		'missing rejects'() {
+		'missing adds'() {
 			const store = createMemoryStore();
 
 			return store
-				.patch({ foo: 'qat', bar: 1}, { id: 1 })
+				.patch({ foo: 'qat', bar: 1 }, { id: 1 })
 				.then(() => {
-					throw new Error('Should have rejected');
-				}, (error) => {
-					assert.instanceOf(error, Error);
-					assert.strictEqual(error.message, 'Object with ID "1" not found, unable to patch.');
+					return store.get(1);
+				})
+				.then((item) => {
+					assert.deepEqual(item, { foo: 'qat', bar: 1, id: 1 });
 				});
 		},
 		'missing id rejects'() {


### PR DESCRIPTION
This PR changes the behaviour of `.patch()` so that if the ID is missing, it will add the object to store instead of rejecting as previous.

Fixes #26