### PR TITLE
d now throws an error for blank tagName.

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ h2
 h2.foo
 h2.foo.bar
 h2.foo.bar#baz
+h2#baz
 
 Where 'classNames' must be period (.) delimited if more than 1 class is specified.
 Please note, both the 'classes' and 'id' portions of the 'selector', are optional.
@@ -173,6 +174,7 @@ h2                  (<h2></h2>)
 h2.foo              (<h2 class="foo"></h2>)
 h2.foo.bar          (<h2 class="foo bar"></h2>)
 h2.foo.bar#baz      (<h2 class="foo bar" id="baz"></h2>)
+h2#baz              (<h2 id="baz"></h2>)
 
 Creates an element with `selector`, with the children specified by the array of `DNode`, `VNode` or `null`.
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ npm install dojo-compose
 npm install dojo-store
 ```
 
-To use dojo-widgets import the module in the project. For more details see [features](#features) below.
+To use dojo-widgets, import the module in the project. For more details see [features](#features) below.
 
 ```ts
 import createButton from 'dojo-widgets/components/button/createButton';
@@ -60,13 +60,13 @@ projector.children = [ d('h1', [ 'Hello, Dojo!' ]) ];
 projector.append();
 ```
 
-It renders a header saying "Hello World" on the page, see the following sections for more details.
+It renders a h1 element saying "Hello World", on the page. See the following sections for more details.
 
 ### Base Widget
 
 The class `createWidgetBase` provides all base dojo-widgets functionality including caching and widget lifecycle management. It can be used directly or extended to create custom widgets.
 
-To customise the widget an optional `options` argument can be provided with the following interface.
+To customise the widget, an optional `options` argument can be provided with the following interface:
 
 **Type**: `WidgetOptions<WidgetState>` - All properties are optional.
 
@@ -151,21 +151,38 @@ import { DNode, HNode, WNode } from 'dojo-widgets/interfaces';
 
 ##### Hyperscript
 
-Creates an element with the `tagName`
+Creates an element with the specified css `selector`
 
 ```ts
-d(tagName: string): HNode[];
+d(selector: string): HNode[];
 ```
 
-Creates an element with the `tagName` with the children specified by the array of `DNode`, `VNode` or `null`.
+where 'selector' is in the form: element.className(s)#id, e.g.
+
+h2
+h2.foo
+h2.foo.bar
+h2.foo.bar#baz
+
+Where 'classNames' must be period (.) delimited if more than 1 class is specified.
+Please note, both the 'classes' and 'id' portions of the 'selector', are optional.
+
+The results of the invocations above are:
+
+h2                  (<h2></h2>)
+h2.foo              (<h2 class="foo"></h2>)
+h2.foo.bar          (<h2 class="foo bar"></h2>)
+h2.foo.bar#baz      (<h2 class="foo bar" id="baz"></h2>)
+
+Creates an element with `selector`, with the children specified by the array of `DNode`, `VNode` or `null`.
 
 ```ts
-d(tagName: string, children: (DNode | VNode | null)[]): HNode[];
+d(selector: string, children: (DNode | VNode | null)[]): HNode[];
 ```
-Creates an element with the `tagName` with the `VNodeProperties` options and optional children specified by the array of `DNode`, `VNode` or `null`.
+Creates an element with `selector`, with `VNodeProperties` options and *optional* children specified by the array of `DNode`, `VNode` or `null`.
 
 ```ts
-d(tagName: string, options: VNodeProperties, children?: (DNode | VNode | null)[]): HNode[];
+d(selector: string, options: VNodeProperties, children?: (DNode | VNode | null)[]): HNode[];
 ```
 ##### Dojo Widget
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ projector.children = [ d('h1', [ 'Hello, Dojo!' ]) ];
 projector.append();
 ```
 
-It renders a h1 element saying "Hello World", on the page. See the following sections for more details.
+It renders a h1 element saying "Hello Dojo!" on the page. See the following sections for more details.
 
 ### Base Widget
 

--- a/README.md
+++ b/README.md
@@ -151,13 +151,13 @@ import { DNode, HNode, WNode } from 'dojo-widgets/interfaces';
 
 ##### Hyperscript
 
-Creates an element with the specified css `selector`
+Creates an element with the specified tagName.
 
 ```ts
-d(selector: string): HNode[];
+d(tagName: string): HNode[];
 ```
 
-where 'selector' is in the form: element.className(s)#id, e.g.
+where 'tagName' is in the form: element.className(s)#id, e.g.
 
 h2
 h2.foo
@@ -166,7 +166,7 @@ h2.foo.bar#baz
 h2#baz
 
 Where 'classNames' must be period (.) delimited if more than 1 class is specified.
-Please note, both the 'classes' and 'id' portions of the 'selector', are optional.
+Please note, both the 'classes' and 'id' portions of the 'tagName', are optional.
 
 The results of the invocations above are:
 
@@ -176,15 +176,15 @@ h2.foo.bar          (<h2 class="foo bar"></h2>)
 h2.foo.bar#baz      (<h2 class="foo bar" id="baz"></h2>)
 h2#baz              (<h2 id="baz"></h2>)
 
-Creates an element with `selector`, with the children specified by the array of `DNode`, `VNode` or `null`.
+Creates an element with `tagName`, with the children specified by the array of `DNode`, `VNode` or `null`.
 
 ```ts
-d(selector: string, children: (DNode | VNode | null)[]): HNode[];
+d(tagName: string, children: (DNode | VNode | null)[]): HNode[];
 ```
-Creates an element with `selector`, with `VNodeProperties` options and *optional* children specified by the array of `DNode`, `VNode` or `null`.
+Creates an element with `tagName`, with `VNodeProperties` options and *optional* children specified by the array of `DNode`, `VNode` or `null`.
 
 ```ts
-d(selector: string, options: VNodeProperties, children?: (DNode | VNode | null)[]): HNode[];
+d(tagName: string, options: VNodeProperties, children?: (DNode | VNode | null)[]): HNode[];
 ```
 ##### Dojo Widget
 

--- a/README.md
+++ b/README.md
@@ -151,13 +151,13 @@ import { DNode, HNode, WNode } from 'dojo-widgets/interfaces';
 
 ##### Hyperscript
 
-Creates an element with the specified tagName.
+Creates an element with the specified `tagName`.
 
 ```ts
 d(tagName: string): HNode[];
 ```
 
-where 'tagName' is in the form: element.className(s)#id, e.g.
+where `tagName` is in the form: element.className(s)#id, e.g.
 
 h2
 h2.foo
@@ -165,8 +165,8 @@ h2.foo.bar
 h2.foo.bar#baz
 h2#baz
 
-Where 'classNames' must be period (.) delimited if more than 1 class is specified.
-Please note, both the 'classes' and 'id' portions of the 'tagName', are optional.
+Where `classNames` must be period (.) delimited if more than 1 class is specified.
+Please note, both the `classes` and `id` portions of the `tagName`, are optional.
 
 The results of the invocations above are:
 

--- a/src/d.ts
+++ b/src/d.ts
@@ -10,24 +10,28 @@ import {
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
 import { h } from 'maquette';
 
-export type TagNameOrFactory<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>> = string | ComposeFactory<W, O>;
+export type selectorOrFactory<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>> = string | ComposeFactory<W, O>;
 
 export type DOptions<S extends WidgetState, O extends WidgetOptions<S>> = VNodeProperties | O;
 
 export type Children = (DNode | VNode | null)[];
 
-function d(tagName: string, options: VNodeProperties, children?: Children): HNode;
-function d(tagName: string, children: Children): HNode;
-function d(tagName: string): HNode;
+function d(selector: string, options: VNodeProperties, children?: Children): HNode;
+function d(selector: string, children: Children): HNode;
+function d(selector: string): HNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(factory: ComposeFactory<W, O>, options: O): WNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(factory: ComposeFactory<W, O>, options: O, children: DNode[]): WNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
-	tagNameOrFactory: TagNameOrFactory<S, W, O>,
+	selectorOrFactory: selectorOrFactory<S, W, O>,
 	optionsOrChildren: DOptions<S, O> = {},
 	children: Children = []
 ): DNode {
 
-	if (typeof tagNameOrFactory === 'string') {
+	if (typeof selectorOrFactory === 'string') {
+		if (selectorOrFactory.length === 0) {
+			throw new Error('Invalid selector: cannot be empty string.');
+		}
+
 		if (Array.isArray(optionsOrChildren)) {
 			children = optionsOrChildren;
 			optionsOrChildren = {};
@@ -38,20 +42,20 @@ function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S
 		return {
 			children: children,
 			render(this: { children: VNode[] }) {
-				return h(<string> tagNameOrFactory, <VNodeProperties> optionsOrChildren, this.children);
+				return h(<string> selectorOrFactory, <VNodeProperties> optionsOrChildren, this.children);
 			}
 		};
 	}
 
-	if (typeof tagNameOrFactory === 'function') {
+	if (typeof selectorOrFactory === 'function') {
 		return {
 			children: <DNode[]> children,
-			factory: tagNameOrFactory,
+			factory: selectorOrFactory,
 			options: <WidgetOptions<WidgetState>> optionsOrChildren
 		};
 	}
 
-	throw new Error('Unsupported tagName or factory type');
+	throw new Error('Unsupported selector or factory type');
 }
 
 export default d;

--- a/src/d.ts
+++ b/src/d.ts
@@ -10,26 +10,26 @@ import {
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
 import { h } from 'maquette';
 
-export type selectorOrFactory<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>> = string | ComposeFactory<W, O>;
+export type tagNameOrFactory<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>> = string | ComposeFactory<W, O>;
 
 export type DOptions<S extends WidgetState, O extends WidgetOptions<S>> = VNodeProperties | O;
 
 export type Children = (DNode | VNode | null)[];
 
-function d(selector: string, options: VNodeProperties, children?: Children): HNode;
-function d(selector: string, children: Children): HNode;
-function d(selector: string): HNode;
+function d(tagName: string, options: VNodeProperties, children?: Children): HNode;
+function d(tagName: string, children: Children): HNode;
+function d(tagName: string): HNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(factory: ComposeFactory<W, O>, options: O): WNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(factory: ComposeFactory<W, O>, options: O, children: DNode[]): WNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
-	selectorOrFactory: selectorOrFactory<S, W, O>,
+	tagNameOrFactory: tagNameOrFactory<S, W, O>,
 	optionsOrChildren: DOptions<S, O> = {},
 	children: Children = []
 ): DNode {
 
-	if (typeof selectorOrFactory === 'string') {
-		if (selectorOrFactory.length === 0) {
-			throw new Error('Invalid selector: cannot be empty string.');
+	if (typeof tagNameOrFactory === 'string') {
+		if (tagNameOrFactory.length === 0) {
+			throw new Error('Invalid tagName: cannot be empty string.');
 		}
 
 		if (Array.isArray(optionsOrChildren)) {
@@ -42,20 +42,20 @@ function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S
 		return {
 			children: children,
 			render(this: { children: VNode[] }) {
-				return h(<string> selectorOrFactory, <VNodeProperties> optionsOrChildren, this.children);
+				return h(<string> tagNameOrFactory, <VNodeProperties> optionsOrChildren, this.children);
 			}
 		};
 	}
 
-	if (typeof selectorOrFactory === 'function') {
+	if (typeof tagNameOrFactory === 'function') {
 		return {
 			children: <DNode[]> children,
-			factory: selectorOrFactory,
+			factory: tagNameOrFactory,
 			options: <WidgetOptions<WidgetState>> optionsOrChildren
 		};
 	}
 
-	throw new Error('Unsupported selector or factory type');
+	throw new Error('Unsupported tagName or factory type');
 }
 
 export default d;

--- a/src/d.ts
+++ b/src/d.ts
@@ -22,13 +22,13 @@ function d(tagName: string): HNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(factory: ComposeFactory<W, O>, options: O): WNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(factory: ComposeFactory<W, O>, options: O, children: DNode[]): WNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
-	TagNameOrFactory: TagNameOrFactory<S, W, O>,
+	tagNameOrFactory: TagNameOrFactory<S, W, O>,
 	optionsOrChildren: DOptions<S, O> = {},
 	children: Children = []
 ): DNode {
 
-	if (typeof TagNameOrFactory === 'string') {
-		if (TagNameOrFactory.length === 0) {
+	if (typeof tagNameOrFactory === 'string') {
+		if (tagNameOrFactory.length === 0) {
 			throw new Error('Invalid tagName: cannot be empty string.');
 		}
 
@@ -42,15 +42,15 @@ function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S
 		return {
 			children: children,
 			render(this: { children: VNode[] }) {
-				return h(<string> TagNameOrFactory, <VNodeProperties> optionsOrChildren, this.children);
+				return h(<string> tagNameOrFactory, <VNodeProperties> optionsOrChildren, this.children);
 			}
 		};
 	}
 
-	if (typeof TagNameOrFactory === 'function') {
+	if (typeof tagNameOrFactory === 'function') {
 		return {
 			children: <DNode[]> children,
-			factory: TagNameOrFactory,
+			factory: tagNameOrFactory,
 			options: <WidgetOptions<WidgetState>> optionsOrChildren
 		};
 	}

--- a/src/d.ts
+++ b/src/d.ts
@@ -10,7 +10,7 @@ import {
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
 import { h } from 'maquette';
 
-export type tagNameOrFactory<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>> = string | ComposeFactory<W, O>;
+export type TagNameOrFactory<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>> = string | ComposeFactory<W, O>;
 
 export type DOptions<S extends WidgetState, O extends WidgetOptions<S>> = VNodeProperties | O;
 
@@ -22,13 +22,13 @@ function d(tagName: string): HNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(factory: ComposeFactory<W, O>, options: O): WNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(factory: ComposeFactory<W, O>, options: O, children: DNode[]): WNode;
 function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
-	tagNameOrFactory: tagNameOrFactory<S, W, O>,
+	TagNameOrFactory: TagNameOrFactory<S, W, O>,
 	optionsOrChildren: DOptions<S, O> = {},
 	children: Children = []
 ): DNode {
 
-	if (typeof tagNameOrFactory === 'string') {
-		if (tagNameOrFactory.length === 0) {
+	if (typeof TagNameOrFactory === 'string') {
+		if (TagNameOrFactory.length === 0) {
 			throw new Error('Invalid tagName: cannot be empty string.');
 		}
 
@@ -42,15 +42,15 @@ function d<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S
 		return {
 			children: children,
 			render(this: { children: VNode[] }) {
-				return h(<string> tagNameOrFactory, <VNodeProperties> optionsOrChildren, this.children);
+				return h(<string> TagNameOrFactory, <VNodeProperties> optionsOrChildren, this.children);
 			}
 		};
 	}
 
-	if (typeof tagNameOrFactory === 'function') {
+	if (typeof TagNameOrFactory === 'function') {
 		return {
 			children: <DNode[]> children,
-			factory: tagNameOrFactory,
+			factory: TagNameOrFactory,
 			options: <WidgetOptions<WidgetState>> optionsOrChildren
 		};
 	}

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -47,7 +47,7 @@ registerSuite({
 		assert.isFunction(hNode.render);
 		assert.lengthOf(hNode.children, 2);
 	},
-	'throws an error if selector/Factory is not a string or a Function'() {
+	'throws an error if tagName/Factory is not a string or a Function'() {
 		assert.throws(() => { d(<any> 1); }, Error);
 	},
 	'throws an error if empty selector'() {

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -1,6 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { WidgetState, WidgetOptions } from './../../src/interfaces';
+import { WidgetState, WidgetOptions } from '../../src/interfaces';
 import createWidgetBase from '../../src/createWidgetBase';
 import d from '../../src/d';
 
@@ -47,7 +47,10 @@ registerSuite({
 		assert.isFunction(hNode.render);
 		assert.lengthOf(hNode.children, 2);
 	},
-	'throws an error if tagName/Factory is not a string or a Function'() {
+	'throws an error if selector/Factory is not a string or a Function'() {
 		assert.throws(() => { d(<any> 1); }, Error);
+	},
+	'throws an error if empty selector'() {
+		assert.throws(() => { d(''); }, Error);
 	}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

If `d` is called with a blank string selector, we now throw an error (Maquette does not trap this).
Updated readme with possible `d` invocations for selector only.
