### PR TITLE
Support properties to update internal state

### DIFF
--- a/README.md
+++ b/README.md
@@ -394,7 +394,7 @@ const projector = createProjector();
 
 projector.children = [
 	w(createTextInput, { id: 'textinput' }),
-	w(createButton, { id: 'button', label: 'Button' })
+	w(createButton, { id: 'button', properties: { label: 'Button' } })
 ];
 
 projector.append().then(() => {
@@ -416,7 +416,7 @@ const createApp = createProjector.mixin({
 		getChildrenNodes: function(this: Projector): DNode[] {
 			return [
 				w(createTextInput, { id: 'textinput' }),
-				w(createButton, { id: 'button', label: 'Button' })
+				w(createButton, { id: 'button', properties: { label: 'Button' } })
 			];
 		},
 		classes: [ 'main-app' ],

--- a/README.md
+++ b/README.md
@@ -83,9 +83,9 @@ A subset of the `Widget` API are intended to be overridden in scenarios where th
 |---|---|---|
 |getNode|Returns the top level node of a widget|Returns a `DNode` with the widgets `tagName`, the result of `this.getNodeAttributes` and `this.children`|
 |getChildrenNodes|Returns the child node structure of a widget|Returns the widgets children `DNode` array|
-|nodeAttributes|An of function that return VNodeProperties to be applied to the top level node|Returns attributes for `data-widget-id`, `classes` and `styles` using the widget's specified `state` (`id`, `classes`, `styles`) at the time of render|
-|diffProperties|Diffs the current properties against the previous properties and returns the updated/new keys in an array|Performs a shallow comparison using `===` of previous and current properties and returns an array of the keys. Function are ignored. |
-|applyChangedProperties|Gets called to process updated/new properties|If there are updared properties they are directly set onto the widgets `state`, `widget.setState(updatedProperties)`|
+|nodeAttributes|An array of functions that return VNodeProperties to be applied to the top level node|Returns attributes for `data-widget-id`, `classes` and `styles` using the widget's specified `state` (`id`, `classes`, `styles`) at the time of render|
+|diffProperties|Diffs the current properties against the previous properties and returns the updated/new keys in an array|Performs a shallow comparison using `===` of previous and current properties and returns an array of the keys.|
+|applyChangedProperties|Gets called to apply updated/new properties|If there are updated properties they are directly set onto the widgets `state` using `setState`.|
 
 To customise the widget an optional `options` argument can be provided with the following interface.
 
@@ -100,8 +100,7 @@ To customise the widget an optional `options` argument can be provided with the 
 |properties|WidgetProperties|Props to be passed to the widget. These can be used to determine state internally|
 |nodeAttributes|Function[]|An array of functions that return VNodeProperties to be applied to the VNode|
 
-A widgets' `state` should **never** be directly set outside of the instance. In order to manipulate widget `state`, `properties` should be updated such as `widget.properties = { 'foo': 'bar' }` and then during the next render the new or updated properties are passed to `instance#processPropertiesChange`.
-
+A widgets' `state` should **never** be directly set outside of the instance. In order to manipulate widget `state`, `properties` should be updated such as `widget.properties = { 'foo': 'bar' }` and then during the next render the new or updated properties are passed to `instance#applyChangedProperties`.
 
 As a convenience, all event handlers are automatically bound to the widget instance, so state and other items on the instance can be easily accessed.
 

--- a/README.md
+++ b/README.md
@@ -255,15 +255,13 @@ registry.define('my-widget', () => {
 
 `w` is an abstraction layer for dojo-widgets that enables dojo 2's lazy instantiation, instance management and caching.
 
-Creates a dojo-widget using the `factory` and `properties`.
-
-**Note:** properties for `id` and `tagName` are automatically copied from the widget properties object and added to the widget options object used when instatiating the widget internally.
+Creates a dojo-widget using the `factory` and `options`.
 
 ```ts
 w(factory: string | ComposeFactory<W, O>, options: O): WNode[];
 ```
 
-Creates a dojo-widget using the `factory` and `properties` and the `children`
+Creates a dojo-widget using the `factory`, `options` and `children`
 
 ```ts
 w(factory: string | ComposeFactory<W, O>, options: O, children: (DNode | null)[]): WNode[];

--- a/README.md
+++ b/README.md
@@ -69,25 +69,39 @@ These are some of the **important** principles to keep in mind when developing w
 1. the widget *render* function should **never** be overridden
 2. with the exception of the top level projector you should **never** have to deal with widget instances.
 3. hyperscript should **always** be written using the dojo-widgets `v` helper function.
+4. `state` should **never** be set outside of the widget instance.
 
 ### Base Widget
 
 The class `createWidgetBase` provides all base dojo-widgets functionality including caching and widget lifecycle management. It can be used directly or extended to create custom widgets.
 
+#### Widget API
+
+A subset of the `Widget` API are intended to be overridden in scenarios where the default implemented behviour does not suffice.
+
+|Function|Description|Default Behaviour|
+|---|---|---|
+|getNode|Returns the top level node of a widget|Returns a `DNode` with the widgets `tagName`, the result of `this.getNodeAttributes` and `this.children`|
+|getChildrenNodes|Returns the child node structure of a widget|Returns the widgets children `DNode` array|
+|nodeAttributes|An of function that return VNodeProperties to be applied to the top level node|Returns attributes for `data-widget-id`, `classes` and `styles` using the widget's specified `state` (`id`, `classes`, `styles`) at the time of render|
+|diffProperties|Diffs the current properties against the previous properties and returns the updated/new keys in an array|Performs a shallow comparison using `===` of previous and current properties and returns an array of the keys. Function are ignored. |
+|applyChangedProperties|Gets called to process updated/new properties|If there are updared properties they are directly set onto the widgets `state`, `widget.setState(updatedProperties)`|
+
 To customise the widget an optional `options` argument can be provided with the following interface.
 
-**Type**: `WidgetOptions<WidgetState>` - All properties are optional.
+**Type**: `WidgetOptions<WidgetState, WidgetProperties>` - All properties are optional.
 
 |Property|Type|Description|
 |---|---|---|
 |id|string|identifier for the widget|
-|state|WidgetState|Initial state of the widget|
 |stateFrom|StoreObservablePatchable|Observable that provides state for the widget|
 |listeners|EventedListenersMap|Map of listeners for to attach to the widget|
 |tagName|string|Override the widgets tagname|
+|properties|WidgetProperties|Props to be passed to the widget. These can be used to determine state internally|
 |nodeAttributes|Function[]|An array of functions that return VNodeProperties to be applied to the VNode|
 
-By default the base widget class applies `id`, `classes` and `styles` from the widget's specified `state` (either by direct state injection or via an observable store).
+A widgets' `state` should **never** be directly set outside of the instance. In order to manipulate widget `state`, `properties` should be updated such as `widget.properties = { 'foo': 'bar' }` and then during the next render the new or updated properties are passed to `instance#processPropertiesChange`.
+
 
 As a convenience, all event handlers are automatically bound to the widget instance, so state and other items on the instance can be easily accessed.
 
@@ -112,7 +126,7 @@ The following example demonstrates how `id`, `classes` and `styles` are applied 
 import createWidgetBase from 'dojo-widgets/createWidgetBase';
 
 const myBasicWidget = createWidgetBase({
-    state: {
+    properties: {
         id: 'my-widget',
         classes: [ 'class-a', 'class-b' ],
         styles: [ 'width:20px' ]
@@ -201,7 +215,7 @@ v(tag: string, children: (DNode | null)[]): HNode[];
 Creates an element with the `tagName` with `VNodeProperties` options and optional children specified by the array of `DNode`, `VNode`, `string` or `null` items.
 
 ```ts
-v(tag: string, options: VNodeProperties, children?: (DNode | null)[]): HNode[];
+v(tag: string, properties: VNodeProperties, children?: (DNode | null)[]): HNode[];
 ```
 
 ##### `registry`
@@ -242,13 +256,15 @@ registry.define('my-widget', () => {
 
 `w` is an abstraction layer for dojo-widgets that enables dojo 2's lazy instantiation, instance management and caching.
 
-Creates a dojo-widget using the `factory` and `options`.
+Creates a dojo-widget using the `factory` and `properties`.
+
+**Note:** properties for `id` and `tagName` are automatically copied from the widget properties object and added to the widget options object used when instatiating the widget internally.
 
 ```ts
 w(factory: string | ComposeFactory<W, O>, options: O): WNode[];
 ```
 
-Creates a dojo-widget using the `factory` and `options` and the `children`
+Creates a dojo-widget using the `factory` and `properties` and the `children`
 
 ```ts
 w(factory: string | ComposeFactory<W, O>, options: O, children: (DNode | null)[]): WNode[];
@@ -378,7 +394,7 @@ const projector = createProjector();
 
 projector.children = [
 	w(createTextInput, { id: 'textinput' }),
-	w(createButton, { id: 'button', state: { label: 'Button' } })
+	w(createButton, { id: 'button', label: 'Button' })
 ];
 
 projector.append().then(() => {
@@ -400,7 +416,7 @@ const createApp = createProjector.mixin({
 		getChildrenNodes: function(this: Projector): DNode[] {
 			return [
 				w(createTextInput, { id: 'textinput' }),
-				w(createButton, { id: 'button', state: { label: 'Button' } })
+				w(createButton, { id: 'button', label: 'Button' })
 			];
 		},
 		classes: [ 'main-app' ],

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "@reactivex/rxjs": "5.0.0-beta.6",
     "dojo-compose": ">=2.0.0-beta.10",
     "dojo-core": ">=2.0.0-alpha.14",
     "dojo-has": ">=2.0.0-alpha.4",

--- a/src/components/button/createButton.ts
+++ b/src/components/button/createButton.ts
@@ -8,9 +8,13 @@ export interface ButtonState extends WidgetState, FormFieldMixinState<string> {
 	label?: string;
 }
 
-export interface ButtonOptions extends WidgetOptions<ButtonState>, FormFieldMixinOptions<any, ButtonState> { }
+export interface ButtonProperties {
+	label: string;
+}
 
-export type Button = Widget<ButtonState> & FormFieldMixin<string, ButtonState>;
+export interface ButtonOptions extends WidgetOptions<ButtonState, ButtonProperties>, FormFieldMixinOptions<any, ButtonState> { }
+
+export type Button = Widget<ButtonState, ButtonProperties> & FormFieldMixin<string, ButtonState>;
 
 export interface ButtonFactory extends ComposeFactory<Button, ButtonOptions> { }
 

--- a/src/components/textinput/createTextInput.ts
+++ b/src/components/textinput/createTextInput.ts
@@ -1,6 +1,6 @@
 import { ComposeFactory } from 'dojo-compose/compose';
 import createWidgetBase from '../../createWidgetBase';
-import { Widget, WidgetOptions, WidgetState } from './../../interfaces';
+import { Widget, WidgetOptions, WidgetState, WidgetProperties } from './../../interfaces';
 import createFormFieldMixin, { FormFieldMixin, FormFieldMixinState, FormFieldMixinOptions } from '../../mixins/createFormFieldMixin';
 
 /* TODO: I suspect this needs to go somewhere else */
@@ -10,9 +10,9 @@ export interface TypedTargetEvent<T extends EventTarget> extends Event {
 
 export type TextInputState = WidgetState & FormFieldMixinState<string>;
 
-export type TextInputOptions = WidgetOptions<TextInputState> & FormFieldMixinOptions<string, TextInputState>;
+export type TextInputOptions = WidgetOptions<TextInputState, WidgetProperties> & FormFieldMixinOptions<string, TextInputState>;
 
-export type TextInput = Widget<TextInputState> & FormFieldMixin<string, TextInputState>;
+export type TextInput = Widget<TextInputState, WidgetProperties> & FormFieldMixin<string, TextInputState>;
 
 export interface TextInputFactory extends ComposeFactory<TextInput, TextInputOptions> { }
 

--- a/src/createProjector.ts
+++ b/src/createProjector.ts
@@ -1,7 +1,7 @@
 import { ComposeFactory } from 'dojo-compose/compose';
 import { EventTargettedObject, Handle } from 'dojo-interfaces/core';
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
-import { Widget, WidgetState, WidgetOptions } from './interfaces';
+import { Widget, WidgetState, WidgetOptions, WidgetProperties } from './interfaces';
 import WeakMap from 'dojo-shim/WeakMap';
 import { createProjector as createMaquetteProjector, Projector as MaquetteProjector } from 'maquette';
 import createWidgetBase from './createWidgetBase';
@@ -37,7 +37,7 @@ export interface AttachOptions {
 /**
  * Projector interface
  */
-export interface ProjectorOptions extends WidgetOptions<WidgetState> {
+export interface ProjectorOptions extends WidgetOptions<WidgetState, WidgetProperties> {
 
 	/**
 	 * An optional root of the projector
@@ -98,7 +98,7 @@ interface ProjectorData {
 	afterCreate?: () => void;
 }
 
-export type Projector = Widget<WidgetState> & ProjectorMixin;
+export type Projector = Widget<WidgetState, WidgetProperties> & ProjectorMixin;
 
 export interface ProjectorFactory extends ComposeFactory<Projector, ProjectorOptions> { }
 

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -222,7 +222,7 @@ const createWidget: WidgetFactory = createStateful
 				return id;
 			},
 
-			processPropertiesChange: function(this: Widget<WidgetState, WidgetProperties>, previousProperties: any, currentProperties): void {
+			applyChangedProperties: function(this: Widget<WidgetState, WidgetProperties>, previousProperties: Partial<WidgetProperties>, currentProperties: Partial<WidgetProperties>): void {
 				if (Object.keys(currentProperties).length) {
 					this.setState(currentProperties);
 				}
@@ -266,7 +266,7 @@ const createWidget: WidgetFactory = createStateful
 			__render__(this: Widget<WidgetState, WidgetProperties>): VNode | string | null {
 				const internalState = widgetInternalStateMap.get(this);
 				const updatedProperties = generateProperties(this, internalState.previousProperties);
-				this.processPropertiesChange(updatedProperties.previousProperties, updatedProperties.currentProperties);
+				this.applyChangedProperties(updatedProperties.previousProperties, updatedProperties.currentProperties);
 
 				if (internalState.dirty || !internalState.cachedVNode) {
 					const widget = dNodeToVNode(this, this.getNode());
@@ -297,7 +297,7 @@ const createWidget: WidgetFactory = createStateful
 
 			instance.properties = properties;
 			instance.tagName = tagName || instance.tagName;
-			instance.processPropertiesChange({}, properties);
+			instance.applyChangedProperties({}, properties);
 
 			widgetInternalStateMap.set(instance, {
 				id,

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -7,6 +7,7 @@ import {
 	WidgetMixin,
 	WidgetState,
 	WidgetOptions,
+	WidgetProperties,
 	WidgetFactory,
 	FactoryRegistryItem
 } from './interfaces';
@@ -21,37 +22,36 @@ import createVNodeEvented from './mixins/createVNodeEvented';
 
 interface WidgetInternalState {
 	children: DNode[];
-	readonly id?: string;
+	readonly id: string;
 	dirty: boolean;
 	widgetClasses: string[];
 	cachedVNode?: VNode | string;
 	factoryRegistry: FactoryRegistry;
 	initializedFactoryMap: Map<string, Promise<WidgetFactory>>;
-	historicChildrenMap: Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState>>;
-	currentChildrenMap: Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState>>;
+	previousProperties: any;
+	historicChildrenMap: Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState, WidgetProperties>>;
+	currentChildrenMap: Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState, WidgetProperties>>;
 };
 
 /**
  * Internal state map for widget instances
  */
-const widgetInternalStateMap = new WeakMap<Widget<WidgetState>, WidgetInternalState>();
+const widgetInternalStateMap = new WeakMap<Widget<WidgetState, WidgetProperties>, WidgetInternalState>();
 
 /**
  * The counter for generating a unique ID
  */
 let widgetCount = 0;
 
-function generateID(instance: Widget<WidgetState>): string {
-	const id = `widget-${++widgetCount}`;
-	instance.setState({ id });
-	return id;
+function generateID(instance: Widget<WidgetState, WidgetProperties>): string {
+	return `widget-${++widgetCount}`;
 }
 
 function isWNode(child: DNode): child is WNode {
 	return Boolean(child && (<WNode> child).factory !== undefined);
 }
 
-function getFromRegistry(instance: Widget<WidgetState>, factoryLabel: string): FactoryRegistryItem | null {
+function getFromRegistry(instance: Widget<WidgetState, WidgetProperties>, factoryLabel: string): FactoryRegistryItem | null {
 	if (instance.registry.has(factoryLabel)) {
 		return instance.registry.get(factoryLabel);
 	}
@@ -59,7 +59,7 @@ function getFromRegistry(instance: Widget<WidgetState>, factoryLabel: string): F
 	return registry.get(factoryLabel);
 }
 
-function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode | string | null {
+function dNodeToVNode(instance: Widget<WidgetState, WidgetProperties>, dNode: DNode): VNode | string | null {
 	const internalState = widgetInternalStateMap.get(instance);
 
 	if (typeof dNode === 'string' || dNode === null) {
@@ -67,10 +67,10 @@ function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode | stri
 	}
 
 	if (isWNode(dNode)) {
-		const { children, options: { id, state } } = dNode;
+		const { children, options: { id, properties } } = dNode;
 
 		let { factory } = dNode;
-		let child: Widget<WidgetState>;
+		let child: Widget<WidgetState, WidgetProperties>;
 
 		if (typeof factory === 'string') {
 			const item = getFromRegistry(instance, factory);
@@ -95,8 +95,8 @@ function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode | stri
 
 		if (cachedChild) {
 			child = cachedChild;
-			if (state) {
-				child.setState(state);
+			if (properties) {
+				child.properties = properties;
 			}
 		}
 		else {
@@ -128,7 +128,7 @@ function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode | stri
 	return dNode.render({ bind: instance });
 }
 
-function manageDetachedChildren(instance: Widget<WidgetState>): void {
+function manageDetachedChildren(instance: Widget<WidgetState, WidgetProperties>): void {
 	const internalState = widgetInternalStateMap.get(instance);
 
 	internalState.historicChildrenMap.forEach((child, key) => {
@@ -147,10 +147,29 @@ function formatTagNameAndClasses(tagName: string, classes: string[]) {
 	return tagName;
 }
 
+function generateProperties(instance: Widget<WidgetState, WidgetProperties>, previousProperties: any): any {
+	const changedPropertyKeys = instance.diffProperties(previousProperties);
+	const changedProperties: { currentProperties: any, previousProperties: any } = {
+		currentProperties: {},
+		previousProperties: {}
+	};
+
+	changedPropertyKeys.forEach((key) => {
+			changedProperties.currentProperties[key] = instance.properties[key];
+		if (previousProperties[key]) {
+			changedProperties.previousProperties[key] = previousProperties[key];
+		}
+	});
+
+	return changedProperties;
+}
+
 const createWidget: WidgetFactory = createStateful
 	.mixin(createVNodeEvented)
-	.mixin<WidgetMixin, WidgetOptions<WidgetState>>({
+	.mixin<WidgetMixin<WidgetProperties>, WidgetOptions<WidgetState, WidgetProperties>>({
 		mixin: {
+			properties: {},
+
 			classes: [],
 
 			getNode(): DNode {
@@ -158,7 +177,7 @@ const createWidget: WidgetFactory = createStateful
 				return v(tag, this.getNodeAttributes(), this.getChildrenNodes());
 			},
 
-			set children(this: Widget<WidgetState>, children: DNode[]) {
+			set children(this: Widget<WidgetState, WidgetProperties>, children: DNode[]) {
 				const internalState = widgetInternalStateMap.get(this);
 				internalState.children = children;
 				this.emit({
@@ -171,11 +190,11 @@ const createWidget: WidgetFactory = createStateful
 				return widgetInternalStateMap.get(this).children;
 			},
 
-			getChildrenNodes(this: Widget<WidgetState>): DNode[] {
+			getChildrenNodes(this: Widget<WidgetState, WidgetProperties>): DNode[] {
 				return this.children;
 			},
 
-			getNodeAttributes(this: Widget<WidgetState>, overrides?: VNodeProperties): VNodeProperties {
+			getNodeAttributes(this: Widget<WidgetState, WidgetProperties>, overrides?: VNodeProperties): VNodeProperties {
 				const props: VNodeProperties = {};
 
 				this.nodeAttributes.forEach((fn) => {
@@ -188,7 +207,7 @@ const createWidget: WidgetFactory = createStateful
 				return props;
 			},
 
-			invalidate(this: Widget<WidgetState>): void {
+			invalidate(this: Widget<WidgetState, WidgetProperties>): void {
 				const internalState = widgetInternalStateMap.get(this);
 				internalState.dirty = true;
 				this.emit({
@@ -197,16 +216,37 @@ const createWidget: WidgetFactory = createStateful
 				});
 			},
 
-			get id(this: Widget<WidgetState>): string {
+			get id(this: Widget<WidgetState, WidgetProperties>): string {
 				const { id } = widgetInternalStateMap.get(this);
 
-				return id || (this.state && this.state.id) || generateID(this);
+				return id;
+			},
+
+			processPropertiesChange: function(this: Widget<WidgetState, WidgetProperties>, previousProperties: any, currentProperties): void {
+				if (Object.keys(currentProperties).length) {
+					this.setState(currentProperties);
+				}
+			},
+
+			diffProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: any): string[] {
+				const changedPropertyKeys: string[] = [];
+				Object.keys(this.properties).forEach((key) => {
+					if (previousProperties[key]) {
+						if (previousProperties[key] !== this.properties[key]) {
+							changedPropertyKeys.push(key);
+						}
+					}
+					else {
+						changedPropertyKeys.push(key);
+					}
+				});
+				return changedPropertyKeys;
 			},
 
 			nodeAttributes: [
-				function (this: Widget<WidgetState>): VNodeProperties {
+				function (this: Widget<WidgetState, WidgetProperties>): VNodeProperties {
 					const baseIdProp = this.state && this.state.id ? { 'data-widget-id': this.state.id } : {};
-					const { styles = {} } = this.state;
+					const { styles = {} } = this.state || {};
 					const classes: { [index: string]: boolean; } = {};
 
 					const internalState = widgetInternalStateMap.get(this);
@@ -221,10 +261,13 @@ const createWidget: WidgetFactory = createStateful
 					return assign(baseIdProp, { key: this, classes, styles });
 				}
 
-			],
+		],
 
-			__render__(this: Widget<WidgetState>): VNode | string | null {
+			__render__(this: Widget<WidgetState, WidgetProperties>): VNode | string | null {
 				const internalState = widgetInternalStateMap.get(this);
+				const updatedProperties = generateProperties(this, internalState.previousProperties);
+				this.processPropertiesChange(updatedProperties.previousProperties, updatedProperties.currentProperties);
+
 				if (internalState.dirty || !internalState.cachedVNode) {
 					const widget = dNodeToVNode(this, this.getNode());
 					manageDetachedChildren(this);
@@ -232,29 +275,39 @@ const createWidget: WidgetFactory = createStateful
 						internalState.cachedVNode = widget;
 					}
 					internalState.dirty = false;
+					internalState.previousProperties = this.properties;
 					return widget;
 				}
 				return internalState.cachedVNode;
 			},
 
-			get registry(this: Widget<WidgetState>): FactoryRegistry {
+			get registry(this: Widget<WidgetState, WidgetProperties>): FactoryRegistry {
 				return widgetInternalStateMap.get(this).factoryRegistry;
 			},
 
 			tagName: 'div'
 		},
-		initialize(instance: Widget<WidgetState>, options: WidgetOptions<WidgetState> = {}) {
-			const { id, tagName } = options;
+		initialize(instance: Widget<WidgetState, WidgetProperties>, options: WidgetOptions<WidgetState, { id?: string }> = {}) {
+			const { tagName, properties = {} } = options;
+			const id = properties.id || options.id || generateID(instance);
+
+			if (!properties.id) {
+				properties.id = id;
+			}
+
+			instance.properties = properties;
 			instance.tagName = tagName || instance.tagName;
+			instance.processPropertiesChange({}, properties);
 
 			widgetInternalStateMap.set(instance, {
 				id,
 				dirty: true,
 				widgetClasses: [],
+				previousProperties: properties,
 				factoryRegistry: new FactoryRegistry(),
 				initializedFactoryMap: new Map<string, Promise<WidgetFactory>>(),
-				historicChildrenMap: new Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState>>(),
-				currentChildrenMap: new Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState>>(),
+				historicChildrenMap: new Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState, WidgetProperties>>(),
+				currentChildrenMap: new Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState, WidgetProperties>>(),
 				children: []
 			});
 

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -28,7 +28,7 @@ interface WidgetInternalState {
 	cachedVNode?: VNode | string;
 	factoryRegistry: FactoryRegistry;
 	initializedFactoryMap: Map<string, Promise<WidgetFactory>>;
-	previousProperties: any;
+	previousProperties: WidgetProperties;
 	historicChildrenMap: Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState, WidgetProperties>>;
 	currentChildrenMap: Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState, WidgetProperties>>;
 };

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -224,7 +224,7 @@ const createWidget: WidgetFactory = createStateful
 
 			applyChangedProperties: function(this: Widget<WidgetState, WidgetProperties>, previousProperties: WidgetProperties, currentProperties: WidgetProperties): void {
 				if (Object.keys(currentProperties).length) {
-					currentProperties.id = this.id;
+					currentProperties['id'] = this.id;
 					this.setState(currentProperties);
 				}
 			},

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -155,7 +155,7 @@ function generateProperties(instance: Widget<WidgetState, WidgetProperties>, pre
 	};
 
 	changedPropertyKeys.forEach((key) => {
-			changedProperties.currentProperties[key] = instance.properties[key];
+		changedProperties.currentProperties[key] = instance.properties[key];
 		if (previousProperties[key]) {
 			changedProperties.previousProperties[key] = previousProperties[key];
 		}
@@ -222,8 +222,9 @@ const createWidget: WidgetFactory = createStateful
 				return id;
 			},
 
-			applyChangedProperties: function(this: Widget<WidgetState, WidgetProperties>, previousProperties: Partial<WidgetProperties>, currentProperties: Partial<WidgetProperties>): void {
+			applyChangedProperties: function(this: Widget<WidgetState, WidgetProperties>, previousProperties: WidgetProperties, currentProperties: WidgetProperties): void {
 				if (Object.keys(currentProperties).length) {
+					currentProperties.id = this.id;
 					this.setState(currentProperties);
 				}
 			},
@@ -290,10 +291,6 @@ const createWidget: WidgetFactory = createStateful
 		initialize(instance: Widget<WidgetState, WidgetProperties>, options: WidgetOptions<WidgetState, { id?: string }> = {}) {
 			const { tagName, properties = {} } = options;
 			const id = properties.id || options.id || generateID(instance);
-
-			if (!properties.id) {
-				properties.id = id;
-			}
 
 			instance.properties = properties;
 			instance.tagName = tagName || instance.tagName;

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -294,7 +294,6 @@ const createWidget: WidgetFactory = createStateful
 
 			instance.properties = properties;
 			instance.tagName = tagName || instance.tagName;
-			instance.applyChangedProperties({}, properties);
 
 			widgetInternalStateMap.set(instance, {
 				id,
@@ -308,6 +307,7 @@ const createWidget: WidgetFactory = createStateful
 				children: []
 			});
 
+			instance.applyChangedProperties({}, properties);
 			instance.own(instance.on('state:changed', () => {
 				instance.invalidate();
 			}));

--- a/src/d.ts
+++ b/src/d.ts
@@ -8,22 +8,23 @@ import {
 	WNode,
 	Widget,
 	WidgetOptions,
-	WidgetState
+	WidgetState,
+	WidgetProperties
 } from './interfaces';
 import FactoryRegistry from './FactoryRegistry';
 
 export const registry = new FactoryRegistry();
 
-export function w<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
+export function w<P extends WidgetProperties, S extends WidgetState, W extends Widget<S, P>, O extends WidgetOptions<S, P>>(
 	factory: ComposeFactory<W, O> | string,
 	options: O
 ): WNode;
-export function w<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
+export function w<P extends WidgetProperties, S extends WidgetState, W extends Widget<S, P>, O extends WidgetOptions<S, P>>(
 	factory: ComposeFactory<W, O> | string,
 	options: O,
 	children?: DNode[]
 ): WNode;
-export function w<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
+export function w<P extends WidgetProperties, S extends WidgetState, W extends Widget<S, P>, O extends WidgetOptions<S, P>>(
 	factory: ComposeFactory<W, O> | string,
 	options: O,
 	children: DNode[] = []
@@ -36,20 +37,20 @@ export function w<S extends WidgetState, W extends Widget<S>, O extends WidgetOp
 	};
 }
 
-export function v(tag: string, options: VNodeProperties, children?: DNode[]): HNode;
+export function v(tag: string, properties: VNodeProperties, children?: DNode[]): HNode;
 export function v(tag: string, children: DNode[]): HNode;
 export function v(tag: string): HNode;
-export function v(tag: string, optionsOrChildren: VNodeProperties = {}, children: DNode[] = []): HNode {
+export function v(tag: string, propertiesOrChildren: VNodeProperties = {}, children: DNode[] = []): HNode {
 
-		if (Array.isArray(optionsOrChildren)) {
-			children = optionsOrChildren;
-			optionsOrChildren = {};
+		if (Array.isArray(propertiesOrChildren)) {
+			children = propertiesOrChildren;
+			propertiesOrChildren = {};
 		}
 
 		return {
 			children,
 			render<T>(this: { children: VNode[] }, options: { bind?: T } = { }) {
-				return h(tag, assign(options, optionsOrChildren), this.children);
+				return h(tag, assign(options, propertiesOrChildren), this.children);
 			}
 		};
 }

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -214,8 +214,9 @@ export interface WidgetOptions<S extends WidgetState, P extends WidgetProperties
 }
 
 export interface WidgetProperties {
-
 	[key: string]: any;
+
+	id?: string;
 }
 
 export interface WidgetState {

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -4,9 +4,8 @@
  * Additional features and functionality are added to widgets by compositing mixins onto these
  * bases.
  */
-
 import Promise from 'dojo-shim/Promise';
-import { EventedListener, State, Stateful, StatefulOptions } from 'dojo-interfaces/bases';
+import { EventedListener, Stateful, StatefulOptions } from 'dojo-interfaces/bases';
 import { EventTargettedObject, Handle, StylesMap } from 'dojo-interfaces/core';
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
 import { ComposeFactory } from 'dojo-compose/compose';
@@ -16,14 +15,14 @@ import { VNodeEvented, VNodeEventedOptions } from './mixins/createVNodeEvented';
  * A function that is called to return top level node
  */
 export interface NodeFunction {
-	(this: Widget<WidgetState>): DNode;
+	(this: Widget<WidgetState, WidgetProperties>): DNode;
 }
 
 /**
  * A function that is called when collecting the children nodes on render.
  */
 export interface ChildNodeFunction {
-	(this: Widget<WidgetState>): DNode[];
+	(this: Widget<WidgetState, WidgetProperties>): DNode[];
 }
 
 /**
@@ -85,7 +84,7 @@ export interface WNode {
 	/**
 	 * Options used to create factory a widget
 	 */
-	options: WidgetOptions<WidgetState>;
+	options: WidgetOptions<WidgetState, WidgetProperties>;
 
 	/**
 	 * DNode children
@@ -95,9 +94,9 @@ export interface WNode {
 
 export type DNode = HNode | WNode | string | null;
 
-export type Widget<S extends WidgetState> = Stateful<S> & WidgetMixin & WidgetOverloads & VNodeEvented;
+export type Widget<S extends WidgetState, P extends WidgetProperties> = Stateful<S> & WidgetMixin<P> & WidgetOverloads & VNodeEvented;
 
-export interface WidgetFactory extends ComposeFactory<Widget<WidgetState>, WidgetOptions<WidgetState>> {}
+export interface WidgetFactory extends ComposeFactory<Widget<WidgetState, WidgetProperties>, WidgetOptions<WidgetState, WidgetProperties>> {}
 
 export interface WidgetOverloads {
 	/**
@@ -106,10 +105,10 @@ export interface WidgetOverloads {
 	 * @param type The event type to listen for
 	 * @param listener The listener to call when the event is emitted
 	 */
-	on(type: 'invalidated', listener: EventedListener<Widget<WidgetState>, EventTargettedObject<Widget<WidgetState>>>): Handle;
+	on(type: 'invalidated', listener: EventedListener<Widget<WidgetState, WidgetProperties>, EventTargettedObject<Widget<WidgetState, WidgetProperties>>>): Handle;
 }
 
-export interface WidgetMixin {
+export interface WidgetMixin<P extends WidgetProperties> {
 	/**
 	 * Classes which are applied upon render.
 	 *
@@ -142,6 +141,21 @@ export interface WidgetMixin {
 	getNodeAttributes(): VNodeProperties;
 
 	/**
+	 * Properties passed to affect state
+	 */
+	properties: Partial<P>;
+
+	/**
+	 * Determine changed or new property keys on render.
+	 */
+	diffProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: P): string[];
+
+	/**
+	 * Process change in properties
+	 */
+	processPropertiesChange(previousProperties: Partial<P>, currentProperties: Partial<P>): void;
+
+	/**
 	 * The ID of the widget, which gets automatically rendered in the VNode property `data-widget-id` when
 	 * rendered.
 	 */
@@ -161,7 +175,7 @@ export interface WidgetMixin {
 	 * making it easy for mixins to alter the behaviour of the render process without needing to override or aspect
 	 * the `getNodeAttributes` method.
 	 */
-	nodeAttributes: NodeAttributeFunction<Widget<WidgetState>>[];
+	nodeAttributes: NodeAttributeFunction<Widget<WidgetState, WidgetProperties>>[];
 
 	/**
 	 * Render the widget, returing the virtual DOM node that represents this widget.
@@ -190,24 +204,21 @@ export interface WidgetMixin {
 	readonly registry: FactoryRegistryInterface;
 }
 
-export interface WidgetOptions<S extends WidgetState> extends StatefulOptions<S>, VNodeEventedOptions {
+export interface WidgetOptions<S extends WidgetState, P extends WidgetProperties> extends StatefulOptions<S>, VNodeEventedOptions {
 	/**
-	 * Any classes that should be added to this instances
+	 * Properties used to affect internal widget state
 	 */
-	classes?: string[];
+	properties?: P;
 
-	/**
-	 * Any node attribute functions that should be added to this instance
-	 */
-	nodeAttributes?: NodeAttributeFunction<Widget<WidgetState>> | NodeAttributeFunction<Widget<WidgetState>>[];
-
-	/**
-	 * Override the tag name for this widget instance
-	 */
 	tagName?: string;
 }
 
-export interface WidgetState extends State {
+export interface WidgetProperties {
+
+	[key: string]: any;
+}
+
+export interface WidgetState {
 	/**
 	 * Any classes that should be mixed into the widget's VNode upon render.
 	 *

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -151,9 +151,9 @@ export interface WidgetMixin<P extends WidgetProperties> {
 	diffProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: P): string[];
 
 	/**
-	 * Process change in properties
+	 * apply change in properties
 	 */
-	processPropertiesChange(previousProperties: Partial<P>, currentProperties: Partial<P>): void;
+	applyChangedProperties(previousProperties: Partial<P>, currentProperties: Partial<P>): void;
 
 	/**
 	 * The ID of the widget, which gets automatically rendered in the VNode property `data-widget-id` when

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -215,8 +215,6 @@ export interface WidgetOptions<S extends WidgetState, P extends WidgetProperties
 
 export interface WidgetProperties {
 	[key: string]: any;
-
-	id?: string;
 }
 
 export interface WidgetState {

--- a/src/mixins/createCssTransitionMixin.ts
+++ b/src/mixins/createCssTransitionMixin.ts
@@ -2,9 +2,9 @@ import { VNodeProperties } from 'dojo-interfaces/vdom';
 import compose, { ComposeFactory } from 'dojo-compose/compose';
 import { NodeAttributeFunction } from './../interfaces';
 import createStateful from 'dojo-compose/bases/createStateful';
-import { State, Stateful, StatefulOptions } from 'dojo-interfaces/bases';
+import { Stateful, StatefulOptions } from 'dojo-interfaces/bases';
 
-export type CssTransitionMixinState = State & {
+export type CssTransitionMixinState = {
 	/**
 	 * The class of the CSS animation to be applied as the widget enters the dom
 	 */

--- a/src/mixins/createFormFieldMixin.ts
+++ b/src/mixins/createFormFieldMixin.ts
@@ -3,7 +3,7 @@ import { ComposeFactory } from 'dojo-compose/compose';
 import createStateful from 'dojo-compose/bases/createStateful';
 import createCancelableEvent from 'dojo-compose/bases/createCancelableEvent';
 import { EventTargettedObject, EventCancelableObject, Handle } from 'dojo-interfaces/core';
-import { EventedListener, Stateful, State, StatefulOptions } from 'dojo-interfaces/bases';
+import { EventedListener, Stateful, StatefulOptions } from 'dojo-interfaces/bases';
 import { assign } from 'dojo-core/lang';
 import { NodeAttributeFunction } from './../interfaces';
 
@@ -19,7 +19,7 @@ export interface FormFieldMixinOptions<V, S extends FormFieldMixinState<V>> exte
 	value?: V;
 }
 
-export interface FormFieldMixinState<V> extends State {
+export interface FormFieldMixinState<V> {
 	/**
 	 * Whether the field is currently disabled or not
 	 */

--- a/tests/unit/components/button/createButton.ts
+++ b/tests/unit/components/button/createButton.ts
@@ -1,13 +1,13 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { VNode } from 'dojo-interfaces/vdom';
-import createButton, { ButtonState } from '../../../../src/components/button/createButton';
+import createButton from '../../../../src/components/button/createButton';
 
 registerSuite({
 	name: 'createButton',
 	construction() {
 		const button = createButton({
-			state: {
+			properties: {
 				id: 'foo',
 				label: 'bar',
 				name: 'baz'
@@ -19,7 +19,7 @@ registerSuite({
 	},
 	render() {
 		const button = createButton({
-			state: {
+			properties: {
 				id: 'foo',
 				label: 'bar',
 				name: 'baz'
@@ -35,7 +35,7 @@ registerSuite({
 	},
 	disable() {
 		const button = createButton({
-			state: <ButtonState> {
+			properties: {
 				id: 'foo',
 				label: 'bar',
 				name: 'baz'

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -96,10 +96,11 @@ registerSuite({
 			assert.lengthOf(updatedKeys, 1);
 		}
 	},
-	processPropertiesChange() {
-		const widgetBase = createWidgetBase();
-		widgetBase.processPropertiesChange({}, { foo: 'bar' });
+	applyChangedProperties() {
+		const widgetBase = createWidgetBase({ id: 'id' });
+		widgetBase.applyChangedProperties({}, { foo: 'bar' });
 		assert.equal((<any> widgetBase.state).foo, 'bar');
+		assert.equal(widgetBase.state.id, 'id');
 	},
 	getChildrenNodes: {
 		'getChildrenNodes with no ChildNodeRenderers'() {

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -2,7 +2,7 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import Promise from 'dojo-shim/Promise';
 import createWidgetBase from '../../src/createWidgetBase';
-import { DNode, HNode, WidgetState, WidgetOptions } from './../../src/interfaces';
+import { DNode, HNode, WidgetState, WidgetOptions, WidgetProperties } from './../../src/interfaces';
 import { VNode } from 'dojo-interfaces/vdom';
 import { v, w, registry } from '../../src/d';
 import { stub } from 'sinon';
@@ -56,7 +56,7 @@ registerSuite({
 		};
 
 		const widgetBase = createWidgetBase({
-			state: { id: 'foo', classes: [ 'bar' ] },
+			properties: { id: 'foo', classes: [ 'bar' ] },
 			listeners: {
 				click: expectedClickFunction
 			}
@@ -76,6 +76,30 @@ registerSuite({
 		nodeAttributes = widgetBase.getNodeAttributes();
 
 		assert.deepEqual(nodeAttributes.classes, { foo: true, bar: false });
+	},
+	diffProperties: {
+		'no updated properties'() {
+			const widgetBase = createWidgetBase({ properties: { id: 'id', foo: 'bar' }});
+			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' });
+			assert.lengthOf(updatedKeys, 0);
+		},
+		'updated properties'() {
+			const widgetBase = createWidgetBase({ properties: { id: 'id', foo: 'bar' }});
+			widgetBase.properties = { id: 'id', foo: 'baz' };
+			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' });
+			assert.lengthOf(updatedKeys, 1);
+		},
+		'new properties'() {
+			const widgetBase = createWidgetBase({ properties: { id: 'id', foo: 'bar' }});
+			widgetBase.properties = { id: 'id', foo: 'bar', bar: 'baz' };
+			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' });
+			assert.lengthOf(updatedKeys, 1);
+		}
+	},
+	processPropertiesChange() {
+		const widgetBase = createWidgetBase();
+		widgetBase.processPropertiesChange({}, { foo: 'bar' });
+		assert.equal((<any> widgetBase.state).foo, 'bar');
 	},
 	getChildrenNodes: {
 		'getChildrenNodes with no ChildNodeRenderers'() {
@@ -332,9 +356,9 @@ registerSuite({
 				.mixin({
 					mixin: {
 						getChildrenNodes: function(this: any): (DNode | null)[] {
-							const state = this.state.classes ? { classes: this.state.classes } : {};
+							const properties: WidgetProperties = this.state.classes ? { classes: this.state.classes } : {};
 							return [
-								this.state.hide ? null : w(testChildWidget, <WidgetOptions<WidgetState>> { tagName: 'footer', state })
+								this.state.hide ? null : w(testChildWidget, { tagName: 'footer', properties })
 							];
 						}
 					}
@@ -366,7 +390,7 @@ registerSuite({
 			assert.strictEqual(thirdRenderChild.vnodeSelector, 'footer');
 			assert.isTrue(thirdRenderChild.properties.classes['test-class']);
 
-			widgetBase.setState({ hide: true });
+			widgetBase.setState(<any> { hide: true });
 			widgetBase.invalidate();
 
 			const forthRenderResult = <VNode> widgetBase.__render__();
@@ -374,7 +398,7 @@ registerSuite({
 			assert.strictEqual(countWidgetDestroyed, 1);
 			assert.lengthOf(forthRenderResult.children, 0);
 
-			widgetBase.setState({ hide: false });
+			widgetBase.setState(<any> { hide: false });
 			widgetBase.invalidate();
 
 			const lastRenderResult = <VNode> widgetBase.__render__();
@@ -402,9 +426,51 @@ registerSuite({
 			assert.isTrue(consoleStub.calledWith('must provide unique keys when using the same widget factory multiple times'));
 			consoleStub.restore();
 		},
+		'render with updated properties'() {
+			let renderCount = 0;
+			const createMyWidget = createWidgetBase.mixin({
+				mixin: {
+					nodeAttributes: [
+						function(this: any): any {
+							const { state: { foo, bar } } = this;
+
+							return { foo, bar };
+						}
+					]
+				}
+			});
+			const widgetBase = createWidgetBase
+				.mixin({
+					mixin: {
+						getChildrenNodes: function(): DNode[] {
+							const options: (WidgetOptions<WidgetState, (WidgetProperties & { foo: string, bar?: string })>) = { properties: { foo: 'bar' }};
+
+							if (renderCount === 1) {
+								options.properties!.bar = 'baz';
+								options.properties!.foo = 'baz';
+							}
+
+							renderCount++;
+
+							return [
+								w(createMyWidget, options)
+							];
+						}
+					}
+				})();
+
+			let result = <VNode> widgetBase.__render__();
+			assert.isUndefined(result!.children![0].properties!['bar']);
+			assert.equal(result!.children![0].properties!['foo'], 'bar');
+
+			widgetBase.invalidate();
+			result = <VNode> widgetBase.__render__();
+			assert.equal(result!.children![0].properties!['foo'], 'baz');
+			assert.equal(result!.children![0].properties!['bar'], 'baz');
+		},
 		'__render__() and invalidate()'() {
 			const widgetBase = createWidgetBase({
-				state: { id: 'foo', label: 'foo' }
+				properties: { id: 'foo', label: 'foo' }
 			});
 			const result1 = <VNode> widgetBase.__render__();
 			const result2 = <VNode> widgetBase.__render__();
@@ -433,27 +499,27 @@ registerSuite({
 		},
 		'in state'() {
 			const widgetBase = createWidgetBase({
-				state: {
+				properties: {
 					id: 'foo'
 				}
 			});
 
 			assert.strictEqual(widgetBase.id, 'foo');
 		},
-		'in options and state'() {
+		'in options and properties'() {
 			const widgetBase = createWidgetBase({
 				id: 'foo',
-				state: {
+				properties: {
 					id: 'bar'
 				}
 			});
 
-			assert.strictEqual(widgetBase.id, 'foo');
+			assert.strictEqual(widgetBase.id, 'bar');
 		},
-		'not in options or state'() {
+		'not in options or properties'() {
 			const widgetBase = createWidgetBase();
 
-			assert.strictEqual(widgetBase.id, 'widget-1');
+			assert.include(widgetBase.id, 'widget-');
 		},
 		'is read only'() {
 			const widgetBase = createWidgetBase();

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -1,6 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { WidgetState, WidgetOptions } from './../../src/interfaces';
+import { WidgetOptions, WidgetState, WidgetProperties } from './../../src/interfaces';
 import createWidgetBase from '../../src/createWidgetBase';
 import { v, w, registry } from '../../src/d';
 import FactoryRegistry from './../../src/FactoryRegistry';
@@ -18,23 +18,23 @@ registerSuite({
 	},
 	w: {
 		'create WNode wrapper'() {
-			const options: WidgetOptions<WidgetState> = { tagName: 'header', state: { hello: 'world' } };
+			const options: WidgetOptions<WidgetState, WidgetProperties> = { id: 'id', tagName: 'header', properties: { hello: 'world' }};
 			const dNode = w(createWidgetBase, options);
 			assert.deepEqual(dNode.factory, createWidgetBase);
-			assert.deepEqual(dNode.options, options);
+			assert.deepEqual(dNode.options, { id: 'id', tagName: 'header', properties: { hello: 'world' } });
 		},
 		'create WNode wrapper using a factory label'() {
 			registry.define('my-widget', createWidgetBase);
-			const options: WidgetOptions<WidgetState> = { tagName: 'header', state: { hello: 'world' } };
+			const options: WidgetOptions<WidgetState, WidgetProperties> = { id: 'id', tagName: 'header', properties: { hello: 'world' }};
 			const dNode = w('my-widget', options);
 			assert.deepEqual(dNode.factory, 'my-widget');
-			assert.deepEqual(dNode.options, options);
+			assert.deepEqual(dNode.options, { id: 'id', tagName: 'header', properties: { hello: 'world' } });
 		},
 		'create WNode wrapper with children'() {
-			const options: WidgetOptions<WidgetState> = { tagName: 'header', state: { hello: 'world' } };
+			const options: WidgetOptions<WidgetState, WidgetProperties> = { id: 'id', tagName: 'header', properties: { hello: 'world' }};
 			const dNode = w(createWidgetBase, options, [ w(createWidgetBase, options) ]);
 			assert.deepEqual(dNode.factory, createWidgetBase);
-			assert.deepEqual(dNode.options, options);
+			assert.deepEqual(dNode.options, { id: 'id', tagName: 'header', properties: { hello: 'world' } });
 			assert.lengthOf(dNode.children, 1);
 		}
 	},

--- a/tests/unit/integrations.ts
+++ b/tests/unit/integrations.ts
@@ -2,7 +2,6 @@ import 'dojo/has!host-node?../support/loadJsdom';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { h, createProjector } from 'maquette';
-import * as rx from 'rxjs/Rx';
 
 registerSuite({
 	name: 'integrations',
@@ -28,8 +27,5 @@ registerSuite({
 			assert.strictEqual(nodes[0].firstChild!.firstChild!.textContent, 'Greetings');
 			assert.strictEqual((<HTMLDivElement> nodes[0].firstChild).className, 'saucer foo');
 		}
-	},
-	rx() {
-		assert(rx);
 	}
 });

--- a/tests/unit/mixins/createCssTransitionMixin.ts
+++ b/tests/unit/mixins/createCssTransitionMixin.ts
@@ -9,12 +9,13 @@ registerSuite({
 		assert.isDefined(cssTranistionMixin);
 	},
 	'getNodeAttributes()'() {
-		const cssTranistionMixin = createCssTransitionMixin({
-			state: {
-				enterAnimation: 'enter-animation-class',
-				exitAnimation: 'exit-animation-class'
-			}
+		const cssTranistionMixin = createCssTransitionMixin({});
+
+		cssTranistionMixin.setState({
+			enterAnimation: 'enter-animation-class',
+			exitAnimation: 'exit-animation-class'
 		});
+
 		const nodeAttributes = cssTranistionMixin.nodeAttributes[0].call(cssTranistionMixin, {});
 		assert.strictEqual(nodeAttributes.enterAnimation, 'enter-animation-class');
 		assert.strictEqual(nodeAttributes.exitAnimation, 'exit-animation-class');

--- a/tests/unit/mixins/createFormFieldMixin.ts
+++ b/tests/unit/mixins/createFormFieldMixin.ts
@@ -6,12 +6,13 @@ registerSuite({
 	name: 'mixins/createFormFieldMixin',
 	construction() {
 		const formfield = createFormFieldMixin({
-			type: 'foo',
-			state: {
-				name: 'foo',
-				value: 2,
-				disabled: false
-			}
+			type: 'foo'
+		});
+
+		formfield.setState({
+			name: 'foo',
+			value: 2,
+			disabled: false
 		});
 		assert.strictEqual(formfield.value, '2');
 		assert.strictEqual(formfield.state.value, 2);
@@ -21,23 +22,13 @@ registerSuite({
 	},
 	'.value'() {
 		const value = { foo: 'foo' };
-		const formfield = createFormFieldMixin({
-			state: { value }
-		});
+		const formfield = createFormFieldMixin({});
+
+		formfield.setState({ value });
 
 		assert.strictEqual(formfield.value, '{"foo":"foo"}');
 		formfield.setState({ value: { foo: 'bar' } });
 		assert.deepEqual(formfield.value, '{"foo":"bar"}');
-	},
-	'.value - setState'() {
-		let count = 0;
-		const createAfterFormFieldMixin = createFormFieldMixin
-			.after('setState', () => count++);
-		const formfield = createAfterFormFieldMixin<string>();
-		formfield.value = 'foo';
-		assert.strictEqual(count, 1);
-		formfield.value = 'foo';
-		assert.strictEqual(count, 1);
 	},
 	'valuechange event': {
 		'emitted'() {
@@ -93,12 +84,10 @@ registerSuite({
 	'getNodeAttributes()': {
 		'truthy value'() {
 			const formfield = createFormFieldMixin({
-				type: 'foo',
-				state: {
-					value: 'bar',
-					name: 'baz'
-				}
+				type: 'foo'
 			});
+
+			formfield.setState({ value: 'bar', name: 'baz' });
 
 			let nodeAttributes = formfield.nodeAttributes[0].call(formfield, {});
 			assert.strictEqual(nodeAttributes['type'], 'foo');
@@ -124,11 +113,11 @@ registerSuite({
 		},
 		'falsey value'() {
 			const formfield = createFormFieldMixin({
-				type: 'foo',
-				state: {
-					value: '',
-					name: 'baz'
-				}
+				type: 'foo'
+			});
+
+			formfield.setState({
+				value: ''
 			});
 
 			let nodeAttributes = formfield.nodeAttributes[0].call(formfield, {});

--- a/typings.json
+++ b/typings.json
@@ -1,8 +1,7 @@
 {
 	"name": "dojo-widgets",
 	"globalDependencies": {
-		"extra-rxjs": "github:dojo/typings/custom/dojo2-extras/rxjs.d.ts#103096ce945dd51a18cc47a9b7cf9191fdac0349",
-		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#9a0185f465a3febe2bb1ff3f1210f43e5f96c5d2"
+		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#003aa24b3448804a2c59e9a1d9740ca56e067e79"
 	},
 	"globalDevDependencies": {
 		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1"


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Support properties that can be passed to widgets that will be used to internally update state on the widget.

By default only new or updated properties will be used to update state automatically. The functions are public and can be customised by a widget consumer if they require different equality checks for current and previous properties or need to perform some mapping or logic to from the properties to the internal state.

Will be dependant on interfaces/compose changes.

Resolves #176
