### PR TITLE
support 'children' as the second argument when creating HNodes

### DIFF
--- a/src/util/d.ts
+++ b/src/util/d.ts
@@ -14,14 +14,15 @@ export type TagNameOrFactory<S extends WidgetState, W extends Widget<S>, O exten
 
 export type DOptions<S extends WidgetState, O extends WidgetOptions<S>> = VNodeProperties | O;
 
-type Children = (DNode | VNode | null)[];
+export type Children = (DNode | VNode | null)[];
 
 function d(tagName: string, optionsOrChildren?: VNodeProperties | Children, children?: Children): HNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(factory: ComposeFactory<W, O>, options: O): WNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
 	tagNameOrFactory: TagNameOrFactory<S, W, O>,
 	optionsOrChildren: DOptions<S, O> = {},
-	children: Children = []): DNode {
+	children: Children = []
+): DNode {
 
 	if (typeof tagNameOrFactory === 'string') {
 		if (Array.isArray(optionsOrChildren)) {

--- a/src/util/d.ts
+++ b/src/util/d.ts
@@ -16,7 +16,9 @@ export type DOptions<S extends WidgetState, O extends WidgetOptions<S>> = VNodeP
 
 export type Children = (DNode | VNode | null)[];
 
-function d(tagName: string, optionsOrChildren?: VNodeProperties | Children, children?: Children): HNode;
+function d(tagName: string, options: VNodeProperties, children: Children): HNode;
+function d(tagName: string, children: Children): HNode;
+function d(tagName: string): HNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(factory: ComposeFactory<W, O>, options: O): WNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
 	tagNameOrFactory: TagNameOrFactory<S, W, O>,

--- a/src/util/d.ts
+++ b/src/util/d.ts
@@ -16,20 +16,25 @@ export type DOptions<S extends WidgetState, O extends WidgetOptions<S>> = VNodeP
 
 type Children = (DNode | VNode | null)[];
 
-function d(tagName: string, options?: VNodeProperties, children?: (DNode | VNode | null)[]): HNode;
+function d(tagName: string, optionsOrChildren?: VNodeProperties | Children, children?: Children): HNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(factory: ComposeFactory<W, O>, options: O): WNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
 	tagNameOrFactory: TagNameOrFactory<S, W, O>,
-	options: DOptions<S, O> = {},
+	optionsOrChildren: DOptions<S, O> = {},
 	children: Children = []): DNode {
 
 	if (typeof tagNameOrFactory === 'string') {
+		if (Array.isArray(optionsOrChildren)) {
+			children = optionsOrChildren;
+			optionsOrChildren = {};
+		}
+
 		children = children.filter((child) => child);
 
 		return {
 			children: children,
 			render(this: { children: VNode[] }) {
-				return h(<string> tagNameOrFactory, <VNodeProperties> options, this.children);
+				return h(<string> tagNameOrFactory, <VNodeProperties> optionsOrChildren, this.children);
 			}
 		};
 	}
@@ -37,7 +42,7 @@ function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S
 	if (typeof tagNameOrFactory === 'function') {
 		return {
 			factory: tagNameOrFactory,
-			options: <WidgetOptions<WidgetState>> options
+			options: <WidgetOptions<WidgetState>> optionsOrChildren
 		};
 	}
 

--- a/src/util/d.ts
+++ b/src/util/d.ts
@@ -16,7 +16,7 @@ export type DOptions<S extends WidgetState, O extends WidgetOptions<S>> = VNodeP
 
 export type Children = (DNode | VNode | null)[];
 
-function d(tagName: string, options: VNodeProperties, children: Children): HNode;
+function d(tagName: string, options: VNodeProperties, children?: Children): HNode;
 function d(tagName: string, children: Children): HNode;
 function d(tagName: string): HNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(factory: ComposeFactory<W, O>, options: O): WNode;

--- a/tests/unit/bases/createWidgetBase.ts
+++ b/tests/unit/bases/createWidgetBase.ts
@@ -121,6 +121,27 @@ registerSuite({
 			assert.lengthOf(result.children, 1);
 			assert.strictEqual(result.children && result.children[0].vnodeSelector, 'header');
 		},
+		'render with nested children'() {
+			const widgetBase = createWidgetBase
+				.mixin({
+					mixin: {
+						childNodeRenderers: [
+							function(): DNode[] {
+								return [
+									d('header', [
+										d('section')
+									])
+								];
+							}
+						]
+					}
+				})();
+
+			const result = widgetBase.render();
+			assert.lengthOf(result.children, 1);
+			assert.strictEqual(result.children![0].vnodeSelector, 'header');
+			assert.strictEqual(result.children![0].children![0].vnodeSelector, 'section');
+		},
 		'render with widget children'() {
 			let countWidgetCreated = 0;
 			let countWidgetDestroyed = 0;

--- a/tests/unit/util/d.ts
+++ b/tests/unit/util/d.ts
@@ -30,6 +30,11 @@ registerSuite({
 		assert.isFunction(hNode.render);
 		assert.lengthOf(hNode.children, 2);
 	},
+	'create HNode wrapper with children as options param'() {
+		const hNode = d('div', [ d('div'), d('div') ]);
+		assert.isFunction(hNode.render);
+		assert.lengthOf(hNode.children, 2);
+	},
 	'throws an error if tagName/Factory is not a string or a Function'() {
 		assert.throws(() => { d(<any> 1); }, Error);
 	}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #114 

Support children as the second param when using `d` to generate a ` HNode`

