### PR TITLE
type 'd' to allow children with null entries

### DIFF
--- a/src/util/d.ts
+++ b/src/util/d.ts
@@ -14,9 +14,9 @@ export type TagNameOrFactory = string | ComposeFactory<Widget<WidgetState>, Widg
 
 export type DOptions = VNodeProperties | WidgetOptions<WidgetState>;
 
-function d(tagName: string, options?: VNodeProperties, children?: (DNode | VNode)[]): HNode;
+function d(tagName: string, options?: VNodeProperties, children?: (DNode | VNode | null)[]): HNode;
 function d(factory: ComposeFactory<Widget<WidgetState>, WidgetOptions<WidgetState>>, options: WidgetOptions<WidgetState>): WNode;
-function d(tagNameOrFactory: TagNameOrFactory, options: DOptions = {}, children: (DNode | VNode)[] = []): DNode {
+function d(tagNameOrFactory: TagNameOrFactory, options: DOptions = {}, children: (DNode | VNode | null)[] = []): DNode {
 
 	if (typeof tagNameOrFactory === 'string') {
 		children = children.filter((child) => child);


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Type `d` to allow `null` entries in children.

Resolves #93

Depends on a release of dojo-interfaces containing https://github.com/dojo/interfaces/pull/33
