### PR TITLE
Label all factories

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,6 +57,6 @@
     "jsdom": "^9.5.0",
     "remap-istanbul": "^0.6.4",
     "tslint": "^3.11.0",
-    "typescript": "^2.0.3"
+    "typescript": "~2.0.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "dojo-shim": ">=2.0.0-alpha.4",
     "dojo-stores": ">=2.0.0-alpha.1",
     "immutable": "^3.8.1",
-    "maquette": "^2.3.5"
+    "maquette": "~2.3.7"
   },
   "devDependencies": {
     "@types/chai": "3.4.*",

--- a/src/createButton.ts
+++ b/src/createButton.ts
@@ -14,7 +14,7 @@ export interface ButtonFactory extends ComposeFactory<Button, ButtonOptions> { }
 const createButton: ButtonFactory = createRenderMixin
 	.mixin(createFormFieldMixin)
 	.mixin(createVNodeEvented)
-	.extend({
+	.extend('Button', {
 		tagName: 'button',
 		type: 'button'
 	});

--- a/src/createContainer.ts
+++ b/src/createContainer.ts
@@ -17,7 +17,7 @@ const createContainer: ContainerFactory = createWidget
 	.mixin(createParentListMixin)
 	.mixin(createRenderableChildrenMixin)
 	.mixin(createStatefulChildrenMixin)
-	.extend({
+	.extend('Container', {
 		tagName: 'dojo-container'
 	});
 

--- a/src/createDijit.ts
+++ b/src/createDijit.ts
@@ -217,6 +217,7 @@ const dijitDataWeakMap = new WeakMap<Dijit<DijitWidget>, DijitData<DijitWidget>>
  */
 const createDijit: DijitFactory = createRenderMixin
 	.mixin({
+		className: 'Dijit',
 		mixin: <DijitMixin<DijitWidget>> {
 			render(this: Dijit<DijitWidget>): VNode {
 				const afterCreate = dijitDataWeakMap.get(this).afterCreate;
@@ -248,6 +249,7 @@ const createDijit: DijitFactory = createRenderMixin
 		}
 	})
 	.mixin({
+		className: 'Dijit',
 		mixin: createEvented,
 		initialize(instance: Dijit<DijitWidget>) {
 			instance.own(instance.on('statechange', (event) => {
@@ -267,6 +269,7 @@ const createDijit: DijitFactory = createRenderMixin
 		}
 	})
 	.mixin({
+		className: 'Dijit',
 		mixin: createDestroyable,
 		initialize(instance: Dijit<DijitWidget>) {
 			instance.own({

--- a/src/createLayoutContainer.ts
+++ b/src/createLayoutContainer.ts
@@ -17,7 +17,7 @@ const createContainer: LayoutContainerFactory = createWidget
 	.mixin(createParentListMixin)
 	.mixin(createRenderableChildrenMixin)
 	.mixin(createStatefulChildrenMixin)
-	.extend({
+	.extend('LayoutContainer', {
 		tagName: 'dojo-container-layout'
 	});
 

--- a/src/createList.ts
+++ b/src/createList.ts
@@ -12,7 +12,7 @@ export interface ListFactory extends ComposeFactory<List<ListStateItem>, WidgetO
 
 const createList: ListFactory = createWidget
 	.mixin(createListMixin)
-	.extend({
+	.extend('List', {
 		tagName: 'dojo-list'
 	});
 

--- a/src/createPanel.ts
+++ b/src/createPanel.ts
@@ -21,7 +21,7 @@ const createPanel: PanelFactory = createWidget
 	.mixin(createParentListMixin)
 	.mixin(createRenderableChildrenMixin)
 	.mixin(createStatefulChildrenMixin)
-	.extend({
+	.extend('Panel', {
 		tagName: 'dojo-panel'
 	});
 

--- a/src/createResizePanel.ts
+++ b/src/createResizePanel.ts
@@ -141,6 +141,7 @@ const createResizePanel: ResizePanelFactory = createWidget
 	.mixin(createRenderableChildrenMixin)
 	.mixin(createStatefulChildrenMixin)
 	.mixin({
+		className: 'ResizePanel',
 		mixin: <ResizePanelMixin> {
 			nodeAttributes: [
 				function (this: ResizePanel, attributes: VNodeProperties): VNodeProperties {
@@ -176,6 +177,7 @@ const createResizePanel: ResizePanelFactory = createWidget
 		tagName: 'dojo-panel-resize'
 	})
 	.mixin({
+		className: 'ResizePanel',
 		mixin: createDestroyable,
 		initialize(instance) {
 			resizeNodePropertiesMap.set(instance, {});

--- a/src/createTabbedPanel.ts
+++ b/src/createTabbedPanel.ts
@@ -15,7 +15,7 @@ export interface TabbedPanelFactory extends ComposeFactory<TabbedPanel, TabbedPa
 const createTabbedPanel: TabbedPanelFactory = createWidget
 	.mixin(createTabbedMixin)
 	.mixin(createStatefulChildrenMixin)
-	.extend({
+	.extend('TabbedPanel', {
 		tagName: 'dojo-panel-tabbed'
 	});
 

--- a/src/createTextInput.ts
+++ b/src/createTextInput.ts
@@ -19,6 +19,7 @@ export interface TextInputFactory extends ComposeFactory<TextInput, TextInputOpt
 const createTextInput: TextInputFactory = createRenderMixin
 	.mixin(createFormFieldMixin)
 	.mixin({
+		className: 'TextInput',
 		mixin: createVNodeEvented,
 		initialize(instance) {
 			instance.own(instance.on('input', (event: TypedTargetEvent<HTMLInputElement>) => {
@@ -26,7 +27,7 @@ const createTextInput: TextInputFactory = createRenderMixin
 			}));
 		}
 	})
-	.extend({
+	.extend('TextInput', {
 		type: 'text',
 		tagName: 'input'
 	});

--- a/src/createWidget.ts
+++ b/src/createWidget.ts
@@ -13,6 +13,7 @@ export interface WidgetFactory extends ComposeFactory<Widget<WidgetState>, Widge
 }
 
 const createWidget: WidgetFactory = createRenderMixin
-	.mixin(createVNodeEvented);
+	.mixin(createVNodeEvented)
+	.extend('Widget', {});
 
 export default createWidget;

--- a/src/mixins/createCloseableMixin.ts
+++ b/src/mixins/createCloseableMixin.ts
@@ -30,6 +30,7 @@ export interface CloseableMixinFactory extends ComposeFactory<CloseableMixin<Clo
 
 const createCloseableMixin: CloseableMixinFactory = createStateful
 	.mixin({
+		className: 'CloseableMixin',
 		mixin: {
 			close(this: CloseableMixin<CloseableState>): Promise<boolean> {
 				if (this.state.closeable) {

--- a/src/mixins/createFormFieldMixin.ts
+++ b/src/mixins/createFormFieldMixin.ts
@@ -109,7 +109,7 @@ const createFormMixin: FormMixinFactory = compose({
 				const props: VNodeProperties = {};
 
 				if (this.type) {
-					props['type'] = this.type;
+					props.type = this.type;
 				}
 				/* value should always be copied */
 				props.value = this.value;
@@ -117,7 +117,7 @@ const createFormMixin: FormMixinFactory = compose({
 					props.name = this.state.name;
 				}
 				if (this.state.disabled) {
-					props['disabled'] = 'disabled';
+					props.disabled = true;
 				}
 
 				return props;
@@ -129,6 +129,7 @@ const createFormMixin: FormMixinFactory = compose({
 		}
 	})
 	.mixin({
+		className: 'FormFieldMixin',
 		mixin: createStateful,
 		initialize(
 			instance: FormFieldMixin<any, FormFieldMixinState<any>>,

--- a/src/mixins/createListMixin.ts
+++ b/src/mixins/createListMixin.ts
@@ -50,6 +50,7 @@ export interface ListMixinFactory extends ComposeFactory<ListMixin, StatefulOpti
 
 const createListMixin: ListMixinFactory = createStateful
 	.mixin({
+		className: 'ListMixin',
 		mixin: <List> {
 			getChildrenNodes(this: ListMixin): (VNode | string)[] {
 				if (this.state && this.state.items) {

--- a/src/mixins/createParentListMixin.ts
+++ b/src/mixins/createParentListMixin.ts
@@ -97,6 +97,7 @@ const createParentMixin: ParentListMixinFactory = compose<ParentList<Child>, Par
 		}
 	})
 	.mixin({
+		className: 'ParentListMixin',
 		mixin: createEvented,
 		initialize(instance, options) {
 			childrenMap.set(instance, List<any>());

--- a/src/mixins/createParentMapMixin.ts
+++ b/src/mixins/createParentMapMixin.ts
@@ -115,6 +115,7 @@ const createParentMapMixin: ParentMapMixinFactory = compose<ParentMap<Child>, Pa
 		}
 	})
 	.mixin({
+		className: 'ParentMapMixin',
 		mixin: createEvented,
 		initialize(instance, options) {
 			childrenMap.set(instance, Map<string, Child>());

--- a/src/mixins/createRenderMixin.ts
+++ b/src/mixins/createRenderMixin.ts
@@ -159,6 +159,7 @@ const widgetClassesMap = new WeakMap<RenderMixin<RenderMixinState>, string[]>();
 
 const createRenderMixin = createStateful
 	.mixin<Render, RenderMixinOptions<RenderMixinState>>({
+		className: 'RenderMixin',
 		mixin: {
 			get classes(this: RenderMixin<RenderMixinState>): string[] {
 				return (this.state && this.state.classes) || shadowClasses.get(this);

--- a/src/mixins/createRenderableChildrenMixin.ts
+++ b/src/mixins/createRenderableChildrenMixin.ts
@@ -27,7 +27,7 @@ export interface RenderableChildrenMixin {
 
 export interface RenderableChildrenFactory extends ComposeFactory<RenderableChildrenMixin, RenderableChildrenOptions> {}
 
-const createRenderableChildrenMixin: RenderableChildrenFactory = compose<RenderableChildrenMixin, RenderableChildrenOptions>({
+const createRenderableChildrenMixin: RenderableChildrenFactory = compose<RenderableChildrenMixin, RenderableChildrenOptions>('RenderableChildrenMixin', {
 	/* When this gets mixed in, if we had the children as part of the interface, we would end up overwritting what is
 	 * likely a get accessor for the children, so to protect ourselves, we won't have it part of the interface */
 	getChildrenNodes(this: RenderableChildrenMixin & { children: List<Child>; }): (VNode | string)[] {

--- a/src/mixins/createStatefulChildrenMixin.ts
+++ b/src/mixins/createStatefulChildrenMixin.ts
@@ -229,6 +229,7 @@ function isCreateChildrenMap<C extends Child, O extends StatefulOptions<S>, S ex
 
 const createStatefulChildrenMixin: StatefulChildrenMixinFactory = createStateful
 	.mixin({
+		className: 'StatefulChildrenMixin',
 		mixin: <StatefulChildren<any>> {
 			createChildren(
 				this: StatefulChildrenMixin<Child, StatefulChildrenState>,

--- a/src/mixins/createStatefulListenersMixin.ts
+++ b/src/mixins/createStatefulListenersMixin.ts
@@ -164,6 +164,7 @@ function manageListeners(evt: StateChangeEvent<StatefulListenersState>): void {
 
 const createStatefulListenersMixin: StatefulListenersMixinFactory = createStateful
 	.mixin({
+		className: 'StatefulListenersMixin',
 		initialize(instance: StatefulListeners<any>, { registryProvider, state }: StatefulListenersOptions<any> = {}) {
 			if (registryProvider) {
 				const registry = registryProvider.get('actions');

--- a/src/mixins/createTabbedMixin.ts
+++ b/src/mixins/createTabbedMixin.ts
@@ -186,7 +186,7 @@ const createTabbedMixin: TabbedMixinFactory = createRenderMixin
 	})
 	.mixin(createParentMapMixin)
 	.mixin(createDestroyable)
-	.extend({
+	.extend('TabbedMixin', {
 		tagName: 'dojo-panel-mixin',
 
 		getChildrenNodes(this: TabbedMixin<TabbedChild>): (VNode | string)[] {

--- a/src/mixins/createVNodeEvented.ts
+++ b/src/mixins/createVNodeEvented.ts
@@ -139,6 +139,7 @@ function handlesArraytoHandle(handles: Handle[]): Handle {
 
 const createVNodeEvented: VNodeEventedFactory = createEvented
 	.mixin({
+		className: 'VNodeEvented',
 		mixin: {
 			listeners: <VNodeListeners> null,
 

--- a/src/projector.ts
+++ b/src/projector.ts
@@ -266,14 +266,7 @@ export const createProjector: ProjectorFactory = compose<ProjectorMixin, Project
 		}
 	})
 	.mixin({
-		mixin: createVNodeEvented,
-		initialize(instance) {
-			/* We have to stub out listeners for Maquette, otherwise it won't allow us to change them down the road */
-			instance.on('touchend', function () {});
-			instance.on('touchmove', function () {});
-		}
-	})
-	.mixin({
+		className: 'Projector',
 		mixin: createParentListMixin,
 		initialize(instance: Projector, { autoAttach = false, root = document.body }: ProjectorOptions = {}) {
 			const projector = createMaquetteProjector({});
@@ -295,6 +288,15 @@ export const createProjector: ProjectorFactory = compose<ProjectorMixin, Project
 					this.invalidate();
 				}
 			}
+		}
+	})
+	.mixin({
+		className: 'Projector',
+		mixin: createVNodeEvented,
+		initialize(instance) {
+			/* We have to stub out listeners for Maquette, otherwise it won't allow us to change them down the road */
+			instance.on('touchend', function () {});
+			instance.on('touchmove', function () {});
 		}
 	});
 

--- a/tests/support/util.ts
+++ b/tests/support/util.ts
@@ -16,3 +16,20 @@ export function isEventuallyRejected<T>(promise: Thenable<T>): Thenable<boolean>
 export function throwImmediatly() {
 	throw new Error('unexpected code path');
 }
+
+let _hasConfigurableName: boolean;
+
+/**
+ * Detects if functions have configurable names, some browsers that are not 100% ES2015
+ * compliant do not.
+ */
+export function hasConfigurableName(): boolean {
+	if (_hasConfigurableName !== undefined) {
+		return _hasConfigurableName;
+	}
+	const nameDescriptor = Object.getOwnPropertyDescriptor(function foo() {}, 'name');
+	if (nameDescriptor && !nameDescriptor.configurable) {
+		return _hasConfigurableName = false;
+	}
+	return _hasConfigurableName = true;
+}

--- a/tests/unit/createButton.ts
+++ b/tests/unit/createButton.ts
@@ -1,6 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createButton, { ButtonState } from '../../src/createButton';
+import { hasConfigurableName } from '../support/util';
 
 registerSuite({
 	name: 'createButton',
@@ -29,7 +30,7 @@ registerSuite({
 		assert.strictEqual(vnode.text, 'bar');
 		assert.strictEqual(vnode.properties['data-widget-id'], 'foo');
 		assert.strictEqual(vnode.properties.name, 'baz');
-		assert.strictEqual(vnode.properties['type'], 'button');
+		assert.strictEqual(vnode.properties.type, 'button');
 		assert.isUndefined(vnode.children);
 	},
 	disable() {
@@ -41,11 +42,18 @@ registerSuite({
 			}
 		});
 		let vnode = button.render();
-		assert.isUndefined(vnode.properties['disabled']);
+		assert.isUndefined(vnode.properties.disabled);
 		button.setState({
 			disabled: true
 		});
 		vnode = button.render();
-		assert.strictEqual(vnode.properties['disabled'], 'disabled');
+		assert.isTrue(vnode.properties.disabled);
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const button = createButton();
+		assert.strictEqual((<any> button).toString(), '[object Button]');
 	}
 });

--- a/tests/unit/createContainer.ts
+++ b/tests/unit/createContainer.ts
@@ -1,6 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createContainer from '../../src/createContainer';
+import { hasConfigurableName } from '../support/util';
 
 registerSuite({
 	name: 'createContainer',
@@ -28,5 +29,12 @@ registerSuite({
 		assert.strictEqual(render.children.length, 1);
 		assert.isUndefined(render.text);
 		assert.isNull(render.domNode);
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const container = createContainer();
+		assert.strictEqual((<any> container).toString(), '[object Container]');
 	}
 });

--- a/tests/unit/createDijit.ts
+++ b/tests/unit/createDijit.ts
@@ -2,6 +2,7 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createDijit from '../../src/createDijit';
 import * as Dijit from '../support/dijit/Dijit';
+import { hasConfigurableName } from '../support/util';
 
 registerSuite({
 	name: 'createDijit',
@@ -217,5 +218,12 @@ registerSuite({
 					}));
 			}, 50);
 		}
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const dijit = createDijit();
+		assert.strictEqual((<any> dijit).toString(), '[object Dijit]');
 	}
 });

--- a/tests/unit/createList.ts
+++ b/tests/unit/createList.ts
@@ -1,6 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createList from '../../src/createList';
+import { hasConfigurableName } from '../support/util';
 
 registerSuite({
 	name: 'createList',
@@ -43,5 +44,12 @@ registerSuite({
 		list.setState({ items });
 		vnode = list.render();
 		assert.strictEqual(vnode.children[0].children.length, 4);
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const list = createList();
+		assert.strictEqual((<any> list).toString(), '[object List]');
 	}
 });

--- a/tests/unit/createWidget.ts
+++ b/tests/unit/createWidget.ts
@@ -1,6 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createWidget from '../../src/createWidget';
+import { hasConfigurableName } from '../support/util';
 
 registerSuite({
 	name: 'createWidget',
@@ -48,5 +49,12 @@ registerSuite({
 		assert.strictEqual(Object.keys(nodeAttributes3).length, 6, 'should have six keys only');
 		assert.strictEqual(nodeAttributes3.id, 'foo');
 		assert.isFunction(nodeAttributes3.onclick, 'onclick is a function');
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const widget = createWidget();
+		assert.strictEqual((<any> widget).toString(), '[object Widget]');
 	}
 });

--- a/tests/unit/mixins/createCloseableMixin.ts
+++ b/tests/unit/mixins/createCloseableMixin.ts
@@ -1,6 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createCloseableMixin from '../../../src/mixins/createCloseableMixin';
+import { hasConfigurableName } from '../../support/util';
 
 registerSuite({
 	name: 'mixins/createCloseableMixin',
@@ -113,5 +114,12 @@ registerSuite({
 				assert.strictEqual(count, 0, 'destroy should not have been called');
 			});
 		}
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const closeable = createCloseableMixin();
+		assert.strictEqual((<any> closeable).toString(), '[object CloseableMixin]');
 	}
 });

--- a/tests/unit/mixins/createFormFieldMixin.ts
+++ b/tests/unit/mixins/createFormFieldMixin.ts
@@ -1,6 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createFormFieldMixin, { ValueChangeEvent } from '../../../src/mixins/createFormFieldMixin';
+import { hasConfigurableName } from '../../support/util';
 
 registerSuite({
 	name: 'mixins/createFormFieldMixin',
@@ -112,7 +113,7 @@ registerSuite({
 			assert.strictEqual(nodeAttributes['type'], 'foo');
 			assert.strictEqual(nodeAttributes['value'], 'bar');
 			assert.strictEqual(nodeAttributes['name'], 'baz');
-			assert.strictEqual(nodeAttributes['disabled'], 'disabled');
+			assert.isTrue(nodeAttributes['disabled']);
 
 			formfield.setState({ disabled: false });
 
@@ -142,5 +143,12 @@ registerSuite({
 			assert.isUndefined(formfield.state.value);
 			assert.strictEqual(nodeAttributes['value'], '');
 		}
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const closeable = createFormFieldMixin();
+		assert.strictEqual((<any> closeable).toString(), '[object FormFieldMixin]');
 	}
 });

--- a/tests/unit/mixins/createListMixin.ts
+++ b/tests/unit/mixins/createListMixin.ts
@@ -1,6 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createListMixin from '../../../src/mixins/createListMixin';
+import { hasConfigurableName } from '../../support/util';
 
 registerSuite({
 	name: 'mixins/createListMixin',
@@ -44,5 +45,12 @@ registerSuite({
 				throw Error('vnode is string');
 			}
 		}
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const closeable = createListMixin();
+		assert.strictEqual((<any> closeable).toString(), '[object ListMixin]');
 	}
 });

--- a/tests/unit/mixins/createParentListMixin.ts
+++ b/tests/unit/mixins/createParentListMixin.ts
@@ -3,6 +3,7 @@ import * as assert from 'intern/chai!assert';
 import createParentListMixin from '../../../src/mixins/createParentListMixin';
 import createRenderMixin from '../../../src/mixins/createRenderMixin';
 import { List } from 'immutable';
+import { hasConfigurableName } from '../../support/util';
 
 registerSuite({
 	name: 'mixins/createParentMixin',
@@ -26,5 +27,12 @@ registerSuite({
 
 			parent.append(child);
 		}
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const closeable = createParentListMixin();
+		assert.strictEqual((<any> closeable).toString(), '[object ParentListMixin]');
 	}
 });

--- a/tests/unit/mixins/createParentMapMixin.ts
+++ b/tests/unit/mixins/createParentMapMixin.ts
@@ -5,6 +5,7 @@ import createRenderMixin from '../../../src/mixins/createRenderMixin';
 import { Child } from '../../../src/mixins/interfaces';
 import { Map } from 'immutable';
 import { from as arrayFrom } from 'dojo-shim/array';
+import { hasConfigurableName } from '../../support/util';
 
 type ParentMapWithInvalidate = ParentMap<Child> & { invalidate?(): void; };
 
@@ -125,5 +126,12 @@ registerSuite({
 		assert.strictEqual(called, 2);
 		parent.clear();
 		assert.strictEqual(called, 3);
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const closeable = createParentMapMixin();
+		assert.strictEqual((<any> closeable).toString(), '[object ParentMapMixin]');
 	}
 });

--- a/tests/unit/mixins/createRenderMixin.ts
+++ b/tests/unit/mixins/createRenderMixin.ts
@@ -3,6 +3,7 @@ import * as assert from 'intern/chai!assert';
 import createRenderMixin from '../../../src/mixins/createRenderMixin';
 import { before } from 'dojo-core/aspect';
 import { createProjector } from '../../../src/projector';
+import { hasConfigurableName } from '../../support/util';
 
 registerSuite({
 	name: 'mixins/createRenderMixin',
@@ -128,5 +129,12 @@ registerSuite({
 		cachedRender.render();
 		cachedRender.invalidate();
 		assert.strictEqual(count, 1);
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const closeable = createRenderMixin();
+		assert.strictEqual((<any> closeable).toString(), '[object RenderMixin]');
 	}
 });

--- a/tests/unit/mixins/createRenderableChildrenMixin.ts
+++ b/tests/unit/mixins/createRenderableChildrenMixin.ts
@@ -5,6 +5,7 @@ import createRenderMixin from '../../../src/mixins/createRenderMixin';
 import { Child } from '../../../src/mixins/interfaces';
 import { List, Map } from 'immutable';
 import { VNode } from 'maquette';
+import { hasConfigurableName } from '../../support/util';
 
 type WithListChildren = RenderableChildrenMixin & { children?: List<Child>; };
 type WithMapChildren = RenderableChildrenMixin & { children?: Map<string, Child>; };
@@ -104,5 +105,12 @@ registerSuite({
 			const vnodes = parent.getChildrenNodes();
 			assert.strictEqual(vnodes.length, 0);
 		}
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const closeable = createRenderableChildrenMixin();
+		assert.strictEqual((<any> closeable).toString(), '[object RenderableChildrenMixin]');
 	}
 });

--- a/tests/unit/mixins/createStatefulChildrenMixin.ts
+++ b/tests/unit/mixins/createStatefulChildrenMixin.ts
@@ -8,6 +8,7 @@ import { Child, RegistryProvider } from '../../../src/mixins/interfaces';
 import compose, { ComposeFactory } from 'dojo-compose/compose';
 import createDestroyable from 'dojo-compose/mixins/createDestroyable';
 import { h } from 'maquette';
+import { hasConfigurableName } from '../../support/util';
 
 const widget1 = createRenderMixin();
 const widget2 = createRenderMixin();
@@ -779,5 +780,12 @@ registerSuite({
 					assert.strictEqual(err.message, 'Unable to resolve registry');
 				}));
 		}
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const closeable = createStatefulChildrenMixin();
+		assert.strictEqual((<any> closeable).toString(), '[object StatefulChildrenMixin]');
 	}
 });

--- a/tests/unit/mixins/createStatefulListenersMixin.ts
+++ b/tests/unit/mixins/createStatefulListenersMixin.ts
@@ -4,6 +4,7 @@ import { Actionable, TargettedEventObject } from 'dojo-compose/mixins/createEven
 import Promise from 'dojo-shim/Promise';
 import createStatefulListenersMixin from '../../../src/mixins/createStatefulListenersMixin';
 import { RegistryProvider } from '../../../src/mixins/interfaces';
+import { hasConfigurableName } from '../../support/util';
 
 type Action = Actionable<TargettedEventObject>;
 
@@ -299,5 +300,12 @@ registerSuite({
 			assert.equal(action2.callCount, 0);
 			assert.equal(action3.callCount, 2);
 		});
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const closeable = createStatefulListenersMixin();
+		assert.strictEqual((<any> closeable).toString(), '[object StatefulListenersMixin]');
 	}
 });

--- a/tests/unit/mixins/createTabbedMixin.ts
+++ b/tests/unit/mixins/createTabbedMixin.ts
@@ -3,6 +3,7 @@ import * as assert from 'intern/chai!assert';
 import createTabbedMixin from '../../../src/mixins/createTabbedMixin';
 import createPanel from '../../../src/createPanel';
 import { from as arrayFrom } from 'dojo-shim/array';
+import { hasConfigurableName } from '../../support/util';
 
 registerSuite({
 	name: 'mixins/ceateTabbedMixin',
@@ -113,5 +114,12 @@ registerSuite({
 	'destroy()'() {
 		const tabbed = createTabbedMixin();
 		return tabbed.destroy();
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const closeable = createTabbedMixin();
+		assert.strictEqual((<any> closeable).toString(), '[object TabbedMixin]');
 	}
 });

--- a/tests/unit/mixins/createVNodeEvented.ts
+++ b/tests/unit/mixins/createVNodeEvented.ts
@@ -1,6 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createVNodeEvented from '../../../src/mixins/createVNodeEvented';
+import { hasConfigurableName } from '../../support/util';
 
 registerSuite({
 	name: 'mixins/createVNodeEvented',
@@ -117,5 +118,12 @@ registerSuite({
 			vnodeEvented.emit({ type: 'touchcancel' });
 			assert.strictEqual(count, 1);
 		}
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		const closeable = createVNodeEvented();
+		assert.strictEqual((<any> closeable).toString(), '[object VNodeEvented]');
 	}
 });

--- a/tests/unit/projector.ts
+++ b/tests/unit/projector.ts
@@ -7,6 +7,7 @@ import createRenderMixin from '../../src/mixins/createRenderMixin';
 import createDestroyable from 'dojo-compose/mixins/createDestroyable';
 import { ComposeFactory } from 'dojo-compose/compose';
 import { Child } from '../../src/mixins/interfaces';
+import { hasConfigurableName } from '../support/util';
 
 const createRenderableChild = createDestroyable
 	.mixin(createRenderMixin) as ComposeFactory<Child, any>;
@@ -160,5 +161,11 @@ registerSuite({
 				attachHandle.destroy();
 			}), 300);
 		}).catch(dfd.reject);
+	},
+	'toString()'(this: any) {
+		if (!hasConfigurableName()) {
+			this.skip('Environment does not allow renaming of functions');
+		}
+		assert.strictEqual((<any> projector).toString(), '[object Projector]');
 	}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:
- [X] There is a related issue
- [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
- [X] Unit or Functional tests are included in the PR

**Description:**

This PR labels all factories in widgets, which can then be used for diagnostic purposes.  In many run-time environments, logging an instance to a console will be logged with the appropriate name and factories will often appear similar to the way classes appear.  Environments that do not support the ES6 for `function.name` to be configurable, they won't be renamed, and in environments that do not support `function.name` at all, the console output will not be impacted, but you can still interrogate the instances and factories directly.

~~Needs dojo/compose#65~~
Resolves #58
