### PR TITLE
Aspect `getChildrenNodes` to check if `state` is available when `stateFrom` configured.

### DIFF
--- a/src/bases/createWidgetBase.ts
+++ b/src/bases/createWidgetBase.ts
@@ -1,6 +1,7 @@
 import { ComposeFactory } from 'dojo-compose/compose';
 import createStateful from 'dojo-compose/bases/createStateful';
 import {
+	ChildNodeFunction,
 	HNode,
 	DNode,
 	WNode,
@@ -181,6 +182,18 @@ const createWidget: WidgetFactory = createStateful
 			},
 
 			tagName: 'div'
+		},
+		aspectAdvice: {
+			around: {
+				getChildrenNodes(origFn): ChildNodeFunction {
+					return function(this: Widget<WidgetState>): DNode[] {
+						if (this.stateFrom && Object.keys(this.state).length === 0) {
+							return [];
+						}
+						return origFn.call(this);
+					};
+				}
+			}
 		},
 		initialize(instance: Widget<WidgetState>, options: WidgetOptions<WidgetState> = {}) {
 			const { id, tagName, getChildrenNodes } = options;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

When passing an `id` and `stateFrom` to a child factory, the `getChildrenNodes` function of the child gets executed before the `state` is actually set. This causes the failures where an expectation of the `state` being available has been presumed in the `getChildrenNodes` function itself.

Proposal to not call the "real" `getChildrenNodes` function until `state` exists when a `stateFrom` has been passed, instead return back an empty array `[]` until the state is set at which point call the real `getChildrenNodes` function. 

If no `stateFrom` observable store is passed to the factory then the check is skipped and `getChildrenNodes` is called as configured.

Resolves #???