### PR TITLE
Add attach type for projector

### DIFF
--- a/src/createProjector.ts
+++ b/src/createProjector.ts
@@ -16,7 +16,14 @@ export enum ProjectorState {
 	Detached
 };
 
-export type AttachType = 'append' | 'merge' | 'replace';
+/**
+ * Attach type for the projector
+ */
+export enum AttachType {
+	Append = 1,
+	Merge = 2,
+	Replace = 3
+};
 
 export interface AttachOptions {
 
@@ -24,7 +31,7 @@ export interface AttachOptions {
 	 * If `'append'` it will append to the root. If `'merge'` it will merge with the root. If `'replace'` it will
 	 * replace the root.
 	 */
-	type?: AttachType;
+	type: AttachType;
 }
 
 /**
@@ -47,11 +54,21 @@ export interface ProjectorOptions extends WidgetOptions<WidgetState> {
 export interface ProjectorMixin {
 
 	/**
-	 * Attach the projector to the an element provided as the root.
-	 *
-	 * `AttachOptions#type` defaults to `append`
+	 * Append the projector to the root.
 	 */
-	attach(options?: AttachOptions): Promise<Handle>;
+	append(): Promise<Handle>;
+
+	/**
+	 * Merge the projector onto the root.
+	 */
+	merge(): Promise<Handle>;
+
+	/**
+	 * Replace the root with the projector node.
+	 *
+	 *
+	 */
+	replace(): Promise<Handle>;
 
 	/**
 	 * Root element to attach the projector
@@ -105,57 +122,79 @@ function scheduleRender(event: EventTargettedObject<Projector>) {
 	}
 }
 
+function attach(instance: Projector, { type }: AttachOptions) {
+	const projectorData = projectorDataMap.get(instance);
+	const render = instance.render.bind(instance);
+
+	if (projectorData.state === ProjectorState.Attached) {
+		return projectorData.attachPromise || Promise.resolve({});
+	}
+	projectorData.state = ProjectorState.Attached;
+
+	projectorData.attachHandle = instance.own({
+		destroy() {
+			if (projectorData.state === ProjectorState.Attached) {
+				projectorData.projector.stop();
+				projectorData.projector.detach(render);
+				projectorData.state = ProjectorState.Detached;
+			}
+			projectorData.attachHandle = { destroy() {} };
+		}
+	});
+
+	projectorData.attachPromise = new Promise((resolve, reject) => {
+		projectorData.afterCreate = () => {
+			instance.emit({
+				type: 'projector:attached',
+				target: instance
+			});
+			resolve(projectorData.attachHandle);
+		};
+	});
+
+	switch (type) {
+		case AttachType.Append:
+			projectorData.projector.append(projectorData.root, render);
+		break;
+		case AttachType.Merge:
+			projectorData.projector.merge(projectorData.root, render);
+		break;
+		case AttachType.Replace:
+			projectorData.projector.replace(projectorData.root, render);
+		break;
+	}
+
+	return projectorData.attachPromise;
+}
+
 /**
  * Projector Factory
  */
 const createProjector: ProjectorFactory = createWidgetBase
 	.mixin({
 		mixin: {
-			attach(this: Projector, { type = 'append' }: AttachOptions = {}) {
-				const projectorData = projectorDataMap.get(this);
-				const render = this.render.bind(this);
+			append(this: Projector) {
+				const options = {
+					type: AttachType.Append
+				};
 
-				if (projectorData.state === ProjectorState.Attached) {
-					return projectorData.attachPromise || Promise.resolve({});
-				}
-				projectorData.state = ProjectorState.Attached;
+				return attach(this, options);
+			},
 
-				projectorData.attachHandle = this.own({
-					destroy() {
-						if (projectorData.state === ProjectorState.Attached) {
-							projectorData.projector.stop();
-							projectorData.projector.detach(render);
-							projectorData.state = ProjectorState.Detached;
-						}
-						projectorData.attachHandle = { destroy() {} };
-					}
-				});
+			merge(this: Projector) {
+				const options = {
+					type: AttachType.Merge
+				};
 
-				projectorData.attachPromise = new Promise((resolve, reject) => {
-					projectorData.afterCreate = () => {
-						this.emit({
-							type: 'projector:attached',
-							target: this
-						});
-						resolve(projectorData.attachHandle);
-					};
-				});
+				return attach(this, options);
+			},
 
-				switch (type) {
-					case 'append':
-						projectorData.projector.append(projectorData.root, render);
-						break;
-					case 'merge':
-						projectorData.projector.merge(projectorData.root, render);
-						break;
-					case 'replace':
-						projectorData.projector.replace(projectorData.root, render);
-						break;
-					default:
-						throw new Error('Unsupported projector attach type.');
-				}
+			replace(this: Projector) {
+				const options = {
+					type: AttachType.Replace
+				};
 
-				return projectorData.attachPromise;
+				return attach(this, options);
 			},
 
 			set root(this: Projector, root: Element) {

--- a/src/createProjector.ts
+++ b/src/createProjector.ts
@@ -16,6 +16,17 @@ export enum ProjectorState {
 	Detached
 };
 
+export type AttachType = 'append' | 'merge' | 'replace';
+
+export interface AttachOptions {
+
+	/**
+	 * If `'append'` it will append to the root. If `'merge'` it will merge with the root. If `'replace'` it will
+	 * replace the root.
+	 */
+	type?: AttachType;
+}
+
 /**
  * Projector interface
  */
@@ -37,8 +48,10 @@ export interface ProjectorMixin {
 
 	/**
 	 * Attach the projector to the an element provided as the root.
+	 *
+	 * `AttachOptions#type` defaults to `append`
 	 */
-	attach(): Promise<Handle>;
+	attach(options?: AttachOptions): Promise<Handle>;
 
 	/**
 	 * Root element to attach the projector
@@ -98,7 +111,7 @@ function scheduleRender(event: EventTargettedObject<Projector>) {
 const createProjector: ProjectorFactory = createWidgetBase
 	.mixin({
 		mixin: {
-			attach(this: Projector) {
+			attach(this: Projector, { type = 'append' }: AttachOptions = {}) {
 				const projectorData = projectorDataMap.get(this);
 				const render = this.render.bind(this);
 
@@ -128,7 +141,19 @@ const createProjector: ProjectorFactory = createWidgetBase
 					};
 				});
 
-				projectorData.projector.append(projectorData.root, render);
+				switch (type) {
+					case 'append':
+						projectorData.projector.append(projectorData.root, render);
+						break;
+					case 'merge':
+						projectorData.projector.merge(projectorData.root, render);
+						break;
+					case 'replace':
+						projectorData.projector.replace(projectorData.root, render);
+						break;
+					default:
+						throw new Error('Unsupported projector attach type.');
+				}
 
 				return projectorData.attachPromise;
 			},

--- a/tests/unit/createProjector.ts
+++ b/tests/unit/createProjector.ts
@@ -8,22 +8,6 @@ import { spy } from 'sinon';
 
 registerSuite({
 	name: 'projector',
-	basic(this: any) {
-		const childNodeLength = document.body.childNodes.length;
-		const projector = createProjector({
-			getChildrenNodes: function() {
-				return [ d('h2', [ 'foo' ] ) ];
-			}
-		});
-
-		return projector.attach().then((attachHandle) => {
-			assert.strictEqual(document.body.childNodes.length, childNodeLength + 1, 'child should have been added');
-			const child = <HTMLElement> document.body.lastChild;
-			assert.strictEqual(child.innerHTML, '<h2>foo</h2>');
-			assert.strictEqual(child.tagName.toLowerCase(), 'div');
-			assert.strictEqual(( <HTMLElement> child.firstChild).tagName.toLowerCase(), 'h2');
-		});
-	},
 	'construct projector with css transitions'() {
 		global.cssTransitions = {};
 		try {
@@ -57,6 +41,70 @@ registerSuite({
 		catch (error) {
 			assert.isTrue(error instanceof Error);
 			assert.equal(error.message, 'Must provide a VNode at the root of a projector');
+		}
+	},
+	'attach type': {
+		'default attach type'() {
+			const childNodeLength = document.body.childNodes.length;
+			const projector = createProjector({
+				getChildrenNodes: function() {
+					return [ d('h2', [ 'foo' ] ) ];
+				}
+			});
+
+			return projector.attach().then((attachHandle) => {
+				assert.strictEqual(document.body.childNodes.length, childNodeLength + 1, 'child should have been added');
+				const child = <HTMLElement> document.body.lastChild;
+				assert.strictEqual(child.innerHTML, '<h2>foo</h2>');
+				assert.strictEqual(child.tagName.toLowerCase(), 'div');
+				assert.strictEqual(( <HTMLElement> child.firstChild).tagName.toLowerCase(), 'h2');
+			});
+		},
+		'append attach type'() {
+			const childNodeLength = document.body.childNodes.length;
+			const projector = createProjector({
+				getChildrenNodes: function() {
+					return [ d('h2', [ 'foo' ] ) ];
+				}
+			});
+
+			return projector.attach({ type: 'append' }).then((attachHandle) => {
+				assert.strictEqual(document.body.childNodes.length, childNodeLength + 1, 'child should have been added');
+				const child = <HTMLElement> document.body.lastChild;
+				assert.strictEqual(child.innerHTML, '<h2>foo</h2>');
+				assert.strictEqual(child.tagName.toLowerCase(), 'div');
+				assert.strictEqual(( <HTMLElement> child.firstChild).tagName.toLowerCase(), 'h2');
+			});
+		},
+		'replace attach type'() {
+			const projector = createProjector({
+				tagName: 'body',
+				getChildrenNodes: function() {
+					return [ d('h2', [ 'foo' ] ) ];
+				}
+			});
+
+			return projector.attach({ type: 'replace' }).then((attachHandle) => {
+				assert.strictEqual(document.body.childNodes.length, 1, 'child should have been added');
+				const child = <HTMLElement> document.body.lastChild;
+				assert.strictEqual(child.innerHTML, 'foo');
+				assert.strictEqual(child.tagName.toLowerCase(), 'h2');
+			});
+		},
+		'merge attach type'() {
+			const childNodeLength = document.body.childNodes.length;
+			const projector = createProjector({
+				getChildrenNodes: function() {
+					return [ d('h2', [ 'foo' ] ) ];
+				}
+			});
+
+			return projector.attach({ type: 'merge' }).then((attachHandle) => {
+				assert.strictEqual(document.body.childNodes.length, childNodeLength + 1, 'child should have been added');
+				const child = <HTMLElement> document.body.lastChild;
+				assert.strictEqual(child.innerHTML, 'foo');
+				assert.strictEqual(child.tagName.toLowerCase(), 'h2');
+			});
 		}
 	},
 	'attach event'() {

--- a/tests/unit/createProjector.ts
+++ b/tests/unit/createProjector.ts
@@ -43,8 +43,8 @@ registerSuite({
 			assert.equal(error.message, 'Must provide a VNode at the root of a projector');
 		}
 	},
-	'attach type': {
-		'default attach type'() {
+	'attach to projector': {
+		'append'() {
 			const childNodeLength = document.body.childNodes.length;
 			const projector = createProjector({
 				getChildrenNodes: function() {
@@ -52,7 +52,7 @@ registerSuite({
 				}
 			});
 
-			return projector.attach().then((attachHandle) => {
+			return projector.append().then((attachHandle) => {
 				assert.strictEqual(document.body.childNodes.length, childNodeLength + 1, 'child should have been added');
 				const child = <HTMLElement> document.body.lastChild;
 				assert.strictEqual(child.innerHTML, '<h2>foo</h2>');
@@ -60,23 +60,7 @@ registerSuite({
 				assert.strictEqual(( <HTMLElement> child.firstChild).tagName.toLowerCase(), 'h2');
 			});
 		},
-		'append attach type'() {
-			const childNodeLength = document.body.childNodes.length;
-			const projector = createProjector({
-				getChildrenNodes: function() {
-					return [ d('h2', [ 'foo' ] ) ];
-				}
-			});
-
-			return projector.attach({ type: 'append' }).then((attachHandle) => {
-				assert.strictEqual(document.body.childNodes.length, childNodeLength + 1, 'child should have been added');
-				const child = <HTMLElement> document.body.lastChild;
-				assert.strictEqual(child.innerHTML, '<h2>foo</h2>');
-				assert.strictEqual(child.tagName.toLowerCase(), 'div');
-				assert.strictEqual(( <HTMLElement> child.firstChild).tagName.toLowerCase(), 'h2');
-			});
-		},
-		'replace attach type'() {
+		'replace'() {
 			const projector = createProjector({
 				tagName: 'body',
 				getChildrenNodes: function() {
@@ -84,14 +68,14 @@ registerSuite({
 				}
 			});
 
-			return projector.attach({ type: 'replace' }).then((attachHandle) => {
+			return projector.replace().then((attachHandle) => {
 				assert.strictEqual(document.body.childNodes.length, 1, 'child should have been added');
 				const child = <HTMLElement> document.body.lastChild;
 				assert.strictEqual(child.innerHTML, 'foo');
 				assert.strictEqual(child.tagName.toLowerCase(), 'h2');
 			});
 		},
-		'merge attach type'() {
+		'merge'() {
 			const childNodeLength = document.body.childNodes.length;
 			const projector = createProjector({
 				getChildrenNodes: function() {
@@ -99,7 +83,7 @@ registerSuite({
 				}
 			});
 
-			return projector.attach({ type: 'merge' }).then((attachHandle) => {
+			return projector.merge().then((attachHandle) => {
 				assert.strictEqual(document.body.childNodes.length, childNodeLength + 1, 'child should have been added');
 				const child = <HTMLElement> document.body.lastChild;
 				assert.strictEqual(child.innerHTML, 'foo');
@@ -124,7 +108,7 @@ registerSuite({
 			assert.strictEqual((<HTMLElement> root.firstChild).tagName.toLowerCase(), 'div');
 			assert.strictEqual((<HTMLElement> root.firstChild).innerHTML, '<h2>foo</h2>');
 		});
-		return projector.attach().then(() => {
+		return projector.append().then(() => {
 			assert.isTrue(eventFired);
 		});
 	},
@@ -139,7 +123,7 @@ registerSuite({
 		const projector = createProjector();
 
 		assert.equal(projector.projectorState, ProjectorState.Detached);
-		return projector.attach().then(() => {
+		return projector.append().then(() => {
 			assert.equal(projector.projectorState, ProjectorState.Attached);
 			projector.destroy();
 			assert.equal(projector.projectorState, ProjectorState.Detached);
@@ -151,7 +135,7 @@ registerSuite({
 		const maquetteProjectorStopSpy = spy(projector.projector, 'stop');
 		const maquetteProjectorDetachSpy = spy(projector.projector, 'detach');
 
-		return projector.attach().then(() => {
+		return projector.append().then(() => {
 			projector.destroy();
 
 			assert.isTrue(maquetteProjectorStopSpy.calledOnce);
@@ -187,7 +171,7 @@ registerSuite({
 			called = true;
 		});
 
-		return projector.attach().then(() => {
+		return projector.append().then(() => {
 			projector.invalidate();
 			assert.isTrue(maquetteProjectorSpy.called);
 			assert.isTrue(called);
@@ -196,14 +180,14 @@ registerSuite({
 	'reattach'() {
 		const root = document.createElement('div');
 		const projector = createProjector({ root });
-		const promise = projector.attach();
-		assert.strictEqual(promise, projector.attach(), 'same promise should be returned');
+		const promise = projector.append();
+		assert.strictEqual(promise, projector.append(), 'same promise should be returned');
 	},
 	'setRoot throws when already attached'() {
 		const projector = createProjector();
 		const div = document.createElement('div');
 		projector.root = div;
-		return projector.attach().then((handle) => {
+		return projector.append().then((handle) => {
 			assert.throws(() => {
 				projector.root = document.body;
 			}, Error, 'already attached');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Add attach type as an option for `projector.attach(...)`

Resolves #150 

