### PR TITLE
Support creating text nodes for children

### DIFF
--- a/src/bases/createWidgetBase.ts
+++ b/src/bases/createWidgetBase.ts
@@ -43,11 +43,11 @@ function generateID(instance: Widget<WidgetState>): string {
 	return id;
 }
 
-function isWNode(child: DNode): child is WNode {
+function isWNode(child: WNode | HNode): child is WNode {
 	return child && (<WNode> child).factory !== undefined;
 }
 
-function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode {
+function dNodeToVNode(instance: Widget<WidgetState>, dNode: WNode | HNode): VNode {
 	const internalState = widgetInternalStateMap.get(instance);
 	let child: HNode | Widget<WidgetState>;
 	if (isWNode(dNode)) {
@@ -78,7 +78,12 @@ function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode {
 	else {
 		child = dNode;
 		if (child.children) {
-			child.children = child.children.map((child: DNode) => dNodeToVNode(instance, child));
+			child.children = child.children.map((child: DNode) => {
+				if (typeof child === 'string') {
+					return child;
+				}
+				return dNodeToVNode(instance, child);
+			});
 		}
 	}
 	return child.render();

--- a/tests/unit/bases/createWidgetBase.ts
+++ b/tests/unit/bases/createWidgetBase.ts
@@ -142,6 +142,40 @@ registerSuite({
 			assert.strictEqual(result.children![0].vnodeSelector, 'header');
 			assert.strictEqual(result.children![0].children![0].vnodeSelector, 'section');
 		},
+	'render with a text node children'() {
+			const widgetBase = createWidgetBase
+				.mixin({
+					mixin: {
+						childNodeRenderers: [
+								function(): DNode[] {
+								return [ 'I am a text node' ];
+							}
+						]
+					}
+				})();
+
+			const result = widgetBase.render();
+			assert.isUndefined(result.children);
+			assert.equal(result.text, 'I am a text node');
+		},
+		'render with multiple text node children'() {
+			const widgetBase = createWidgetBase
+				.mixin({
+					mixin: {
+						childNodeRenderers: [
+							function(): DNode[] {
+								return [ 'I am a text node', 'Second text node' ];
+							}
+						]
+					}
+				})();
+
+			const result = widgetBase.render();
+			assert.isUndefined(result.text);
+			assert.lengthOf(result.children, 2);
+			assert.strictEqual(result.children![0].text, 'I am a text node');
+			assert.strictEqual(result.children![1].text, 'Second text node');
+		},
 		'render with widget children'() {
 			let countWidgetCreated = 0;
 			let countWidgetDestroyed = 0;

--- a/tests/unit/util/d.ts
+++ b/tests/unit/util/d.ts
@@ -35,6 +35,11 @@ registerSuite({
 		assert.isFunction(hNode.render);
 		assert.lengthOf(hNode.children, 2);
 	},
+	'create HNode wrapper with text node children'() {
+		const hNode = d('div', {}, [ 'This Text Node', 'That Text Node' ]);
+		assert.isFunction(hNode.render);
+		assert.lengthOf(hNode.children, 2);
+	},
 	'throws an error if tagName/Factory is not a string or a Function'() {
 		assert.throws(() => { d(<any> 1); }, Error);
 	}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Support being able to pass a `string` as a child which will get passed to maquette to use a text node.

Resolves #118 

Depends on https://github.com/dojo/interfaces/pull/40

