### PR TITLE
Replace references to `extend` with `mixin` or `override`

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "grunt-ts": "^5.5.1",
     "grunt-tslint": "^3.1.0",
     "grunt-typings": ">=0.1.5",
-    "intern": "^3.2.3",
+    "intern": "3.3.2",
     "istanbul": "^0.4.5",
     "jsdom": "^9.5.0",
     "postcss-modules": "^0.5.1",

--- a/src/createButton.ts
+++ b/src/createButton.ts
@@ -19,15 +19,17 @@ export interface ButtonFactory extends ComposeFactory<Button, ButtonOptions> { }
 const createButton: ButtonFactory = createWidgetBase
 	.mixin(createFormFieldMixin)
 	.mixin(createVNodeEvented)
-	.extend({
-		nodeAttributes: [
-			function(this: Button): VNodeProperties {
-				return { innerHTML: this.state.label };
-			}
-		],
-		tagName: 'button',
-		type: 'button',
-		classes: [ css.button ]
+	.mixin({
+		mixin: {
+			nodeAttributes: [
+				function(this: Button): VNodeProperties {
+					return { innerHTML: this.state.label };
+				}
+			],
+			tagName: 'button',
+			type: 'button',
+			classes: [ css.button ]
+		}
 	});
 
 export default createButton;

--- a/src/createContainer.ts
+++ b/src/createContainer.ts
@@ -18,7 +18,7 @@ const createContainer: ContainerFactory = createWidgetBase
 	.mixin(createParentListMixin)
 	.mixin(createRenderableChildrenMixin)
 	.mixin(createStatefulChildrenMixin)
-	.extend({
+	.override({
 		tagName: 'dojo-container'
 	});
 

--- a/src/createDijit.ts
+++ b/src/createDijit.ts
@@ -280,13 +280,15 @@ const createDijit: DijitFactory = createWidgetBase
 			});
 		}
 	})
-	.extend({
-		nodeAttributes: [
-			function(this: Dijit<DijitWidget>): VNodeProperties {
-				const afterCreate = dijitDataWeakMap.get(this).afterCreate;
-				return { afterCreate };
-			}
-		]
+	.mixin({
+		mixin: {
+			nodeAttributes: [
+				function(this: Dijit<DijitWidget>): VNodeProperties {
+					const afterCreate = dijitDataWeakMap.get(this).afterCreate;
+					return { afterCreate };
+				}
+			]
+		}
 	});
 
 export default createDijit;

--- a/src/createLayoutContainer.ts
+++ b/src/createLayoutContainer.ts
@@ -18,7 +18,7 @@ const createContainer: LayoutContainerFactory = createWidgetBase
 	.mixin(createParentListMixin)
 	.mixin(createRenderableChildrenMixin)
 	.mixin(createStatefulChildrenMixin)
-	.extend({
+	.override({
 		tagName: 'dojo-container-layout'
 	});
 

--- a/src/createList.ts
+++ b/src/createList.ts
@@ -13,7 +13,7 @@ export interface ListFactory extends ComposeFactory<List<ListStateItem>, WidgetO
 
 const createList: ListFactory = createWidgetBase
 	.mixin(createListMixin)
-	.extend({
+	.override({
 		tagName: 'dojo-list'
 	});
 

--- a/src/createPanel.ts
+++ b/src/createPanel.ts
@@ -22,7 +22,7 @@ const createPanel: PanelFactory = createWidgetBase
 	.mixin(createParentListMixin)
 	.mixin(createRenderableChildrenMixin)
 	.mixin(createStatefulChildrenMixin)
-	.extend({
+	.override({
 		tagName: 'dojo-panel'
 	});
 

--- a/src/createTabbedPanel.ts
+++ b/src/createTabbedPanel.ts
@@ -16,9 +16,11 @@ export interface TabbedPanelFactory extends ComposeFactory<TabbedPanel, TabbedPa
 const createTabbedPanel: TabbedPanelFactory = createWidgetBase
 	.mixin(createTabbedMixin)
 	.mixin(createStatefulChildrenMixin)
-	.extend({
-		tagName: 'dojo-panel-tabbed',
-		classes: [ css.tabs ]
+	.mixin({
+		mixin: {
+			tagName: 'dojo-panel-tabbed',
+			classes: [ css.tabs ]
+		}
 	});
 
 export default createTabbedPanel;

--- a/src/createTextInput.ts
+++ b/src/createTextInput.ts
@@ -27,9 +27,11 @@ const createTextInput: TextInputFactory = createWidgetBase
 			}));
 		}
 	})
-	.extend({
-		type: 'text',
-		tagName: 'input'
+	.mixin({
+		mixin: {
+			type: 'text',
+			tagName: 'input'
+		}
 	});
 
 export default createTextInput;

--- a/src/mixins/createListMixin.ts
+++ b/src/mixins/createListMixin.ts
@@ -52,16 +52,18 @@ const createListMixin: ListMixinFactory = createWidgetBase
 			}
 		}
 	})
-	.extend({
-		childNodeRenderers: [
-			function(this: ListMixin): DNode[] {
-				if (this.state && this.state.items) {
-					const items = this.state.items;
-					return [ d(this.tagNames.list, {}, items.map((item) => d(this.tagNames.item, { key: item, innerHTML: item.label }))) ];
+	.mixin({
+		mixin: {
+			childNodeRenderers: [
+				function(this: ListMixin): DNode[] {
+					if (this.state && this.state.items) {
+						const items = this.state.items;
+						return [ d(this.tagNames.list, {}, items.map((item) => d(this.tagNames.item, { key: item, innerHTML: item.label }))) ];
+					}
+					return [];
 				}
-				return [];
-			}
-		]
+			]
+		}
 	});
 
 export default createListMixin;

--- a/tests/functional/tabbedPanel.ts
+++ b/tests/functional/tabbedPanel.ts
@@ -4,12 +4,14 @@ import createWidget from '../../src/createWidget';
 import projector from '../../src/projector';
 
 const tabbedPanel = createTabbedPanel();
-const createLabel = createWidget.extend({
-	nodeAttributes: [
-		function (this: any): any {
-			return { innerHTML: this.state.label };
-		}
-	]
+const createLabel = createWidget.mixin({
+	mixin: {
+		nodeAttributes: [
+			function (this: any): any {
+				return { innerHTML: this.state.label };
+			}
+		]
+	}
 });
 
 const tab1 = createPanel({

--- a/tests/unit/bases/createWidgetBase.ts
+++ b/tests/unit/bases/createWidgetBase.ts
@@ -24,14 +24,14 @@ registerSuite({
 			assert.deepEqual(renderedWidget.vnodeSelector, 'div');
 		},
 		'Applies overridden tagName'() {
-			const widget = createWidgetBase.extend({ tagName: 'header' })();
+			const widget = createWidgetBase.override({ tagName: 'header' })();
 			assert.deepEqual(widget.tagName, 'header');
 			const renderedWidget = widget.render();
 			assert.deepEqual(renderedWidget.vnodeSelector, 'header');
 		}
 		},
 		'Applies classes to tagName'() {
-			const widget = createWidgetBase.extend({ tagName: 'header', classes: [ 'class-one', 'classTwo' ] })();
+			const widget = createWidgetBase.override({ tagName: 'header', classes: [ 'class-one', 'classTwo' ] })();
 			const renderedWidget = widget.render();
 			assert.deepEqual(renderedWidget.vnodeSelector, 'header.class-one.classTwo');
 	},
@@ -58,12 +58,14 @@ registerSuite({
 		},
 		'getChildrenNodes with a ChildNodeRenderer'() {
 			const widgetBase = createWidgetBase
-				.extend({
-					childNodeRenderers: [
-						function(): DNode[] {
-							return [ d('div') ];
-						}
-					]
+				.mixin({
+					mixin: {
+						childNodeRenderers: [
+							function(): DNode[] {
+								return [ d('div') ];
+							}
+						]
+					}
 				})();
 
 			const childrenNodes = widgetBase.getChildrenNodes();
@@ -74,19 +76,23 @@ registerSuite({
 		},
 		'getChildrenNodes with multiple ChildNodeRenderers'() {
 			const widgetBase = createWidgetBase
-				.extend({
-					childNodeRenderers: [
-						function(): DNode[] {
-							return [ d('div') ];
-						}
-					]
+				.mixin({
+					mixin: {
+						childNodeRenderers: [
+							function(): DNode[] {
+								return [ d('div') ];
+							}
+						]
+					}
 				})
-				.extend({
-					childNodeRenderers: [
-						function(): DNode[] {
-							return [ d('div', {}, [ d('div') ]) ];
-						}
-					]
+				.mixin({
+					mixin: {
+						childNodeRenderers: [
+							function(): DNode[] {
+								return [ d('div', {}, [ d('div') ]) ];
+							}
+						]
+					}
 				})();
 
 			const childrenNodes = widgetBase.getChildrenNodes();
@@ -101,12 +107,14 @@ registerSuite({
 	render: {
 		'render with non widget children'() {
 			const widgetBase = createWidgetBase
-				.extend({
-					childNodeRenderers: [
-						function(): DNode[] {
-							return [ d('header') ];
-						}
-					]
+				.mixin({
+					mixin: {
+						childNodeRenderers: [
+							function(): DNode[] {
+								return [ d('header') ];
+							}
+						]
+					}
 				})();
 
 			const result = widgetBase.render();
@@ -130,15 +138,17 @@ registerSuite({
 			});
 
 			const widgetBase = createWidgetBase
-				.extend({
-					childNodeRenderers: [
-						function(this: any): (DNode | null)[] {
-							const state = this.state.classes ? { classes: this.state.classes } : {};
-							return [
-								this.state.hide ? null : d(testChildWidget, <WidgetOptions<WidgetState>> { tagName: 'footer', state })
-							];
-						}
-					]
+				.mixin({
+					mixin: {
+						childNodeRenderers: [
+							function(this: any): (DNode | null)[] {
+								const state = this.state.classes ? { classes: this.state.classes } : {};
+								return [
+									this.state.hide ? null : d(testChildWidget, <WidgetOptions<WidgetState>> { tagName: 'footer', state })
+								];
+							}
+						]
+					}
 				})();
 
 			const firstRenderResult = widgetBase.render();
@@ -187,15 +197,17 @@ registerSuite({
 		},
 		'render with multiple children of the same type without an id'() {
 			const widgetBase = createWidgetBase
-				.extend({
-					childNodeRenderers: [
-						function(this: any): (DNode | null)[] {
-							return [
-								d(createWidgetBase, {}),
-								d(createWidgetBase, {})
-							];
-						}
-					]
+				.mixin({
+					mixin: {
+						childNodeRenderers: [
+							function(this: any): (DNode | null)[] {
+								return [
+									d(createWidgetBase, {}),
+									d(createWidgetBase, {})
+								];
+							}
+						]
+					}
 				})();
 
 			const consoleStub = stub(console, 'error');

--- a/tests/unit/mixins/createStatefulChildrenMixin.ts
+++ b/tests/unit/mixins/createStatefulChildrenMixin.ts
@@ -26,13 +26,17 @@ const registryProvider: RegistryProvider<Child> = {
 };
 
 const createStatefulChildrenList = createStatefulChildrenMixin
-	.extend({
-		children: List<Child>()
+	.mixin({
+		mixin: {
+			children: List<Child>()
+		}
 	});
 
 const createStatefulChildrenMap = createStatefulChildrenMixin
-	.extend({
-		children: Map<string, Child>()
+	.mixin({
+		mixin: {
+			children: Map<string, Child>()
+		}
 	});
 
 function delay() {

--- a/tests/unit/projector.ts
+++ b/tests/unit/projector.ts
@@ -15,7 +15,7 @@ registerSuite({
 		const dfd = this.async();
 		const childNodeLength = document.body.childNodes.length;
 		let nodeText = 'foo';
-		const renderable = createWidgetBase.extend({
+		const renderable = createWidgetBase.override({
 			render() {
 				return h('h2', [ nodeText ] );
 			}
@@ -46,7 +46,7 @@ registerSuite({
 		const projector1 = createProjector({});
 		projector1.setRoot(div);
 		let nodeText = 'bar';
-		const renderable = createWidgetBase.extend({
+		const renderable = createWidgetBase.override({
 			render() {
 				return h('h1', [ nodeText ]);
 			}
@@ -96,7 +96,7 @@ registerSuite({
 		const projector1 = createProjector({});
 		projector1.setRoot(div);
 		let nodeText = 'bar';
-		const renderable = createWidgetBase.extend({
+		const renderable = createWidgetBase.override({
 			render() {
 				return h('h1', [ nodeText ]);
 			}
@@ -141,8 +141,8 @@ registerSuite({
 		document.body.appendChild(div);
 		projector.setRoot(div);
 		const handle = projector.append([
-			createWidgetBase.extend({ render() { return h('foo', [ 'foo' ]); } })(),
-			createWidgetBase.extend({ render() { return h('bar', [ 'bar' ]); } })()
+			createWidgetBase.override({ render() { return h('foo', [ 'foo' ]); } })(),
+			createWidgetBase.override({ render() { return h('bar', [ 'bar' ]); } })()
 		]);
 		projector.attach().then((attachHandle) => {
 			assert.strictEqual(div.childNodes.length, 2);
@@ -163,7 +163,7 @@ registerSuite({
 		const div = document.createElement('div');
 		document.body.appendChild(div);
 		projector.setRoot(div);
-		const handle = projector.insert(createWidgetBase.extend({ render(): any { return h('foo', [ 'foo' ]); } })(), 'first');
+		const handle = projector.insert(createWidgetBase.override({ render(): any { return h('foo', [ 'foo' ]); } })(), 'first');
 		projector.attach().then((attachHandle) => {
 			assert.strictEqual(div.childNodes.length, 1);
 			assert.strictEqual((<HTMLElement> div.firstChild).innerHTML, 'foo');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Remove references to `compose.extend` and replace with `.override` or `.mixin`

Also pin `intern` to version `3.3.2`

Resolves #112
