### PR TITLE
Support props to update internal state

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ These are some of the **important** principles to keep in mind when developing w
 1. the widget *render* function should **never** be overridden
 2. with the exception of the top level projector you should **never** have to deal with widget instances.
 3. hyperscript should **always** be written using the dojo-widgets `v` helper function.
+4. `state` should **never** be set outside of the widget instance.
 
 ### Base Widget
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,8 @@ registry.define('my-widget', () => {
 
 Creates a dojo-widget using the `factory` and `properties`.
 
+**Note:** properties for `id` and `tagName` are automatically copied from the widget properties object and added to the widget options object used when instatiating the widget internally.
+
 ```ts
 w(factory: string | ComposeFactory<W, O>, properties: O): WNode[];
 ```

--- a/package.json
+++ b/package.json
@@ -23,7 +23,6 @@
     "test": "grunt test"
   },
   "peerDependencies": {
-    "@reactivex/rxjs": "5.0.0-beta.6",
     "dojo-compose": ">=2.0.0-beta.10",
     "dojo-core": ">=2.0.0-alpha.14",
     "dojo-has": ">=2.0.0-alpha.4",

--- a/src/components/button/createButton.ts
+++ b/src/components/button/createButton.ts
@@ -8,9 +8,13 @@ export interface ButtonState extends WidgetState, FormFieldMixinState<string> {
 	label?: string;
 }
 
-export interface ButtonOptions extends WidgetOptions<ButtonState>, FormFieldMixinOptions<any, ButtonState> { }
+export interface ButtonProperties {
+	label: string;
+}
 
-export type Button = Widget<ButtonState> & FormFieldMixin<string, ButtonState>;
+export interface ButtonOptions extends WidgetOptions<ButtonState, ButtonProperties>, FormFieldMixinOptions<any, ButtonState> { }
+
+export type Button = Widget<ButtonState, ButtonProperties> & FormFieldMixin<string, ButtonState>;
 
 export interface ButtonFactory extends ComposeFactory<Button, ButtonOptions> { }
 

--- a/src/components/textinput/createTextInput.ts
+++ b/src/components/textinput/createTextInput.ts
@@ -1,6 +1,6 @@
 import { ComposeFactory } from 'dojo-compose/compose';
 import createWidgetBase from '../../createWidgetBase';
-import { Widget, WidgetOptions, WidgetState } from './../../interfaces';
+import { Widget, WidgetOptions, WidgetState, WidgetProperties } from './../../interfaces';
 import createFormFieldMixin, { FormFieldMixin, FormFieldMixinState, FormFieldMixinOptions } from '../../mixins/createFormFieldMixin';
 
 /* TODO: I suspect this needs to go somewhere else */
@@ -10,9 +10,9 @@ export interface TypedTargetEvent<T extends EventTarget> extends Event {
 
 export type TextInputState = WidgetState & FormFieldMixinState<string>;
 
-export type TextInputOptions = WidgetOptions<TextInputState> & FormFieldMixinOptions<string, TextInputState>;
+export type TextInputOptions = WidgetOptions<TextInputState, WidgetProperties> & FormFieldMixinOptions<string, TextInputState>;
 
-export type TextInput = Widget<TextInputState> & FormFieldMixin<string, TextInputState>;
+export type TextInput = Widget<TextInputState, WidgetProperties> & FormFieldMixin<string, TextInputState>;
 
 export interface TextInputFactory extends ComposeFactory<TextInput, TextInputOptions> { }
 

--- a/src/createProjector.ts
+++ b/src/createProjector.ts
@@ -1,7 +1,7 @@
 import { ComposeFactory } from 'dojo-compose/compose';
 import { EventTargettedObject, Handle } from 'dojo-interfaces/core';
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
-import { Widget, WidgetState, WidgetOptions } from './interfaces';
+import { Widget, WidgetState, WidgetOptions, WidgetProperties } from './interfaces';
 import WeakMap from 'dojo-shim/WeakMap';
 import { createProjector as createMaquetteProjector, Projector as MaquetteProjector } from 'maquette';
 import createWidgetBase from './createWidgetBase';
@@ -37,7 +37,7 @@ export interface AttachOptions {
 /**
  * Projector interface
  */
-export interface ProjectorOptions extends WidgetOptions<WidgetState> {
+export interface ProjectorOptions extends WidgetOptions<WidgetState, WidgetProperties> {
 
 	/**
 	 * An optional root of the projector
@@ -98,7 +98,7 @@ interface ProjectorData {
 	afterCreate?: () => void;
 }
 
-export type Projector = Widget<WidgetState> & ProjectorMixin;
+export type Projector = Widget<WidgetState, WidgetProperties> & ProjectorMixin;
 
 export interface ProjectorFactory extends ComposeFactory<Projector, ProjectorOptions> { }
 

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -155,8 +155,8 @@ function generateProperties(instance: Widget<WidgetState, WidgetProperties>, pre
 	};
 
 	changedPropertyKeys.forEach((key) => {
-		if (instance.properties[key]) {
 			changedProperties.currentProperties[key] = instance.properties[key];
+		if (previousProperties[key]) {
 			changedProperties.previousProperties[key] = previousProperties[key];
 		}
 	});

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -7,6 +7,7 @@ import {
 	WidgetMixin,
 	WidgetState,
 	WidgetOptions,
+	WidgetProperties,
 	WidgetFactory,
 	FactoryRegistryItem
 } from './interfaces';
@@ -21,37 +22,36 @@ import createVNodeEvented from './mixins/createVNodeEvented';
 
 interface WidgetInternalState {
 	children: DNode[];
-	readonly id?: string;
+	readonly id: string;
 	dirty: boolean;
 	widgetClasses: string[];
 	cachedVNode?: VNode | string;
 	factoryRegistry: FactoryRegistry;
 	initializedFactoryMap: Map<string, Promise<WidgetFactory>>;
-	historicChildrenMap: Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState>>;
-	currentChildrenMap: Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState>>;
+	previousProperties: any;
+	historicChildrenMap: Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState, WidgetProperties>>;
+	currentChildrenMap: Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState, WidgetProperties>>;
 };
 
 /**
  * Internal state map for widget instances
  */
-const widgetInternalStateMap = new WeakMap<Widget<WidgetState>, WidgetInternalState>();
+const widgetInternalStateMap = new WeakMap<Widget<WidgetState, WidgetProperties>, WidgetInternalState>();
 
 /**
  * The counter for generating a unique ID
  */
 let widgetCount = 0;
 
-function generateID(instance: Widget<WidgetState>): string {
-	const id = `widget-${++widgetCount}`;
-	instance.setState({ id });
-	return id;
+function generateID(instance: Widget<WidgetState, WidgetProperties>): string {
+	return `widget-${++widgetCount}`;
 }
 
 function isWNode(child: DNode): child is WNode {
 	return Boolean(child && (<WNode> child).factory !== undefined);
 }
 
-function getFromRegistry(instance: Widget<WidgetState>, factoryLabel: string): FactoryRegistryItem | null {
+function getFromRegistry(instance: Widget<WidgetState, WidgetProperties>, factoryLabel: string): FactoryRegistryItem | null {
 	if (instance.registry.has(factoryLabel)) {
 		return instance.registry.get(factoryLabel);
 	}
@@ -59,7 +59,7 @@ function getFromRegistry(instance: Widget<WidgetState>, factoryLabel: string): F
 	return registry.get(factoryLabel);
 }
 
-function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode | string | null {
+function dNodeToVNode(instance: Widget<WidgetState, WidgetProperties>, dNode: DNode): VNode | string | null {
 	const internalState = widgetInternalStateMap.get(instance);
 
 	if (typeof dNode === 'string' || dNode === null) {
@@ -67,10 +67,10 @@ function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode | stri
 	}
 
 	if (isWNode(dNode)) {
-		const { children, options: { id, state } } = dNode;
+		const { children, options: { id, properties } } = dNode;
 
 		let { factory } = dNode;
-		let child: Widget<WidgetState>;
+		let child: Widget<WidgetState, WidgetProperties>;
 
 		if (typeof factory === 'string') {
 			const item = getFromRegistry(instance, factory);
@@ -95,8 +95,8 @@ function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode | stri
 
 		if (cachedChild) {
 			child = cachedChild;
-			if (state) {
-				child.setState(state);
+			if (properties) {
+				child.properties = properties;
 			}
 		}
 		else {
@@ -128,7 +128,7 @@ function dNodeToVNode(instance: Widget<WidgetState>, dNode: DNode): VNode | stri
 	return dNode.render({ bind: instance });
 }
 
-function manageDetachedChildren(instance: Widget<WidgetState>): void {
+function manageDetachedChildren(instance: Widget<WidgetState, WidgetProperties>): void {
 	const internalState = widgetInternalStateMap.get(instance);
 
 	internalState.historicChildrenMap.forEach((child, key) => {
@@ -147,10 +147,29 @@ function formatTagNameAndClasses(tagName: string, classes: string[]) {
 	return tagName;
 }
 
+function generateProperties(instance: Widget<WidgetState, WidgetProperties>, previousProperties: any): any {
+	const changedPropertyKeys = instance.diffProperties(previousProperties);
+	const changedProperties: { currentProperties: any, previousProperties: any } = {
+		currentProperties: {},
+		previousProperties: {}
+	};
+
+	changedPropertyKeys.forEach((key) => {
+		if (instance.properties[key]) {
+			changedProperties.currentProperties[key] = instance.properties[key];
+			changedProperties.previousProperties[key] = previousProperties[key];
+		}
+	});
+
+	return changedProperties;
+}
+
 const createWidget: WidgetFactory = createStateful
 	.mixin(createVNodeEvented)
-	.mixin<WidgetMixin, WidgetOptions<WidgetState>>({
+	.mixin<WidgetMixin<WidgetProperties>, WidgetOptions<WidgetState, WidgetProperties>>({
 		mixin: {
+			properties: {},
+
 			classes: [],
 
 			getNode(): DNode {
@@ -158,7 +177,7 @@ const createWidget: WidgetFactory = createStateful
 				return v(tag, this.getNodeAttributes(), this.getChildrenNodes());
 			},
 
-			set children(this: Widget<WidgetState>, children: DNode[]) {
+			set children(this: Widget<WidgetState, WidgetProperties>, children: DNode[]) {
 				const internalState = widgetInternalStateMap.get(this);
 				internalState.children = children;
 				this.emit({
@@ -171,11 +190,11 @@ const createWidget: WidgetFactory = createStateful
 				return widgetInternalStateMap.get(this).children;
 			},
 
-			getChildrenNodes(this: Widget<WidgetState>): DNode[] {
+			getChildrenNodes(this: Widget<WidgetState, WidgetProperties>): DNode[] {
 				return this.children;
 			},
 
-			getNodeAttributes(this: Widget<WidgetState>, overrides?: VNodeProperties): VNodeProperties {
+			getNodeAttributes(this: Widget<WidgetState, WidgetProperties>, overrides?: VNodeProperties): VNodeProperties {
 				const props: VNodeProperties = {};
 
 				this.nodeAttributes.forEach((fn) => {
@@ -188,7 +207,7 @@ const createWidget: WidgetFactory = createStateful
 				return props;
 			},
 
-			invalidate(this: Widget<WidgetState>): void {
+			invalidate(this: Widget<WidgetState, WidgetProperties>): void {
 				const internalState = widgetInternalStateMap.get(this);
 				internalState.dirty = true;
 				this.emit({
@@ -197,16 +216,37 @@ const createWidget: WidgetFactory = createStateful
 				});
 			},
 
-			get id(this: Widget<WidgetState>): string {
+			get id(this: Widget<WidgetState, WidgetProperties>): string {
 				const { id } = widgetInternalStateMap.get(this);
 
-				return id || (this.state && this.state.id) || generateID(this);
+				return id;
+			},
+
+			processPropertiesChange: function(this: Widget<WidgetState, WidgetProperties>, previousProperties: any, currentProperties): void {
+				if (Object.keys(currentProperties).length) {
+					this.state = currentProperties;
+				}
+			},
+
+			diffProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: any): string[] {
+				const changedPropertyKeys: string[] = [];
+				Object.keys(this.properties).forEach((key) => {
+					if (previousProperties[key]) {
+						if (previousProperties[key] !== this.properties[key]) {
+							changedPropertyKeys.push(key);
+						}
+					}
+					else {
+						changedPropertyKeys.push(key);
+					}
+				});
+				return changedPropertyKeys;
 			},
 
 			nodeAttributes: [
-				function (this: Widget<WidgetState>): VNodeProperties {
+				function (this: Widget<WidgetState, WidgetProperties>): VNodeProperties {
 					const baseIdProp = this.state && this.state.id ? { 'data-widget-id': this.state.id } : {};
-					const { styles = {} } = this.state;
+					const { styles = {} } = this.state || {};
 					const classes: { [index: string]: boolean; } = {};
 
 					const internalState = widgetInternalStateMap.get(this);
@@ -221,10 +261,13 @@ const createWidget: WidgetFactory = createStateful
 					return assign(baseIdProp, { key: this, classes, styles });
 				}
 
-			],
+		],
 
-			__render__(this: Widget<WidgetState>): VNode | string | null {
+			__render__(this: Widget<WidgetState, WidgetProperties>): VNode | string | null {
 				const internalState = widgetInternalStateMap.get(this);
+				const updatedProperties = generateProperties(this, internalState.previousProperties);
+				this.processPropertiesChange(updatedProperties.previousProperties, updatedProperties.currentProperties);
+
 				if (internalState.dirty || !internalState.cachedVNode) {
 					const widget = dNodeToVNode(this, this.getNode());
 					manageDetachedChildren(this);
@@ -232,29 +275,39 @@ const createWidget: WidgetFactory = createStateful
 						internalState.cachedVNode = widget;
 					}
 					internalState.dirty = false;
+					internalState.previousProperties = this.properties;
 					return widget;
 				}
 				return internalState.cachedVNode;
 			},
 
-			get registry(this: Widget<WidgetState>): FactoryRegistry {
+			get registry(this: Widget<WidgetState, WidgetProperties>): FactoryRegistry {
 				return widgetInternalStateMap.get(this).factoryRegistry;
 			},
 
 			tagName: 'div'
 		},
-		initialize(instance: Widget<WidgetState>, options: WidgetOptions<WidgetState> = {}) {
-			const { id, tagName } = options;
+		initialize(instance: Widget<WidgetState, WidgetProperties>, options: WidgetOptions<WidgetState, { id?: string }> = {}) {
+			const { tagName, properties = {} } = options;
+			const id = properties.id || options.id || generateID(instance);
+
+			if (!properties.id) {
+				properties.id = id;
+			}
+
+			instance.properties = properties;
 			instance.tagName = tagName || instance.tagName;
+			instance.processPropertiesChange({}, properties);
 
 			widgetInternalStateMap.set(instance, {
 				id,
 				dirty: true,
 				widgetClasses: [],
+				previousProperties: properties,
 				factoryRegistry: new FactoryRegistry(),
 				initializedFactoryMap: new Map<string, Promise<WidgetFactory>>(),
-				historicChildrenMap: new Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState>>(),
-				currentChildrenMap: new Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState>>(),
+				historicChildrenMap: new Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState, WidgetProperties>>(),
+				currentChildrenMap: new Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState, WidgetProperties>>(),
 				children: []
 			});
 

--- a/src/d.ts
+++ b/src/d.ts
@@ -8,26 +8,39 @@ import {
 	WNode,
 	Widget,
 	WidgetOptions,
-	WidgetState
+	WidgetState,
+	WidgetProperties
 } from './interfaces';
 import FactoryRegistry from './FactoryRegistry';
 
 export const registry = new FactoryRegistry();
 
-export function w<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
+export function w<P extends WidgetProperties, S extends WidgetState, W extends Widget<S, P>, O extends WidgetOptions<S, P>>(
 	factory: ComposeFactory<W, O> | string,
-	options: O
+	properties: P
 ): WNode;
-export function w<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
+export function w<P extends WidgetProperties, S extends WidgetState, W extends Widget<S, P>, O extends WidgetOptions<S, P>>(
 	factory: ComposeFactory<W, O> | string,
-	options: O,
+	properties: P,
 	children?: DNode[]
 ): WNode;
-export function w<S extends WidgetState, W extends Widget<S>, O extends WidgetOptions<S>>(
+export function w<P extends WidgetProperties, S extends WidgetState, W extends Widget<S, P>, O extends WidgetOptions<S, P>>(
 	factory: ComposeFactory<W, O> | string,
-	options: O,
+	properties: P,
 	children: DNode[] = []
 ): WNode {
+
+	const options = <O> {
+		properties
+	};
+
+	if (properties.id) {
+		options.id = properties.id;
+	}
+
+	if (properties.tagName) {
+		options.tagName = properties.tagName;
+	}
 
 	return {
 		children,
@@ -36,20 +49,20 @@ export function w<S extends WidgetState, W extends Widget<S>, O extends WidgetOp
 	};
 }
 
-export function v(tag: string, options: VNodeProperties, children?: DNode[]): HNode;
+export function v(tag: string, properties: VNodeProperties, children?: DNode[]): HNode;
 export function v(tag: string, children: DNode[]): HNode;
 export function v(tag: string): HNode;
-export function v(tag: string, optionsOrChildren: VNodeProperties = {}, children: DNode[] = []): HNode {
+export function v(tag: string, propertiesOrChildren: VNodeProperties = {}, children: DNode[] = []): HNode {
 
-		if (Array.isArray(optionsOrChildren)) {
-			children = optionsOrChildren;
-			optionsOrChildren = {};
+		if (Array.isArray(propertiesOrChildren)) {
+			children = propertiesOrChildren;
+			propertiesOrChildren = {};
 		}
 
 		return {
 			children,
 			render<T>(this: { children: VNode[] }, options: { bind?: T } = { }) {
-				return h(tag, assign(options, optionsOrChildren), this.children);
+				return h(tag, assign(options, propertiesOrChildren), this.children);
 			}
 		};
 }

--- a/src/d.ts
+++ b/src/d.ts
@@ -9,37 +9,37 @@ import {
 	Widget,
 	WidgetOptions,
 	WidgetState,
-	WidgetProperties
+	WidgetProps
 } from './interfaces';
 import FactoryRegistry from './FactoryRegistry';
 
 export const registry = new FactoryRegistry();
 
-export function w<P extends WidgetProperties, S extends WidgetState, W extends Widget<S, P>, O extends WidgetOptions<S, P>>(
+export function w<P extends WidgetProps, S extends WidgetState, W extends Widget<S, P>, O extends WidgetOptions<S, P>>(
 	factory: ComposeFactory<W, O> | string,
-	properties: P
+	props: P
 ): WNode;
-export function w<P extends WidgetProperties, S extends WidgetState, W extends Widget<S, P>, O extends WidgetOptions<S, P>>(
+export function w<P extends WidgetProps, S extends WidgetState, W extends Widget<S, P>, O extends WidgetOptions<S, P>>(
 	factory: ComposeFactory<W, O> | string,
-	properties: P,
+	props: P,
 	children?: DNode[]
 ): WNode;
-export function w<P extends WidgetProperties, S extends WidgetState, W extends Widget<S, P>, O extends WidgetOptions<S, P>>(
+export function w<P extends WidgetProps, S extends WidgetState, W extends Widget<S, P>, O extends WidgetOptions<S, P>>(
 	factory: ComposeFactory<W, O> | string,
-	properties: P,
+	props: P,
 	children: DNode[] = []
 ): WNode {
 
 	const options = <O> {
-		properties
+		props
 	};
 
-	if (properties.id) {
-		options.id = properties.id;
+	if (props.id) {
+		options.id = props.id;
 	}
 
-	if (properties.tagName) {
-		options.tagName = properties.tagName;
+	if (props.tagName) {
+		options.tagName = props.tagName;
 	}
 
 	return {
@@ -49,20 +49,20 @@ export function w<P extends WidgetProperties, S extends WidgetState, W extends W
 	};
 }
 
-export function v(tag: string, properties: VNodeProperties, children?: DNode[]): HNode;
+export function v(tag: string, props: VNodeProperties, children?: DNode[]): HNode;
 export function v(tag: string, children: DNode[]): HNode;
 export function v(tag: string): HNode;
-export function v(tag: string, propertiesOrChildren: VNodeProperties = {}, children: DNode[] = []): HNode {
+export function v(tag: string, propsOrChildren: VNodeProperties = {}, children: DNode[] = []): HNode {
 
-		if (Array.isArray(propertiesOrChildren)) {
-			children = propertiesOrChildren;
-			propertiesOrChildren = {};
+		if (Array.isArray(propsOrChildren)) {
+			children = propsOrChildren;
+			propsOrChildren = {};
 		}
 
 		return {
 			children,
 			render<T>(this: { children: VNode[] }, options: { bind?: T } = { }) {
-				return h(tag, assign(options, propertiesOrChildren), this.children);
+				return h(tag, assign(options, propsOrChildren), this.children);
 			}
 		};
 }

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -15,19 +15,19 @@ import { VNodeEvented, VNodeEventedOptions } from './mixins/createVNodeEvented';
  * A function that is called to return top level node
  */
 export interface NodeFunction {
-	(this: Widget<WidgetState, WidgetProperties>): DNode;
+	(this: Widget<WidgetState, WidgetProps>): DNode;
 }
 
 /**
  * A function that is called when collecting the children nodes on render.
  */
 export interface ChildNodeFunction {
-	(this: Widget<WidgetState, WidgetProperties>): DNode[];
+	(this: Widget<WidgetState, WidgetProps>): DNode[];
 }
 
 /**
  * A function that is called when collecting the node attributes on render, accepting the current map of
- * attributes and returning a set of VNode properties that should mixed into the current attributes.
+ * attributes and returning a set of VNode props that should mixed into the current attributes.
  */
 export interface NodeAttributeFunction {
 	/**
@@ -35,7 +35,7 @@ export interface NodeAttributeFunction {
 	 *
 	 * @param attributes The current VNodeProperties that will be part of the render
 	 */
-	(this: Widget<WidgetState, WidgetProperties>, attributes: VNodeProperties): VNodeProperties;
+	(this: Widget<WidgetState, WidgetProps>, attributes: VNodeProperties): VNodeProperties;
 }
 
 export type WidgetFactoryFunction = () => Promise<WidgetFactory>
@@ -84,7 +84,7 @@ export interface WNode {
 	/**
 	 * Options used to create factory a widget
 	 */
-	options: WidgetOptions<WidgetState, WidgetProperties>;
+	options: WidgetOptions<WidgetState, WidgetProps>;
 
 	/**
 	 * DNode children
@@ -94,9 +94,9 @@ export interface WNode {
 
 export type DNode = HNode | WNode | string | null;
 
-export type Widget<S extends WidgetState, P extends WidgetProperties> = Stateful<S> & WidgetMixin<P> & WidgetOverloads & VNodeEvented;
+export type Widget<S extends WidgetState, P extends WidgetProps> = Stateful<S> & WidgetMixin<P> & WidgetOverloads & VNodeEvented;
 
-export interface WidgetFactory extends ComposeFactory<Widget<WidgetState, WidgetProperties>, WidgetOptions<WidgetState, WidgetProperties>> {}
+export interface WidgetFactory extends ComposeFactory<Widget<WidgetState, WidgetProps>, WidgetOptions<WidgetState, WidgetProps>> {}
 
 export interface WidgetOverloads {
 	/**
@@ -105,10 +105,10 @@ export interface WidgetOverloads {
 	 * @param type The event type to listen for
 	 * @param listener The listener to call when the event is emitted
 	 */
-	on(type: 'invalidated', listener: EventedListener<Widget<WidgetState, WidgetProperties>, EventTargettedObject<Widget<WidgetState, WidgetProperties>>>): Handle;
+	on(type: 'invalidated', listener: EventedListener<Widget<WidgetState, WidgetProps>, EventTargettedObject<Widget<WidgetState, WidgetProps>>>): Handle;
 }
 
-export interface WidgetMixin<P extends WidgetProperties> {
+export interface WidgetMixin<P extends WidgetProps> {
 	/**
 	 * Classes which are applied upon render.
 	 *
@@ -141,19 +141,19 @@ export interface WidgetMixin<P extends WidgetProperties> {
 	getNodeAttributes(): VNodeProperties;
 
 	/**
-	 * Properties passed to affect state
+	 * Props passed to affect state
 	 */
-	properties: Partial<P>;
+	props: Partial<P>;
 
 	/**
 	 * Determine changed or new property keys on render.
 	 */
-	diffProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: P): string[];
+	diffProps(this: Widget<WidgetState, WidgetProps>, previousProps: P): string[];
 
 	/**
-	 * Process change in properties
+	 * Process change in props
 	 */
-	processPropertiesChange(previousProperties: Partial<P>, currentProperties: Partial<P>): void;
+	processPropsChange(previousProps: Partial<P>, currentProps: Partial<P>): void;
 
 	/**
 	 * The ID of the widget, which gets automatically rendered in the VNode property `data-widget-id` when
@@ -171,7 +171,7 @@ export interface WidgetMixin<P extends WidgetProperties> {
 
 	/**
 	 * An array of functions that return a map of VNodeProperties which should be mixed into the final
-	 * properties used when rendering this widget.  These are intended to be "static" and bund to the class,
+	 * props used when rendering this widget.  These are intended to be "static" and bund to the class,
 	 * making it easy for mixins to alter the behaviour of the render process without needing to override or aspect
 	 * the `getNodeAttributes` method.
 	 */
@@ -204,19 +204,19 @@ export interface WidgetMixin<P extends WidgetProperties> {
 	readonly registry: FactoryRegistryInterface;
 }
 
-export interface WidgetOptions<S extends WidgetState, P extends WidgetProperties> extends StatefulOptions<S>, VNodeEventedOptions {
+export interface WidgetOptions<S extends WidgetState, P extends WidgetProps> extends StatefulOptions<S>, VNodeEventedOptions {
 	/**
-	 * Properties used to affect internal widget state
+	 * Props used to affect internal widget state
 	 */
-	properties?: P;
+	props?: P;
 
 	/**
-	 * Properties used to affect internal widget state
+	 * Props used to affect internal widget state
 	 */
 	tagName?: string;
 }
 
-export interface WidgetProperties {
+export interface WidgetProps {
 
 	[key: string]: any;
 

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -4,9 +4,8 @@
  * Additional features and functionality are added to widgets by compositing mixins onto these
  * bases.
  */
-
 import Promise from 'dojo-shim/Promise';
-import { EventedListener, State, Stateful, StatefulOptions } from 'dojo-interfaces/bases';
+import { EventedListener, Stateful, StatefulOptions } from 'dojo-interfaces/bases';
 import { EventTargettedObject, Handle, StylesMap } from 'dojo-interfaces/core';
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
 import { ComposeFactory } from 'dojo-compose/compose';
@@ -16,14 +15,14 @@ import { VNodeEvented, VNodeEventedOptions } from './mixins/createVNodeEvented';
  * A function that is called to return top level node
  */
 export interface NodeFunction {
-	(this: Widget<WidgetState>): DNode;
+	(this: Widget<WidgetState, WidgetProperties>): DNode;
 }
 
 /**
  * A function that is called when collecting the children nodes on render.
  */
 export interface ChildNodeFunction {
-	(this: Widget<WidgetState>): DNode[];
+	(this: Widget<WidgetState, WidgetProperties>): DNode[];
 }
 
 /**
@@ -36,7 +35,7 @@ export interface NodeAttributeFunction {
 	 *
 	 * @param attributes The current VNodeProperties that will be part of the render
 	 */
-	(this: Widget<WidgetState>, attributes: VNodeProperties): VNodeProperties;
+	(this: Widget<WidgetState, WidgetProperties>, attributes: VNodeProperties): VNodeProperties;
 }
 
 export type WidgetFactoryFunction = () => Promise<WidgetFactory>
@@ -85,7 +84,7 @@ export interface WNode {
 	/**
 	 * Options used to create factory a widget
 	 */
-	options: WidgetOptions<WidgetState>;
+	options: WidgetOptions<WidgetState, WidgetProperties>;
 
 	/**
 	 * DNode children
@@ -95,9 +94,9 @@ export interface WNode {
 
 export type DNode = HNode | WNode | string | null;
 
-export type Widget<S extends WidgetState> = Stateful<S> & WidgetMixin & WidgetOverloads & VNodeEvented;
+export type Widget<S extends WidgetState, P extends WidgetProperties> = Stateful<S> & WidgetMixin<P> & WidgetOverloads & VNodeEvented;
 
-export interface WidgetFactory extends ComposeFactory<Widget<WidgetState>, WidgetOptions<WidgetState>> {}
+export interface WidgetFactory extends ComposeFactory<Widget<WidgetState, WidgetProperties>, WidgetOptions<WidgetState, WidgetProperties>> {}
 
 export interface WidgetOverloads {
 	/**
@@ -106,10 +105,10 @@ export interface WidgetOverloads {
 	 * @param type The event type to listen for
 	 * @param listener The listener to call when the event is emitted
 	 */
-	on(type: 'invalidated', listener: EventedListener<Widget<WidgetState>, EventTargettedObject<Widget<WidgetState>>>): Handle;
+	on(type: 'invalidated', listener: EventedListener<Widget<WidgetState, WidgetProperties>, EventTargettedObject<Widget<WidgetState, WidgetProperties>>>): Handle;
 }
 
-export interface WidgetMixin {
+export interface WidgetMixin<P extends WidgetProperties> {
 	/**
 	 * Classes which are applied upon render.
 	 *
@@ -140,6 +139,21 @@ export interface WidgetMixin {
 	 * `nodeAttributes` property, which will automatically get called by this method upon render.
 	 */
 	getNodeAttributes(): VNodeProperties;
+
+	/**
+	 * Properties passed to affect state
+	 */
+	properties: Partial<P>;
+
+	/**
+	 * Determine changed or new property keys on render.
+	 */
+	diffProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: P): string[];
+
+	/**
+	 * Process change in properties
+	 */
+	processPropertiesChange(previousProperties: Partial<P>, currentProperties: Partial<P>): void;
 
 	/**
 	 * The ID of the widget, which gets automatically rendered in the VNode property `data-widget-id` when
@@ -190,24 +204,28 @@ export interface WidgetMixin {
 	readonly registry: FactoryRegistryInterface;
 }
 
-export interface WidgetOptions<S extends WidgetState> extends StatefulOptions<S>, VNodeEventedOptions {
+export interface WidgetOptions<S extends WidgetState, P extends WidgetProperties> extends StatefulOptions<S>, VNodeEventedOptions {
 	/**
-	 * Any classes that should be added to this instances
+	 * Properties used to affect internal widget state
 	 */
-	classes?: string[];
+	properties?: P;
 
 	/**
-	 * Any node attribute functions that should be added to this instance
-	 */
-	nodeAttributes?: NodeAttributeFunction | NodeAttributeFunction[];
-
-	/**
-	 * Override the tag name for this widget instance
+	 * Properties used to affect internal widget state
 	 */
 	tagName?: string;
 }
 
-export interface WidgetState extends State {
+export interface WidgetProperties {
+
+	[key: string]: any;
+
+	id?: string;
+
+	tagName?: string;
+}
+
+export interface WidgetState {
 	/**
 	 * Any classes that should be mixed into the widget's VNode upon render.
 	 *

--- a/src/mixins/createCssTransitionMixin.ts
+++ b/src/mixins/createCssTransitionMixin.ts
@@ -2,9 +2,9 @@ import { VNodeProperties } from 'dojo-interfaces/vdom';
 import compose, { ComposeFactory } from 'dojo-compose/compose';
 import { NodeAttributeFunction } from './../interfaces';
 import createStateful from 'dojo-compose/bases/createStateful';
-import { State, Stateful, StatefulOptions } from 'dojo-interfaces/bases';
+import { Stateful, StatefulOptions } from 'dojo-interfaces/bases';
 
-export type CssTransitionMixinState = State & {
+export type CssTransitionMixinState = {
 	/**
 	 * The class of the CSS animation to be applied as the widget enters the dom
 	 */

--- a/src/mixins/createFormFieldMixin.ts
+++ b/src/mixins/createFormFieldMixin.ts
@@ -3,7 +3,7 @@ import { ComposeFactory } from 'dojo-compose/compose';
 import createStateful from 'dojo-compose/bases/createStateful';
 import createCancelableEvent from 'dojo-compose/bases/createCancelableEvent';
 import { EventTargettedObject, EventCancelableObject, Handle } from 'dojo-interfaces/core';
-import { EventedListener, Stateful, State, StatefulOptions } from 'dojo-interfaces/bases';
+import { EventedListener, Stateful, StatefulOptions } from 'dojo-interfaces/bases';
 import { assign } from 'dojo-core/lang';
 import { NodeAttributeFunction } from './../interfaces';
 
@@ -19,7 +19,7 @@ export interface FormFieldMixinOptions<V, S extends FormFieldMixinState<V>> exte
 	value?: V;
 }
 
-export interface FormFieldMixinState<V> extends State {
+export interface FormFieldMixinState<V> {
 	/**
 	 * Whether the field is currently disabled or not
 	 */
@@ -152,7 +152,7 @@ const createFormMixin: FormMixinFactory = createStateful
 					});
 					this.emit(event);
 					if (!event.defaultPrevented) {
-						this.setState({ value: stringToValue(event.value) });
+						this.state = { value: stringToValue(event.value) };
 					}
 				}
 			},
@@ -171,7 +171,7 @@ const createFormMixin: FormMixinFactory = createStateful
 			{ value, type }: FormFieldMixinOptions<any, FormFieldMixinState<any>> = {}
 		) {
 			if (value) {
-				instance.setState({ value });
+				instance.state = { value };
 			}
 			if (type) {
 				instance.type = type;

--- a/tests/unit/components/button/createButton.ts
+++ b/tests/unit/components/button/createButton.ts
@@ -1,13 +1,13 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { VNode } from 'dojo-interfaces/vdom';
-import createButton, { ButtonState } from '../../../../src/components/button/createButton';
+import createButton from '../../../../src/components/button/createButton';
 
 registerSuite({
 	name: 'createButton',
 	construction() {
 		const button = createButton({
-			state: {
+			properties: {
 				id: 'foo',
 				label: 'bar',
 				name: 'baz'
@@ -19,7 +19,7 @@ registerSuite({
 	},
 	render() {
 		const button = createButton({
-			state: {
+			properties: {
 				id: 'foo',
 				label: 'bar',
 				name: 'baz'
@@ -35,7 +35,7 @@ registerSuite({
 	},
 	disable() {
 		const button = createButton({
-			state: <ButtonState> {
+			properties: {
 				id: 'foo',
 				label: 'bar',
 				name: 'baz'
@@ -43,9 +43,9 @@ registerSuite({
 		});
 		let vnode = <VNode> button.__render__();
 		assert.isFalse(vnode.properties!['disabled']);
-		button.setState({
+		button.state = {
 			disabled: true
-		});
+		};
 		vnode = <VNode> button.__render__();
 		assert.isTrue(vnode.properties!['disabled']);
 	}

--- a/tests/unit/components/button/createButton.ts
+++ b/tests/unit/components/button/createButton.ts
@@ -7,7 +7,7 @@ registerSuite({
 	name: 'createButton',
 	construction() {
 		const button = createButton({
-			properties: {
+			props: {
 				id: 'foo',
 				label: 'bar',
 				name: 'baz'
@@ -19,7 +19,7 @@ registerSuite({
 	},
 	render() {
 		const button = createButton({
-			properties: {
+			props: {
 				id: 'foo',
 				label: 'bar',
 				name: 'baz'
@@ -35,7 +35,7 @@ registerSuite({
 	},
 	disable() {
 		const button = createButton({
-			properties: {
+			props: {
 				id: 'foo',
 				label: 'bar',
 				name: 'baz'

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -2,7 +2,7 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import Promise from 'dojo-shim/Promise';
 import createWidgetBase from '../../src/createWidgetBase';
-import { DNode, HNode, WidgetProperties } from './../../src/interfaces';
+import { DNode, HNode, WidgetProps } from './../../src/interfaces';
 import { VNode } from 'dojo-interfaces/vdom';
 import { v, w, registry } from '../../src/d';
 import { stub } from 'sinon';
@@ -56,7 +56,7 @@ registerSuite({
 		};
 
 		const widgetBase = createWidgetBase({
-			properties: { id: 'foo', classes: [ 'bar' ] },
+			props: { id: 'foo', classes: [ 'bar' ] },
 			listeners: {
 				click: expectedClickFunction
 			}
@@ -77,28 +77,28 @@ registerSuite({
 
 		assert.deepEqual(nodeAttributes.classes, { foo: true, bar: false });
 	},
-	diffProperties: {
-		'no updated properties'() {
-			const widgetBase = createWidgetBase({ properties: { id: 'id', foo: 'bar' }});
-			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' });
+	diffProps: {
+		'no updated props'() {
+			const widgetBase = createWidgetBase({ props: { id: 'id', foo: 'bar' }});
+			const updatedKeys = widgetBase.diffProps({ id: 'id', foo: 'bar' });
 			assert.lengthOf(updatedKeys, 0);
 		},
-		'updated properties'() {
-			const widgetBase = createWidgetBase({ properties: { id: 'id', foo: 'bar' }});
-			widgetBase.properties = { id: 'id', foo: 'baz' };
-			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' });
+		'updated props'() {
+			const widgetBase = createWidgetBase({ props: { id: 'id', foo: 'bar' }});
+			widgetBase.props = { id: 'id', foo: 'baz' };
+			const updatedKeys = widgetBase.diffProps({ id: 'id', foo: 'bar' });
 			assert.lengthOf(updatedKeys, 1);
 		},
-		'new properties'() {
-			const widgetBase = createWidgetBase({ properties: { id: 'id', foo: 'bar' }});
-			widgetBase.properties = { id: 'id', foo: 'bar', bar: 'baz' };
-			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' });
+		'new props'() {
+			const widgetBase = createWidgetBase({ props: { id: 'id', foo: 'bar' }});
+			widgetBase.props = { id: 'id', foo: 'bar', bar: 'baz' };
+			const updatedKeys = widgetBase.diffProps({ id: 'id', foo: 'bar' });
 			assert.lengthOf(updatedKeys, 1);
 		}
 	},
-	processPropertiesChange() {
+	processPropsChange() {
 		const widgetBase = createWidgetBase();
-		widgetBase.processPropertiesChange({}, { foo: 'bar' });
+		widgetBase.processPropsChange({}, { foo: 'bar' });
 		assert.equal((<any> widgetBase.state).foo, 'bar');
 	},
 	getChildrenNodes: {
@@ -356,10 +356,10 @@ registerSuite({
 				.mixin({
 					mixin: {
 						getChildrenNodes: function(this: any): (DNode | null)[] {
-							const properties: WidgetProperties = this.state.classes ? { classes: this.state.classes } : {};
-							properties.tagName = 'footer';
+							const props: WidgetProps = this.state.classes ? { classes: this.state.classes } : {};
+							props.tagName = 'footer';
 							return [
-								this.state.hide ? null : w(testChildWidget, properties)
+								this.state.hide ? null : w(testChildWidget, props)
 							];
 						}
 					}
@@ -389,7 +389,7 @@ registerSuite({
 			assert.lengthOf(thirdRenderResult.children, 1);
 			const thirdRenderChild: any = thirdRenderResult.children && thirdRenderResult.children[0];
 			assert.strictEqual(thirdRenderChild.vnodeSelector, 'footer');
-			assert.isTrue(thirdRenderChild.properties.classes['test-class']);
+			assert.isTrue(thirdRenderChild.props.classes['test-class']);
 
 			widgetBase.state = <any> { hide: true };
 			widgetBase.invalidate();
@@ -427,7 +427,7 @@ registerSuite({
 			assert.isTrue(consoleStub.calledWith('must provide unique keys when using the same widget factory multiple times'));
 			consoleStub.restore();
 		},
-		'render with updated properties'() {
+		'render with updated props'() {
 			let renderCount = 0;
 			const createMyWidget = createWidgetBase.mixin({
 				mixin: {
@@ -444,17 +444,17 @@ registerSuite({
 				.mixin({
 					mixin: {
 						getChildrenNodes: function(): DNode[] {
-							let properties: (WidgetProperties & { foo: string, bar?: string }) | undefined = { foo: 'bar' };
+							let props: (WidgetProps & { foo: string, bar?: string }) | undefined = { foo: 'bar' };
 
 							if (renderCount === 1) {
-								properties.bar = 'baz';
-								properties.foo = 'baz';
+								props.bar = 'baz';
+								props.foo = 'baz';
 							}
 
 							renderCount++;
 
 							return [
-								w(createMyWidget, properties)
+								w(createMyWidget, props)
 							];
 						}
 					}
@@ -471,7 +471,7 @@ registerSuite({
 		},
 		'__render__() and invalidate()'() {
 			const widgetBase = createWidgetBase({
-				properties: { id: 'foo', label: 'foo' }
+				props: { id: 'foo', label: 'foo' }
 			});
 			const result1 = <VNode> widgetBase.__render__();
 			const result2 = <VNode> widgetBase.__render__();
@@ -500,24 +500,24 @@ registerSuite({
 		},
 		'in state'() {
 			const widgetBase = createWidgetBase({
-				properties: {
+				props: {
 					id: 'foo'
 				}
 			});
 
 			assert.strictEqual(widgetBase.id, 'foo');
 		},
-		'in options and properties'() {
+		'in options and props'() {
 			const widgetBase = createWidgetBase({
 				id: 'foo',
-				properties: {
+				props: {
 					id: 'bar'
 				}
 			});
 
 			assert.strictEqual(widgetBase.id, 'bar');
 		},
-		'not in options or properties'() {
+		'not in options or props'() {
 			const widgetBase = createWidgetBase();
 
 			assert.include(widgetBase.id, 'widget-');

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -2,7 +2,7 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import Promise from 'dojo-shim/Promise';
 import createWidgetBase from '../../src/createWidgetBase';
-import { DNode, HNode, WidgetState, WidgetOptions } from './../../src/interfaces';
+import { DNode, HNode, WidgetProperties } from './../../src/interfaces';
 import { VNode } from 'dojo-interfaces/vdom';
 import { v, w, registry } from '../../src/d';
 import { stub } from 'sinon';
@@ -56,7 +56,7 @@ registerSuite({
 		};
 
 		const widgetBase = createWidgetBase({
-			state: { id: 'foo', classes: [ 'bar' ] },
+			properties: { id: 'foo', classes: [ 'bar' ] },
 			listeners: {
 				click: expectedClickFunction
 			}
@@ -71,7 +71,7 @@ registerSuite({
 		nodeAttributes.onclick!();
 		assert.isTrue(clickCalled);
 
-		widgetBase.setState({ 'id': 'foo', classes: ['foo'] });
+		widgetBase.state = { 'id': 'foo', classes: ['foo'] };
 
 		nodeAttributes = widgetBase.getNodeAttributes();
 
@@ -332,9 +332,10 @@ registerSuite({
 				.mixin({
 					mixin: {
 						getChildrenNodes: function(this: any): (DNode | null)[] {
-							const state = this.state.classes ? { classes: this.state.classes } : {};
+							const properties: WidgetProperties = this.state.classes ? { classes: this.state.classes } : {};
+							properties.tagName = 'footer';
 							return [
-								this.state.hide ? null : w(testChildWidget, <WidgetOptions<WidgetState>> { tagName: 'footer', state })
+								this.state.hide ? null : w(testChildWidget, properties)
 							];
 						}
 					}
@@ -356,7 +357,7 @@ registerSuite({
 			const secondRenderChild: any = secondRenderResult.children && secondRenderResult.children[0];
 			assert.strictEqual(secondRenderChild.vnodeSelector, 'footer');
 
-			widgetBase.setState({ 'classes': ['test-class'] });
+			widgetBase.state = { 'classes': ['test-class'] };
 			widgetBase.invalidate();
 			const thirdRenderResult = <VNode> widgetBase.__render__();
 			assert.strictEqual(countWidgetCreated, 1);
@@ -366,7 +367,7 @@ registerSuite({
 			assert.strictEqual(thirdRenderChild.vnodeSelector, 'footer');
 			assert.isTrue(thirdRenderChild.properties.classes['test-class']);
 
-			widgetBase.setState({ hide: true });
+			widgetBase.state = <any> { hide: true };
 			widgetBase.invalidate();
 
 			const forthRenderResult = <VNode> widgetBase.__render__();
@@ -374,7 +375,7 @@ registerSuite({
 			assert.strictEqual(countWidgetDestroyed, 1);
 			assert.lengthOf(forthRenderResult.children, 0);
 
-			widgetBase.setState({ hide: false });
+			widgetBase.state = <any> { hide: false };
 			widgetBase.invalidate();
 
 			const lastRenderResult = <VNode> widgetBase.__render__();
@@ -404,13 +405,13 @@ registerSuite({
 		},
 		'__render__() and invalidate()'() {
 			const widgetBase = createWidgetBase({
-				state: { id: 'foo', label: 'foo' }
+				properties: { id: 'foo', label: 'foo' }
 			});
 			const result1 = <VNode> widgetBase.__render__();
 			const result2 = <VNode> widgetBase.__render__();
 			widgetBase.invalidate();
 			widgetBase.invalidate();
-			widgetBase.setState({});
+			widgetBase.state = {};
 			const result3 = widgetBase.__render__();
 			const result4 = widgetBase.__render__();
 			assert.strictEqual(result1, result2);
@@ -433,27 +434,27 @@ registerSuite({
 		},
 		'in state'() {
 			const widgetBase = createWidgetBase({
-				state: {
+				properties: {
 					id: 'foo'
 				}
 			});
 
 			assert.strictEqual(widgetBase.id, 'foo');
 		},
-		'in options and state'() {
+		'in options and properties'() {
 			const widgetBase = createWidgetBase({
 				id: 'foo',
-				state: {
+				properties: {
 					id: 'bar'
 				}
 			});
 
-			assert.strictEqual(widgetBase.id, 'foo');
+			assert.strictEqual(widgetBase.id, 'bar');
 		},
-		'not in options or state'() {
+		'not in options or properties'() {
 			const widgetBase = createWidgetBase();
 
-			assert.strictEqual(widgetBase.id, 'widget-1');
+			assert.include(widgetBase.id, 'widget-');
 		},
 		'is read only'() {
 			const widgetBase = createWidgetBase();

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -1,6 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { WidgetProperties } from './../../src/interfaces';
+import { WidgetProps } from './../../src/interfaces';
 import createWidgetBase from '../../src/createWidgetBase';
 import { v, w, registry } from '../../src/d';
 import FactoryRegistry from './../../src/FactoryRegistry';
@@ -18,23 +18,23 @@ registerSuite({
 	},
 	w: {
 		'create WNode wrapper'() {
-			const options: WidgetProperties = { id: 'id', tagName: 'header', hello: 'world' };
+			const options: WidgetProps = { id: 'id', tagName: 'header', hello: 'world' };
 			const dNode = w(createWidgetBase, options);
 			assert.deepEqual(dNode.factory, createWidgetBase);
-			assert.deepEqual(dNode.options, { id: 'id', tagName: 'header', properties: options });
+			assert.deepEqual(dNode.options, { id: 'id', tagName: 'header', props: options });
 		},
 		'create WNode wrapper using a factory label'() {
 			registry.define('my-widget', createWidgetBase);
-			const options: WidgetProperties = { id: 'id', tagName: 'header', hello: 'world' };
+			const options: WidgetProps = { id: 'id', tagName: 'header', hello: 'world' };
 			const dNode = w('my-widget', options);
 			assert.deepEqual(dNode.factory, 'my-widget');
-			assert.deepEqual(dNode.options, { id: 'id', tagName: 'header', properties: options });
+			assert.deepEqual(dNode.options, { id: 'id', tagName: 'header', props: options });
 		},
 		'create WNode wrapper with children'() {
-			const options: WidgetProperties = { id: 'id', tagName: 'header', hello: 'world' };
+			const options: WidgetProps = { id: 'id', tagName: 'header', hello: 'world' };
 			const dNode = w(createWidgetBase, options, [ w(createWidgetBase, options) ]);
 			assert.deepEqual(dNode.factory, createWidgetBase);
-			assert.deepEqual(dNode.options, { id: 'id', tagName: 'header', properties: options });
+			assert.deepEqual(dNode.options, { id: 'id', tagName: 'header', props: options });
 			assert.lengthOf(dNode.children, 1);
 		}
 	},

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -18,23 +18,23 @@ registerSuite({
 	},
 	w: {
 		'create WNode wrapper'() {
-			const options: WidgetProperties = { tagName: 'header', hello: 'world' };
+			const options: WidgetProperties = { id: 'id', tagName: 'header', hello: 'world' };
 			const dNode = w(createWidgetBase, options);
 			assert.deepEqual(dNode.factory, createWidgetBase);
-			assert.deepEqual(dNode.options, { tagName: 'header', properties: options });
+			assert.deepEqual(dNode.options, { id: 'id', tagName: 'header', properties: options });
 		},
 		'create WNode wrapper using a factory label'() {
 			registry.define('my-widget', createWidgetBase);
-			const options: WidgetProperties = { tagName: 'header', hello: 'world' };
+			const options: WidgetProperties = { id: 'id', tagName: 'header', hello: 'world' };
 			const dNode = w('my-widget', options);
 			assert.deepEqual(dNode.factory, 'my-widget');
-			assert.deepEqual(dNode.options, { tagName: 'header', properties: options });
+			assert.deepEqual(dNode.options, { id: 'id', tagName: 'header', properties: options });
 		},
 		'create WNode wrapper with children'() {
-			const options: WidgetProperties = { tagName: 'header', hello: 'world' };
+			const options: WidgetProperties = { id: 'id', tagName: 'header', hello: 'world' };
 			const dNode = w(createWidgetBase, options, [ w(createWidgetBase, options) ]);
 			assert.deepEqual(dNode.factory, createWidgetBase);
-			assert.deepEqual(dNode.options, { tagName: 'header', properties: options });
+			assert.deepEqual(dNode.options, { id: 'id', tagName: 'header', properties: options });
 			assert.lengthOf(dNode.children, 1);
 		}
 	},

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -1,6 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { WidgetState, WidgetOptions } from './../../src/interfaces';
+import { WidgetProperties } from './../../src/interfaces';
 import createWidgetBase from '../../src/createWidgetBase';
 import { v, w, registry } from '../../src/d';
 import FactoryRegistry from './../../src/FactoryRegistry';
@@ -18,23 +18,23 @@ registerSuite({
 	},
 	w: {
 		'create WNode wrapper'() {
-			const options: WidgetOptions<WidgetState> = { tagName: 'header', state: { hello: 'world' } };
+			const options: WidgetProperties = { tagName: 'header', hello: 'world' };
 			const dNode = w(createWidgetBase, options);
 			assert.deepEqual(dNode.factory, createWidgetBase);
-			assert.deepEqual(dNode.options, options);
+			assert.deepEqual(dNode.options, { tagName: 'header', properties: options });
 		},
 		'create WNode wrapper using a factory label'() {
 			registry.define('my-widget', createWidgetBase);
-			const options: WidgetOptions<WidgetState> = { tagName: 'header', state: { hello: 'world' } };
+			const options: WidgetProperties = { tagName: 'header', hello: 'world' };
 			const dNode = w('my-widget', options);
 			assert.deepEqual(dNode.factory, 'my-widget');
-			assert.deepEqual(dNode.options, options);
+			assert.deepEqual(dNode.options, { tagName: 'header', properties: options });
 		},
 		'create WNode wrapper with children'() {
-			const options: WidgetOptions<WidgetState> = { tagName: 'header', state: { hello: 'world' } };
+			const options: WidgetProperties = { tagName: 'header', hello: 'world' };
 			const dNode = w(createWidgetBase, options, [ w(createWidgetBase, options) ]);
 			assert.deepEqual(dNode.factory, createWidgetBase);
-			assert.deepEqual(dNode.options, options);
+			assert.deepEqual(dNode.options, { tagName: 'header', properties: options });
 			assert.lengthOf(dNode.children, 1);
 		}
 	},

--- a/tests/unit/integrations.ts
+++ b/tests/unit/integrations.ts
@@ -2,7 +2,6 @@ import 'dojo/has!host-node?../support/loadJsdom';
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { h, createProjector } from 'maquette';
-import * as rx from 'rxjs/Rx';
 
 registerSuite({
 	name: 'integrations',
@@ -28,8 +27,5 @@ registerSuite({
 			assert.strictEqual(nodes[0].firstChild!.firstChild!.textContent, 'Greetings');
 			assert.strictEqual((<HTMLDivElement> nodes[0].firstChild).className, 'saucer foo');
 		}
-	},
-	rx() {
-		assert(rx);
 	}
 });

--- a/tests/unit/mixins/createCssTransitionMixin.ts
+++ b/tests/unit/mixins/createCssTransitionMixin.ts
@@ -9,12 +9,12 @@ registerSuite({
 		assert.isDefined(cssTranistionMixin);
 	},
 	'getNodeAttributes()'() {
-		const cssTranistionMixin = createCssTransitionMixin({
-			state: {
-				enterAnimation: 'enter-animation-class',
-				exitAnimation: 'exit-animation-class'
-			}
-		});
+		const cssTranistionMixin = createCssTransitionMixin({});
+
+		cssTranistionMixin.state = {
+			enterAnimation: 'enter-animation-class',
+			exitAnimation: 'exit-animation-class'
+		};
 		const nodeAttributes = cssTranistionMixin.nodeAttributes[0].call(cssTranistionMixin, {});
 		assert.strictEqual(nodeAttributes.enterAnimation, 'enter-animation-class');
 		assert.strictEqual(nodeAttributes.exitAnimation, 'exit-animation-class');

--- a/tests/unit/mixins/createFormFieldMixin.ts
+++ b/tests/unit/mixins/createFormFieldMixin.ts
@@ -6,13 +6,14 @@ registerSuite({
 	name: 'mixins/createFormFieldMixin',
 	construction() {
 		const formfield = createFormFieldMixin({
-			type: 'foo',
-			state: {
-				name: 'foo',
-				value: 2,
-				disabled: false
-			}
+			type: 'foo'
 		});
+
+		formfield.state = {
+			name: 'foo',
+			value: 2,
+			disabled: false
+		};
 		assert.strictEqual(formfield.value, '2');
 		assert.strictEqual(formfield.state.value, 2);
 		assert.strictEqual(formfield.type, 'foo');
@@ -21,23 +22,13 @@ registerSuite({
 	},
 	'.value'() {
 		const value = { foo: 'foo' };
-		const formfield = createFormFieldMixin({
-			state: { value }
-		});
+		const formfield = createFormFieldMixin({});
+
+		formfield.state = { value };
 
 		assert.strictEqual(formfield.value, '{"foo":"foo"}');
-		formfield.setState({ value: { foo: 'bar' } });
+		formfield.state = { value: { foo: 'bar' } };
 		assert.deepEqual(formfield.value, '{"foo":"bar"}');
-	},
-	'.value - setState'() {
-		let count = 0;
-		const createAfterFormFieldMixin = createFormFieldMixin
-			.after('setState', () => count++);
-		const formfield = createAfterFormFieldMixin<string>();
-		formfield.value = 'foo';
-		assert.strictEqual(count, 1);
-		formfield.value = 'foo';
-		assert.strictEqual(count, 1);
 	},
 	'valuechange event': {
 		'emitted'() {
@@ -93,12 +84,10 @@ registerSuite({
 	'getNodeAttributes()': {
 		'truthy value'() {
 			const formfield = createFormFieldMixin({
-				type: 'foo',
-				state: {
-					value: 'bar',
-					name: 'baz'
-				}
+				type: 'foo'
 			});
+
+			formfield.state = { value: 'bar', name: 'baz' };
 
 			let nodeAttributes = formfield.nodeAttributes[0].call(formfield, {});
 			assert.strictEqual(nodeAttributes['type'], 'foo');
@@ -106,7 +95,7 @@ registerSuite({
 			assert.strictEqual(nodeAttributes['name'], 'baz');
 			assert.isFalse(nodeAttributes['disabled']);
 
-			formfield.setState({ disabled: true });
+			formfield.state = { disabled: true };
 
 			nodeAttributes = formfield.nodeAttributes[0].call(formfield, {});
 			assert.strictEqual(nodeAttributes['type'], 'foo');
@@ -114,7 +103,7 @@ registerSuite({
 			assert.strictEqual(nodeAttributes['name'], 'baz');
 			assert.isTrue(nodeAttributes['disabled']);
 
-			formfield.setState({ disabled: false });
+			formfield.state = { disabled: false };
 
 			nodeAttributes = formfield.nodeAttributes[0].call(formfield, {});
 			assert.strictEqual(nodeAttributes['type'], 'foo');
@@ -124,19 +113,19 @@ registerSuite({
 		},
 		'falsey value'() {
 			const formfield = createFormFieldMixin({
-				type: 'foo',
-				state: {
-					value: '',
-					name: 'baz'
-				}
+				type: 'foo'
 			});
+
+			formfield.state = {
+				value: ''
+			};
 
 			let nodeAttributes = formfield.nodeAttributes[0].call(formfield, {});
 			assert.strictEqual(nodeAttributes['value'], '');
 
-			formfield.setState({
+			formfield.state = {
 				value: undefined
-			});
+			};
 
 			nodeAttributes = formfield.nodeAttributes[0].call(formfield, {});
 			assert.isUndefined(formfield.state.value);

--- a/typings.json
+++ b/typings.json
@@ -1,8 +1,7 @@
 {
 	"name": "dojo-widgets",
 	"globalDependencies": {
-		"extra-rxjs": "github:dojo/typings/custom/dojo2-extras/rxjs.d.ts#103096ce945dd51a18cc47a9b7cf9191fdac0349",
-		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#9a0185f465a3febe2bb1ff3f1210f43e5f96c5d2"
+		"symbol-shim": "github:dojo/typings/custom/symbol-shim/symbol-shim.d.ts#003aa24b3448804a2c59e9a1d9740ca56e067e79"
 	},
 	"globalDevDependencies": {
 		"dojo2-dev": "github:dojo/typings/custom/dev/dev.d.ts#288d3a9868194f0e1ad6687371dffd1d96cb39a1"


### PR DESCRIPTION
**Type:** feature

**This as the same as #181 but using `props` over `properties`.**

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Support props that can be passed to widgets that will be used to internally update state on the widget.

By default only new or updated props will be used to update state automatically. The functions are public and can be customised by a widget consumer if they require different equality checks for current and previous props or need to perform some mapping or logic to from the props to the internal state.

Will be dependant on interfaces/compose changes.

Resolves #176
