### PR TITLE
Work around VNodeProperties attributes being marked as readonly

### DIFF
--- a/src/mixins/createFormFieldMixin.ts
+++ b/src/mixins/createFormFieldMixin.ts
@@ -106,20 +106,10 @@ const createFormMixin: FormMixinFactory = compose({
 
 		nodeAttributes: [
 			function (this: FormFieldMixin<any, FormFieldMixinState<any>>): VNodeProperties {
-				const props: VNodeProperties = {};
+				const { type, value, state } = this;
+				const { disabled, name } = state;
 
-				if (this.type) {
-					props['type'] = this.type;
-				}
-				/* value should always be copied */
-				props.value = this.value;
-				if (this.state && this.state.name) {
-					props.name = this.state.name;
-				}
-
-				props.disabled = Boolean(this.state.disabled);
-
-				return props;
+				return { type, value, name, disabled: Boolean(disabled) };
 			}
 		]
 	}, (instance: FormField<any>, { type } = <any> {}) => {

--- a/src/mixins/createRenderMixin.ts
+++ b/src/mixins/createRenderMixin.ts
@@ -212,10 +212,8 @@ const createRenderMixin = createStateful
 
 			nodeAttributes: [
 				function (this: RenderMixin<RenderMixinState>): VNodeProperties {
-					const props: VNodeProperties = this.state && this.state.id
-						? { 'data-widget-id': this.state.id }
-						: {};
-
+					const baseIdProp = this.state && this.state.id ? { 'data-widget-id': this.state.id } : {};
+					const styles = this.styles || {};
 					const classes: { [index: string]: boolean; } = {};
 					const widgetClasses = widgetClassesMap.get(this);
 
@@ -226,10 +224,7 @@ const createRenderMixin = createStateful
 						widgetClassesMap.set(this, this.classes);
 					}
 
-					props.classes = classes;
-					props.styles = this.styles || {};
-					props.key = this;
-					return props;
+					return Object.assign(baseIdProp, { key: this, classes, styles });
 				}
 			],
 

--- a/src/mixins/createRenderMixin.ts
+++ b/src/mixins/createRenderMixin.ts
@@ -224,7 +224,7 @@ const createRenderMixin = createStateful
 						widgetClassesMap.set(this, this.classes);
 					}
 
-					return Object.assign(baseIdProp, { key: this, classes, styles });
+					return assign(baseIdProp, { key: this, classes, styles });
 				}
 			],
 

--- a/src/projector.ts
+++ b/src/projector.ts
@@ -146,10 +146,23 @@ const noopHandle = { destroy() { } };
 const emptyVNode = h('div');
 const noopVNode = function(): VNode { return emptyVNode; };
 
+interface ProjectorAttributes {
+
+	classes?: {
+		[index: string]: boolean | null | undefined;
+	};
+
+	styles?: {
+		[index: string]: string | null | undefined;
+	};
+
+	[index: string]: any;
+}
+
 export const createProjector: ProjectorFactory = compose<ProjectorMixin, ProjectorOptions>({
 		getNodeAttributes(this: Projector, overrides?: VNodeProperties): VNodeProperties {
 			/* TODO: This is the same logic as createCachedRenderMixin, merge somehow */
-			const props: VNodeProperties = {};
+			const props: ProjectorAttributes  = {};
 			for (let key in this.listeners) {
 				props[key] = this.listeners[key];
 			}


### PR DESCRIPTION
In the latest release of Maquette all the properties of `VNodeProperties` are marked as `readonly` - these changes prevent the regressions noted in issue #62.

We could also maintain a local interface the represents `VNodeProperties` but that might become a pain to maintain (although I added a partial interface for the `projector`, so am open to all suggestions)

resolves #62