### PR TITLE
remove dojo-stores as a peer dep

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "dojo-core": ">=2.0.0-alpha.14",
     "dojo-has": ">=2.0.0-alpha.4",
     "dojo-shim": ">=2.0.0-beta.1",
-    "dojo-stores": "2.0.0-alpha.4",
     "maquette": ">=2.3.7 <=2.4.1"
   },
   "devDependencies": {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

`dojo-stores` is no longer a peer dependency.

Resolves #159

