### PR TITLE
Impement Factory Registry

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,7 +136,7 @@ const myBasicWidget = createWidgetBase({
 
 #### `d`
 
-`d` is the module used to express hierarchical widget structures within Dojo 2. This structure constructed of `DNode`s (`DNode` is the intersection type of `HNode` and `WNode`).
+`d` is the module that provides the functions and helper utilities that can be used to express widget structures within Dojo 2. This structure constructed of `DNode`s (`DNode` is the intersection type of `HNode` and `WNode`).
 
 When creating custom widgets, you use the `v` and `w` functions from the `d` module.
 
@@ -172,6 +172,44 @@ Creates an element with the `tagName` with the `VNodeProperties` options and opt
 ```ts
 v(tag: string, options: VNodeProperties, children?: (DNode | null)[]): HNode[];
 ```
+
+##### `globalFactoryRegistry`
+
+The d module exports a `globalFactoryRegistry` to be used to define a factory label against a `WidgetFactory`, `Promise<WidgetFactory>` or `() => Promise<WidgetFactory`.
+
+This enables consumers to specify a `string` label when authoring widgets using the `w` function (see below) and allows the factory to resolve asyncronously (for example if the module had not been loaded).
+
+```ts
+import { globalFactoryRegistry } from 'dojo-widgets/d';
+import createMyWidget from './createMyWidget';
+
+// registers the widget factory that will be available immediately
+globalFactoryRegistry.define('my-widget-1', createMyWidget);
+
+// registers a promise that is resolving to a widget factory and will be 
+// available as soon as the promise resolves.
+globalFactoryRegistry.define('my-widget-2', Promise.resolve(createMyWidget));
+
+// registers a function that will be lazily executed the first time the factory 
+// label is used within a widget render pipeline. The widget will be available 
+// as soon as the promise is resolved after the initial get.
+globalFactoryRegistry.define('my-widget-3', () => Promise.resolve(createMyWidget));
+```
+
+It is recommmended to use the factory registry when defining widgets using `w` in order to support lazy factory resolution when required. Example of registering a function that returns a `Promise` that resolves to a `Factory`.
+
+```ts
+import load from 'dojo-core/load';
+
+globalFactoryRegistry.define('my-widget-1', () => {
+	return load('./my-widget-1');
+});
+
+globalFactoryRegistry.define('my-widget-2', () => {
+	return load('./my-widget-2');
+});
+```
+
 ##### `w`
 
 `w` is an abstraction layer for dojo-widgets that enables dojo 2's lazy instantiation, instance management and caching.
@@ -179,13 +217,19 @@ v(tag: string, options: VNodeProperties, children?: (DNode | null)[]): HNode[];
 Creates a dojo-widget using the `factory` and `options`.
 
 ```ts
-w(factory: ComposeFactory<W, O>, options: O): WNode[];
+w(factory: string | ComposeFactory<W, O>, options: O): WNode[];
 ```
 
 Creates a dojo-widget using the `factory` and `options` and the `children`
 
 ```ts
-w(factory: ComposeFactory<W, O>, options: O, children: (DNode | null)[]): WNode[];
+w(factory: string | ComposeFactory<W, O>, options: O, children: (DNode | null)[]): WNode[];
+```
+Example `w` constucts:
+
+```ts
+w(createFactory, options, children);
+w('my-factory', options, children);
 ```
 
 ### Authoring Custom Widgets

--- a/README.md
+++ b/README.md
@@ -36,10 +36,9 @@ npm install dojo-has
 npm install dojo-shim
 npm install dojo-core
 npm install dojo-compose
-npm install dojo-store
 ```
 
-To use dojo-widgets import the module in the project. For more details see [features](#features) below.
+To use dojo-widgets, import the module in the project. For more details see [features](#features) below.
 
 ```ts
 import createButton from 'dojo-widgets/components/button/createButton';
@@ -60,7 +59,7 @@ projector.children = [ v('h1', [ 'Hello, Dojo!' ]) ];
 projector.append();
 ```
 
-It renders a header saying "Hello World" on the page, see the following sections for more details.
+It renders a `h1` element saying "Hello, Dojo!" on the page. See the following sections for more details.
 
 ### Base Widget
 
@@ -156,26 +155,47 @@ import { DNode, HNode, WNode } from 'dojo-widgets/interfaces';
 
 `v` is an abstraction of Hyperscript that allows dojo 2 to manage caching and lazy creation.
 
-Creates an element with the `tag`
+Creates an element with the specified `tag`
 
 ```ts
 v(tag: string): HNode[];
 ```
 
-Creates an element with the `tag` with the children specified by the array of `DNode`, `VNode` or `null`.
+where `tag` is in the form: element.className(s)#id, e.g.
+
+h2
+h2.foo
+h2.foo.bar
+h2.foo.bar#baz
+h2#baz
+
+`classNames` must be period (.) delimited if more than 1 class is specified.
+Please note, both the `classes` and `id` portions of the `tag` are optional.
+
+The results of the invocations above are:
+
+```
+h2                  (<h2></h2>)
+h2.foo              (<h2 class="foo"></h2>)
+h2.foo.bar          (<h2 class="foo bar"></h2>)
+h2.foo.bar#baz      (<h2 class="foo bar" id="baz"></h2>)
+h2#baz              (<h2 id="baz"></h2>)
+```
+
+Creates an element with the `tag` with the children specified by the array of `DNode`, `VNode`, `string` or `null` items.
 
 ```ts
 v(tag: string, children: (DNode | null)[]): HNode[];
 ```
-Creates an element with the `tagName` with the `VNodeProperties` options and optional children specified by the array of `DNode`, `VNode` or `null`.
+Creates an element with the `tagName` with `VNodeProperties` options and optional children specified by the array of `DNode`, `VNode`, `string` or `null` items.
 
 ```ts
 v(tag: string, options: VNodeProperties, children?: (DNode | null)[]): HNode[];
 ```
 
-##### `globalFactoryRegistry`
+##### `registry`
 
-The d module exports a `globalFactoryRegistry` to be used to define a factory label against a `WidgetFactory`, `Promise<WidgetFactory>` or `() => Promise<WidgetFactory`.
+The d module exports a global `registry` to be used to define a factory label against a `WidgetFactory`, `Promise<WidgetFactory>` or `() => Promise<WidgetFactory`.
 
 This enables consumers to specify a `string` label when authoring widgets using the `w` function (see below) and allows the factory to resolve asyncronously (for example if the module had not been loaded).
 

--- a/src/FactoryRegistry.ts
+++ b/src/FactoryRegistry.ts
@@ -1,4 +1,5 @@
 import { isComposeFactory } from 'dojo-compose/compose';
+import Promise from 'dojo-shim/Promise';
 import {
 	FactoryRegistryInterface,
 	FactoryRegistryItem,

--- a/src/FactoryRegistry.ts
+++ b/src/FactoryRegistry.ts
@@ -1,0 +1,47 @@
+import { isComposeFactory } from 'dojo-compose/compose';
+import {
+	FactoryRegistryInterface,
+	FactoryRegistryItem,
+	WidgetFactoryFunction
+} from './interfaces';
+
+export default class FactoryRegistry implements FactoryRegistryInterface {
+	protected registry: Map<string, FactoryRegistryItem>;
+
+	constructor() {
+		this.registry = new Map<string, FactoryRegistryItem>();
+	}
+
+	has(factoryLabel: string): boolean {
+		return this.registry.has(factoryLabel);
+	}
+
+	define(factoryLabel: string, registryItem: FactoryRegistryItem): void {
+		if (this.registry.has(factoryLabel)) {
+			throw new Error(`factory has already been registered for '${factoryLabel}'`);
+		}
+		this.registry.set(factoryLabel, registryItem);
+	}
+
+	get(factoryLabel: string): any {
+		if (!this.has(factoryLabel)) {
+			throw new Error(`No factory has been registered for '${factoryLabel}'`);
+		}
+
+		const item = this.registry.get(factoryLabel);
+
+		if (isComposeFactory(item) || item instanceof Promise) {
+			return item;
+		}
+
+		const promise = (<WidgetFactoryFunction> item)();
+		this.registry.set(factoryLabel, promise);
+
+		return (<WidgetFactoryFunction> item)().then((factory) => {
+			this.registry.set(factoryLabel, factory);
+			return factory;
+		}, (error) => {
+			throw error;
+		});
+	}
+}

--- a/src/FactoryRegistry.ts
+++ b/src/FactoryRegistry.ts
@@ -1,6 +1,8 @@
 import { isComposeFactory } from 'dojo-compose/compose';
 import Promise from 'dojo-shim/Promise';
+import Map from 'dojo-shim/Map';
 import {
+	WidgetFactory,
 	FactoryRegistryInterface,
 	FactoryRegistryItem,
 	WidgetFactoryFunction
@@ -24,9 +26,9 @@ export default class FactoryRegistry implements FactoryRegistryInterface {
 		this.registry.set(factoryLabel, registryItem);
 	}
 
-	get(factoryLabel: string): any {
+	get(factoryLabel: string): WidgetFactory | Promise<WidgetFactory> | null {
 		if (!this.has(factoryLabel)) {
-			throw new Error(`No factory has been registered for '${factoryLabel}'`);
+			return null;
 		}
 
 		const item = this.registry.get(factoryLabel);
@@ -38,7 +40,7 @@ export default class FactoryRegistry implements FactoryRegistryInterface {
 		const promise = (<WidgetFactoryFunction> item)();
 		this.registry.set(factoryLabel, promise);
 
-		return (<WidgetFactoryFunction> item)().then((factory) => {
+		return promise.then((factory) => {
 			this.registry.set(factoryLabel, factory);
 			return factory;
 		}, (error) => {

--- a/src/createProjector.ts
+++ b/src/createProjector.ts
@@ -221,8 +221,8 @@ const createProjector: ProjectorFactory = createWidgetBase
 		},
 		aspectAdvice: {
 			after: {
-				render(this: Projector, result: VNode | string) {
-					if (typeof result === 'string') {
+				render(this: Projector, result: VNode | string | null) {
+					if (typeof result === 'string' || result === null) {
 						throw new Error('Must provide a VNode at the root of a projector');
 					}
 					return result;

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -15,7 +15,7 @@ import { assign } from 'dojo-core/lang';
 import WeakMap from 'dojo-shim/WeakMap';
 import Promise from 'dojo-shim/Promise';
 import Map from 'dojo-shim/Map';
-import { v, globalFactoryRegistry } from './d';
+import { v, registry } from './d';
 import FactoryRegistry from './FactoryRegistry';
 import createVNodeEvented from './mixins/createVNodeEvented';
 
@@ -56,7 +56,7 @@ function getFromRegistry(instance: Widget<WidgetState>, factoryLabel: string): F
 		return instance.registry.get(factoryLabel);
 	}
 
-	return globalFactoryRegistry.get(factoryLabel);
+	return registry.get(factoryLabel);
 }
 
 function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode | string | null {

--- a/src/d.ts
+++ b/src/d.ts
@@ -11,7 +11,7 @@ import {
 } from './interfaces';
 import FactoryRegistry from './FactoryRegistry';
 
-export const globalFactoryRegistry = new FactoryRegistry();
+export const registry = new FactoryRegistry();
 
 export function w<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
 	factory: ComposeFactory<W, O> | string,

--- a/src/d.ts
+++ b/src/d.ts
@@ -5,50 +5,63 @@ import {
 	DNode,
 	HNode,
 	WNode,
-	Children,
 	Widget,
 	WidgetOptions,
-	WidgetState
+	WidgetState,
+	WidgetFactory
 } from './interfaces';
+import FactoryRegistry from './FactoryRegistry';
+
+export let defaultFactoryRegistry = new FactoryRegistry();
+
+export function setDefaultFactoryRegistry(factoryRegistry: FactoryRegistry) {
+	defaultFactoryRegistry = factoryRegistry;
+}
 
 export function w<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
-	factory: ComposeFactory<W, O>,
+	factory: ComposeFactory<W, O> | string,
 	options: O
 ): WNode;
 export function w<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
-	factory: ComposeFactory<W, O>,
+	factory: ComposeFactory<W, O> | string,
 	options: O,
-	children?: Children
+	children?: DNode[]
 ): WNode;
 export function w<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
-	factory: ComposeFactory<W, O>,
+	factory: ComposeFactory<W, O> | string,
 	options: O,
-	children: Children = []
+	children: DNode[] = []
 ): WNode {
 
-	const filteredChildren = <(DNode)[]> children.filter((child) => child);
+	let widgetFactory: WidgetFactory | Promise<WidgetFactory>;
+
+	if (typeof factory === 'string') {
+		const registry = options.factoryRegistry || defaultFactoryRegistry;
+		widgetFactory = registry.get(factory);
+	}
+	else {
+		widgetFactory = factory;
+	}
 
 	return {
-		children: filteredChildren,
-		factory,
+		children,
+		factory: widgetFactory,
 		options
 	};
 }
 
-export function v(tag: string, options: VNodeProperties, children?: Children): HNode;
-export function v(tag: string, children: Children): HNode;
+export function v(tag: string, options: VNodeProperties, children?: DNode[]): HNode;
+export function v(tag: string, children: DNode[]): HNode;
 export function v(tag: string): HNode;
-export function v(tag: string, optionsOrChildren: VNodeProperties = {}, children: Children = []): HNode {
+export function v(tag: string, optionsOrChildren: VNodeProperties = {}, children: DNode[] = []): HNode {
 
 		if (Array.isArray(optionsOrChildren)) {
 			children = optionsOrChildren;
 			optionsOrChildren = {};
 		}
 
-		const filteredChildren = <DNode[]> children.filter((child) => child);
-
 		return {
-			children: filteredChildren,
+			children,
 			render(this: { children: VNode[] }) {
 				return h(tag, optionsOrChildren, this.children);
 			}

--- a/src/d.ts
+++ b/src/d.ts
@@ -1,4 +1,5 @@
 import { ComposeFactory } from 'dojo-compose/compose';
+import Promise from 'dojo-shim/Promise';
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
 import { h } from 'maquette';
 import {

--- a/src/d.ts
+++ b/src/d.ts
@@ -1,5 +1,4 @@
 import { ComposeFactory } from 'dojo-compose/compose';
-import Promise from 'dojo-shim/Promise';
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
 import { h } from 'maquette';
 import {
@@ -8,16 +7,11 @@ import {
 	WNode,
 	Widget,
 	WidgetOptions,
-	WidgetState,
-	WidgetFactory
+	WidgetState
 } from './interfaces';
 import FactoryRegistry from './FactoryRegistry';
 
-export let defaultFactoryRegistry = new FactoryRegistry();
-
-export function setDefaultFactoryRegistry(factoryRegistry: FactoryRegistry) {
-	defaultFactoryRegistry = factoryRegistry;
-}
+export const globalFactoryRegistry = new FactoryRegistry();
 
 export function w<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
 	factory: ComposeFactory<W, O> | string,
@@ -34,19 +28,9 @@ export function w<S extends WidgetState, W extends Widget<S>, O extends WidgetOp
 	children: DNode[] = []
 ): WNode {
 
-	let widgetFactory: WidgetFactory | Promise<WidgetFactory>;
-
-	if (typeof factory === 'string') {
-		const registry = options.factoryRegistry || defaultFactoryRegistry;
-		widgetFactory = registry.get(factory);
-	}
-	else {
-		widgetFactory = factory;
-	}
-
 	return {
 		children,
-		factory: widgetFactory,
+		factory,
 		options
 	};
 }

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -246,7 +246,7 @@ export interface FactoryRegistryInterface {
 	/**
 	 * Return the registered FactoryRegistryItem for the label.
 	 */
-	get(factoryLabel: string): WidgetFactory | Promise<WidgetFactory>;
+	get(factoryLabel: string): WidgetFactory | Promise<WidgetFactory> | null;
 
 	/**
 	 * Check if the factory label has already been used to define a FactoryRegistryItem.

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -17,6 +17,7 @@ import { Renderable, RenderableParent } from 'dojo-interfaces/abilities';
 import { EventedListener, State, Stateful, StatefulOptions } from 'dojo-interfaces/bases';
 import { EventTargettedObject, Factory, Handle, StylesMap } from 'dojo-interfaces/core';
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
+import { ComposeFactory } from 'dojo-compose/compose';
 import { VNodeEvented, VNodeEventedOptions } from './mixins/createVNodeEvented';
 
 /**
@@ -228,6 +229,31 @@ export interface SubWidgetManager<W extends Renderable> {
 	readonly size: number;
 }
 
+export type WidgetFactoryFunction = () => Promise<WidgetFactory>
+
+export type FactoryRegistryItem = WidgetFactory | Promise<WidgetFactory> | WidgetFactoryFunction
+
+/**
+ * Factory Registry
+ */
+export interface FactoryRegistryInterface {
+
+	/**
+	 * Define a FactoryRegistryItem against a factory label
+	 */
+	define(factoryLabel: string, registryItem: FactoryRegistryItem): void;
+
+	/**
+	 * Return the registered FactoryRegistryItem for the label.
+	 */
+	get(factoryLabel: string): WidgetFactory | Promise<WidgetFactory>;
+
+	/**
+	 * Check if the factory label has already been used to define a FactoryRegistryItem.
+	 */
+	has(factoryLabel: string): boolean;
+}
+
 export interface HNode {
 	/**
 	 * Specified children
@@ -244,7 +270,7 @@ export interface WNode {
 	/**
 	 * Factory to create a widget
 	 */
-	factory: Factory<Widget<WidgetState>, WidgetOptions<WidgetState>>;
+	factory: WidgetFactory | Promise<WidgetFactory>;
 
 	/**
 	 * Options used to create factory a widget
@@ -257,11 +283,11 @@ export interface WNode {
 	children: DNode[];
 }
 
-export type Children = (DNode | null)[];
-
-export type DNode = HNode | WNode | string;
+export type DNode = HNode | WNode | string | null;
 
 export type Widget<S extends WidgetState> = Stateful<S> & WidgetMixin & WidgetOverloads & VNodeEvented;
+
+export interface WidgetFactory extends ComposeFactory<Widget<WidgetState>, WidgetOptions<WidgetState>> {}
 
 export interface WidgetOverloads {
 	/**
@@ -338,7 +364,7 @@ export interface WidgetMixin {
 	 * return h(this.tagName, this.getNodeAttributes(), this.getChildrenNodes());
 	 * ```
 	 */
-	render(): VNode | string;
+	render(): VNode | string | null;
 
 	/**
 	 * The tagName (selector) that should be used when rendering the node.
@@ -347,6 +373,11 @@ export interface WidgetMixin {
 	 * this property with a getter.
 	 */
 	tagName: string;
+
+	/**
+	 * The specific Factory Registry passed to the widget via the `WidgetOptions`
+	 */
+	readonly factoryRegistry: FactoryRegistryInterface | undefined;
 }
 
 export interface WidgetOptions<S extends WidgetState> extends StatefulOptions<S>, VNodeEventedOptions {
@@ -369,6 +400,11 @@ export interface WidgetOptions<S extends WidgetState> extends StatefulOptions<S>
 	 * Override the tag name for this widget instance
 	 */
 	tagName?: string;
+
+	/**
+	 * The specific Factory Registry to be used to look up factories during render,
+	 */
+	factoryRegistry?: FactoryRegistryInterface;
 }
 
 export interface WidgetState extends State {

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -270,7 +270,7 @@ export interface WNode {
 	/**
 	 * Factory to create a widget
 	 */
-	factory: WidgetFactory | Promise<WidgetFactory>;
+	factory: WidgetFactory | string;
 
 	/**
 	 * Options used to create factory a widget
@@ -377,7 +377,7 @@ export interface WidgetMixin {
 	/**
 	 * The specific Factory Registry passed to the widget via the `WidgetOptions`
 	 */
-	readonly factoryRegistry: FactoryRegistryInterface | undefined;
+	readonly registry: FactoryRegistryInterface;
 }
 
 export interface WidgetOptions<S extends WidgetState> extends StatefulOptions<S>, VNodeEventedOptions {
@@ -400,11 +400,6 @@ export interface WidgetOptions<S extends WidgetState> extends StatefulOptions<S>
 	 * Override the tag name for this widget instance
 	 */
 	tagName?: string;
-
-	/**
-	 * The specific Factory Registry to be used to look up factories during render,
-	 */
-	factoryRegistry?: FactoryRegistryInterface;
 }
 
 export interface WidgetState extends State {

--- a/tests/unit/FactoryRegistry.ts
+++ b/tests/unit/FactoryRegistry.ts
@@ -1,0 +1,104 @@
+import FactoryRegistry from './../../src/FactoryRegistry';
+import createWidgetBase from './../../src/createWidgetBase';
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+
+registerSuite({
+	name: 'FactoryRegistry',
+	'api'() {
+		const factoryRegistry = new FactoryRegistry();
+
+		assert.isFunction(factoryRegistry.define);
+		assert.isFunction(factoryRegistry.has);
+		assert.isFunction(factoryRegistry.get);
+	},
+	'has'() {
+		const factoryRegistry = new FactoryRegistry();
+		assert.isFalse(factoryRegistry.has('my-widget'));
+		factoryRegistry.define('my-widget', createWidgetBase);
+		assert.isTrue(factoryRegistry.has('my-widget'));
+	},
+	define: {
+		'able to define factories and lazy factories'() {
+			const lazyFactory = () => {
+				return Promise.resolve(createWidgetBase);
+			};
+			const factoryRegistry = new FactoryRegistry();
+			factoryRegistry.define('my-widget', createWidgetBase);
+			factoryRegistry.define('my-lazy-widget', lazyFactory);
+			assert.isTrue(factoryRegistry.has('my-widget'));
+			assert.isTrue(factoryRegistry.has('my-lazy-widget'));
+		},
+		'throw an error using a previously registered factory label'() {
+			const factoryRegistry = new FactoryRegistry();
+			factoryRegistry.define('my-widget', createWidgetBase);
+			try {
+				factoryRegistry.define('my-widget', createWidgetBase);
+				assert.fail();
+			}
+			catch (error) {
+				assert.isTrue(error instanceof Error);
+				assert.equal(error.message, 'factory has already been registered for \'my-widget\'');
+			}
+		}
+	},
+	get: {
+		'get a registered factory'() {
+			const factoryRegistry = new FactoryRegistry();
+			factoryRegistry.define('my-widget', createWidgetBase);
+			const factory = factoryRegistry.get('my-widget');
+			assert.strictEqual(factory, createWidgetBase);
+		},
+		'throws an error if factory has not been registered.'() {
+			const factoryRegistry = new FactoryRegistry();
+			try {
+				factoryRegistry.get('my-widget');
+				assert.fail();
+			}
+			catch (error) {
+				assert.isTrue(error instanceof Error);
+				assert.equal(error.message, 'No factory has been registered for \'my-widget\'');
+			}
+		},
+		'replaces promise with result on resolution'() {
+			let resolveFunction: any;
+			let promise: any;
+			const lazyFactory = () => {
+				promise = new Promise((resolve) => {
+					resolveFunction = resolve;
+				});
+				return promise;
+			};
+			const factoryRegistry = new FactoryRegistry();
+			factoryRegistry.define('my-widget', lazyFactory);
+			let factory = factoryRegistry.get('my-widget');
+			assert.deepEqual(factory, promise);
+			resolveFunction(createWidgetBase);
+			return promise.then(() => {
+				factory = factoryRegistry.get('my-widget');
+				assert.strictEqual(factory, createWidgetBase);
+			});
+		},
+		'throws error from rejected promise'() {
+			let promise: Promise<any> = Promise.resolve();
+			let rejectFunc: any;
+			const lazyFactory = (): any => {
+				promise = new Promise((resolve, reject) => {
+					rejectFunc = reject;
+				});
+				return promise;
+			};
+			const factoryRegistry = new FactoryRegistry();
+			factoryRegistry.define('my-widget', lazyFactory);
+			factoryRegistry.get('my-widget');
+			rejectFunc(new Error('reject error'));
+			return promise.then(() => {
+				assert.fail();
+			},
+			(error) => {
+				assert.isTrue(error instanceof Error);
+				assert.equal(error.message, 'reject error');
+			});
+		}
+	}
+});

--- a/tests/unit/FactoryRegistry.ts
+++ b/tests/unit/FactoryRegistry.ts
@@ -1,5 +1,6 @@
 import FactoryRegistry from './../../src/FactoryRegistry';
 import createWidgetBase from './../../src/createWidgetBase';
+import Promise from 'dojo-shim/Promise';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 
@@ -51,14 +52,8 @@ registerSuite({
 		},
 		'throws an error if factory has not been registered.'() {
 			const factoryRegistry = new FactoryRegistry();
-			try {
-				factoryRegistry.get('my-widget');
-				assert.fail();
-			}
-			catch (error) {
-				assert.isTrue(error instanceof Error);
-				assert.equal(error.message, 'No factory has been registered for \'my-widget\'');
-			}
+			const item = factoryRegistry.get('my-widget');
+			assert.isNull(item);
 		},
 		'replaces promise with result on resolution'() {
 			let resolveFunction: any;
@@ -71,11 +66,10 @@ registerSuite({
 			};
 			const factoryRegistry = new FactoryRegistry();
 			factoryRegistry.define('my-widget', lazyFactory);
-			let factory = factoryRegistry.get('my-widget');
-			assert.deepEqual(factory, promise);
+			factoryRegistry.get('my-widget');
 			resolveFunction(createWidgetBase);
 			return promise.then(() => {
-				factory = factoryRegistry.get('my-widget');
+				const factory = factoryRegistry.get('my-widget');
 				assert.strictEqual(factory, createWidgetBase);
 			});
 		},

--- a/tests/unit/all.ts
+++ b/tests/unit/all.ts
@@ -3,5 +3,6 @@ import './createWidgetBase';
 import './d';
 import './integrations';
 import './main';
+import './FactoryRegistry';
 import './components/all';
 import './mixins/all';

--- a/tests/unit/createProjector.ts
+++ b/tests/unit/createProjector.ts
@@ -22,13 +22,30 @@ registerSuite({
 		global.cssTransitions = undefined;
 		try {
 			createProjector({ cssTransitions: true });
+			assert.fail();
 		}
 		catch (err) {
 			assert.isTrue(err instanceof Error);
 			assert.equal(err.message, 'Unable to create projector with css transitions enabled. Is the \'css-transition.js\' script loaded in the page?');
 		}
 	},
-	'render throws an error for non VNode result'() {
+	'render throws an error for null result'() {
+		const projector = createProjector.override({
+			getNode() {
+				return null;
+			}
+		})();
+
+		try {
+			projector.render();
+			assert.fail();
+		}
+		catch (error) {
+			assert.isTrue(error instanceof Error);
+			assert.equal(error.message, 'Must provide a VNode at the root of a projector');
+		}
+	},
+	'render throws an error for string result'() {
 		const projector = createProjector.override({
 			getNode() {
 				return '';
@@ -37,6 +54,7 @@ registerSuite({
 
 		try {
 			projector.render();
+			assert.fail();
 		}
 		catch (error) {
 			assert.isTrue(error instanceof Error);

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -3,7 +3,7 @@ import * as assert from 'intern/chai!assert';
 import createWidgetBase from '../../src/createWidgetBase';
 import { DNode, HNode, WidgetState, WidgetOptions } from './../../src/interfaces';
 import { VNode } from 'dojo-interfaces/vdom';
-import { v, w, defaultFactoryRegistry } from '../../src/d';
+import { v, w, globalFactoryRegistry } from '../../src/d';
 import { stub } from 'sinon';
 
 registerSuite({
@@ -120,7 +120,7 @@ registerSuite({
 					resolveFunction = resolve;
 				});
 			};
-			defaultFactoryRegistry.define('my-header', loadFunction);
+			globalFactoryRegistry.define('my-header', loadFunction);
 
 			const createMyWidget = createWidgetBase
 				.mixin({

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -4,7 +4,7 @@ import Promise from 'dojo-shim/Promise';
 import createWidgetBase from '../../src/createWidgetBase';
 import { DNode, HNode, WidgetState, WidgetOptions } from './../../src/interfaces';
 import { VNode } from 'dojo-interfaces/vdom';
-import { v, w, globalFactoryRegistry } from '../../src/d';
+import { v, w, registry } from '../../src/d';
 import { stub } from 'sinon';
 
 registerSuite({
@@ -121,7 +121,7 @@ registerSuite({
 					resolveFunction = resolve;
 				});
 			};
-			globalFactoryRegistry.define('my-header', loadFunction);
+			registry.define('my-header', loadFunction);
 
 			const createMyWidget = createWidgetBase
 				.mixin({
@@ -169,7 +169,7 @@ registerSuite({
 					resolveFunction = resolve;
 				});
 			};
-			globalFactoryRegistry.define('my-header1', loadFunction);
+			registry.define('my-header1', loadFunction);
 
 			const createMyWidget = createWidgetBase
 				.mixin({

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -2,7 +2,7 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { WidgetState, WidgetOptions } from './../../src/interfaces';
 import createWidgetBase from '../../src/createWidgetBase';
-import { v, w, globalFactoryRegistry } from '../../src/d';
+import { v, w, registry } from '../../src/d';
 import FactoryRegistry from './../../src/FactoryRegistry';
 
 class TestFactoryRegistry extends FactoryRegistry {
@@ -14,7 +14,7 @@ class TestFactoryRegistry extends FactoryRegistry {
 registerSuite({
 	name: 'd',
 	'provides default factory registry'() {
-		assert.isObject(globalFactoryRegistry);
+		assert.isObject(registry);
 	},
 	w: {
 		'create WNode wrapper'() {
@@ -24,7 +24,7 @@ registerSuite({
 			assert.deepEqual(dNode.options, options);
 		},
 		'create WNode wrapper using a factory label'() {
-			globalFactoryRegistry.define('my-widget', createWidgetBase);
+			registry.define('my-widget', createWidgetBase);
 			const options: WidgetOptions<WidgetState> = { tagName: 'header', state: { hello: 'world' } };
 			const dNode = w('my-widget', options);
 			assert.deepEqual(dNode.factory, 'my-widget');

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -2,7 +2,7 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { WidgetState, WidgetOptions } from './../../src/interfaces';
 import createWidgetBase from '../../src/createWidgetBase';
-import { v, w, defaultFactoryRegistry, setDefaultFactoryRegistry } from '../../src/d';
+import { v, w, globalFactoryRegistry } from '../../src/d';
 import FactoryRegistry from './../../src/FactoryRegistry';
 
 class TestFactoryRegistry extends FactoryRegistry {
@@ -14,12 +14,7 @@ class TestFactoryRegistry extends FactoryRegistry {
 registerSuite({
 	name: 'd',
 	'provides default factory registry'() {
-		assert.isObject(defaultFactoryRegistry);
-	},
-	'set default factory registry'() {
-		const customFactoryRegistry = new FactoryRegistry();
-		setDefaultFactoryRegistry(customFactoryRegistry);
-		assert.strictEqual(defaultFactoryRegistry, customFactoryRegistry);
+		assert.isObject(globalFactoryRegistry);
 	},
 	w: {
 		'create WNode wrapper'() {
@@ -29,10 +24,10 @@ registerSuite({
 			assert.deepEqual(dNode.options, options);
 		},
 		'create WNode wrapper using a factory label'() {
-			defaultFactoryRegistry.define('my-widget', createWidgetBase);
+			globalFactoryRegistry.define('my-widget', createWidgetBase);
 			const options: WidgetOptions<WidgetState> = { tagName: 'header', state: { hello: 'world' } };
 			const dNode = w('my-widget', options);
-			assert.deepEqual(dNode.factory, createWidgetBase);
+			assert.deepEqual(dNode.factory, 'my-widget');
 			assert.deepEqual(dNode.options, options);
 		},
 		'create WNode wrapper with children'() {

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -2,14 +2,36 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { WidgetState, WidgetOptions } from './../../src/interfaces';
 import createWidgetBase from '../../src/createWidgetBase';
-import { v, w } from '../../src/d';
+import { v, w, defaultFactoryRegistry, setDefaultFactoryRegistry } from '../../src/d';
+import FactoryRegistry from './../../src/FactoryRegistry';
+
+class TestFactoryRegistry extends FactoryRegistry {
+	clear() {
+		this.registry.clear();
+	}
+}
 
 registerSuite({
 	name: 'd',
+	'provides default factory registry'() {
+		assert.isObject(defaultFactoryRegistry);
+	},
+	'set default factory registry'() {
+		const customFactoryRegistry = new FactoryRegistry();
+		setDefaultFactoryRegistry(customFactoryRegistry);
+		assert.strictEqual(defaultFactoryRegistry, customFactoryRegistry);
+	},
 	w: {
 		'create WNode wrapper'() {
 			const options: WidgetOptions<WidgetState> = { tagName: 'header', state: { hello: 'world' } };
 			const dNode = w(createWidgetBase, options);
+			assert.deepEqual(dNode.factory, createWidgetBase);
+			assert.deepEqual(dNode.options, options);
+		},
+		'create WNode wrapper using a factory label'() {
+			defaultFactoryRegistry.define('my-widget', createWidgetBase);
+			const options: WidgetOptions<WidgetState> = { tagName: 'header', state: { hello: 'world' } };
+			const dNode = w('my-widget', options);
 			assert.deepEqual(dNode.factory, createWidgetBase);
 			assert.deepEqual(dNode.options, options);
 		},


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

As per the issue, implement `FactoryRegistry` to enable support for lazily loading factories during the render.

Resolves #165
