### PR TITLE
update typescript to ~2.1.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -58,6 +58,6 @@
     "remap-istanbul": "^0.6.4",
     "sinon": "^1.17.6",
     "tslint": "^3.11.0",
-    "typescript": "~2.0.3"
+    "typescript": "~2.1.4"
   }
 }

--- a/tests/unit/integrations.ts
+++ b/tests/unit/integrations.ts
@@ -25,7 +25,7 @@ registerSuite({
 			assert.strictEqual(nodes.length, 1);
 			assert.strictEqual(nodes[0].childNodes.length, 1);
 			assert.strictEqual(nodes[0].parentElement, document.body);
-			assert.strictEqual(nodes[0].firstChild.firstChild.textContent, 'Greetings');
+			assert.strictEqual(nodes[0].firstChild!.firstChild!.textContent, 'Greetings');
 			assert.strictEqual((<HTMLDivElement> nodes[0].firstChild).className, 'saucer foo');
 		}
 	},


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:** 

Update `typescript` dependency to `~2.1.4`

**Reference Issue:** #https://github.com/dojo/meta/issues/124