### PR TITLE
Expose top level getNode function

### DIFF
--- a/src/createProjector.ts
+++ b/src/createProjector.ts
@@ -1,9 +1,9 @@
 import { ComposeFactory } from 'dojo-compose/compose';
 import { EventTargettedObject, Handle } from 'dojo-interfaces/core';
-import { VNodeProperties } from 'dojo-interfaces/vdom';
+import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
 import { Widget, WidgetState, WidgetOptions } from './interfaces';
 import WeakMap from 'dojo-shim/WeakMap';
-import { createProjector as createMaquetteProjector, Projector as MaquetteProjector } from 'maquette';
+import { h, createProjector as createMaquetteProjector, Projector as MaquetteProjector } from 'maquette';
 import createWidgetBase from './createWidgetBase';
 import global from 'dojo-core/global';
 import Promise from 'dojo-shim/Promise';
@@ -153,6 +153,16 @@ const createProjector: ProjectorFactory = createWidgetBase
 			get projectorState(this: Projector): ProjectorState {
 				const projectorData = projectorDataMap.get(this);
 				return projectorData && projectorData.state;
+			}
+		},
+		aspectAdvice: {
+			after: {
+				render(this: Projector, result: VNode | string) {
+					if (typeof result === 'string') {
+						return h(this.tagName, result);
+					}
+					return result;
+				}
 			}
 		},
 		initialize(instance: Projector, options: ProjectorOptions = {}) {

--- a/src/createProjector.ts
+++ b/src/createProjector.ts
@@ -3,7 +3,7 @@ import { EventTargettedObject, Handle } from 'dojo-interfaces/core';
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
 import { Widget, WidgetState, WidgetOptions } from './interfaces';
 import WeakMap from 'dojo-shim/WeakMap';
-import { h, createProjector as createMaquetteProjector, Projector as MaquetteProjector } from 'maquette';
+import { createProjector as createMaquetteProjector, Projector as MaquetteProjector } from 'maquette';
 import createWidgetBase from './createWidgetBase';
 import global from 'dojo-core/global';
 import Promise from 'dojo-shim/Promise';
@@ -159,7 +159,7 @@ const createProjector: ProjectorFactory = createWidgetBase
 			after: {
 				render(this: Projector, result: VNode | string) {
 					if (typeof result === 'string') {
-						return h(this.tagName, result);
+						throw new Error('Must provide a VNode at the root of a projector');
 					}
 					return result;
 				}

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -1,7 +1,6 @@
 import { ComposeFactory } from 'dojo-compose/compose';
 import createStateful from 'dojo-compose/bases/createStateful';
 import {
-	HNode,
 	DNode,
 	WNode,
 	Widget,
@@ -22,7 +21,7 @@ interface WidgetInternalState {
 	readonly id?: string;
 	dirty: boolean;
 	widgetClasses: string[];
-	cachedVNode?: VNode;
+	cachedVNode?: VNode | string;
 	historicChildrenMap: Map<string | Factory<Widget<WidgetState>, WidgetOptions<WidgetState>>, Widget<WidgetState>>;
 	currentChildrenMap: Map<string | Factory<Widget<WidgetState>, WidgetOptions<WidgetState>>, Widget<WidgetState>>;
 };
@@ -43,17 +42,24 @@ function generateID(instance: Widget<WidgetState>): string {
 	return id;
 }
 
-function isWNode(child: WNode | HNode): child is WNode {
-	return child && (<WNode> child).factory !== undefined;
+function isWNode(child: DNode): child is WNode {
+	return Boolean(child && (<WNode> child).factory !== undefined);
 }
 
-function dNodeToVNode(instance: Widget<WidgetState>, dNode: WNode | HNode): VNode {
+function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode | string {
 	const internalState = widgetInternalStateMap.get(instance);
-	let child: HNode | Widget<WidgetState>;
+
+	if (typeof dNode === 'string') {
+		return dNode;
+	}
+
 	if (isWNode(dNode)) {
 		const { factory, options: { id, state } } = dNode;
 		const childrenMapKey = id || factory;
 		const cachedChild = internalState.historicChildrenMap.get(childrenMapKey);
+
+		let child: Widget<WidgetState>;
+
 		if (cachedChild) {
 			child = cachedChild;
 			if (state) {
@@ -74,19 +80,15 @@ function dNodeToVNode(instance: Widget<WidgetState>, dNode: WNode | HNode): VNod
 			instance.emit({ type: 'error', target: instance, error: new Error(errorMsg) });
 		}
 		internalState.currentChildrenMap.set(childrenMapKey, child);
+
+		return child.render();
 	}
-	else {
-		child = dNode;
-		if (child.children) {
-			child.children = child.children.map((child: DNode) => {
-				if (typeof child === 'string') {
-					return child;
-				}
-				return dNodeToVNode(instance, child);
-			});
-		}
-	}
-	return child.render();
+
+	dNode.children = dNode.children.map((child: DNode) => {
+		return dNodeToVNode(instance, child);
+	});
+
+	return dNode.render();
 }
 
 function manageDetachedChildren(instance: Widget<WidgetState>): void {
@@ -112,6 +114,12 @@ const createWidget: WidgetFactory = createStateful
 	.mixin<WidgetMixin, WidgetOptions<WidgetState>>({
 		mixin: {
 			classes: [],
+
+			getNode(): DNode {
+				return d(formatTagNameAndClasses(this.tagName, this.classes),
+							this.getNodeAttributes(),
+							this.getChildrenNodes());
+			},
 
 			getChildrenNodes(this: Widget<WidgetState>): DNode[] {
 				return [];
@@ -165,14 +173,10 @@ const createWidget: WidgetFactory = createStateful
 
 			],
 
-			render(this: Widget<WidgetState>): VNode {
+			render(this: Widget<WidgetState>): VNode | string {
 				const internalState = widgetInternalStateMap.get(this);
 				if (internalState.dirty || !internalState.cachedVNode) {
-					const dNode = d(formatTagNameAndClasses(this.tagName, this.classes),
-									this.getNodeAttributes(),
-									this.getChildrenNodes());
-
-					const widget = dNodeToVNode(this, dNode);
+					const widget = dNodeToVNode(this, this.getNode());
 					manageDetachedChildren(this);
 					internalState.cachedVNode = widget;
 					internalState.dirty = false;

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -116,9 +116,8 @@ const createWidget: WidgetFactory = createStateful
 			classes: [],
 
 			getNode(): DNode {
-				return d(formatTagNameAndClasses(this.tagName, this.classes),
-							this.getNodeAttributes(),
-							this.getChildrenNodes());
+				const tag = formatTagNameAndClasses(this.tagName, this.classes);
+				return d(tag, this.getNodeAttributes(), this.getChildrenNodes());
 			},
 
 			getChildrenNodes(this: Widget<WidgetState>): DNode[] {

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -19,6 +19,13 @@ import { EventTargettedObject, Factory, Handle, StylesMap } from 'dojo-interface
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
 
 /**
+ * A function that is called to return top level node
+ */
+export interface NodeFunction {
+	(this: Widget<WidgetState>): DNode;
+}
+
+/**
  * A function that is called when collecting the children nodes on render.
  */
 export interface ChildNodeFunction {
@@ -268,6 +275,11 @@ export interface WidgetMixin {
 	readonly classes: string[];
 
 	/**
+	 * Get the top level node and children when rendering the widget.
+	 */
+	getNode: NodeFunction;
+
+	/**
 	 * Generate the children nodes when rendering the widget.
 	 */
 	getChildrenNodes: ChildNodeFunction;
@@ -313,7 +325,7 @@ export interface WidgetMixin {
 	 * return h(this.tagName, this.getNodeAttributes(), this.getChildrenNodes());
 	 * ```
 	 */
-	render(): VNode;
+	render(): VNode | string;
 
 	/**
 	 * The tagName (selector) that should be used when rendering the node.

--- a/tests/unit/components/button/createButton.ts
+++ b/tests/unit/components/button/createButton.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import { VNode } from 'dojo-interfaces/vdom';
 import createButton, { ButtonState } from '../../../../src/components/button/createButton';
 
 registerSuite({
@@ -24,7 +25,7 @@ registerSuite({
 				name: 'baz'
 			}
 		});
-		const vnode = button.render();
+		const vnode = <VNode> button.render();
 		assert.strictEqual(vnode.vnodeSelector, 'button');
 		assert.strictEqual(vnode.properties!.innerHTML, 'bar');
 		assert.strictEqual(vnode.properties!['data-widget-id'], 'foo');
@@ -40,12 +41,12 @@ registerSuite({
 				name: 'baz'
 			}
 		});
-		let vnode = button.render();
+		let vnode = <VNode> button.render();
 		assert.isFalse(vnode.properties!['disabled']);
 		button.setState({
 			disabled: true
 		});
-		vnode = button.render();
+		vnode = <VNode> button.render();
 		assert.isTrue(vnode.properties!['disabled']);
 	}
 });

--- a/tests/unit/createProjector.ts
+++ b/tests/unit/createProjector.ts
@@ -44,6 +44,21 @@ registerSuite({
 			assert.equal(err.message, 'Unable to create projector with css transitions enabled. Is the \'css-transition.js\' script loaded in the page?');
 		}
 	},
+	'render throws an error for non VNode result'() {
+		const projector = createProjector.override({
+			getNode() {
+				return '';
+			}
+		})();
+
+		try {
+			projector.render();
+		}
+		catch (error) {
+			assert.isTrue(error instanceof Error);
+			assert.equal(error.message, 'Must provide a VNode at the root of a projector');
+		}
+	},
 	'attach event'() {
 		const root = document.createElement('div');
 		document.body.appendChild(root);

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -2,6 +2,7 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import createWidgetBase from '../../src/createWidgetBase';
 import { DNode, HNode, WidgetState, WidgetOptions } from './../../src/interfaces';
+import { VNode } from 'dojo-interfaces/vdom';
 import d from '../../src/d';
 import { stub } from 'sinon';
 
@@ -18,19 +19,19 @@ registerSuite({
 		'Applies default tagName'() {
 			const widget = createWidgetBase();
 			assert.deepEqual(widget.tagName, 'div');
-			const renderedWidget = widget.render();
+			const renderedWidget = <VNode> widget.render();
 			assert.deepEqual(renderedWidget.vnodeSelector, 'div');
 		},
 		'Applies overridden tagName'() {
 			const widget = createWidgetBase.override({ tagName: 'header' })();
 			assert.deepEqual(widget.tagName, 'header');
-			const renderedWidget = widget.render();
+			const renderedWidget = <VNode> widget.render();
 			assert.deepEqual(renderedWidget.vnodeSelector, 'header');
 		}
 		},
 		'Applies classes to tagName'() {
 			const widget = createWidgetBase.override({ tagName: 'header', classes: [ 'class-one', 'classTwo' ] })();
-			const renderedWidget = widget.render();
+			const renderedWidget = <VNode> widget.render();
 			assert.deepEqual(renderedWidget.vnodeSelector, 'header.class-one.classTwo');
 	},
 	'getNodeAttributes()'() {
@@ -82,7 +83,7 @@ registerSuite({
 					}
 				})();
 
-			const result = widgetBase.render();
+			const result = <VNode> widgetBase.render();
 			assert.lengthOf(result.children, 1);
 			assert.strictEqual(result.children && result.children[0].vnodeSelector, 'header');
 		},
@@ -100,7 +101,7 @@ registerSuite({
 					}
 				})();
 
-			const result = widgetBase.render();
+			const result = <VNode> widgetBase.render();
 			assert.lengthOf(result.children, 1);
 			assert.strictEqual(result.children![0].vnodeSelector, 'header');
 			assert.strictEqual(result.children![0].children![0].vnodeSelector, 'section');
@@ -115,7 +116,7 @@ registerSuite({
 					}
 				})();
 
-			const result = widgetBase.render();
+			const result = <VNode> widgetBase.render();
 			assert.isUndefined(result.children);
 			assert.equal(result.text, 'I am a text node');
 		},
@@ -129,7 +130,7 @@ registerSuite({
 					}
 				})();
 
-			const result = widgetBase.render();
+			const result = <VNode> widgetBase.render();
 			assert.isUndefined(result.text);
 			assert.lengthOf(result.children, 2);
 			assert.strictEqual(result.children![0].text, 'I am a text node');
@@ -142,7 +143,7 @@ registerSuite({
 				}
 			});
 
-			const result = widgetBase.render();
+			const result = <VNode> widgetBase.render();
 			assert.lengthOf(result.children, 1);
 			assert.strictEqual(result.children![0].vnodeSelector, 'header');
 		},
@@ -174,7 +175,7 @@ registerSuite({
 					}
 				})();
 
-			const firstRenderResult = widgetBase.render();
+			const firstRenderResult = <VNode> widgetBase.render();
 			assert.strictEqual(countWidgetCreated, 1);
 			assert.strictEqual(countWidgetDestroyed, 0);
 			assert.lengthOf(firstRenderResult.children, 1);
@@ -183,7 +184,7 @@ registerSuite({
 
 			widgetBase.invalidate();
 
-			const secondRenderResult = widgetBase.render();
+			const secondRenderResult = <VNode> widgetBase.render();
 			assert.strictEqual(countWidgetCreated, 1);
 			assert.strictEqual(countWidgetDestroyed, 0);
 			assert.lengthOf(secondRenderResult.children, 1);
@@ -192,7 +193,7 @@ registerSuite({
 
 			widgetBase.setState({ 'classes': ['test-class'] });
 			widgetBase.invalidate();
-			const thirdRenderResult = widgetBase.render();
+			const thirdRenderResult = <VNode> widgetBase.render();
 			assert.strictEqual(countWidgetCreated, 1);
 			assert.strictEqual(countWidgetDestroyed, 0);
 			assert.lengthOf(thirdRenderResult.children, 1);
@@ -203,7 +204,7 @@ registerSuite({
 			widgetBase.setState({ hide: true });
 			widgetBase.invalidate();
 
-			const forthRenderResult = widgetBase.render();
+			const forthRenderResult = <VNode> widgetBase.render();
 			assert.strictEqual(countWidgetCreated, 1);
 			assert.strictEqual(countWidgetDestroyed, 1);
 			assert.lengthOf(forthRenderResult.children, 0);
@@ -211,7 +212,7 @@ registerSuite({
 			widgetBase.setState({ hide: false });
 			widgetBase.invalidate();
 
-			const lastRenderResult = widgetBase.render();
+			const lastRenderResult = <VNode> widgetBase.render();
 			assert.strictEqual(countWidgetCreated, 2);
 			assert.strictEqual(countWidgetDestroyed, 1);
 			assert.lengthOf(lastRenderResult.children, 1);
@@ -240,8 +241,8 @@ registerSuite({
 			const widgetBase = createWidgetBase({
 				state: { id: 'foo', label: 'foo' }
 			});
-			const result1 = widgetBase.render();
-			const result2 = widgetBase.render();
+			const result1 = <VNode> widgetBase.render();
+			const result2 = <VNode> widgetBase.render();
 			widgetBase.invalidate();
 			widgetBase.invalidate();
 			widgetBase.setState({});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Implement `getNode` that returns the top level node for a widget and called by `render`

Resolves #144

Depends on: https://github.com/dojo/interfaces/pull/46

