### PR TITLE
include VNodeEvented in Widget base

### DIFF
--- a/src/components/button/createButton.ts
+++ b/src/components/button/createButton.ts
@@ -2,22 +2,20 @@ import { ComposeFactory } from 'dojo-compose/compose';
 import { VNodeProperties } from 'dojo-interfaces/vdom';
 import createWidgetBase from '../../createWidgetBase';
 import { Widget, WidgetOptions, WidgetState } from './../../interfaces';
-import createVNodeEvented, { VNodeEvented, VNodeEventedOptions } from '../../mixins/createVNodeEvented';
 import createFormFieldMixin, { FormFieldMixin, FormFieldMixinState, FormFieldMixinOptions } from '../../mixins/createFormFieldMixin';
 
 export interface ButtonState extends WidgetState, FormFieldMixinState<string> {
 	label?: string;
 }
 
-export interface ButtonOptions extends VNodeEventedOptions, WidgetOptions<ButtonState>, FormFieldMixinOptions<any, ButtonState> { }
+export interface ButtonOptions extends WidgetOptions<ButtonState>, FormFieldMixinOptions<any, ButtonState> { }
 
-export type Button = Widget<ButtonState> & FormFieldMixin<string, ButtonState> & VNodeEvented;
+export type Button = Widget<ButtonState> & FormFieldMixin<string, ButtonState>;
 
 export interface ButtonFactory extends ComposeFactory<Button, ButtonOptions> { }
 
 const createButton: ButtonFactory = createWidgetBase
 	.mixin(createFormFieldMixin)
-	.mixin(createVNodeEvented)
 	.mixin({
 		mixin: {
 			nodeAttributes: [

--- a/src/components/textinput/createTextInput.ts
+++ b/src/components/textinput/createTextInput.ts
@@ -2,7 +2,6 @@ import { ComposeFactory } from 'dojo-compose/compose';
 import createWidgetBase from '../../createWidgetBase';
 import { Widget, WidgetOptions, WidgetState } from './../../interfaces';
 import createFormFieldMixin, { FormFieldMixin, FormFieldMixinState, FormFieldMixinOptions } from '../../mixins/createFormFieldMixin';
-import createVNodeEvented, { VNodeEvented, VNodeEventedOptions } from '../../mixins/createVNodeEvented';
 
 /* TODO: I suspect this needs to go somewhere else */
 export interface TypedTargetEvent<T extends EventTarget> extends Event {
@@ -11,26 +10,23 @@ export interface TypedTargetEvent<T extends EventTarget> extends Event {
 
 export type TextInputState = WidgetState & FormFieldMixinState<string>;
 
-export type TextInputOptions = WidgetOptions<TextInputState> & VNodeEventedOptions & FormFieldMixinOptions<string, TextInputState>;
+export type TextInputOptions = WidgetOptions<TextInputState> & FormFieldMixinOptions<string, TextInputState>;
 
-export type TextInput = Widget<TextInputState> & VNodeEvented & FormFieldMixin<string, TextInputState>;
+export type TextInput = Widget<TextInputState> & FormFieldMixin<string, TextInputState>;
 
 export interface TextInputFactory extends ComposeFactory<TextInput, TextInputOptions> { }
 
 const createTextInput: TextInputFactory = createWidgetBase
 	.mixin(createFormFieldMixin)
 	.mixin({
-		mixin: createVNodeEvented,
+		mixin: {
+			type: 'text',
+			tagName: 'input'
+		},
 		initialize(instance) {
 			instance.own(instance.on('input', (event: TypedTargetEvent<HTMLInputElement>) => {
 				instance.value = event.target.value;
 			}));
-		}
-	})
-	.mixin({
-		mixin: {
-			type: 'text',
-			tagName: 'input'
 		}
 	});
 

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -14,9 +14,19 @@ import { assign } from 'dojo-core/lang';
 import WeakMap from 'dojo-shim/WeakMap';
 import Map from 'dojo-shim/Map';
 import d from './d';
-import createVNodeEvented from './mixins/createVNodeEvented';
+import createVNodeEvented, { VNodeEvented, VNodeEventedOptions } from './mixins/createVNodeEvented';
 
-export interface WidgetFactory extends ComposeFactory<Widget<WidgetState>, WidgetOptions<WidgetState>> {}
+/**
+ * Widget Base
+ */
+export type WidgetBase = Widget<WidgetState> & VNodeEvented
+
+/**
+ * Widget Base Options
+ */
+export type WidgetBaseOptions = WidgetOptions<WidgetState> & VNodeEventedOptions
+
+export interface WidgetFactory extends ComposeFactory<WidgetBase, WidgetBaseOptions> {}
 
 interface WidgetInternalState {
 	children: DNode[];

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -14,6 +14,7 @@ import { assign } from 'dojo-core/lang';
 import WeakMap from 'dojo-shim/WeakMap';
 import Map from 'dojo-shim/Map';
 import d from './d';
+import createVNodeEvented from './mixins/createVNodeEvented';
 
 export interface WidgetFactory extends ComposeFactory<Widget<WidgetState>, WidgetOptions<WidgetState>> {}
 
@@ -114,6 +115,7 @@ function formatTagNameAndClasses(tagName: string, classes: string[]) {
 }
 
 const createWidget: WidgetFactory = createStateful
+	.mixin(createVNodeEvented)
 	.mixin<WidgetMixin, WidgetOptions<WidgetState>>({
 		mixin: {
 			classes: [],

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -44,14 +44,26 @@ registerSuite({
 			assert.deepEqual(renderedWidget.vnodeSelector, 'header.class-one.classTwo');
 	},
 	'getNodeAttributes()'() {
+		let clickCalled = false;
+		const expectedClickFunction = () => {
+			clickCalled = true;
+		};
+
 		const widgetBase = createWidgetBase({
-			state: { id: 'foo', classes: [ 'bar' ] }
+			state: { id: 'foo', classes: [ 'bar' ] },
+			listeners: {
+				click: expectedClickFunction
+			}
 		});
 
 		let nodeAttributes = widgetBase.getNodeAttributes();
+
 		assert.strictEqual(nodeAttributes['data-widget-id'], 'foo');
 		assert.deepEqual(nodeAttributes.classes, { bar: true });
-		assert.strictEqual(Object.keys(nodeAttributes).length, 4);
+		assert.strictEqual(Object.keys(nodeAttributes).length, 5);
+		assert.isFunction(nodeAttributes.onclick);
+		nodeAttributes.onclick!();
+		assert.isTrue(clickCalled);
 
 		widgetBase.setState({ 'id': 'foo', classes: ['foo'] });
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Add `VNodeEvented` to `createWidgetBase` by default.

Resolves #115

