### PR TITLE
Use ~ instead of ^ for typescript version

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,6 +63,6 @@
     "remap-istanbul": "^0.6.4",
     "sinon": "^1.17.6",
     "tslint": "^3.11.0",
-    "typescript": "^2.0.3"
+    "typescript": "~2.0.3"
   }
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Used `~` instead of `^` to stop typescript 2.1 being installed

Resolves https://github.com/dojo/widgets/issues/97

