### PR TITLE
Feature: Support CSS Transitions with Maquette Projector and Widget Mixin

### DIFF
--- a/src/mixins/createCssTransitionMixin.ts
+++ b/src/mixins/createCssTransitionMixin.ts
@@ -1,0 +1,40 @@
+import { VNodeProperties } from 'maquette';
+import compose, { ComposeFactory } from 'dojo-compose/compose';
+import { NodeAttributeFunction } from './createRenderMixin';
+import createStateful, { State, Stateful, StatefulOptions } from 'dojo-compose/mixins/createStateful';
+
+export type CssTransitionMixinState = State & {
+	/**
+	 * The class of the CSS animation to be applied as the widget enters the dom
+	 */
+	enterAnimation?: string;
+
+	/**
+	 * The class of the CSS animation to be applied as the widget exits the dom
+	 */
+	exitAnimation?: string;
+}
+
+export interface CssTransition {
+	/**
+	 * An array of node attribute functions which return additional attributes that should be mixed into
+	 * the final VNode during a render call
+	 */
+	nodeAttributes: NodeAttributeFunction[];
+}
+
+export type CssTransitionMixin<S extends CssTransitionMixinState> = CssTransition & Stateful<S>;
+
+export interface CssTransitionMixinFactory extends ComposeFactory<CssTransitionMixin<CssTransitionMixinState>, StatefulOptions<CssTransitionMixinState>> {};
+
+const createCssTransitionMixin: CssTransitionMixinFactory = compose({
+		nodeAttributes: [
+			function (this: CssTransitionMixin<CssTransitionMixinState>): VNodeProperties {
+				const { enterAnimation, exitAnimation } = this.state;
+				return { enterAnimation, exitAnimation };
+			}
+		]
+	})
+	.mixin(createStateful);
+
+export default createCssTransitionMixin;

--- a/src/projector.ts
+++ b/src/projector.ts
@@ -24,6 +24,12 @@ export interface ProjectorOptions extends ParentListMixinOptions<Child>, Evented
 	 * provided (see `AttachOptions`). The attach type determines how the projector is attached.
 	 */
 	autoAttach?: boolean | AttachType;
+
+	/**
+	 * If `true`, will configure the projector to support css transitions using `cssTransitions` global object.
+	 * The projector will fail create if the options is true but the global object cannot be found.
+	 */
+	cssTransitions?: boolean;
 }
 
 export interface AttachOptions {
@@ -275,8 +281,17 @@ export const createProjector: ProjectorFactory = compose<ProjectorMixin, Project
 	})
 	.mixin({
 		mixin: createParentListMixin,
-		initialize(instance: Projector, { autoAttach = false, root = document.body }: ProjectorOptions = {}) {
-			const projector = createMaquetteProjector({});
+		initialize(instance: Projector, { cssTransitions = false, autoAttach = false, root = document.body }: ProjectorOptions = {}) {
+			const options: { transitions?: any } = {};
+			if (cssTransitions) {
+				if (global.cssTransitions) {
+					options.transitions = global.cssTransitions;
+				}
+				else {
+					throw new Error('Unable to create projector with css transitions enabled. Is the \'css-transition.js\' script loaded in the page?');
+				}
+			}
+			const projector = createMaquetteProjector(options);
 			projectorDataMap.set(instance, {
 				projector,
 				root,

--- a/tests/unit/mixins/all.ts
+++ b/tests/unit/mixins/all.ts
@@ -1,4 +1,5 @@
 import './createCloseableMixin';
+import './createCssTransitionMixin';
 import './createFormFieldMixin';
 import './createListMixin';
 import './createParentListMixin';

--- a/tests/unit/mixins/createCssTransitionMixin.ts
+++ b/tests/unit/mixins/createCssTransitionMixin.ts
@@ -1,0 +1,22 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import createCssTransitionMixin from '../../../src/mixins/createCssTransitionMixin';
+
+registerSuite({
+	name: 'mixins/createCssTransitionMixin',
+	construction() {
+		const cssTranistionMixin = createCssTransitionMixin();
+		assert.isDefined(cssTranistionMixin);
+	},
+	'getNodeAttributes()'() {
+		const cssTranistionMixin = createCssTransitionMixin({
+			state: {
+				enterAnimation: 'enter-animation-class',
+				exitAnimation: 'exit-animation-class'
+			}
+		});
+		const nodeAttributes = cssTranistionMixin.nodeAttributes[0].call(cssTranistionMixin, {});
+		assert.strictEqual(nodeAttributes.enterAnimation, 'enter-animation-class');
+		assert.strictEqual(nodeAttributes.exitAnimation, 'exit-animation-class');
+	}
+});

--- a/tests/unit/projector.ts
+++ b/tests/unit/projector.ts
@@ -6,6 +6,7 @@ import { h } from 'maquette';
 import createRenderMixin from '../../src/mixins/createRenderMixin';
 import createDestroyable from 'dojo-compose/mixins/createDestroyable';
 import { ComposeFactory } from 'dojo-compose/compose';
+import global from 'dojo-core/global';
 import { Child } from '../../src/mixins/interfaces';
 
 const createRenderableChild = createDestroyable
@@ -74,6 +75,26 @@ registerSuite({
 				}), 300);
 			}, 300);
 		}).catch(dfd.reject);
+	},
+	'construct projector with css transitions'() {
+		global.cssTransitions = {};
+		try {
+			createProjector({ cssTransitions: true });
+		}
+		catch (err) {
+			assert.fail(null, null, 'Projector should be created without throwing an error');
+		}
+
+	},
+	'construting projector configured for css transitions throws when css-transitions script is not loaded.'() {
+		global.cssTransitions = undefined;
+		try {
+			createProjector({ cssTransitions: true });
+		}
+		catch (err) {
+			assert.isTrue(err instanceof Error);
+			assert.equal(err.message, 'Unable to create projector with css transitions enabled. Is the \'css-transition.js\' script loaded in the page?');
+		}
 	},
 	'\'attach\' event'() {
 		const div = document.createElement('div');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Widget mixin to support CSS transitions within the widget architecture.

Using css transitions with Maquette requires loading Maquette's provided `css-transitions.js` in the page, this is then used within the Maquette projector construction assuming the `cssTransitions` options has been set to `true`.

Currently due to limitations in the provided `css-transitions.js` script, `exitAnimation` is only supported for CSS Transitions and not CSS Animations (like those provided by `animate.css`), currently the element is not being correctly removed from the DOM on completion of the exitAnimation.

Related to #56 

