### PR TITLE
rename 'render' to '__render__'

### DIFF
--- a/src/createProjector.ts
+++ b/src/createProjector.ts
@@ -124,7 +124,7 @@ function scheduleRender(event: EventTargettedObject<Projector>) {
 
 function attach(instance: Projector, { type }: AttachOptions) {
 	const projectorData = projectorDataMap.get(instance);
-	const render = instance.render.bind(instance);
+	const render = instance.__render__.bind(instance);
 
 	if (projectorData.state === ProjectorState.Attached) {
 		return projectorData.attachPromise || Promise.resolve({});
@@ -221,7 +221,7 @@ const createProjector: ProjectorFactory = createWidgetBase
 		},
 		aspectAdvice: {
 			after: {
-				render(this: Projector, result: VNode | string | null) {
+				__render__(this: Projector, result: VNode | string | null) {
 					if (typeof result === 'string' || result === null) {
 						throw new Error('Must provide a VNode at the root of a projector');
 					}

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -116,7 +116,7 @@ function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode | stri
 		child.children = children;
 		internalState.currentChildrenMap.set(childrenMapKey, child);
 
-		return child.render();
+		return child.__render__();
 	}
 
 	dNode.children = dNode.children
@@ -223,7 +223,7 @@ const createWidget: WidgetFactory = createStateful
 
 			],
 
-			render(this: Widget<WidgetState>): VNode | string | null {
+			__render__(this: Widget<WidgetState>): VNode | string | null {
 				const internalState = widgetInternalStateMap.get(this);
 				if (internalState.dirty || !internalState.cachedVNode) {
 					const widget = dNodeToVNode(this, this.getNode());

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -174,7 +174,7 @@ export interface WidgetMixin {
 	 * return h(this.tagName, this.getNodeAttributes(), this.getChildrenNodes());
 	 * ```
 	 */
-	render(): VNode | string | null;
+	__render__(): VNode | string | null;
 
 	/**
 	 * The tagName (selector) that should be used when rendering the node.

--- a/tests/unit/components/button/createButton.ts
+++ b/tests/unit/components/button/createButton.ts
@@ -25,7 +25,7 @@ registerSuite({
 				name: 'baz'
 			}
 		});
-		const vnode = <VNode> button.render();
+		const vnode = <VNode> button.__render__();
 		assert.strictEqual(vnode.vnodeSelector, 'button');
 		assert.strictEqual(vnode.properties!.innerHTML, 'bar');
 		assert.strictEqual(vnode.properties!['data-widget-id'], 'foo');
@@ -41,12 +41,12 @@ registerSuite({
 				name: 'baz'
 			}
 		});
-		let vnode = <VNode> button.render();
+		let vnode = <VNode> button.__render__();
 		assert.isFalse(vnode.properties!['disabled']);
 		button.setState({
 			disabled: true
 		});
-		vnode = <VNode> button.render();
+		vnode = <VNode> button.__render__();
 		assert.isTrue(vnode.properties!['disabled']);
 	}
 });

--- a/tests/unit/createProjector.ts
+++ b/tests/unit/createProjector.ts
@@ -37,7 +37,7 @@ registerSuite({
 		})();
 
 		try {
-			projector.render();
+			projector.__render__();
 			assert.fail();
 		}
 		catch (error) {
@@ -53,7 +53,7 @@ registerSuite({
 		})();
 
 		try {
-			projector.render();
+			projector.__render__();
 			assert.fail();
 		}
 		catch (error) {

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -34,19 +34,19 @@ registerSuite({
 		'Applies default tagName'() {
 			const widget = createWidgetBase();
 			assert.deepEqual(widget.tagName, 'div');
-			const renderedWidget = <VNode> widget.render();
+			const renderedWidget = <VNode> widget.__render__();
 			assert.deepEqual(renderedWidget.vnodeSelector, 'div');
 		},
 		'Applies overridden tagName'() {
 			const widget = createWidgetBase.override({ tagName: 'header' })();
 			assert.deepEqual(widget.tagName, 'header');
-			const renderedWidget = <VNode> widget.render();
+			const renderedWidget = <VNode> widget.__render__();
 			assert.deepEqual(renderedWidget.vnodeSelector, 'header');
 		}
 		},
 		'Applies classes to tagName'() {
 			const widget = createWidgetBase.override({ tagName: 'header', classes: [ 'class-one', 'classTwo' ] })();
-			const renderedWidget = <VNode> widget.render();
+			const renderedWidget = <VNode> widget.__render__();
 			assert.deepEqual(renderedWidget.vnodeSelector, 'header.class-one.classTwo');
 	},
 	'getNodeAttributes()'() {
@@ -110,7 +110,7 @@ registerSuite({
 					}
 				})();
 
-			const result = <VNode> widgetBase.render();
+			const result = <VNode> widgetBase.__render__();
 			assert.lengthOf(result.children, 1);
 			assert.strictEqual(result.children && result.children[0].vnodeSelector, 'header');
 		},
@@ -144,20 +144,20 @@ registerSuite({
 				invalidateCount++;
 			});
 
-			let result = <VNode> myWidget.render();
+			let result = <VNode> myWidget.__render__();
 			assert.lengthOf(result.children, 0);
 
 			myWidget.invalidate();
-			myWidget.render();
+			myWidget.__render__();
 			myWidget.invalidate();
-			myWidget.render();
+			myWidget.__render__();
 
 			resolveFunction(createHeader);
 
 			const promise = new Promise((resolve) => setTimeout(resolve, 100));
 			return promise.then(() => {
 				assert.equal(invalidateCount, 3);
-				result = <VNode> myWidget.render();
+				result = <VNode> myWidget.__render__();
 				assert.lengthOf(result.children, 1);
 				assert.strictEqual(result.children![0].vnodeSelector, 'header');
 			});
@@ -187,13 +187,13 @@ registerSuite({
 
 			const myWidget = createMyWidget();
 
-			let result = <VNode> myWidget.render();
+			let result = <VNode> myWidget.__render__();
 			assert.lengthOf(result.children, 0);
 
 			resolveFunction(createHeader);
 			return new Promise((resolve) => {
 				myWidget.on('invalidated', () => {
-					result = <VNode> myWidget.render();
+					result = <VNode> myWidget.__render__();
 					assert.lengthOf(result.children, 1);
 					assert.strictEqual(result.children![0].vnodeSelector, 'header');
 					resolve();
@@ -218,7 +218,7 @@ registerSuite({
 
 			const myWidget = createMyWidget();
 
-			let result = <VNode> myWidget.render();
+			let result = <VNode> myWidget.__render__();
 			assert.lengthOf(result.children, 1);
 			assert.strictEqual(result.children![0].vnodeSelector, 'header');
 		},
@@ -236,7 +236,7 @@ registerSuite({
 					}
 				})();
 
-			const result = <VNode> widgetBase.render();
+			const result = <VNode> widgetBase.__render__();
 			assert.lengthOf(result.children, 1);
 			assert.strictEqual(result.children![0].vnodeSelector, 'header');
 			assert.strictEqual(result.children![0].children![0].vnodeSelector, 'section');
@@ -251,7 +251,7 @@ registerSuite({
 					}
 				})();
 
-			const result = <VNode> widgetBase.render();
+			const result = <VNode> widgetBase.__render__();
 			assert.isUndefined(result.children);
 			assert.equal(result.text, 'I am a text node');
 		},
@@ -269,7 +269,7 @@ registerSuite({
 				}
 			})();
 
-			const result = <VNode> widgetBase.render();
+			const result = <VNode> widgetBase.__render__();
 			assert.lengthOf(result.children, 1);
 			assert.strictEqual(result.properties!.bind, widgetBase);
 			assert.strictEqual(result.children![0].properties!.bind, widgetBase);
@@ -290,7 +290,7 @@ registerSuite({
 				}
 			})();
 
-			const result = <VNode> widgetBase.render();
+			const result = <VNode> widgetBase.__render__();
 			assert.lengthOf(result.children, 1);
 			assert.strictEqual(result.properties!.bind, widgetBase);
 			assert.strictEqual(result.children![0].properties!.bind, customThis);
@@ -306,7 +306,7 @@ registerSuite({
 					}
 				})();
 
-			const result = <VNode> widgetBase.render();
+			const result = <VNode> widgetBase.__render__();
 			assert.isUndefined(result.text);
 			assert.lengthOf(result.children, 2);
 			assert.strictEqual(result.children![0].text, 'I am a text node');
@@ -340,7 +340,7 @@ registerSuite({
 					}
 				})();
 
-			const firstRenderResult = <VNode> widgetBase.render();
+			const firstRenderResult = <VNode> widgetBase.__render__();
 			assert.strictEqual(countWidgetCreated, 1);
 			assert.strictEqual(countWidgetDestroyed, 0);
 			assert.lengthOf(firstRenderResult.children, 1);
@@ -349,7 +349,7 @@ registerSuite({
 
 			widgetBase.invalidate();
 
-			const secondRenderResult = <VNode> widgetBase.render();
+			const secondRenderResult = <VNode> widgetBase.__render__();
 			assert.strictEqual(countWidgetCreated, 1);
 			assert.strictEqual(countWidgetDestroyed, 0);
 			assert.lengthOf(secondRenderResult.children, 1);
@@ -358,7 +358,7 @@ registerSuite({
 
 			widgetBase.setState({ 'classes': ['test-class'] });
 			widgetBase.invalidate();
-			const thirdRenderResult = <VNode> widgetBase.render();
+			const thirdRenderResult = <VNode> widgetBase.__render__();
 			assert.strictEqual(countWidgetCreated, 1);
 			assert.strictEqual(countWidgetDestroyed, 0);
 			assert.lengthOf(thirdRenderResult.children, 1);
@@ -369,7 +369,7 @@ registerSuite({
 			widgetBase.setState({ hide: true });
 			widgetBase.invalidate();
 
-			const forthRenderResult = <VNode> widgetBase.render();
+			const forthRenderResult = <VNode> widgetBase.__render__();
 			assert.strictEqual(countWidgetCreated, 1);
 			assert.strictEqual(countWidgetDestroyed, 1);
 			assert.lengthOf(forthRenderResult.children, 0);
@@ -377,7 +377,7 @@ registerSuite({
 			widgetBase.setState({ hide: false });
 			widgetBase.invalidate();
 
-			const lastRenderResult = <VNode> widgetBase.render();
+			const lastRenderResult = <VNode> widgetBase.__render__();
 			assert.strictEqual(countWidgetCreated, 2);
 			assert.strictEqual(countWidgetDestroyed, 1);
 			assert.lengthOf(lastRenderResult.children, 1);
@@ -398,21 +398,21 @@ registerSuite({
 				})();
 
 			const consoleStub = stub(console, 'error');
-			widgetBase.render();
+			widgetBase.__render__();
 			assert.isTrue(consoleStub.calledWith('must provide unique keys when using the same widget factory multiple times'));
 			consoleStub.restore();
 		},
-		'render() and invalidate()'() {
+		'__render__() and invalidate()'() {
 			const widgetBase = createWidgetBase({
 				state: { id: 'foo', label: 'foo' }
 			});
-			const result1 = <VNode> widgetBase.render();
-			const result2 = <VNode> widgetBase.render();
+			const result1 = <VNode> widgetBase.__render__();
+			const result2 = <VNode> widgetBase.__render__();
 			widgetBase.invalidate();
 			widgetBase.invalidate();
 			widgetBase.setState({});
-			const result3 = widgetBase.render();
-			const result4 = widgetBase.render();
+			const result3 = widgetBase.__render__();
+			const result4 = widgetBase.__render__();
 			assert.strictEqual(result1, result2);
 			assert.strictEqual(result3, result4);
 			assert.notStrictEqual(result1, result3);
@@ -469,7 +469,7 @@ registerSuite({
 			console.log('invalid');
 			count++;
 		});
-		widgetBase.render();
+		widgetBase.__render__();
 		widgetBase.invalidate();
 		assert.strictEqual(count, 1);
 	}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Rename `createWidgetBase.render` to `createWidgetBase.__render__` 

Resolves #179

