### PR TITLE
Pass widget instance as `bind` attribute when `h` is called

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,8 @@ To customise the widget an optional `options` argument can be provided with the 
 
 By default the base widget class applies `id`, `classes` and `styles` from the widget's specified `state` (either by direct state injection or via an observable store).
 
+As a convenience, all event handlers are automatically bound to the widget instance, so state and other items on the instance can be easily accessed.
+
 #### Simple Widgets
 
 To create a basic widget `createWidgetBase` can be used directly by importing the class.

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -125,7 +125,7 @@ function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode | stri
 			return dNodeToVNode(instance, child);
 		});
 
-	return dNode.render();
+	return dNode.render({ bind: instance });
 }
 
 function manageDetachedChildren(instance: Widget<WidgetState>): void {

--- a/src/d.ts
+++ b/src/d.ts
@@ -49,7 +49,6 @@ export function v(tag: string, optionsOrChildren: VNodeProperties = {}, children
 		return {
 			children,
 			render<T>(this: { children: VNode[] }, options: { bind?: T } = { }) {
-
 				return h(tag, assign(options, optionsOrChildren), this.children);
 			}
 		};

--- a/src/d.ts
+++ b/src/d.ts
@@ -1,4 +1,5 @@
 import { ComposeFactory } from 'dojo-compose/compose';
+import { assign } from 'dojo-core/lang';
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
 import { h } from 'maquette';
 import {
@@ -47,8 +48,9 @@ export function v(tag: string, optionsOrChildren: VNodeProperties = {}, children
 
 		return {
 			children,
-			render(this: { children: VNode[] }) {
-				return h(tag, optionsOrChildren, this.children);
+			render<T>(this: { children: VNode[] }, options: { bind?: T } = { }) {
+
+				return h(tag, assign(options, optionsOrChildren), this.children);
 			}
 		};
 }

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -263,7 +263,7 @@ export interface HNode {
 	/**
 	 * render function that wraps returns VNode
 	 */
-	render(): VNode;
+	render<T>(options?: { bind: T }): VNode;
 }
 
 export interface WNode {

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -275,6 +275,27 @@ registerSuite({
 			assert.strictEqual(result.children![0].properties!.bind, widgetBase);
 			assert.strictEqual(result.children![0].children![0].properties!.bind, widgetBase);
 		},
+		'bind does not get overriden when specifically configured for the element'() {
+			const customThis = {};
+			const widgetBase = createWidgetBase
+			.mixin({
+				mixin: {
+					getChildrenNodes: function(): DNode[] {
+						return [
+							v('header', { bind: customThis }, [
+								v('section')
+							])
+						];
+					}
+				}
+			})();
+
+			const result = <VNode> widgetBase.render();
+			assert.lengthOf(result.children, 1);
+			assert.strictEqual(result.properties!.bind, widgetBase);
+			assert.strictEqual(result.children![0].properties!.bind, customThis);
+			assert.strictEqual(result.children![0].children![0].properties!.bind, widgetBase);
+		},
 		'render with multiple text node children'() {
 			const widgetBase = createWidgetBase
 				.mixin({

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -255,6 +255,26 @@ registerSuite({
 			assert.isUndefined(result.children);
 			assert.equal(result.text, 'I am a text node');
 		},
+		'instance gets passed to VNodeProperties as bind to widget and all children'() {
+			const widgetBase = createWidgetBase
+			.mixin({
+				mixin: {
+					getChildrenNodes: function(): DNode[] {
+						return [
+							v('header', [
+								v('section')
+							])
+						];
+					}
+				}
+			})();
+
+			const result = <VNode> widgetBase.render();
+			assert.lengthOf(result.children, 1);
+			assert.strictEqual(result.properties!.bind, widgetBase);
+			assert.strictEqual(result.children![0].properties!.bind, widgetBase);
+			assert.strictEqual(result.children![0].children![0].properties!.bind, widgetBase);
+		},
 		'render with multiple text node children'() {
 			const widgetBase = createWidgetBase
 				.mixin({


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Automatically pass the widget instance to `h`, this becomes the value of `this` for all event handlers.

Resolves #168

