### PR TITLE
Invalidate projector on setting children

### DIFF
--- a/src/createProjector.ts
+++ b/src/createProjector.ts
@@ -242,6 +242,7 @@ const createProjector: ProjectorFactory = createWidgetBase
 				}
 			}
 
+			instance.own(instance.on('widget:children', instance.invalidate));
 			instance.own(instance.on('invalidated', scheduleRender));
 
 			const projector = createMaquetteProjector(maquetteProjectorOptions);

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -138,6 +138,10 @@ const createWidget: WidgetFactory = createStateful
 			set children(this: Widget<WidgetState>, children: DNode[]) {
 				const internalState = widgetInternalStateMap.get(this);
 				internalState.children = children;
+				this.emit({
+					type: 'widget:children',
+					target: this
+				});
 			},
 
 			get children() {

--- a/tests/unit/createProjector.ts
+++ b/tests/unit/createProjector.ts
@@ -148,6 +148,18 @@ registerSuite({
 		});
 
 	},
+	'invalidate on setting children'() {
+		const projector = createProjector();
+		let called = false;
+
+		projector.on('invalidated', () => {
+			called = true;
+		});
+
+		projector.children = [ d('div') ];
+
+		assert.isTrue(called);
+	},
 	'invalidate before attached'() {
 		const projector = createProjector();
 		const maquetteProjectorSpy = spy(projector.projector, 'scheduleRender');

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -16,13 +16,18 @@ registerSuite({
 		assert.isFunction(widgetBase.invalidate);
 	},
 	children() {
+		let childrenEventEmitted = false;
 		const expectedChild = d('div');
 		const widget = createWidgetBase();
+		widget.on('widget:children', () => {
+			childrenEventEmitted = true;
+		});
 
 		assert.lengthOf(widget.children, 0);
 		widget.children = [ expectedChild ];
 		assert.lengthOf(widget.children, 1);
 		assert.strictEqual(widget.children[0], expectedChild);
+		assert.isTrue(childrenEventEmitted);
 	},
 	tagName: {
 		'Applies default tagName'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Invalidate the `projector` when children are set.

Resolves #155 


