### PR TITLE
Use `hasOwnProperty` to check for key and `deepAssign` properties for internal state.

### DIFF
--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -232,7 +232,7 @@ const createWidget: WidgetFactory = createStateful
 			diffProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: any): string[] {
 				const changedPropertyKeys: string[] = [];
 				Object.keys(this.properties).forEach((key) => {
-					if (previousProperties[key]) {
+					if (previousProperties.hasOwnProperty(key)) {
 						if (previousProperties[key] !== this.properties[key]) {
 							changedPropertyKeys.push(key);
 						}

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -12,7 +12,7 @@ import {
 	FactoryRegistryItem
 } from './interfaces';
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
-import { assign } from 'dojo-core/lang';
+import { deepAssign, assign } from 'dojo-core/lang';
 import WeakMap from 'dojo-shim/WeakMap';
 import Promise from 'dojo-shim/Promise';
 import Map from 'dojo-shim/Map';
@@ -276,7 +276,7 @@ const createWidget: WidgetFactory = createStateful
 						internalState.cachedVNode = widget;
 					}
 					internalState.dirty = false;
-					internalState.previousProperties = this.properties;
+					internalState.previousProperties = deepAssign({}, this.properties);
 					return widget;
 				}
 				return internalState.cachedVNode;
@@ -299,7 +299,7 @@ const createWidget: WidgetFactory = createStateful
 				id,
 				dirty: true,
 				widgetClasses: [],
-				previousProperties: properties,
+				previousProperties: deepAssign({}, properties),
 				factoryRegistry: new FactoryRegistry(),
 				initializedFactoryMap: new Map<string, Promise<WidgetFactory>>(),
 				historicChildrenMap: new Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState, WidgetProperties>>(),

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -94,6 +94,13 @@ registerSuite({
 			widgetBase.properties = { id: 'id', foo: 'bar', bar: 'baz' };
 			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' });
 			assert.lengthOf(updatedKeys, 1);
+		},
+		'updated / new properties with falsy values'() {
+			const widgetBase = createWidgetBase({ properties: { id: 'id', foo: 'bar' }});
+			widgetBase.properties = { id: 'id', foo: '', bar: null, baz: 0, qux: false };
+			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' });
+			assert.lengthOf(updatedKeys, 4);
+			assert.deepEqual(updatedKeys, [ 'foo', 'bar', 'baz', 'qux']);
 		}
 	},
 	applyChangedProperties() {

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -476,6 +476,41 @@ registerSuite({
 			assert.equal(result!.children![0].properties!['foo'], 'baz');
 			assert.equal(result!.children![0].properties!['bar'], 'baz');
 		},
+		'__render__ with updated array properties'() {
+			const properties = {
+				items: [
+					'a', 'b'
+				]
+			};
+
+			const myWidget = createWidgetBase({ properties });
+			myWidget.__render__();
+			assert.deepEqual((<any> myWidget.state).items, [ 'a', 'b' ]);
+			properties.items.push('c');
+			myWidget.properties = properties;
+			myWidget.invalidate();
+			myWidget.__render__();
+			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b', 'c' ]);
+			properties.items.push('d');
+			myWidget.properties = properties;
+			myWidget.invalidate();
+			myWidget.__render__();
+			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b', 'c', 'd' ]);
+		},
+		'__render__ with internally updated array state'() {
+			const properties = {
+				items: [
+					'a', 'b'
+				]
+			};
+
+			const myWidget = createWidgetBase({ properties });
+			myWidget.__render__();
+			assert.deepEqual((<any> myWidget.state).items, [ 'a', 'b' ]);
+			myWidget.setState(<any> { items: [ 'a', 'b', 'c'] });
+			myWidget.__render__();
+			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b' ]);
+		},
 		'__render__() and invalidate()'() {
 			const widgetBase = createWidgetBase({
 				properties: { id: 'foo', label: 'foo' }


### PR DESCRIPTION
**Type:** bug(s)

The following has been addressed in the PR:

* [x] There is a related issue(s)
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Ensure properties are "reset" by `deepAssign`ing them before setting them on internal state and use `hasOwnProperty` to check if a `key` exists on the `previousProperties`

Resolves #188 
Resolves #189
