### PR TITLE
Change WidgetBase event type 'invalidate' to 'invalidated'

### DIFF
--- a/src/bases/createWidgetBase.ts
+++ b/src/bases/createWidgetBase.ts
@@ -62,7 +62,7 @@ function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode {
 		}
 		else {
 			child = factory(dNode.options);
-			child.own(child.on('invalidate', () => {
+			child.own(child.on('invalidated', () => {
 				instance.invalidate();
 			}));
 			internalState.historicChildrenMap.set(childrenMapKey, child);
@@ -138,7 +138,7 @@ const createWidget: WidgetFactory = createStateful
 				const internalState = widgetInternalStateMap.get(this);
 				internalState.dirty = true;
 				this.emit({
-					type: 'invalidate',
+					type: 'invalidated',
 					target: this
 				});
 			},

--- a/src/mixins/createParentListMixin.ts
+++ b/src/mixins/createParentListMixin.ts
@@ -63,7 +63,7 @@ const createParentMixin: ParentListMixinFactory = compose<ParentList<Child>, Par
 					// Workaround for https://github.com/facebook/immutable-js/pull/919
 					// istanbul ignore else
 					if (widget) {
-						widget.on('invalidate', () => {
+						widget.on('invalidated', () => {
 							if (this.invalidate) {
 								this.invalidate();
 							}

--- a/src/mixins/createParentMapMixin.ts
+++ b/src/mixins/createParentMapMixin.ts
@@ -84,7 +84,7 @@ const createParentMapMixin: ParentMapMixinFactory = compose<ParentMap<Child>, Pa
 					// Workaround for https://github.com/facebook/immutable-js/pull/919
 					// istanbul ignore else
 					if (widget) {
-						widget.on('invalidate', () => {
+						widget.on('invalidated', () => {
 							if (this.invalidate) {
 								this.invalidate();
 							}

--- a/tests/unit/bases/createWidgetBase.ts
+++ b/tests/unit/bases/createWidgetBase.ts
@@ -278,10 +278,10 @@ registerSuite({
 		widgetBase.invalidate();
 		assert.strictEqual(count, 3);
 	},
-	'invalidate emits invalidate event'() {
+	'invalidate emits invalidated event'() {
 		const widgetBase = createWidgetBase();
 		let count = 0;
-		widgetBase.on('invalidate', function() {
+		widgetBase.on('invalidated', function() {
 			console.log('invalid');
 			count++;
 		});


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [X] There is a related issue
* [X] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Renames the `WidgetBase` event type `invalidate` to `invalidated`.

Resolves #100 

