### PR TITLE
Move 'generation' increment to after the 'state.children' check

### DIFF
--- a/src/mixins/createStatefulChildrenMixin.ts
+++ b/src/mixins/createStatefulChildrenMixin.ts
@@ -136,15 +136,16 @@ function manageChildren(evt: StateChangeEvent<StatefulChildrenState>): void {
 	if (!internalState.current) {
 		internalState.current = List<string>();
 	}
-	/* Increment the generation vector. Used when children are replaced asynchronously to ensure
-	 * no newer state is overriden. */
-	const generation = ++internalState.generation;
 
 	const currentChildrenIDs = evt.state.children ? List(evt.state.children) : List<string>();
 	if (currentChildrenIDs.equals(internalState.current)) {
 		/* There are no changes to the children */
 		return;
 	}
+
+	// Increment the generation vector. Used when children are replaced asynchronously to ensure
+	// no newer state is overriden.
+	const generation = ++internalState.generation;
 
 	internalState.current = currentChildrenIDs;
 	const resolvingWidgets: [ Promise<Child>, string, number ][] = [];


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

When two identical updates to `state.children` occur sequentially it is possible for the first update to be invalidated due to a "later state change" but the "later state change" fall into the short circuit return, that checks whether the `children` of the internalState and the current widget `state` match.

The generation increment should occur after the check against the known state of the children.

Resolves #78 


