### PR TITLE
Ensure destroyed widgets are not added to the a parent

### DIFF
--- a/src/examples/index.ts
+++ b/src/examples/index.ts
@@ -60,6 +60,9 @@ const widgetRegistry = {
 	},
 	create(factory: ComposeFactory<any, any>, options?: any): Promise<[ string, Child ]> {
 		return factory(options);
+	},
+	has(id: string | symbol) {
+		return Promise.resolve(true);
 	}
 };
 

--- a/src/mixins/interfaces.ts
+++ b/src/mixins/interfaces.ts
@@ -52,6 +52,15 @@ export interface CreatableRegistry<T extends Child> extends Registry<T> {
 	 * @param options Any options that should be passed to the factory when realizing the child
 	 */
 	create<U extends T, O>(factory: ComposeFactory<U, O>, options?: O): Promise<[ string, U ]>;
+
+	/**
+	 * Check if the registry constains a widget with the identifier provided.
+	 *
+	 * @param id Identifier for the instance to check whether exists in the registry.
+	 * @return A promise for the result of the has check. The promise resolves to `true` if
+	 *   an instance is found and `false` otherwise.
+	 */
+	has(id: string | symbol): Promise<boolean>;
 }
 
 /**

--- a/tests/support/mockRegistryProvider.ts
+++ b/tests/support/mockRegistryProvider.ts
@@ -34,7 +34,13 @@ const widgetRegistry = {
 	stack: <(string | symbol)[]> [],
 	get(id: string | symbol): Promise<RenderMixin<RenderMixinState>> {
 		widgetRegistry.stack.push(id);
-		return Promise.resolve(widgetMap.get(id));
+		const widget = widgetMap.get(id);
+		if (widget) {
+			return Promise.resolve(widgetMap.get(id));
+		}
+		else {
+			return Promise.reject(new Error(`Cannot find widget with id ${id}`));
+		}
 	},
 	identify(value: RenderMixin<RenderMixinState>): string | symbol {
 		const id = widgetIdMap.get(value);

--- a/tests/support/mockRegistryProvider.ts
+++ b/tests/support/mockRegistryProvider.ts
@@ -1,0 +1,58 @@
+import createRenderMixin, { RenderMixin, RenderMixinState } from '../../src/mixins/createRenderMixin';
+import Promise from 'dojo-shim/Promise';
+import { Child } from '../../src/mixins/interfaces';
+import { ComposeFactory } from 'dojo-compose/compose';
+import Map from 'dojo-shim/Map';
+import WeakMap from 'dojo-shim/WeakMap';
+
+export const widgetMap: Map<string | symbol, Child> = new Map<string | symbol, Child>();
+const widgetIdMap: WeakMap<Child, string | symbol> = new WeakMap<Child, string | symbol>();
+
+const widgetIds: string[] = [ 'widget1', 'widget2', 'widget3', 'widget4' ];
+let widgetUID = 5;
+
+function reset() {
+	widgetMap.clear();
+	widgetUID = 5;
+	widgetRegistry.stack = [];
+
+	widgetIds.forEach((id) => {
+		const widget = createRenderMixin({ id });
+		widget.own({
+			destroy() {
+				widgetMap.delete(id);
+				widgetIdMap.delete(widget);
+			}
+		});
+		widgetMap.set(id, widget);
+		widgetIdMap.set(widget, id);
+	});
+}
+
+const widgetRegistry = {
+	reset,
+	stack: <(string | symbol)[]> [],
+	get(id: string | symbol): Promise<RenderMixin<RenderMixinState>> {
+		widgetRegistry.stack.push(id);
+		return Promise.resolve(widgetMap.get(id));
+	},
+	identify(value: RenderMixin<RenderMixinState>): string | symbol {
+		const id = widgetIdMap.get(value);
+		if (!id) {
+			throw new Error('Cannot identify value');
+		}
+		else {
+			return id;
+		}
+	},
+	create<C extends RenderMixin<RenderMixinState>>(factory: ComposeFactory<C, any>, options?: any): Promise<[string | symbol, C]> {;
+		return Promise.resolve<[ string, C ]>([options && options.id || `widget${widgetUID++}`, factory(options)]);
+	},
+	has(id: string | symbol): Promise<boolean> {
+		return Promise.resolve(widgetMap.has(id));
+	}
+};
+
+reset();
+
+export default widgetRegistry;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Attempt to handle stale (destroyed) widget's ids being set on the children array in parent's state, this occurs when multiple children are destroyed asynchronously. Which calls `setState` on the parent widget to reconcile the children state, but by the time the `manageChildren` function is exec's some or all of the remaining children from the `setState` have also be destroyed.

Resolves #75 

Depends on `has` being exposed from the widget registry in `app` (https://github.com/dojo/app/pull/79)

