### PR TITLE
Use latest intern release (^3.4.1)

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "grunt-ts": "^5.5.1",
     "grunt-tslint": "^3.1.0",
     "grunt-typings": ">=0.1.5",
-    "intern": "3.3.2",
+    "intern": "^3.4.1",
     "istanbul": "^0.4.5",
     "jsdom": "^9.5.0",
     "postcss-modules": "^0.5.1",

--- a/typings.json
+++ b/typings.json
@@ -4,11 +4,7 @@
 		"extra-rxjs": "github:dojo/typings/custom/dojo2-extras/rxjs.d.ts#103096ce945dd51a18cc47a9b7cf9191fdac0349"
 	},
 	"globalDevDependencies": {
-		"digdug": "github:dojo/typings/custom/digdug/digdug.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
-		"dojo2": "github:dojo/typings/custom/dojo2/dojo.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1",
-		"intern": "github:dojo/typings/custom/intern/intern.d.ts#122b1902bdbdb7b94bdee35bbc27bc6747e1979d",
-		"leadfoot": "github:dojo/typings/custom/leadfoot/leadfoot.d.ts#a62873258aa1deed48f9882c193c335436100d4b",
 		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#9a0185f465a3febe2bb1ff3f1210f43e5f96c5d2"
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Using the latest release of intern `3.4.1` and remove explicit types from `package.json`

