### PR TITLE
Support children for widgets

### DIFF
--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -133,8 +133,7 @@ const createWidget: WidgetFactory = createStateful
 			},
 
 			getChildrenNodes(this: Widget<WidgetState>): DNode[] {
-				const internalState = widgetInternalStateMap.get(this);
-				return internalState.children;
+				return this.children;
 			},
 
 			getNodeAttributes(this: Widget<WidgetState>, overrides?: VNodeProperties): VNodeProperties {

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -18,6 +18,7 @@ import d from './d';
 export interface WidgetFactory extends ComposeFactory<Widget<WidgetState>, WidgetOptions<WidgetState>> {}
 
 interface WidgetInternalState {
+	children: DNode[];
 	readonly id?: string;
 	dirty: boolean;
 	widgetClasses: string[];
@@ -54,7 +55,7 @@ function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode | stri
 	}
 
 	if (isWNode(dNode)) {
-		const { factory, options: { id, state } } = dNode;
+		const { children, factory, options: { id, state } } = dNode;
 		const childrenMapKey = id || factory;
 		const cachedChild = internalState.historicChildrenMap.get(childrenMapKey);
 
@@ -79,6 +80,8 @@ function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode | stri
 			console.error(errorMsg);
 			instance.emit({ type: 'error', target: instance, error: new Error(errorMsg) });
 		}
+
+		child.children = children;
 		internalState.currentChildrenMap.set(childrenMapKey, child);
 
 		return child.render();
@@ -120,8 +123,18 @@ const createWidget: WidgetFactory = createStateful
 				return d(tag, this.getNodeAttributes(), this.getChildrenNodes());
 			},
 
+			set children(this: Widget<WidgetState>, children: DNode[]) {
+				const internalState = widgetInternalStateMap.get(this);
+				internalState.children = children;
+			},
+
+			get children() {
+				return widgetInternalStateMap.get(this).children;
+			},
+
 			getChildrenNodes(this: Widget<WidgetState>): DNode[] {
-				return [];
+				const internalState = widgetInternalStateMap.get(this);
+				return internalState.children;
 			},
 
 			getNodeAttributes(this: Widget<WidgetState>, overrides?: VNodeProperties): VNodeProperties {
@@ -198,7 +211,8 @@ const createWidget: WidgetFactory = createStateful
 				dirty: true,
 				widgetClasses: [],
 				historicChildrenMap: new Map<string | Factory<Widget<WidgetState>, WidgetOptions<WidgetState>>, Widget<WidgetState>>(),
-				currentChildrenMap: new Map<string | Factory<Widget<WidgetState>, WidgetOptions<WidgetState>>, Widget<WidgetState>>()
+				currentChildrenMap: new Map<string | Factory<Widget<WidgetState>, WidgetOptions<WidgetState>>, Widget<WidgetState>>(),
+				children: []
 			});
 
 			instance.own(instance.on('state:changed', () => {

--- a/src/d.ts
+++ b/src/d.ts
@@ -20,6 +20,7 @@ function d(tagName: string, options: VNodeProperties, children?: Children): HNod
 function d(tagName: string, children: Children): HNode;
 function d(tagName: string): HNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(factory: ComposeFactory<W, O>, options: O): WNode;
+function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(factory: ComposeFactory<W, O>, options: O, children: DNode[]): WNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
 	tagNameOrFactory: TagNameOrFactory<S, W, O>,
 	optionsOrChildren: DOptions<S, O> = {},
@@ -44,6 +45,7 @@ function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S
 
 	if (typeof tagNameOrFactory === 'function') {
 		return {
+			children: <DNode[]> children,
 			factory: tagNameOrFactory,
 			options: <WidgetOptions<WidgetState>> optionsOrChildren
 		};

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -249,6 +249,11 @@ export interface WNode {
 	 * Options used to create factory a widget
 	 */
 	options: WidgetOptions<WidgetState>;
+
+	/**
+	 * DNode children
+	 */
+	children: DNode[];
 }
 
 export type DNode = HNode | WNode | string;
@@ -273,6 +278,11 @@ export interface WidgetMixin {
 	 * stored in the instances state object.
 	 */
 	readonly classes: string[];
+
+	/**
+	 * An array of children `DNode`s returned via `getChildrenNodes`
+	 */
+	children: DNode[];
 
 	/**
 	 * Get the top level node and children when rendering the widget.

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -15,6 +15,15 @@ registerSuite({
 		assert.isFunction(widgetBase.getChildrenNodes);
 		assert.isFunction(widgetBase.invalidate);
 	},
+	children() {
+		const expectedChild = d('div');
+		const widget = createWidgetBase();
+
+		assert.lengthOf(widget.children, 0);
+		widget.children = [ expectedChild ];
+		assert.lengthOf(widget.children, 1);
+		assert.strictEqual(widget.children[0], expectedChild);
+	},
 	tagName: {
 		'Applies default tagName'() {
 			const widget = createWidgetBase();

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -6,11 +6,18 @@ import d from '../../src/d';
 
 registerSuite({
 	name: 'util/d',
-	'create DNode wrapper'() {
+	'create WNode wrapper'() {
 		const options: WidgetOptions<WidgetState> = { tagName: 'header', state: { hello: 'world' } };
 		const dNode = d(createWidgetBase, options);
 		assert.deepEqual(dNode.factory, createWidgetBase);
 		assert.deepEqual(dNode.options, options);
+	},
+	'create WNode wrapper with children'() {
+		const options: WidgetOptions<WidgetState> = { tagName: 'header', state: { hello: 'world' } };
+		const dNode = d(createWidgetBase, options, [d('div')]);
+		assert.deepEqual(dNode.factory, createWidgetBase);
+		assert.deepEqual(dNode.options, options);
+		assert.lengthOf(dNode.children, 1);
 	},
 	'create HNode wrapper'() {
 		const hNode = d('div');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Add support in `d` and `createWidgetBase` for passing `children` to when creating a widget using a factory.

Resolves #145

Depends on https://github.com/dojo/interfaces/pull/47
