### PR TITLE
added 'watchForAsyncResult' function to make testing async functions …

### DIFF
--- a/tests/support/util.ts
+++ b/tests/support/util.ts
@@ -16,3 +16,22 @@ export function isEventuallyRejected<T>(promise: Thenable<T>): Thenable<boolean>
 export function throwImmediatly() {
 	throw new Error('unexpected code path');
 }
+
+export function waitForAsyncResult(test: () => boolean, callback: () => void, timeout = 5000) {
+	const timeStep = 10;
+	const timeoutTime = new Date();
+	timeoutTime.setMilliseconds(timeoutTime.getMilliseconds() + timeout);
+
+	function checkForSolution() {
+		if (test()) {
+			return callback();
+		}
+		else if (shouldCancel || Date.now() > timeoutTime.getTime()) {
+			return;
+		} else {
+			setTimeout(checkForSolution, timeStep);
+		}
+	}
+
+	checkForSolution();
+}

--- a/tests/support/util.ts
+++ b/tests/support/util.ts
@@ -26,7 +26,7 @@ export function waitForAsyncResult(test: () => boolean, callback: () => void, ti
 		if (test()) {
 			return callback();
 		}
-		else if (shouldCancel || Date.now() > timeoutTime.getTime()) {
+		else if (Date.now() > timeoutTime.getTime()) {
 			return;
 		} else {
 			setTimeout(checkForSolution, timeStep);

--- a/tests/unit/createDijit.ts
+++ b/tests/unit/createDijit.ts
@@ -2,6 +2,7 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createDijit from '../../src/createDijit';
 import * as Dijit from '../support/dijit/Dijit';
+import { waitForAsyncResult } from '../support/util';
 
 class ParamsSpy extends Dijit {
 	constructor(params: any, srcNodeRef: any) {
@@ -9,30 +10,6 @@ class ParamsSpy extends Dijit {
 		this.spiedParams = params;
 	}
 	spiedParams: any;
-}
-
-function watchForAsyncResult(test: () => boolean, callback: () => void, timeout = 5000) {
-	let shouldCancel = false;
-	function cancel() {
-		shouldCancel = true;
-	}
-
-	const timeStep = 50;
-	const timeoutTime = new Date();
-	timeoutTime.setMilliseconds(timeoutTime.getMilliseconds() + timeout);
-
-	function checkForSolution() {
-		if (test()) {
-			return callback();
-		}
-		else if (shouldCancel || Date.now() > timeoutTime.getTime()) {
-			return;
-		} else {
-			setTimeout(checkForSolution, timeStep);
-		}
-	}
-
-	checkForSolution();
 }
 
 registerSuite({
@@ -75,10 +52,12 @@ registerSuite({
 				params: { foo: 'bar' }
 			});
 
-			setTimeout(dfd.callback(() => {
+			waitForAsyncResult(() => {
+				return typeof dijit.Ctor !== 'undefined';
+			}, dfd.callback(() => {
 				assert.strictEqual(dijit.Ctor, 'tests/support/dijit/Dijit');
 				assert.deepEqual(dijit.params, { foo: 'bar' });
-			}), 50);
+			}));
 		}
 	},
 	'render()': {
@@ -101,8 +80,8 @@ registerSuite({
 			assert.isUndefined(dijit.dijit);
 			vnode.properties!.afterCreate!(domNode, {}, vnode.vnodeSelector, {}, []);
 
-			watchForAsyncResult(() => {
-				return typeof dijit.dijit !== 'undefined' && typeof dijit.dijit.domNode !== 'undefined'
+			waitForAsyncResult(() => {
+				return typeof dijit.dijit !== 'undefined' && typeof dijit.dijit.domNode !== 'undefined';
 			}, () => {
 				assert.strictEqual(dijit.dijit.domNode, domNode);
 				assert.strictEqual(dijit.dijit.srcNodeRef, domNode);
@@ -123,13 +102,15 @@ registerSuite({
 			const domNode = document.createElement(vnode.vnodeSelector);
 			assert.isUndefined(dijit.dijit);
 			vnode.properties!.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties!, vnode.children!);
-			setTimeout(dfd.callback(() => {
+			waitForAsyncResult(() => {
+				return typeof dijit.dijit !== 'undefined' && typeof dijit.dijit.domNode !== 'undefined';
+			}, dfd.callback(() => {
 				assert.strictEqual(dijit.dijit.domNode, domNode);
 				assert.strictEqual(dijit.dijit.srcNodeRef, domNode);
 				assert.deepEqual(dijit.dijit.params, { foo: 'bar' });
 				assert.deepEqual(dijit.dijit._startupCalled, 1);
 				assert.deepEqual(dijit.dijit._destroyCalled, 0);
-			}), 50);
+			}));
 		},
 		'afterCreate w/ load from cache'(this: any) {
 			const dfd = this.async();
@@ -142,13 +123,15 @@ registerSuite({
 			const domNode = document.createElement(vnode.vnodeSelector);
 			assert.isUndefined(dijit.dijit);
 			vnode.properties!.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties!, vnode.children!);
-			setTimeout(dfd.callback(() => {
+			waitForAsyncResult(() => {
+				return typeof dijit.dijit !== 'undefined' && typeof dijit.dijit.domNode !== 'undefined';
+			}, dfd.callback(() => {
 				assert.strictEqual(dijit.dijit.domNode, domNode);
 				assert.strictEqual(dijit.dijit.srcNodeRef, domNode);
 				assert.deepEqual(dijit.dijit.params, { foo: 'bar' });
 				assert.deepEqual(dijit.dijit._startupCalled, 1);
 				assert.deepEqual(dijit.dijit._destroyCalled, 0);
-			}), 50);
+			}));
 		},
 		'afterCreate w/ no Ctor'(this: any) {
 			const dfd = this.async(100);
@@ -211,9 +194,11 @@ registerSuite({
 			const domNode = document.createElement(vnode.vnodeSelector);
 			vnode.properties!.afterCreate!(domNode, {}, vnode.vnodeSelector, vnode.properties!, vnode.children!);
 
-			setTimeout(dfd.callback(() => {
+			waitForAsyncResult(() => {
+				return typeof dijit.dijit !== 'undefined';
+			}, dfd.callback(() => {
 				assert.deepEqual(dijit.dijit.spiedParams, {});
-			}), 50);
+			}));
 		},
 		'afterCreate - new dom node'(this: any) {
 			const dfd = this.async();
@@ -226,7 +211,9 @@ registerSuite({
 			document.body.appendChild(domNode);
 			const afterCreate = vnode.properties!.afterCreate;
 			afterCreate!(domNode, {}, vnode.vnodeSelector, {}, []);
-			setTimeout(dfd.callback(() => {
+			waitForAsyncResult(() => {
+				return typeof dijit.dijit !== 'undefined';
+			}, dfd.callback(() => {
 				assert(dijit.dijit);
 				const newVNode = dijit.render();
 				assert.strictEqual(newVNode.properties!.afterCreate, afterCreate, 'should not change listeners');
@@ -237,7 +224,7 @@ registerSuite({
 				afterCreate!(newDomNode, {}, vnode.vnodeSelector, {}, []);
 				assert.strictEqual(dijit.dijit.domNode, domNode);
 				assert.strictEqual(dijit.dijit.domNode.parentNode, document.body);
-			}), 50);
+			}));
 		}
 	},
 	'destroy()': {
@@ -259,14 +246,16 @@ registerSuite({
 			const domNode = document.createElement(vnode.vnodeSelector);
 			const afterCreate = vnode.properties!.afterCreate;
 			afterCreate!(domNode, {}, vnode.vnodeSelector, {}, []);
-			setTimeout(() => {
+			waitForAsyncResult(() => {
+				return typeof dijit.dijit !== 'undefined';
+			}, () => {
 				const dijitWidget = dijit.dijit;
 				assert.strictEqual(dijitWidget._destroyCalled, 0);
 				dijit.destroy()
 					.then(dfd.callback(() => {
 						assert.strictEqual(dijitWidget._destroyCalled, 1);
 					}));
-			}, 50);
+			});
 		}
 	}
 });

--- a/tests/unit/mixins/createStatefulChildrenMixin.ts
+++ b/tests/unit/mixins/createStatefulChildrenMixin.ts
@@ -9,6 +9,7 @@ import compose from 'dojo-compose/compose';
 import createDestroyable from 'dojo-compose/bases/createDestroyable';
 import { h } from 'maquette';
 import widgetRegistry, { widgetMap } from '../../support/mockRegistryProvider';
+import { waitForAsyncResult } from '../../support/util';
 
 let widget1: Child;
 let widget2: Child;
@@ -59,10 +60,12 @@ registerSuite({
 				}
 			});
 
-			setTimeout(dfd.callback(() => {
+			waitForAsyncResult(() => {
+				return widgetRegistry.stack.length > 0;
+			}, dfd.callback(() => {
 				assert.deepEqual(widgetRegistry.stack, [ 'widget1' ]);
 				assert.isTrue(List<Child>([ widget1 ]).equals(parent.children));
-			}), 50);
+			}));
 		},
 		setState(this: any) {
 			const dfd = this.async();
@@ -72,10 +75,12 @@ registerSuite({
 
 			parent.setState({ children: [ 'widget2' ] });
 
-			setTimeout(dfd.callback(() => {
+			waitForAsyncResult(() => {
+				return widgetRegistry.stack.length > 0;
+			}, dfd.callback(() => {
 				assert.deepEqual(widgetRegistry.stack, [ 'widget2' ]);
 				assert.isTrue(List<Child>([ widget2 ]).equals(parent.children));
-			}), 50);
+			}));
 		},
 		'caching widgets'(this: any) {
 			const dfd = this.async();
@@ -85,17 +90,21 @@ registerSuite({
 
 			parent.setState({ children: [ 'widget1' ]});
 
-			setTimeout(() => {
+			waitForAsyncResult(() => {
+				return parent.children.count() === 1;
+			},() => {
 				widgetRegistry.stack = [];
 				parent.setState({ children: [ 'widget1', 'widget2' ] });
-				setTimeout(dfd.callback(() => {
+				waitForAsyncResult(() => {
+					return parent.children.count() === 2;
+				}, dfd.callback(() => {
 					assert.deepEqual(widgetRegistry.stack, [ 'widget2' ], 'should not have called the widget registry');
 					assert.isTrue(List<Child>([ widget1, widget2 ]).equals(parent.children));
 
 					parent.setState({ children: [ 'widget2', 'widget1' ] });
 					assert.isTrue(List<Child>([ widget2, widget1 ]).equals(parent.children), 'should synchronously update children when cached');
-				}), 100);
-			}, 100);
+				}));
+			});
 		},
 		'cached widgets should be removed on destroy'(this: any) {
 			const dfd = this.async();
@@ -105,14 +114,18 @@ registerSuite({
 
 			parent.setState({ children: [ 'widget1', 'widget2' ] });
 
-			setTimeout(() => {
+			waitForAsyncResult(() => {
+					return parent.children.count() === 2;
+				}, () => {
 				widget2.destroy();
 				parent.setState({ children: [ 'widget2', 'widget1' ] });
 
-				setTimeout(dfd.callback(() => {
+				waitForAsyncResult(() => {
+					return parent.children.count() === 1;
+				}, dfd.callback(() => {
 					assert.isTrue(List<Child>([ widget1 ]).equals(parent.children), 'Should not');
-				}), 100);
-			}, 100);
+				}));
+			});
 		},
 		'childList'(this: any) {
 			const dfd = this.async();
@@ -127,17 +140,21 @@ registerSuite({
 				children: List([ widget1, widget3 ])
 			});
 
-			setTimeout(() => {
+			waitForAsyncResult(() => {
+					return parent.children.count() === 2;
+				}, () => {
 				assert.deepEqual(parent.state.children, [ 'widget1', 'widget3' ]);
 				parent.emit({
 					type: 'childlist',
 					target: parent,
 					children: List([ widget2, widget3 ])
 				});
-				setTimeout(dfd.callback(() => {
+				waitForAsyncResult(() => {
+					return parent.children.count() === 2;
+				}, dfd.callback(() => {
 					assert.deepEqual(parent.state.children, [ 'widget2', 'widget3' ]);
-				}), 50);
-			}, 50);
+				}));
+			});
 		}
 	},
 
@@ -151,10 +168,12 @@ registerSuite({
 				}
 			});
 
-			setTimeout(dfd.callback(() => {
+			waitForAsyncResult(() => {
+					return parent.children.count() === 1;
+				}, dfd.callback(() => {
 				assert.deepEqual(widgetRegistry.stack, [ 'widget1' ]);
 				assert.isTrue(Map<string, Child>({ widget1 }).equals(parent.children));
-			}), 50);
+			}));
 		},
 		setState(this: any) {
 			const dfd = this.async();
@@ -164,10 +183,12 @@ registerSuite({
 
 			parent.setState({ children: [ 'widget2' ] });
 
-			setTimeout(dfd.callback(() => {
+			waitForAsyncResult(() => {
+					return parent.children.count() === 1;
+				}, dfd.callback(() => {
 				assert.deepEqual(widgetRegistry.stack, [ 'widget2' ]);
 				assert.isTrue(Map<Child>({ widget2 }).equals(parent.children));
-			}), 50);
+			}));
 		},
 		'caching widgets'(this: any) {
 			const dfd = this.async();
@@ -177,17 +198,21 @@ registerSuite({
 
 			parent.setState({ children: [ 'widget1' ]});
 
-			setTimeout(() => {
+			waitForAsyncResult(() => {
+					return parent.children.count() === 1;
+				}, () => {
 				widgetRegistry.stack = [];
 				parent.setState({ children: [ 'widget1', 'widget2' ] });
-				setTimeout(dfd.callback(() => {
+				waitForAsyncResult(() => {
+					return parent.children.count() === 2;
+				}, dfd.callback(() => {
 					assert.deepEqual(widgetRegistry.stack, [ 'widget2' ], 'should not have called the widget registry');
 					assert.isTrue(Map<Child>({ widget1, widget2 }).equals(parent.children));
 
 					parent.setState({ children: [ 'widget2', 'widget1' ] });
 					assert.isTrue(Map<Child>({ widget2, widget1 }).equals(parent.children), 'should synchronously update children when cached');
-				}), 100);
-			}, 100);
+				}));
+			});
 		},
 		'childList'(this: any) {
 			const dfd = this.async();
@@ -202,17 +227,21 @@ registerSuite({
 				children: Map({ widget1, widget3 })
 			});
 
-			setTimeout(() => {
+			waitForAsyncResult(() => {
+					return parent.children.count() === 2;
+				}, () => {
 				assert.deepEqual(parent.state.children, [ 'widget1', 'widget3' ]);
 				parent.emit({
 					type: 'childlist',
 					target: parent,
 					children: Map({ widget2, widget3 })
 				});
-				setTimeout(dfd.callback(() => {
+				waitForAsyncResult(() => {
+					return parent.children.count() === 2;
+				}, dfd.callback(() => {
 					assert.deepEqual(parent.state.children, [ 'widget2', 'widget3' ]);
-				}), 50);
-			}, 50);
+				}));
+			});
 		}
 	},
 

--- a/tests/unit/mixins/createStatefulChildrenMixin.ts
+++ b/tests/unit/mixins/createStatefulChildrenMixin.ts
@@ -92,7 +92,7 @@ registerSuite({
 
 			waitForAsyncResult(() => {
 				return parent.children.count() === 1;
-			},() => {
+			}, () => {
 				widgetRegistry.stack = [];
 				parent.setState({ children: [ 'widget1', 'widget2' ] });
 				waitForAsyncResult(() => {

--- a/tests/unit/mixins/createStatefulChildrenMixin.ts
+++ b/tests/unit/mixins/createStatefulChildrenMixin.ts
@@ -149,11 +149,9 @@ registerSuite({
 					target: parent,
 					children: List([ widget2, widget3 ])
 				});
-				waitForAsyncResult(() => {
-					return parent.children.count() === 2;
-				}, dfd.callback(() => {
+				setTimeout(dfd.callback(() => {
 					assert.deepEqual(parent.state.children, [ 'widget2', 'widget3' ]);
-				}));
+				}), 100);
 			});
 		}
 	},
@@ -169,7 +167,7 @@ registerSuite({
 			});
 
 			waitForAsyncResult(() => {
-					return parent.children.count() === 1;
+					return widgetRegistry.stack.length === 1;
 				}, dfd.callback(() => {
 				assert.deepEqual(widgetRegistry.stack, [ 'widget1' ]);
 				assert.isTrue(Map<string, Child>({ widget1 }).equals(parent.children));
@@ -260,12 +258,16 @@ registerSuite({
 		});
 
 		parent.setState({ children: [ 'widget1' ]});
-		return delay().then(() => {
+		waitForAsyncResult(() => {
+			return setCount === 1;
+		}, () => {
 			assert.equal(setCount, 1);
 			parent.setState({ children: [ 'widget1' ]});
-			return delay();
-		}).then(() => {
-			assert.equal(setCount, 1);
+			waitForAsyncResult(() => {
+			return setCount === 1;
+			}, () => {
+				assert.equal(setCount, 1);
+			});
 		});
 	},
 
@@ -287,7 +289,9 @@ registerSuite({
 			children: List([ widget1 ])
 		});
 
-		return delay().then(() => {
+		waitForAsyncResult(() => {
+			return setCount === 1;
+		}, () => {
 			assert.equal(setCount, 1);
 
 			parent.emit({
@@ -296,16 +300,17 @@ registerSuite({
 				children: List([ widget1 ])
 			});
 
-			return delay();
-		}).then(() => {
-			assert.equal(setCount, 1);
+			waitForAsyncResult(() => {
+			return setCount === 1;
+			}, () => {
+				assert.equal(setCount, 1);
+			});
 		});
 	},
 	destroy() {
 		const parent = createStatefulChildrenList({
 			registryProvider
 		});
-
 		return delay().then(() => {
 			assert.doesNotThrow(() => {
 				parent.destroy();

--- a/tests/unit/projector.ts
+++ b/tests/unit/projector.ts
@@ -165,11 +165,12 @@ registerSuite({
 			assert.strictEqual((<HTMLElement> div.lastChild).innerHTML, 'bar');
 			handle.destroy();
 			projector.invalidate();
-			setTimeout(dfd.callback(() => {
-				handle.destroy();
+			waitForAsyncResult(() => {
+				return div.childNodes.length === 0;
+			}, dfd.callback(() => {
 				assert.strictEqual(div.childNodes.length, 0);
 				attachHandle.destroy();
-			}), 300);
+			}));
 		}).catch(dfd.reject);
 	},
 	'insert()'(this: any) {
@@ -184,11 +185,12 @@ registerSuite({
 			assert.strictEqual((<HTMLElement> div.firstChild).innerHTML, 'foo');
 			handle.destroy();
 			projector.invalidate();
-			setTimeout(dfd.callback(() => {
-				handle.destroy();
+			waitForAsyncResult(() => {
+				return div.childNodes.length === 0;
+			}, dfd.callback(() => {
 				assert.strictEqual(div.childNodes.length, 0);
 				attachHandle.destroy();
-			}), 300);
+			}));
 		}).catch(dfd.reject);
 	}
 });

--- a/tests/unit/projector.ts
+++ b/tests/unit/projector.ts
@@ -8,6 +8,7 @@ import createDestroyable from 'dojo-compose/mixins/createDestroyable';
 import { ComposeFactory } from 'dojo-compose/compose';
 import global from 'dojo-core/global';
 import { Child } from '../../src/mixins/interfaces';
+import { waitForAsyncResult } from '../support/util';
 
 const createRenderableChild = createDestroyable
 	.mixin(createRenderMixin) as ComposeFactory<Child, any>;
@@ -33,16 +34,20 @@ registerSuite({
 			assert.strictEqual((<HTMLElement> document.body.lastChild).tagName.toLowerCase(), 'h2');
 			nodeText = 'bar';
 			projector.invalidate();
-			setTimeout(() => {
+			waitForAsyncResult(() => {
+				return (<HTMLElement> document.body.lastChild).innerHTML === nodeText;
+			}, () => {
 				assert.strictEqual((<HTMLElement> document.body.lastChild).innerHTML, nodeText);
 				renderable.destroy().then(() => {
 					projector.invalidate();
-					setTimeout(dfd.callback(() => {
+					waitForAsyncResult(() => {
+						return document.body.childNodes.length === childNodeLength;
+					}, dfd.callback(() => {
 						assert.strictEqual(document.body.childNodes.length, childNodeLength, 'child should have been removed');
 						attachHandle.destroy();
-					}), 300);
+					}));
 				});
-			}, 300);
+			});
 		}).catch(dfd.reject);
 	},
 	'lifecycle'(this: any) {
@@ -65,15 +70,19 @@ registerSuite({
 			assert.strictEqual((<HTMLElement> div.firstChild).innerHTML, nodeText);
 			nodeText = 'foo';
 			projector1.invalidate();
-			setTimeout(() => {
+			waitForAsyncResult(() => {
+				return (<HTMLElement> div.firstChild).innerHTML === nodeText;
+			}, () => {
 				assert.strictEqual((<HTMLElement> div.firstChild).innerHTML, nodeText);
 				addHandle.destroy();
 				projector1.invalidate();
-				setTimeout(dfd.callback(() => {
+				waitForAsyncResult(() => {
+					return div.childNodes.length === 0;
+				}, dfd.callback(() => {
 					assert.strictEqual(div.childNodes.length, 0, 'the node should be removed');
 					projector1.destroy();
-				}), 300);
-			}, 300);
+				}));
+			});
 		}).catch(dfd.reject);
 	},
 	'construct projector with css transitions'() {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

The current test suite for this repository relies heavily on testing the results of asynchronous actions that don't return promises or offer any other simple method for knowing when the results are ready to be checked. This has led to the heavy use of the setTimeout function with an arbitrary timeout value set. The challenge with this is that values that are too small can cause false failures to be thrown (especially on slow continuous integration machines) or the suite to take too long to complete, if the value is set too high.

This PR adds a wrapper for the setTimeout function that allows a test to be provided that can be used to trigger whether the callback (presumably holding the assertions) will be called or not.

Resolves #5 