### PR TITLE
Add placeholder HTML attribute support to TextInput

### DIFF
--- a/src/createTextInput.ts
+++ b/src/createTextInput.ts
@@ -1,3 +1,4 @@
+import { VNodeProperties } from 'maquette/maquette';
 import { ComposeFactory } from 'dojo-compose/compose';
 import createWidget, { Widget, WidgetOptions } from './createWidget';
 import createFormFieldMixin, { FormFieldMixin, FormFieldMixinState, FormFieldMixinOptions } from './mixins/createFormFieldMixin';
@@ -7,7 +8,12 @@ export interface TypedTargetEvent<T extends EventTarget> extends Event {
 	target: T;
 }
 
-export interface TextInputOptions extends WidgetOptions<FormFieldMixinState<string>>, FormFieldMixinOptions<string, FormFieldMixinState<string>> { }
+export interface TextInputOptions extends WidgetOptions<FormFieldMixinState<string>>, FormFieldMixinOptions<string, FormFieldMixinState<string>> {
+	/**
+	 * The form widget's placeholder value
+	 */
+	placeholder?: string;
+}
 
 export type TextInput = Widget<FormFieldMixinState<string>> & FormFieldMixin<string, FormFieldMixinState<string>>;
 
@@ -16,6 +22,17 @@ export interface TextInputFactory extends ComposeFactory<TextInput, TextInputOpt
 const createTextInput: TextInputFactory = createWidget
 	.mixin({
 		mixin: createFormFieldMixin,
+		aspectAdvice: {
+			before: {
+				getNodeAttributes(overrides: VNodeProperties = {}) {
+					if (this.state.placeholder !== undefined) {
+						overrides.placeholder = this.state.placeholder;
+					}
+
+					return [overrides];
+				}
+			}
+		},
 		initialize(instance) {
 			instance.own(instance.on('input', (event: TypedTargetEvent<HTMLInputElement>) => {
 				instance.value = event.target.value;


### PR DESCRIPTION
This PR is more to start a conversation around HTML attribute support on various input types. While it accomplishes the goal of adding placeholder support to TextInput, I'm not sure it's the right way to go. There will be other input types that can have a placeholder, so maybe it should be a mixin. I'm also not sure the aspect-based method used here is what we will settle on.