### PR TITLE
Enable strict null checks

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dojo-shim": ">=2.0.0-beta.1",
     "dojo-stores": ">=2.0.0-alpha.1",
     "immutable": "^3.8.1",
-    "maquette": "^2.3.5"
+    "maquette": ">=2.3.7 <=2.4.1"
   },
   "devDependencies": {
     "@types/chai": "3.4.*",

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
   "peerDependencies": {
     "@reactivex/rxjs": "5.0.0-beta.6",
     "dojo-compose": ">=2.0.0-beta.10",
-    "dojo-core": ">=2.0.0-alpha.12",
+    "dojo-core": ">=2.0.0-alpha.14",
     "dojo-has": ">=2.0.0-alpha.4",
-    "dojo-shim": ">=2.0.0-alpha.4",
+    "dojo-shim": ">=2.0.0-beta.1",
     "dojo-stores": ">=2.0.0-alpha.1",
     "immutable": "^3.8.1",
     "maquette": "^2.3.5"

--- a/src/createDijit.ts
+++ b/src/createDijit.ts
@@ -108,7 +108,7 @@ function constructDijitWidget(dijit: Dijit<DijitWidget>, srcNodeRef: Node): Prom
 	const dijitData = dijitDataWeakMap.get(dijit);
 	return resolveCtor(dijitData.Ctor)
 		.then((/* tslint:disable */Ctor/* tslint:enable */) => {
-			const dijitWidget = new Ctor(dijitData.params, srcNodeRef);
+			const dijitWidget = new Ctor(dijitData.params || {}, srcNodeRef);
 			dijitWidget.startup();
 			return dijitWidget;
 		});
@@ -246,7 +246,7 @@ const createDijit: DijitFactory = createRenderMixin
 			dijitData.afterCreate = afterCreate.bind(instance);
 			if (options) {
 				dijitData.Ctor = options.Ctor;
-				dijitData.params = options.params || {};
+				dijitData.params = options.params;
 			}
 		}
 	})

--- a/src/createDijit.ts
+++ b/src/createDijit.ts
@@ -222,15 +222,15 @@ const createDijit: DijitFactory = createRenderMixin
 				const afterCreate = dijitDataWeakMap.get(this).afterCreate;
 				return h(this.tagName, { afterCreate });
 			},
-			get dijit(this: Dijit<DijitWidget>): DijitWidget {
+			get dijit(this: Dijit<DijitWidget>): DijitWidget | undefined {
 				return dijitDataWeakMap.get(this).dijitWidget;
 			},
 
-			get Ctor(this: Dijit<DijitWidget>): DijitWidgetConstructor<DijitWidget> | string {
+			get Ctor(this: Dijit<DijitWidget>): DijitWidgetConstructor<DijitWidget> | string | undefined {
 				return dijitDataWeakMap.get(this).Ctor;
 			},
 
-			get params(this: Dijit<DijitWidget>): DijitWidgetParams {
+			get params(this: Dijit<DijitWidget>): DijitWidgetParams | undefined {
 				return dijitDataWeakMap.get(this).params;
 			}
 		},

--- a/src/createDijit.ts
+++ b/src/createDijit.ts
@@ -151,7 +151,10 @@ const ctorMap = new Map<string, DijitWidgetConstructor<DijitWidget>>();
  * Returns a `Promise` which resolves with the constructor.
  * @param Ctor The Dijit widget constructor to be resolved
  */
-function resolveCtor<D extends DijitWidget>(/* tslint:disable */Ctor/* tslint:enable */: DijitWidgetConstructor<D> | string): Promise<DijitWidgetConstructor<D>> {
+function resolveCtor<D extends DijitWidget>(/* tslint:disable */Ctor/* tslint:enable */: DijitWidgetConstructor<D> | string | undefined): Promise<DijitWidgetConstructor<D>> {
+	if (Ctor === undefined) {
+		return Promise.reject(new Error('Cannot load undefined constructor'));
+	}
 	if (typeof Ctor !== 'string') {
 		return Promise.resolve(Ctor);
 	}

--- a/src/createResizePanel.ts
+++ b/src/createResizePanel.ts
@@ -151,7 +151,7 @@ const createResizePanel: ResizePanelFactory = createWidget
 			nodeAttributes: [
 				function (this: ResizePanel, attributes: VNodeProperties): VNodeProperties {
 					const styles = assign({}, attributes.styles);
-					styles['width'] = this.width || '200px';
+					styles['width'] = this.width;
 					return { styles };
 				}
 			],
@@ -161,7 +161,7 @@ const createResizePanel: ResizePanelFactory = createWidget
 			},
 
 			get width(this: ResizePanel): string {
-				return this.state && this.state && this.state.width;
+				return this.state && this.state && this.state.width || '200px';
 			},
 
 			set width(value: string) {

--- a/src/createResizePanel.ts
+++ b/src/createResizePanel.ts
@@ -50,23 +50,27 @@ function setResizeListeners(resizePanel: ResizePanel): Handle {
 	let ontouchmoveHandle: Handle;
 
 	function onmouseupListener(evt: MouseEvent): boolean {
-		if (resizingMap.get(resizePanel)) {
-			evt.preventDefault();
-			resizingMap.delete(resizePanel);
-			onmousemoveHandle.destroy();
-			onmouseupHandle.destroy();
-			resizePanel.invalidate();
-			return true;
+		if (!resizingMap.has(resizePanel)) {
+			return false;
 		}
+
+		evt.preventDefault();
+		resizingMap.delete(resizePanel);
+		onmousemoveHandle.destroy();
+		onmouseupHandle.destroy();
+		resizePanel.invalidate();
+		return true;
 	}
 
 	function onmousemoveListener(evt: MouseEvent): boolean {
 		const originalWidth = resizingMap.get(resizePanel);
-		if (originalWidth) {
-			evt.preventDefault();
-			resizePanel.width = String(originalWidth.width + evt.clientX - originalWidth.clientX) + 'px';
-			return true;
+		if (!originalWidth) {
+			return false;
 		}
+
+		evt.preventDefault();
+		resizePanel.width = String(originalWidth.width + evt.clientX - originalWidth.clientX) + 'px';
+		return true;
 	}
 
 	function onmousedownListener(evt: MouseEvent): boolean {
@@ -81,6 +85,8 @@ function setResizeListeners(resizePanel: ResizePanel): Handle {
 				return true;
 			}
 		}
+
+		return false;
 	}
 
 	function ontouchendListener(evt: TouchEvent): boolean {

--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -30,40 +30,32 @@ const widgetStore = createMemoryStore({
  */
 const widgetRegistry = {
 	get(id: string | symbol): Promise<Child> {
-		let widget: Child;
 		switch (id) {
 		case 'panel-1':
-			widget = panel1;
-			break;
+			return Promise.resolve(panel1);
 		case 'panel-2':
-			widget = panel2;
-			break;
+			return Promise.resolve(panel2);
 		case 'panel-3':
-			widget = panel3;
-			break;
+			return Promise.resolve(panel3);
 		case 'panel-4':
-			widget = panel4;
-			break;
+			return Promise.resolve(panel4);
+		default:
+			return Promise.reject(new Error('Unknown widget'));
 		}
-		return Promise.resolve(widget);
 	},
 	identify(value: Child): string | symbol {
-		let id: string | symbol;
 		switch (value) {
 		case panel1:
-			id = 'panel-1';
-			break;
+			return 'panel-1';
 		case panel2:
-			id = 'panel-2';
-			break;
+			return 'panel-2';
 		case panel3:
-			id = 'panel-3';
-			break;
+			return 'panel-3';
 		case panel4:
-			id = 'panel-4';
-			break;
+			return 'panel-4';
+		default:
+			throw new Error('Not registered');
 		}
-		return id;
 	},
 	create(factory: ComposeFactory<any, any>, options?: any): Promise<[ string, Child ]> {
 		return factory(options);

--- a/src/examples/scratch.ts
+++ b/src/examples/scratch.ts
@@ -11,7 +11,7 @@ function render(): VNode {
 	return h('dojo-panel-tabbed', {
 		id: 'tabbed-panel'
 	}, [
-		h('ul', {}, [
+		h('ul', [
 			h('li', { classes: { active: false }, key: panel1 }, [ h('div.tab-label', [ 'tab 1' ]), h('div.tab-close', [ 'X' ]) ]),
 			h('li', { classes: { active: closed }, key: panel2 }, [ h('div.tab-label', [ 'tab 2' ]), h('div.tab-close', [ 'X' ]) ]),
 			h('li', { classes: { active: false }, key: panel3 }, [ h('div.tab-label', [ 'tab 3' ]), h('div.tab-close', [ 'X' ]) ]),
@@ -37,8 +37,9 @@ const projector = createProjector({});
 projector.append(document.body, render);
 
 const next = document.getElementById('next');
-
-next.addEventListener('click', (event) => {
-	closed = true;
-	projector.scheduleRender();
-});
+if (next) {
+	next.addEventListener('click', (event) => {
+		closed = true;
+		projector.scheduleRender();
+	});
+}

--- a/src/mixins/createParentListMixin.ts
+++ b/src/mixins/createParentListMixin.ts
@@ -59,10 +59,14 @@ const createParentMixin: ParentListMixinFactory = compose<ParentList<Child>, Par
 		set children(this: ParentListMixin<Child> & { invalidate?(): void; }, value: List<Child>) {
 			if (!value.equals(childrenMap.get(this))) {
 				value.forEach((widget) => {
-					if (widget.parent !== this) {
-						widget.parent = this;
-						/* TODO: If a child gets attached and reattached it may own multiple handles */
-						getRemoveHandle(this, widget);
+					// Workaround for https://github.com/facebook/immutable-js/pull/919
+					// istanbul ignore else
+					if (widget) {
+						if (widget.parent !== this) {
+							widget.parent = this;
+							/* TODO: If a child gets attached and reattached it may own multiple handles */
+							getRemoveHandle(this, widget);
+						}
 					}
 				});
 				childrenMap.set(this, value);
@@ -85,7 +89,13 @@ const createParentMixin: ParentListMixinFactory = compose<ParentList<Child>, Par
 		clear(this: ParentListMixin<Child>): void {
 			const children = childrenMap.get(this);
 			if (children) {
-				children.forEach((child) => { child.parent === undefined; });
+				children.forEach((child) => {
+					// Workaround for https://github.com/facebook/immutable-js/pull/919
+					// istanbul ignore else
+					if (child) {
+						child.parent === undefined;
+					}
+				});
 				this.children = List<Child>();
 			}
 		},
@@ -106,7 +116,13 @@ const createParentMixin: ParentListMixinFactory = compose<ParentList<Child>, Par
 			instance.own({
 				destroy() {
 					const children = childrenMap.get(instance);
-					children.forEach((child) => child.destroy());
+					children.forEach((child) => {
+						// Workaround for https://github.com/facebook/immutable-js/pull/919
+						// istanbul ignore else
+						if (child) {
+							child.destroy();
+						}
+					});
 				}
 			});
 		}

--- a/src/mixins/createParentListMixin.ts
+++ b/src/mixins/createParentListMixin.ts
@@ -52,11 +52,11 @@ export interface ParentListMixinFactory extends ComposeFactory<ParentListMixin<C
 const childrenMap = new WeakMap<ParentListMixin<Child>, List<Child>>();
 
 const createParentMixin: ParentListMixinFactory = compose<ParentList<Child>, ParentListMixinOptions<Child>>({
-		get children(this: ParentListMixin<Child> & { invalidate?(): void; } ): List<Child> {
+		get children(this: ParentListMixin<Child>): List<Child> {
 			return childrenMap.get(this);
 		},
 
-		set children(this: ParentListMixin<Child> & { invalidate?(): void; }, value: List<Child>) {
+		set children(this: ParentListMixin<Child>, value: List<Child>) {
 			if (!value.equals(childrenMap.get(this))) {
 				value.forEach((widget) => {
 					// Workaround for https://github.com/facebook/immutable-js/pull/919

--- a/src/mixins/createParentMapMixin.ts
+++ b/src/mixins/createParentMapMixin.ts
@@ -80,10 +80,14 @@ const createParentMapMixin: ParentMapMixinFactory = compose<ParentMap<Child>, Pa
 		set children(this: ParentMapMixin<Child> & { invalidate?(): void; }, value: Map<string, Child>) {
 			if (!value.equals(childrenMap.get(this))) {
 				value.forEach((widget) => {
-					if (widget.parent !== this) {
-						widget.parent = this;
-						/* TODO: If a child gets attached and reattached it may own multiple handles */
-						getRemoveHandle(this, widget);
+					// Workaround for https://github.com/facebook/immutable-js/pull/919
+					// istanbul ignore else
+					if (widget) {
+						if (widget.parent !== this) {
+							widget.parent = this;
+							/* TODO: If a child gets attached and reattached it may own multiple handles */
+							getRemoveHandle(this, widget);
+						}
 					}
 				});
 				childrenMap.set(this, value);
@@ -124,7 +128,13 @@ const createParentMapMixin: ParentMapMixinFactory = compose<ParentMap<Child>, Pa
 			instance.own({
 				destroy() {
 					const children = childrenMap.get(instance);
-					children.forEach((child) => child.destroy());
+					children.forEach((child) => {
+						// Workaround for https://github.com/facebook/immutable-js/pull/919
+						// istanbul ignore else
+						if (child) {
+							child.destroy();
+						}
+					});
 				}
 			});
 		}

--- a/src/mixins/createRenderMixin.ts
+++ b/src/mixins/createRenderMixin.ts
@@ -260,7 +260,7 @@ const createRenderMixin = createStateful
 
 			tagName: 'div'
 		},
-		initialize(instance, options = {}) {
+		initialize(instance: RenderMixin<RenderMixinState>, options: RenderMixinOptions<RenderMixinState> = {}) {
 			const { tagName, render, parent } = options;
 			instance.tagName = tagName || instance.tagName;
 			instance.render = render || instance.render;

--- a/src/mixins/createRenderMixin.ts
+++ b/src/mixins/createRenderMixin.ts
@@ -191,7 +191,7 @@ const createRenderMixin = createStateful
 			},
 
 			getChildrenNodes(this: RenderMixin<RenderMixinState>): (VNode | string)[] {
-				return this.state.label ? [ this.state.label ] : undefined;
+				return this.state.label ? [ this.state.label ] : [];
 			},
 
 			get id(this: RenderMixin<RenderMixinState>): string {

--- a/src/mixins/createRenderableChildrenMixin.ts
+++ b/src/mixins/createRenderableChildrenMixin.ts
@@ -40,7 +40,13 @@ const createRenderableChildrenMixin: RenderableChildrenFactory = compose<Rendera
 					.forEach(([ , child ]) => results.push(child.render()));
 			}
 			else {
-				children.forEach((child) => results.push(child.render()));
+				children.forEach((child) => {
+					// Workaround for https://github.com/facebook/immutable-js/pull/919
+					// istanbul ignore else
+					if (child) {
+						results.push(child.render());
+					}
+				});
 			}
 			return results;
 		}

--- a/src/mixins/createStatefulChildrenMixin.ts
+++ b/src/mixins/createStatefulChildrenMixin.ts
@@ -140,7 +140,7 @@ function manageChildren(evt: StateChangeEvent<StatefulChildrenState>): void {
 	 * no newer state is overriden. */
 	const generation = ++internalState.generation;
 
-	const currentChildrenIDs = List(evt.state.children);
+	const currentChildrenIDs = evt.state.children ? List(evt.state.children) : List<string>();
 	if (currentChildrenIDs.equals(internalState.current)) {
 		/* There are no changes to the children */
 		return;
@@ -240,7 +240,8 @@ function manageChildrenState(evt: ChildListEvent<any, Child>) {
 		currentChildrenIDs = List(evtChildren.keys());
 	}
 
-	if (!currentChildrenIDs.equals(List(parent.state.children))) {
+	const storedChildren = parent.state.children ? List(parent.state.children) : List<string>();
+	if (!currentChildrenIDs.equals(storedChildren)) {
 		const children = currentChildrenIDs.toArray();
 		parent.setState({ children });
 	}

--- a/src/mixins/createStatefulChildrenMixin.ts
+++ b/src/mixins/createStatefulChildrenMixin.ts
@@ -128,8 +128,9 @@ function manageChildren(evt: StateChangeEvent<StatefulChildrenState>): void {
 	/* Assume this function cannot be called without the widget being in the management map */
 	const internalState = managementMap.get(parent);
 	/* Initialize cache */
+	const { cache = new Map<string, Child>() } = internalState;
 	if (!internalState.cache) {
-		internalState.cache = new Map<string, Child>();
+		internalState.cache = cache;
 	}
 	/* Initialize current children IDs */
 	if (!internalState.current) {
@@ -159,12 +160,12 @@ function manageChildren(evt: StateChangeEvent<StatefulChildrenState>): void {
 		// Workaround for https://github.com/facebook/immutable-js/pull/919
 		// istanbul ignore else
 		if (id !== undefined && key !== undefined) {
-			if (internalState.cache.has(id)) {
+			if (cache.has(id)) {
 				if (childrenIsList) {
-					childrenList[key] = internalState.cache.get(id);
+					childrenList[key] = <Child> cache.get(id);
 				}
 				else {
-					childrenMap[id] = internalState.cache.get(id);
+					childrenMap[id] = <Child> cache.get(id);
 				}
 			}
 			else {
@@ -193,7 +194,7 @@ function manageChildren(evt: StateChangeEvent<StatefulChildrenState>): void {
 					else {
 						childrenMap[id] = widget;
 					}
-					internalState.cache.set(id, widget);
+					cache.set(id, widget);
 				});
 				/* Some parents have a List, some have a Map, so setting them varies */
 				parent.children = isList(parent.children) ? List(childrenList) : ImmutableMap<string, Child>(childrenMap);

--- a/src/mixins/createStatefulListenersMixin.ts
+++ b/src/mixins/createStatefulListenersMixin.ts
@@ -107,8 +107,9 @@ function manageListeners(evt: StateChangeEvent<StatefulListenersState>): void {
 	// Assume this function cannot be called without the widget being in the management map.
 	const internalState = managementMap.get(widget);
 	// Initialize cache.
+	const { cache = new Map<string | symbol, EventedListener<TargettedEventObject>>() } = internalState;
 	if (!internalState.cache) {
-		internalState.cache = new Map<string | symbol, Actionable<TargettedEventObject>>();
+		internalState.cache = cache;
 	}
 	// Increment the generation vector. Used when listeners are replaced asynchronously to ensure
 	// no newer state is overriden.
@@ -122,7 +123,7 @@ function manageListeners(evt: StateChangeEvent<StatefulListenersState>): void {
 	const newListeners: EventedListenersMap = {};
 	// `promise` will be undefined if all actions are resolved synchronously
 	const promise = eventTypes.reduce<Promise<void>>((promise, eventType) => {
-		const [ value, listenersPromise ] = resolveListeners(internalState.registry, internalState.cache, listeners[eventType]);
+		const [ value, listenersPromise ] = resolveListeners(internalState.registry, cache, listeners[eventType]);
 		if (value) {
 			newListeners[eventType] = value;
 			return promise;

--- a/src/mixins/createStatefulListenersMixin.ts
+++ b/src/mixins/createStatefulListenersMixin.ts
@@ -122,7 +122,7 @@ function manageListeners(evt: StateChangeEvent<StatefulListenersState>): void {
 
 	const newListeners: EventedListenersMap = {};
 	// `promise` will be undefined if all actions are resolved synchronously
-	const promise = eventTypes.reduce<Promise<void>>((promise, eventType) => {
+	const promise = eventTypes.reduce<Promise<void> | undefined>((promise, eventType) => {
 		const [ value, listenersPromise ] = resolveListeners(internalState.registry, cache, listeners[eventType]);
 		if (value) {
 			newListeners[eventType] = value;

--- a/src/mixins/createStatefulListenersMixin.ts
+++ b/src/mixins/createStatefulListenersMixin.ts
@@ -1,5 +1,5 @@
 import { ComposeFactory } from 'dojo-compose/compose';
-import { Actionable, EventedListenersMap, EventedListenerOrArray, TargettedEventObject } from 'dojo-compose/mixins/createEvented';
+import { Actionable, EventedListenersMap, TargettedEventObject } from 'dojo-compose/mixins/createEvented';
 import createStateful, { Stateful, StatefulOptions, StateChangeEvent } from 'dojo-compose/mixins/createStateful';
 import { Handle } from 'dojo-core/interfaces';
 import Map from 'dojo-shim/Map';
@@ -27,6 +27,25 @@ export interface StatefulListenersMixinFactory extends ComposeFactory<Stateful<S
 	(options?: StatefulListenersOptions<StatefulListenersState>): Stateful<StatefulListenersState>;
 }
 
+// Use generics to avoid annoying repetition of the Actionable<TargettedEventObject> type.
+type ResolvedListeners<T> = [T[], undefined] | [undefined, Promise<T[]>];
+function carriesValue<T>(result: ResolvedListeners<T>): result is [T[], undefined] {
+	return result[0] !== undefined;
+}
+
+type MixedResultOverride<T> = {
+	// Property on the array to track whether it contains promises, which makes the withoutPromises() type
+	// guard possible.
+	containsPromises?: boolean;
+	// These seem to need to be redeclared. Declared them as narrowly as possible for the actual usage below.
+	push(result: T[]): number;
+	push(result: Promise<T[]>): number;
+};
+type MixedResults<T> = (T[][] | (T[] | Promise<T[]>)[]) & MixedResultOverride<T>;
+function withoutPromises<T>(mixed: MixedResults<T>): mixed is T[][] & MixedResultOverride<T> {
+	return mixed.containsPromises !== true;
+}
+
 /**
  * Internal function that resolves listeners from the registry and then attaches them to the instance
  *
@@ -34,41 +53,48 @@ export interface StatefulListenersMixinFactory extends ComposeFactory<Stateful<S
  * @param cache The cache of already resolved listeners
  * @param ref The reference to resolve
  */
-function resolveListeners(
-	registry: Registry<Actionable<TargettedEventObject>>,
-	cache: Map<string | symbol, Actionable<TargettedEventObject>>,
+function resolveListeners<T>(
+	registry: Registry<T>,
+	cache: Map<string | symbol, T>,
 	ref: ListenerOrArray
-): [(EventedListenerOrArray<TargettedEventObject>), Promise<(EventedListenerOrArray<TargettedEventObject>)>] {
+): ResolvedListeners<T> {
 	if (Array.isArray(ref)) {
-		let isSync = true;
-		const results: (Actionable<TargettedEventObject> | Promise<Actionable<TargettedEventObject>>)[] = [];
+		const mixed: MixedResults<T> = [];
 		for (const item of ref) {
-			const [value, promise] = <[Actionable<TargettedEventObject>, Promise<Actionable<TargettedEventObject>>]> resolveListeners(registry, cache, item);
-			if (value) {
-				results.push(value);
+			const result = resolveListeners<T>(registry, cache, item);
+			if (carriesValue(result)) {
+				mixed.push(result[0]);
 			}
 			else {
-				isSync = false;
-				results.push(promise);
+				mixed.containsPromises = true;
+				mixed.push(result[1]);
 			}
 		}
 
-		if (isSync) {
-			return [<Actionable<TargettedEventObject>[]> results, undefined];
+		const flattened: T[] = [];
+		if (withoutPromises(mixed)) {
+			return [flattened.concat(...mixed), undefined];
 		}
-		return [ undefined, Promise.all(results) ];
+
+		return [
+			undefined,
+			Promise.all(mixed)
+				.then((results) => flattened.concat(...results))
+		];
 	}
 
-	const id = <string | symbol> ref;
-	if (cache.has(id)) {
-		return [ cache.get(id), undefined ];
+	if (cache.has(ref)) {
+		return [[<T> cache.get(ref)], undefined];
 	}
 
-	const promise = registry.get(id);
-	promise.then((action) => {
-		cache.set(id, action);
-	});
-	return [ undefined, promise ];
+	return [
+		undefined,
+		registry.get(ref)
+			.then((action) => {
+				cache.set(ref, action);
+				return [action];
+			})
+	];
 }
 
 interface ManagementState {
@@ -107,7 +133,7 @@ function manageListeners(evt: StateChangeEvent<StatefulListenersState>): void {
 	// Assume this function cannot be called without the widget being in the management map.
 	const internalState = managementMap.get(widget);
 	// Initialize cache.
-	const { cache = new Map<string | symbol, EventedListener<TargettedEventObject>>() } = internalState;
+	const { cache = new Map<string | symbol, Actionable<TargettedEventObject>>() } = internalState;
 	if (!internalState.cache) {
 		internalState.cache = cache;
 	}
@@ -123,13 +149,13 @@ function manageListeners(evt: StateChangeEvent<StatefulListenersState>): void {
 	const newListeners: EventedListenersMap = {};
 	// `promise` will be undefined if all actions are resolved synchronously
 	const promise = eventTypes.reduce<Promise<void> | undefined>((promise, eventType) => {
-		const [ value, listenersPromise ] = resolveListeners(internalState.registry, cache, listeners[eventType]);
-		if (value) {
-			newListeners[eventType] = value;
+		const result = resolveListeners<Actionable<TargettedEventObject>>(internalState.registry, cache, listeners[eventType]);
+		if (carriesValue(result)) {
+			newListeners[eventType] = result[0];
 			return promise;
 		}
 
-		return listenersPromise.then((value) => {
+		return result[1].then((value) => {
 			newListeners[eventType] = value;
 			return promise;
 		});

--- a/src/mixins/createTabbedMixin.ts
+++ b/src/mixins/createTabbedMixin.ts
@@ -94,7 +94,7 @@ function getActiveTab(tabbed: TabbedMixin<TabbedChild>): TabbedChild {
 		if (!tab) {
 			return false;
 		}
-		return tab.state.active;
+		return tab.state.active === true;
 	});
 	/* TODO: when a tab closes, instead of going back to the previous active tab, it will always
 	 * revert to the first tab, maybe it would be better to keep track of a stack of tabs? */

--- a/src/mixins/createTabbedMixin.ts
+++ b/src/mixins/createTabbedMixin.ts
@@ -69,8 +69,12 @@ export type TabbedMixin<C extends TabbedChild> = Tabbed<C> & ParentMapMixin<C> &
 function setActiveTab(tabbed: TabbedMixin<TabbedChild>, activeTab: TabbedChild) {
 	if (activeTab.parent === tabbed) {
 		tabbed.children.forEach((tab) => {
-			if (tab !== activeTab && tab.state.active) {
-				tab.setState({ active: false });
+			// Workaround for https://github.com/facebook/immutable-js/pull/919
+			// istanbul ignore else
+			if (tab) {
+				if (tab !== activeTab && tab.state.active) {
+					tab.setState({ active: false });
+				}
 			}
 		});
 		if (!activeTab.state.active) {
@@ -84,7 +88,14 @@ function setActiveTab(tabbed: TabbedMixin<TabbedChild>, activeTab: TabbedChild) 
  * @param tabbed The tabbed mixin to return the active child for
  */
 function getActiveTab(tabbed: TabbedMixin<TabbedChild>): TabbedChild {
-	let activeTab = tabbed.children.find((tab) => tab.state.active);
+	let activeTab = tabbed.children.find((tab) => {
+		// Workaround for https://github.com/facebook/immutable-js/pull/919
+		// istanbul ignore if
+		if (!tab) {
+			return false;
+		}
+		return tab.state.active;
+	});
 	/* TODO: when a tab closes, instead of going back to the previous active tab, it will always
 	 * revert to the first tab, maybe it would be better to keep track of a stack of tabs? */
 	if (!activeTab) {

--- a/src/mixins/createTabbedMixin.ts
+++ b/src/mixins/createTabbedMixin.ts
@@ -206,7 +206,10 @@ const createTabbedMixin: TabbedMixinFactory = createRenderMixin
 
 			function getTabChildVNode(tab: TabbedChild): (VNode | string)[] {
 				const tabListeners = getTabListeners(tabbed, tab);
-				const nodes = [ h('div.tab-label', { onclick: tabListeners.onclickTabListener }, [ tab.state.label ]) ];
+				const nodes: VNode[] = [];
+				if (tab.state.label) {
+					nodes.push(h('div.tab-label', { onclick: tabListeners.onclickTabListener }, [ tab.state.label ]));
+				}
 				if (tab.state.closeable) {
 					nodes.push(h('div.tab-close', { onclick: tabListeners.onclickTabCloseListener }, [ 'X' ]));
 				}

--- a/src/mixins/createTabbedMixin.ts
+++ b/src/mixins/createTabbedMixin.ts
@@ -236,10 +236,18 @@ const createTabbedMixin: TabbedMixinFactory = createRenderMixin
 
 			children.forEach(([ , tab ], idx) => {
 				const isActiveTab = tab === activeTab;
-				if (isActiveTab || (childrenNodes[idx] && childrenNodes[idx].properties.classes['visible'])) {
+				const node = childrenNodes[idx];
+				const isVisibleNode = node &&
+					node.properties &&
+					node.properties.classes &&
+					node.properties.classes['visible'];
+
+				if (isActiveTab || isVisibleNode) {
 					tab.invalidate();
 					const tabVNode = tab.render();
-					tabVNode.properties.classes['visible'] = isActiveTab;
+					if (tabVNode.properties && tabVNode.properties.classes) {
+						tabVNode.properties.classes['visible'] = isActiveTab;
+					}
 					childrenNodes[idx] = tabVNode;
 				}
 				/* else, this tab isn't active and hasn't been previously rendered */

--- a/src/mixins/createTabbedMixin.ts
+++ b/src/mixins/createTabbedMixin.ts
@@ -204,7 +204,7 @@ const createTabbedMixin: TabbedMixinFactory = createRenderMixin
 			const tabbed = this;
 			const activeTab = getActiveTab(tabbed);
 
-			function getTabChildVNode(tab: TabbedChild): (VNode | string)[] {
+			function getTabChildVNode(tab: TabbedChild): VNode[] {
 				const tabListeners = getTabListeners(tabbed, tab);
 				const nodes: VNode[] = [];
 				if (tab.state.label) {

--- a/src/mixins/createVNodeEvented.ts
+++ b/src/mixins/createVNodeEvented.ts
@@ -17,7 +17,7 @@ import { NodeAttributeFunction } from './createRenderMixin';
 export type VNodeListenerReturn = boolean | undefined | null;
 
 export interface VNodeListeners {
-	[on: string]: (ev?: TargettedEventObject) => VNodeListenerReturn;
+	[on: string]: undefined | ((ev?: TargettedEventObject) => VNodeListenerReturn);
 	ontouchcancel?(ev?: TouchEvent): VNodeListenerReturn;
 	ontouchend?(ev?: TouchEvent): VNodeListenerReturn;
 	ontouchmove?(ev?: TouchEvent): VNodeListenerReturn;

--- a/src/mixins/createVNodeEvented.ts
+++ b/src/mixins/createVNodeEvented.ts
@@ -137,10 +137,12 @@ function handlesArraytoHandle(handles: Handle[]): Handle {
 	};
 }
 
+const UNINITIALIZED_LISTENERS = Object.freeze({});
+
 const createVNodeEvented: VNodeEventedFactory = createEvented
 	.mixin({
 		mixin: {
-			listeners: <VNodeListeners> null,
+			listeners: UNINITIALIZED_LISTENERS,
 
 			nodeAttributes: [
 				function (this: VNodeEvented): VNodeProperties {
@@ -159,7 +161,7 @@ const createVNodeEvented: VNodeEventedFactory = createEvented
 							* determine if the value is unitialized here, ensuring that this.listeners is
 							* always valid.
 							*/
-							if (this.listeners === null) {
+							if (this.listeners === UNINITIALIZED_LISTENERS) {
 								this.listeners = {};
 							}
 							let type: string;

--- a/src/projector.ts
+++ b/src/projector.ts
@@ -131,9 +131,9 @@ export enum ProjectorState {
 
 interface ProjectorData {
 	afterInitialCreate?: () => void;
-	attachHandle?: Handle;
+	attachHandle: Handle;
 	attachPromise?: Promise<Handle>;
-	boundRender?: () => VNode;
+	boundRender: () => VNode;
 	projector: MaquetteProjector;
 	root: Element;
 	state: ProjectorState;
@@ -314,6 +314,8 @@ export const createProjector: ProjectorFactory = compose<ProjectorMixin, Project
 			}
 			const projector = createMaquetteProjector(options);
 			projectorDataMap.set(instance, {
+				attachHandle: noopHandle,
+				boundRender: noopVNode,
 				projector,
 				root,
 				state: ProjectorState.Detached,

--- a/src/projector.ts
+++ b/src/projector.ts
@@ -134,9 +134,9 @@ interface ProjectorData {
 	attachHandle?: Handle;
 	attachPromise?: Promise<Handle>;
 	boundRender?: () => VNode;
-	projector?: MaquetteProjector;
-	root?: Element;
-	state?: ProjectorState;
+	projector: MaquetteProjector;
+	root: Element;
+	state: ProjectorState;
 	tagName: string;
 }
 

--- a/src/projector.ts
+++ b/src/projector.ts
@@ -137,7 +137,7 @@ interface ProjectorData {
 	projector?: MaquetteProjector;
 	root?: Element;
 	state?: ProjectorState;
-	tagName?: string;
+	tagName: string;
 }
 
 const projectorDataMap = new WeakMap<Projector, ProjectorData>();
@@ -191,13 +191,15 @@ export const createProjector: ProjectorFactory = compose<ProjectorMixin, Project
 			props.afterCreate = projectorData.afterInitialCreate;
 			return h(projectorData.tagName, props, childVNodes);
 		},
-		attach(this: Projector, { type, tagName = 'div' }: AttachOptions = {}): Promise<Handle> {
+		attach(this: Projector, { type, tagName }: AttachOptions = {}): Promise<Handle> {
 			const projectorData = projectorDataMap.get(this);
 			if (projectorData.state === ProjectorState.Attached) {
 				return projectorData.attachPromise;
 			}
 			projectorData.boundRender = this.render.bind(this);
-			projectorData.tagName = tagName;
+			if (tagName !== undefined) {
+				projectorData.tagName = tagName;
+			}
 			projectorData.state = ProjectorState.Attached;
 			projectorData.attachHandle = this.own({
 				destroy() {
@@ -314,7 +316,8 @@ export const createProjector: ProjectorFactory = compose<ProjectorMixin, Project
 			projectorDataMap.set(instance, {
 				projector,
 				root,
-				state: ProjectorState.Detached
+				state: ProjectorState.Detached,
+				tagName: 'div'
 			});
 			if (autoAttach === true) {
 				instance.attach({ type: 'merge' });

--- a/src/projector.ts
+++ b/src/projector.ts
@@ -194,7 +194,7 @@ export const createProjector: ProjectorFactory = compose<ProjectorMixin, Project
 		attach(this: Projector, { type, tagName }: AttachOptions = {}): Promise<Handle> {
 			const projectorData = projectorDataMap.get(this);
 			if (projectorData.state === ProjectorState.Attached) {
-				return projectorData.attachPromise;
+				return projectorData.attachPromise || Promise.resolve(noopHandle);
 			}
 			projectorData.boundRender = this.render.bind(this);
 			if (tagName !== undefined) {

--- a/src/projector.ts
+++ b/src/projector.ts
@@ -337,6 +337,42 @@ export const createProjector: ProjectorFactory = compose<ProjectorMixin, Project
 		}
 	});
 
-const defaultProjector: Projector = typeof global.document === 'undefined' ? null : createProjector();
+// Projectors cannot be created outside of browser environments. Ensure that a default projector can always be
+// exported, even if it can't do anything.
+const createStubbedProjector: ProjectorFactory = compose({
+		getNodeAttributes(): VNodeProperties {
+			throw new Error('Projector is stubbed');
+		},
+		render(): VNode {
+			throw new Error('Projector is stubbed');
+		},
+		attach(): Promise<Handle> {
+			throw new Error('Projector is stubbed');
+		},
+		invalidate() {
+			throw new Error('Projector is stubbed');
+		},
+		setRoot(root: Element) {
+			throw new Error('Projector is stubbed');
+		},
+		get projector(): MaquetteProjector {
+			throw new Error('Projector is stubbed');
+		},
+		get root(): Element {
+			throw new Error('Projector is stubbed');
+		},
+		get document(): Document {
+			throw new Error('Projector is stubbed');
+		},
+		get state(): ProjectorState {
+			throw new Error('Projector is stubbed');
+		}
+	})
+	.mixin(createVNodeEvented)
+	.mixin(createParentListMixin);
+
+const defaultProjector: Projector = typeof global.document === 'undefined' ?
+	createStubbedProjector() :
+	createProjector();
 
 export default defaultProjector;

--- a/src/projector.ts
+++ b/src/projector.ts
@@ -180,7 +180,13 @@ export const createProjector: ProjectorFactory = compose<ProjectorMixin, Project
 		render(this: Projector): VNode {
 			const projectorData = projectorDataMap.get(this);
 			const childVNodes: VNode[] = [];
-			this.children.forEach((child) => childVNodes.push(child.render()));
+			this.children.forEach((child) => {
+				// Workaround for https://github.com/facebook/immutable-js/pull/919
+				// istanbul ignore else
+				if (child) {
+					childVNodes.push(child.render());
+				}
+			});
 			const props = this.getNodeAttributes();
 			props.afterCreate = projectorData.afterInitialCreate;
 			return h(projectorData.tagName, props, childVNodes);

--- a/src/util/lang.ts
+++ b/src/util/lang.ts
@@ -133,7 +133,7 @@ export function getRemoveHandle<C extends Child>(parent: Parent, child: C | C[] 
 				}
 				destroyed = true;
 				if (c.parent === parent) {
-					c.parent = undefined;
+					c.parent = null;
 				}
 			}
 		});

--- a/src/util/lang.ts
+++ b/src/util/lang.ts
@@ -22,13 +22,13 @@ function getIndex<T>(list: List<T> | T[], item: T, position: Position, reference
 			idx = Array.isArray(list) ? list.length : list.size;
 			break;
 		case 'before':
-			idx = list.indexOf(reference);
+			idx = reference === undefined ? -1 : list.indexOf(reference);
 			if (idx === -1) {
 				throw new Error('reference not contained in this list');
 			}
 			break;
 		case 'after':
-			idx = list.indexOf(reference) + 1;
+			idx = reference === undefined ? 0 : list.indexOf(reference) + 1;
 			if (idx === 0) {
 				throw new Error('reference not contained in this list');
 			}

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -38,7 +38,7 @@ export const maxConcurrency = 1;
 export const tunnel = 'BrowserStackTunnel';
 
 // Support running unit tests from a web server that isn't the intern proxy
-export const initialBaseUrl: string = (function () {
+export const initialBaseUrl: string | null = (function () {
 	if (typeof location !== 'undefined' && location.pathname.indexOf('__intern/') > -1) {
 		return '/';
 	}

--- a/tests/support/dijit/Dijit.ts
+++ b/tests/support/dijit/Dijit.ts
@@ -6,7 +6,7 @@ class Dijit {
 			throw new Error('Ooops!!!');
 		}
 		if (typeof srcNodeRef === 'string') {
-			srcNodeRef = document.getElementById(<string> srcNodeRef);
+			srcNodeRef = document.getElementById(srcNodeRef) || undefined;
 		}
 		this.srcNodeRef = <HTMLElement> srcNodeRef;
 		this.domNode = <HTMLElement> srcNodeRef;

--- a/tests/unit/createButton.ts
+++ b/tests/unit/createButton.ts
@@ -27,9 +27,9 @@ registerSuite({
 		const vnode = button.render();
 		assert.strictEqual(vnode.vnodeSelector, 'button');
 		assert.strictEqual(vnode.text, 'bar');
-		assert.strictEqual(vnode.properties['data-widget-id'], 'foo');
-		assert.strictEqual(vnode.properties.name, 'baz');
-		assert.strictEqual(vnode.properties['type'], 'button');
+		assert.strictEqual(vnode.properties!['data-widget-id'], 'foo');
+		assert.strictEqual(vnode.properties!.name, 'baz');
+		assert.strictEqual(vnode.properties!['type'], 'button');
 		assert.isUndefined(vnode.children);
 	},
 	disable() {
@@ -41,11 +41,11 @@ registerSuite({
 			}
 		});
 		let vnode = button.render();
-		assert.isFalse(vnode.properties['disabled']);
+		assert.isFalse(vnode.properties!['disabled']);
 		button.setState({
 			disabled: true
 		});
 		vnode = button.render();
-		assert.isTrue(vnode.properties['disabled']);
+		assert.isTrue(vnode.properties!['disabled']);
 	}
 });

--- a/tests/unit/createContainer.ts
+++ b/tests/unit/createContainer.ts
@@ -25,7 +25,7 @@ registerSuite({
 		container.append(createContainer());
 		const render = container.render();
 		assert.strictEqual(render.vnodeSelector, 'dojo-container');
-		assert.strictEqual(render.children.length, 1);
+		assert.strictEqual(render.children!.length, 1);
 		assert.isUndefined(render.text);
 		assert.isNull(render.domNode);
 	}

--- a/tests/unit/createDijit.ts
+++ b/tests/unit/createDijit.ts
@@ -75,7 +75,7 @@ registerSuite({
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
 			assert.isUndefined(dijit.dijit);
-			vnode.properties.afterCreate!(domNode, {}, vnode.vnodeSelector, {}, []);
+			vnode.properties!.afterCreate!(domNode, {}, vnode.vnodeSelector, {}, []);
 			setTimeout(dfd.callback(() => {
 				assert.strictEqual(dijit.dijit.domNode, domNode);
 				assert.strictEqual(dijit.dijit.srcNodeRef, domNode);
@@ -94,7 +94,7 @@ registerSuite({
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
 			assert.isUndefined(dijit.dijit);
-			vnode.properties.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
+			vnode.properties!.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties!, vnode.children!);
 			setTimeout(dfd.callback(() => {
 				assert.strictEqual(dijit.dijit.domNode, domNode);
 				assert.strictEqual(dijit.dijit.srcNodeRef, domNode);
@@ -113,7 +113,7 @@ registerSuite({
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
 			assert.isUndefined(dijit.dijit);
-			vnode.properties.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
+			vnode.properties!.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties!, vnode.children!);
 			setTimeout(dfd.callback(() => {
 				assert.strictEqual(dijit.dijit.domNode, domNode);
 				assert.strictEqual(dijit.dijit.srcNodeRef, domNode);
@@ -135,7 +135,7 @@ registerSuite({
 
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
-			vnode.properties.afterCreate!(domNode, {}, vnode.vnodeSelector, {}, []);
+			vnode.properties!.afterCreate!(domNode, {}, vnode.vnodeSelector, {}, []);
 		},
 		'afterCreate w/ bad mid'(this: any) {
 			const dfd = this.async();
@@ -152,7 +152,7 @@ registerSuite({
 
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
-			vnode.properties.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
+			vnode.properties!.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties!, vnode.children!);
 		},
 		'afterCreate w/ Ctor throws'(this: any) {
 			const dfd = this.async(100);
@@ -170,7 +170,7 @@ registerSuite({
 
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
-			vnode.properties.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
+			vnode.properties!.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties!, vnode.children!);
 		},
 		'afterCreate - default empty params'(this: any) {
 			const dfd = this.async();
@@ -181,7 +181,7 @@ registerSuite({
 
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
-			vnode.properties.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
+			vnode.properties!.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties!, vnode.children!);
 
 			setTimeout(dfd.callback(() => {
 				assert.deepEqual(dijit.dijit.spiedParams, {});
@@ -196,12 +196,12 @@ registerSuite({
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
 			document.body.appendChild(domNode);
-			const afterCreate = vnode.properties.afterCreate;
+			const afterCreate = vnode.properties!.afterCreate;
 			afterCreate!(domNode, {}, vnode.vnodeSelector, {}, []);
 			setTimeout(dfd.callback(() => {
 				assert(dijit.dijit);
 				const newVNode = dijit.render();
-				assert.strictEqual(newVNode.properties.afterCreate, afterCreate, 'should not change listeners');
+				assert.strictEqual(newVNode.properties!.afterCreate, afterCreate, 'should not change listeners');
 				document.body.removeChild(domNode);
 				const newDomNode = document.createElement(vnode.vnodeSelector);
 				document.body.appendChild(newDomNode);
@@ -229,7 +229,7 @@ registerSuite({
 
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
-			const afterCreate = vnode.properties.afterCreate;
+			const afterCreate = vnode.properties!.afterCreate;
 			afterCreate!(domNode, {}, vnode.vnodeSelector, {}, []);
 			setTimeout(() => {
 				const dijitWidget = dijit.dijit;

--- a/tests/unit/createDijit.ts
+++ b/tests/unit/createDijit.ts
@@ -3,6 +3,14 @@ import * as assert from 'intern/chai!assert';
 import createDijit from '../../src/createDijit';
 import * as Dijit from '../support/dijit/Dijit';
 
+class ParamsSpy extends Dijit {
+	constructor(params: any, srcNodeRef: any) {
+		super(params, srcNodeRef);
+		this.spiedParams = params;
+	}
+	spiedParams: any;
+}
+
 registerSuite({
 	name: 'createDijit',
 	creation: {
@@ -163,6 +171,21 @@ registerSuite({
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
 			vnode.properties.afterCreate(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
+		},
+		'afterCreate - default empty params'(this: any) {
+			const dfd = this.async();
+
+			const dijit = createDijit({
+				Ctor: ParamsSpy
+			});
+
+			const vnode = dijit.render();
+			const domNode = document.createElement(vnode.vnodeSelector);
+			vnode.properties.afterCreate(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
+
+			setTimeout(dfd.callback(() => {
+				assert.deepEqual(dijit.dijit.spiedParams, {});
+			}), 50);
 		},
 		'afterCreate - new dom node'(this: any) {
 			const dfd = this.async();

--- a/tests/unit/createDijit.ts
+++ b/tests/unit/createDijit.ts
@@ -75,7 +75,7 @@ registerSuite({
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
 			assert.isUndefined(dijit.dijit);
-			vnode.properties.afterCreate(domNode, {}, vnode.vnodeSelector, {}, []);
+			vnode.properties.afterCreate!(domNode, {}, vnode.vnodeSelector, {}, []);
 			setTimeout(dfd.callback(() => {
 				assert.strictEqual(dijit.dijit.domNode, domNode);
 				assert.strictEqual(dijit.dijit.srcNodeRef, domNode);
@@ -94,7 +94,7 @@ registerSuite({
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
 			assert.isUndefined(dijit.dijit);
-			vnode.properties.afterCreate(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
+			vnode.properties.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
 			setTimeout(dfd.callback(() => {
 				assert.strictEqual(dijit.dijit.domNode, domNode);
 				assert.strictEqual(dijit.dijit.srcNodeRef, domNode);
@@ -113,7 +113,7 @@ registerSuite({
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
 			assert.isUndefined(dijit.dijit);
-			vnode.properties.afterCreate(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
+			vnode.properties.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
 			setTimeout(dfd.callback(() => {
 				assert.strictEqual(dijit.dijit.domNode, domNode);
 				assert.strictEqual(dijit.dijit.srcNodeRef, domNode);
@@ -135,7 +135,7 @@ registerSuite({
 
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
-			vnode.properties.afterCreate(domNode, {}, vnode.vnodeSelector, {}, []);
+			vnode.properties.afterCreate!(domNode, {}, vnode.vnodeSelector, {}, []);
 		},
 		'afterCreate w/ bad mid'(this: any) {
 			const dfd = this.async();
@@ -152,7 +152,7 @@ registerSuite({
 
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
-			vnode.properties.afterCreate(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
+			vnode.properties.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
 		},
 		'afterCreate w/ Ctor throws'(this: any) {
 			const dfd = this.async(100);
@@ -170,7 +170,7 @@ registerSuite({
 
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
-			vnode.properties.afterCreate(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
+			vnode.properties.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
 		},
 		'afterCreate - default empty params'(this: any) {
 			const dfd = this.async();
@@ -181,7 +181,7 @@ registerSuite({
 
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
-			vnode.properties.afterCreate(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
+			vnode.properties.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties, vnode.children);
 
 			setTimeout(dfd.callback(() => {
 				assert.deepEqual(dijit.dijit.spiedParams, {});
@@ -197,7 +197,7 @@ registerSuite({
 			const domNode = document.createElement(vnode.vnodeSelector);
 			document.body.appendChild(domNode);
 			const afterCreate = vnode.properties.afterCreate;
-			afterCreate(domNode, {}, vnode.vnodeSelector, {}, []);
+			afterCreate!(domNode, {}, vnode.vnodeSelector, {}, []);
 			setTimeout(dfd.callback(() => {
 				assert(dijit.dijit);
 				const newVNode = dijit.render();
@@ -206,7 +206,7 @@ registerSuite({
 				const newDomNode = document.createElement(vnode.vnodeSelector);
 				document.body.appendChild(newDomNode);
 				assert.isNull(dijit.dijit.domNode.parentNode);
-				afterCreate(newDomNode, {}, vnode.vnodeSelector, {}, []);
+				afterCreate!(newDomNode, {}, vnode.vnodeSelector, {}, []);
 				assert.strictEqual(dijit.dijit.domNode, domNode);
 				assert.strictEqual(dijit.dijit.domNode.parentNode, document.body);
 			}), 50);
@@ -230,7 +230,7 @@ registerSuite({
 			const vnode = dijit.render();
 			const domNode = document.createElement(vnode.vnodeSelector);
 			const afterCreate = vnode.properties.afterCreate;
-			afterCreate(domNode, {}, vnode.vnodeSelector, {}, []);
+			afterCreate!(domNode, {}, vnode.vnodeSelector, {}, []);
 			setTimeout(() => {
 				const dijitWidget = dijit.dijit;
 				assert.strictEqual(dijitWidget._destroyCalled, 0);

--- a/tests/unit/createList.ts
+++ b/tests/unit/createList.ts
@@ -35,13 +35,13 @@ registerSuite({
 		});
 		let vnode = list.render();
 		assert.strictEqual(vnode.vnodeSelector, 'dojo-list');
-		assert.strictEqual(vnode.children.length, 1);
-		assert.strictEqual(vnode.children[0].vnodeSelector, 'ul');
-		assert.strictEqual(vnode.children[0].children.length, 5);
-		assert.strictEqual(vnode.children[0].children[0].vnodeSelector, 'li');
+		assert.strictEqual(vnode.children!.length, 1);
+		assert.strictEqual(vnode.children![0].vnodeSelector, 'ul');
+		assert.strictEqual(vnode.children![0].children!.length, 5);
+		assert.strictEqual(vnode.children![0].children![0].vnodeSelector, 'li');
 		items.pop();
 		list.setState({ items });
 		vnode = list.render();
-		assert.strictEqual(vnode.children[0].children.length, 4);
+		assert.strictEqual(vnode.children![0].children!.length, 4);
 	}
 });

--- a/tests/unit/createList.ts
+++ b/tests/unit/createList.ts
@@ -15,11 +15,11 @@ registerSuite({
 			{ id: 5, label: 'qux' }
 		];
 		list.setState({ items });
-		assert.strictEqual(list.state.items.length, 5);
+		assert.strictEqual(list.state.items!.length, 5);
 		items.pop();
-		assert.strictEqual(list.state.items.length, 5);
+		assert.strictEqual(list.state.items!.length, 5);
 		list.setState({ items });
-		assert.strictEqual(list.state.items.length, 4);
+		assert.strictEqual(list.state.items!.length, 4);
 	},
 
 	render() {

--- a/tests/unit/mixins/createListMixin.ts
+++ b/tests/unit/mixins/createListMixin.ts
@@ -28,8 +28,8 @@ registerSuite({
 			if (typeof vnode !== 'string') {
 				assert.strictEqual(vnode.vnodeSelector, 'ul');
 				assert.isUndefined(vnode.text);
-				assert.strictEqual(vnode.children.length, 3);
-				const [ node1, node2, node3 ] = vnode.children;
+				assert.strictEqual(vnode.children!.length, 3);
+				const [ node1, node2, node3 ] = vnode.children!;
 				assert.strictEqual(node1.vnodeSelector, 'li');
 				assert.strictEqual(node1.text, 'foo');
 				assert.isUndefined(node1.children);

--- a/tests/unit/mixins/createRenderMixin.ts
+++ b/tests/unit/mixins/createRenderMixin.ts
@@ -42,7 +42,7 @@ registerSuite({
 	},
 	'getChildrenNodes()'() {
 		const cachedRender = createRenderMixin();
-		assert.isUndefined(cachedRender.getChildrenNodes());
+		assert.deepEqual(cachedRender.getChildrenNodes(), []);
 		cachedRender.setState({ label: 'foo' });
 		assert.deepEqual(cachedRender.getChildrenNodes(), [ 'foo' ]);
 	},

--- a/tests/unit/mixins/createRenderMixin.ts
+++ b/tests/unit/mixins/createRenderMixin.ts
@@ -64,7 +64,7 @@ registerSuite({
 		assert.deepEqual(result1, result3);
 		assert.deepEqual(result2, result4);
 		assert.strictEqual(result1.vnodeSelector, 'div');
-		assert.strictEqual(result1.properties['data-widget-id'], 'foo');
+		assert.strictEqual(result1.properties!['data-widget-id'], 'foo');
 		assert.strictEqual(result1.text, 'foo');
 	},
 	'id': {

--- a/tests/unit/mixins/createStatefulListenersMixin.ts
+++ b/tests/unit/mixins/createStatefulListenersMixin.ts
@@ -53,7 +53,7 @@ const actionRegistry = {
 			case action4:
 				return 'action4';
 			default:
-				return undefined;
+				throw new Error('Could not identify');
 		}
 	}
 };
@@ -145,7 +145,7 @@ registerSuite({
 
 			widget.setState({
 				listeners: {
-					foo: undefined,
+					foo: [],
 					bar: ['action2', 'action3']
 				}
 			});

--- a/tests/unit/mixins/createTabbedMixin.ts
+++ b/tests/unit/mixins/createTabbedMixin.ts
@@ -92,7 +92,7 @@ registerSuite({
 				children: { foo, bar }
 			});
 			const [ tabBar ] = tabbed.render().children;
-			tabBar.children[0].children[0].properties.onclick(<any> {
+			tabBar.children[0].children[0].properties.onclick!(<any> {
 				preventDefault() { count++; }
 			});
 			assert.strictEqual(tabbed.activeChild, foo);

--- a/tests/unit/mixins/createTabbedMixin.ts
+++ b/tests/unit/mixins/createTabbedMixin.ts
@@ -28,25 +28,25 @@ registerSuite({
 				key: tabbed
 			});
 			assert.strictEqual(vnode.vnodeSelector, 'dojo-panel-mixin');
-			assert.strictEqual(vnode.children.length, 2, 'should have two children');
+			assert.strictEqual(vnode.children!.length, 2, 'should have two children');
 
-			const [ tabBar, panels ] = vnode.children;
+			const [ tabBar, panels ] = vnode.children!;
 			assert.strictEqual(tabBar.vnodeSelector, 'ul');
-			assert.strictEqual(tabBar.children.length, 4);
-			tabBar.children.forEach((child) => assert.strictEqual(child.vnodeSelector, 'li'));
+			assert.strictEqual(tabBar.children!.length, 4);
+			tabBar.children!.forEach((child) => assert.strictEqual(child.vnodeSelector, 'li'));
 
-			const [ child1, child2, child3, child4 ] = tabBar.children;
-			assert.strictEqual(child1.children[0].text, 'foo');
-			assert.strictEqual(child1.children.length, 2);
-			assert.strictEqual(child2.children[0].text, 'bar');
-			assert.strictEqual(child2.children.length, 1);
-			assert.strictEqual(child3.children[0].text, 'baz');
-			assert.strictEqual(child3.children.length, 2);
-			assert.strictEqual(child4.children[0].text, 'qat');
-			assert.strictEqual(child4.children.length, 1);
+			const [ child1, child2, child3, child4 ] = tabBar.children!;
+			assert.strictEqual(child1.children![0].text, 'foo');
+			assert.strictEqual(child1.children!.length, 2);
+			assert.strictEqual(child2.children![0].text, 'bar');
+			assert.strictEqual(child2.children!.length, 1);
+			assert.strictEqual(child3.children![0].text, 'baz');
+			assert.strictEqual(child3.children!.length, 2);
+			assert.strictEqual(child4.children![0].text, 'qat');
+			assert.strictEqual(child4.children!.length, 1);
 
 			assert.strictEqual(panels.vnodeSelector, 'div.panels');
-			assert.strictEqual(panels.children.length, 1);
+			assert.strictEqual(panels.children!.length, 1);
 
 			assert.strictEqual(vnode, tabbed.render(), 'should cache results, if not invalidated');
 
@@ -91,8 +91,8 @@ registerSuite({
 			const tabbed = createTabbedMixin({
 				children: { foo, bar }
 			});
-			const [ tabBar ] = tabbed.render().children;
-			tabBar.children[0].children[0].properties.onclick!(<any> {
+			const [ tabBar ] = tabbed.render().children!;
+			tabBar.children![0].children![0].properties!.onclick!(<any> {
 				preventDefault() { count++; }
 			});
 			assert.strictEqual(tabbed.activeChild, foo);

--- a/tests/unit/mixins/createVNodeEvented.ts
+++ b/tests/unit/mixins/createVNodeEvented.ts
@@ -7,7 +7,7 @@ registerSuite({
 	'register vdom event'() {
 		let count = 0;
 		const vnodeEvented = createVNodeEvented();
-		assert.isNull(vnodeEvented.listeners);
+		assert.deepEqual(vnodeEvented.listeners, {});
 		vnodeEvented.on('touchcancel', (event) => {
 			assert.strictEqual(event.type, 'touchcancel');
 			count++;
@@ -19,12 +19,13 @@ registerSuite({
 	'register non vdom event'() {
 		let count = 0;
 		const vnodeEvented = createVNodeEvented();
-		assert.isNull(vnodeEvented.listeners);
+		const { listeners: initialListeners } = vnodeEvented;
 		vnodeEvented.on('foo', (event) => {
 			assert.strictEqual(event.type, 'foo');
 			count ++;
 		});
 		assert.strictEqual(Object.keys(vnodeEvented.listeners).length, 0);
+		assert.notStrictEqual(vnodeEvented.listeners, initialListeners);
 		vnodeEvented.emit({ type: 'foo' });
 		assert.strictEqual(count, 1);
 	},

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
 		"outDir": "_build/",
 		"removeComments": false,
 		"sourceMap": true,
+		"strictNullChecks": true,
 		"target": "es5"
 	},
 	"include": [


### PR DESCRIPTION
Enables strict null checks and fixes violations. Some changes impact exported typings but I don't think it breaks behavior for consuming libraries that have not yet enabled strict null checks.

Depends on <https://github.com/dojo/shim/pull/19> and <https://github.com/dojo/core/pull/194> being on npm.