### PR TITLE
remove 'getChildrenNodes' from WidgetOptions

### DIFF
--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -210,12 +210,8 @@ const createWidget: WidgetFactory = createStateful
 			tagName: 'div'
 		},
 		initialize(instance: Widget<WidgetState>, options: WidgetOptions<WidgetState> = {}) {
-			const { id, tagName, getChildrenNodes } = options;
+			const { id, tagName } = options;
 			instance.tagName = tagName || instance.tagName;
-
-			if (getChildrenNodes) {
-				instance.getChildrenNodes = getChildrenNodes;
-			}
 
 			widgetInternalStateMap.set(instance, {
 				id,

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -348,11 +348,6 @@ export interface WidgetMixin {
 
 export interface WidgetOptions<S extends WidgetState> extends StatefulOptions<S> {
 	/**
-	 * Any child node render functions that should be added to this instance
-	 */
-	getChildrenNodes?: ChildNodeFunction;
-
-	/**
 	 * Any classes that should be added to this instances
 	 */
 	classes?: string[];

--- a/tests/unit/createProjector.ts
+++ b/tests/unit/createProjector.ts
@@ -46,11 +46,9 @@ registerSuite({
 	'attach to projector': {
 		'append'() {
 			const childNodeLength = document.body.childNodes.length;
-			const projector = createProjector({
-				getChildrenNodes: function() {
-					return [ d('h2', [ 'foo' ] ) ];
-				}
-			});
+			const projector = createProjector();
+
+			projector.children = [ d('h2', [ 'foo' ] ) ];
 
 			return projector.append().then((attachHandle) => {
 				assert.strictEqual(document.body.childNodes.length, childNodeLength + 1, 'child should have been added');
@@ -62,11 +60,10 @@ registerSuite({
 		},
 		'replace'() {
 			const projector = createProjector({
-				tagName: 'body',
-				getChildrenNodes: function() {
-					return [ d('h2', [ 'foo' ] ) ];
-				}
+				tagName: 'body'
 			});
+
+			projector.children = [ d('h2', [ 'foo' ] ) ];
 
 			return projector.replace().then((attachHandle) => {
 				assert.strictEqual(document.body.childNodes.length, 1, 'child should have been added');
@@ -77,11 +74,9 @@ registerSuite({
 		},
 		'merge'() {
 			const childNodeLength = document.body.childNodes.length;
-			const projector = createProjector({
-				getChildrenNodes: function() {
-					return [ d('h2', [ 'foo' ] ) ];
-				}
-			});
+			const projector = createProjector();
+
+			projector.children = [ d('h2', [ 'foo' ] ) ];
 
 			return projector.merge().then((attachHandle) => {
 				assert.strictEqual(document.body.childNodes.length, childNodeLength + 1, 'child should have been added');
@@ -95,11 +90,11 @@ registerSuite({
 		const root = document.createElement('div');
 		document.body.appendChild(root);
 		const projector = createProjector({
-			getChildrenNodes: function() {
-				return [ d('h2', [ 'foo' ] ) ];
-			},
 			root
 		});
+
+		projector.children = [ d('h2', [ 'foo' ] ) ];
+
 		assert.strictEqual(root.childNodes.length, 0, 'there should be no children');
 		let eventFired = false;
 		projector.on('projector:attached', () => {

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -157,17 +157,6 @@ registerSuite({
 			assert.strictEqual(result.children![0].text, 'I am a text node');
 			assert.strictEqual(result.children![1].text, 'Second text node');
 		},
-		'render with children provided via options'() {
-			const widgetBase = createWidgetBase({
-				getChildrenNodes: function(): DNode[] {
-					return [ d('header') ];
-				}
-			});
-
-			const result = <VNode> widgetBase.render();
-			assert.lengthOf(result.children, 1);
-			assert.strictEqual(result.children![0].vnodeSelector, 'header');
-		},
 		'render with widget children'() {
 			let countWidgetCreated = 0;
 			let countWidgetDestroyed = 0;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

With the `children` API `getChildrenNodes` is not required to be available as an option to pass on instantiation.

Resolves #153

