### PR TITLE
VNodeProperties disabled attribute is typed as boolean

### DIFF
--- a/src/mixins/createFormFieldMixin.ts
+++ b/src/mixins/createFormFieldMixin.ts
@@ -116,9 +116,8 @@ const createFormMixin: FormMixinFactory = compose({
 				if (this.state && this.state.name) {
 					props.name = this.state.name;
 				}
-				if (this.state.disabled) {
-					props['disabled'] = 'disabled';
-				}
+
+				props.disabled = Boolean(this.state.disabled);
 
 				return props;
 			}

--- a/tests/unit/createButton.ts
+++ b/tests/unit/createButton.ts
@@ -41,11 +41,11 @@ registerSuite({
 			}
 		});
 		let vnode = button.render();
-		assert.isUndefined(vnode.properties['disabled']);
+		assert.isFalse(vnode.properties['disabled']);
 		button.setState({
 			disabled: true
 		});
 		vnode = button.render();
-		assert.strictEqual(vnode.properties['disabled'], 'disabled');
+		assert.isTrue(vnode.properties['disabled']);
 	}
 });

--- a/tests/unit/mixins/createFormFieldMixin.ts
+++ b/tests/unit/mixins/createFormFieldMixin.ts
@@ -104,7 +104,7 @@ registerSuite({
 			assert.strictEqual(nodeAttributes['type'], 'foo');
 			assert.strictEqual(nodeAttributes['value'], 'bar');
 			assert.strictEqual(nodeAttributes['name'], 'baz');
-			assert.isUndefined(nodeAttributes['disabled']);
+			assert.isFalse(nodeAttributes['disabled']);
 
 			formfield.setState({ disabled: true });
 
@@ -112,7 +112,7 @@ registerSuite({
 			assert.strictEqual(nodeAttributes['type'], 'foo');
 			assert.strictEqual(nodeAttributes['value'], 'bar');
 			assert.strictEqual(nodeAttributes['name'], 'baz');
-			assert.strictEqual(nodeAttributes['disabled'], 'disabled');
+			assert.isTrue(nodeAttributes['disabled']);
 
 			formfield.setState({ disabled: false });
 
@@ -120,7 +120,7 @@ registerSuite({
 			assert.strictEqual(nodeAttributes['type'], 'foo');
 			assert.strictEqual(nodeAttributes['value'], 'bar');
 			assert.strictEqual(nodeAttributes['name'], 'baz');
-			assert.isUndefined(nodeAttributes['disabled']);
+			assert.isFalse(nodeAttributes['disabled']);
 		},
 		'falsey value'() {
 			const formfield = createFormFieldMixin({


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Lint error reporting `disabled` attribute of `VNodeProperties` is typed as `boolean` not string.

Lint Error: `src/mixins/createFormFieldMixin.ts(120,6): error TS2322: Type 'string' is not assignable to type 'boolean'.`

