### PR TITLE
Shallow Property Comparison Mixin

### DIFF
--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -19,6 +19,7 @@ import Map from 'dojo-shim/Map';
 import { v, registry } from './d';
 import FactoryRegistry from './FactoryRegistry';
 import createVNodeEvented from './mixins/createVNodeEvented';
+import shallowPropertyComparisonMixin from './mixins/shallowPropertyComparisonMixin';
 
 interface WidgetInternalState {
 	children: DNode[];
@@ -230,18 +231,7 @@ const createWidget: WidgetFactory = createStateful
 			},
 
 			diffProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: any): string[] {
-				const changedPropertyKeys: string[] = [];
-				Object.keys(this.properties).forEach((key) => {
-					if (previousProperties.hasOwnProperty(key)) {
-						if (previousProperties[key] !== this.properties[key]) {
-							changedPropertyKeys.push(key);
-						}
-					}
-					else {
-						changedPropertyKeys.push(key);
-					}
-				});
-				return changedPropertyKeys;
+				return Object.keys(this.properties);
 			},
 
 			nodeAttributes: [
@@ -261,8 +251,7 @@ const createWidget: WidgetFactory = createStateful
 
 					return assign(baseIdProp, { key: this, classes, styles });
 				}
-
-		],
+			],
 
 			__render__(this: Widget<WidgetState, WidgetProperties>): VNode | string | null {
 				const internalState = widgetInternalStateMap.get(this);
@@ -312,6 +301,7 @@ const createWidget: WidgetFactory = createStateful
 				instance.invalidate();
 			}));
 		}
-	});
+	})
+	.mixin(shallowPropertyComparisonMixin);
 
 export default createWidget;

--- a/src/mixins/shallowPropertyComparisonMixin.ts
+++ b/src/mixins/shallowPropertyComparisonMixin.ts
@@ -1,0 +1,57 @@
+import { entries } from 'dojo-shim/Object';
+
+export interface ShallowPropertyComparisonMixin {
+	diffProperties(previousProperties: any): string[];
+}
+
+function isObject(value: any) {
+	return Object.prototype.toString.call(value) === '[object Object]';
+}
+
+function shallowCompare(from: any, to: any) {
+	if (to) {
+		return Object.keys(from).every((key) => from[key] === to[key]);
+	}
+	return false;
+}
+
+const shallowPropertyComparisonMixin: { mixin: ShallowPropertyComparisonMixin } = {
+	mixin: {
+		diffProperties(this: { properties: any }, previousProperties: any): string[] {
+			const changedPropertyKeys: string[] = [];
+
+			entries(this.properties).forEach(([key, value]) => {
+				let isEqual = true;
+				if (previousProperties.hasOwnProperty(key)) {
+					if (!(typeof value === 'function')) {
+						if (Array.isArray(value)) {
+							isEqual = value.every((item: any, index: number) => {
+								if (isObject(item)) {
+									return shallowCompare(item, previousProperties[key][index]);
+								}
+								else {
+									return item === previousProperties[key][index];
+								}
+							});
+						}
+						else if (isObject(value)) {
+							isEqual = shallowCompare(value, previousProperties[key]);
+						}
+						else {
+							isEqual = value === previousProperties[key];
+						}
+					}
+				}
+				else {
+					isEqual = false;
+				}
+				if (!isEqual) {
+					changedPropertyKeys.push(key);
+				}
+			});
+			return changedPropertyKeys;
+		}
+	}
+};
+
+export default shallowPropertyComparisonMixin;

--- a/src/mixins/shallowPropertyComparisonMixin.ts
+++ b/src/mixins/shallowPropertyComparisonMixin.ts
@@ -1,4 +1,4 @@
-import { entries } from 'dojo-shim/Object';
+import { entries } from 'dojo-shim/object';
 import { WidgetProperties } from './../interfaces';
 
 /**

--- a/src/mixins/shallowPropertyComparisonMixin.ts
+++ b/src/mixins/shallowPropertyComparisonMixin.ts
@@ -1,13 +1,23 @@
 import { entries } from 'dojo-shim/Object';
+import { WidgetProperties } from './../interfaces';
 
+/**
+ * Interface for `diffProperties`
+ */
 export interface ShallowPropertyComparisonMixin {
-	diffProperties(previousProperties: any): string[];
+	diffProperties<T>(previousProperties: T): string[];
 }
 
+/**
+ * Determine if the value is an Object
+ */
 function isObject(value: any) {
 	return Object.prototype.toString.call(value) === '[object Object]';
 }
 
+/**
+ * Shallow comparison of all keys on the objects
+ */
 function shallowCompare(from: any, to: any) {
 	if (to) {
 		return Object.keys(from).every((key) => from[key] === to[key]);
@@ -15,9 +25,18 @@ function shallowCompare(from: any, to: any) {
 	return false;
 }
 
+/**
+ * Mixin that overrides the `diffProperties` method providing a shallow comparison of attributes.
+ *
+ * For Objects, values for all `keys` are compared against the equivalent `key` on the `previousProperties`
+ * attribute using `===`. If the `key` does not exists on the `previousProperties` attribute it is considered unequal.
+ *
+ * For Arrays, each `item` is compared with the `item` in the equivalent `index` of the `previousProperties` attribute.
+ * If the `item` is an `object` then the object comparison described above is applied otherwise a simple `===` is used.
+ */
 const shallowPropertyComparisonMixin: { mixin: ShallowPropertyComparisonMixin } = {
 	mixin: {
-		diffProperties(this: { properties: any }, previousProperties: any): string[] {
+		diffProperties<T extends WidgetProperties>(this: { properties: T }, previousProperties: T): string[] {
 			const changedPropertyKeys: string[] = [];
 
 			entries(this.properties).forEach(([key, value]) => {

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -509,7 +509,7 @@ registerSuite({
 			assert.deepEqual((<any> myWidget.state).items, [ 'a', 'b' ]);
 			myWidget.setState(<any> { items: [ 'a', 'b', 'c'] });
 			myWidget.__render__();
-			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b' ]);
+			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b', 'c' ]);
 		},
 		'__render__() and invalidate()'() {
 			const widgetBase = createWidgetBase({

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -3,6 +3,8 @@ import * as assert from 'intern/chai!assert';
 import Promise from 'dojo-shim/Promise';
 import createWidgetBase from '../../src/createWidgetBase';
 import { DNode, HNode, WidgetState, WidgetOptions, WidgetProperties } from './../../src/interfaces';
+import shallowPropertyComparisonMixin from './../../src/mixins/shallowPropertyComparisonMixin';
+import { deepAssign } from 'dojo-core/lang';
 import { VNode } from 'dojo-interfaces/vdom';
 import { v, w, registry } from '../../src/d';
 import { stub } from 'sinon';
@@ -101,6 +103,22 @@ registerSuite({
 			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' });
 			assert.lengthOf(updatedKeys, 4);
 			assert.deepEqual(updatedKeys, [ 'foo', 'bar', 'baz', 'qux']);
+		},
+		'test compatibility with shallowPropertyComparisonMixin'() {
+			const properties = {
+				id: 'id',
+				items: [
+					{ foo: 'bar' }
+				]
+			};
+			const updatedProperties = deepAssign({}, properties);
+			updatedProperties.items[0].foo = 'foo';
+
+			const widgetBase = createWidgetBase.mixin(shallowPropertyComparisonMixin)({ properties });
+			widgetBase.properties = updatedProperties;
+			const updatedKeys = widgetBase.diffProperties(properties);
+			assert.lengthOf(updatedKeys, 1);
+			assert.deepEqual(updatedKeys, [ 'items' ]);
 		}
 	},
 	applyChangedProperties() {

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -3,8 +3,6 @@ import * as assert from 'intern/chai!assert';
 import Promise from 'dojo-shim/Promise';
 import createWidgetBase from '../../src/createWidgetBase';
 import { DNode, HNode, WidgetState, WidgetOptions, WidgetProperties } from './../../src/interfaces';
-import shallowPropertyComparisonMixin from './../../src/mixins/shallowPropertyComparisonMixin';
-import { deepAssign } from 'dojo-core/lang';
 import { VNode } from 'dojo-interfaces/vdom';
 import { v, w, registry } from '../../src/d';
 import { stub } from 'sinon';
@@ -103,22 +101,6 @@ registerSuite({
 			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' });
 			assert.lengthOf(updatedKeys, 4);
 			assert.deepEqual(updatedKeys, [ 'foo', 'bar', 'baz', 'qux']);
-		},
-		'test compatibility with shallowPropertyComparisonMixin'() {
-			const properties = {
-				id: 'id',
-				items: [
-					{ foo: 'bar' }
-				]
-			};
-			const updatedProperties = deepAssign({}, properties);
-			updatedProperties.items[0].foo = 'foo';
-
-			const widgetBase = createWidgetBase.mixin(shallowPropertyComparisonMixin)({ properties });
-			widgetBase.properties = updatedProperties;
-			const updatedKeys = widgetBase.diffProperties(properties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'items' ]);
 		}
 	},
 	applyChangedProperties() {

--- a/tests/unit/mixins/all.ts
+++ b/tests/unit/mixins/all.ts
@@ -1,3 +1,4 @@
 import './createCssTransitionMixin';
 import './createFormFieldMixin';
 import './createVNodeEvented';
+import './shallowPropertyComparisonMixin';

--- a/tests/unit/mixins/shallowPropertyComparisonMixin.ts
+++ b/tests/unit/mixins/shallowPropertyComparisonMixin.ts
@@ -2,6 +2,7 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { deepAssign } from 'dojo-core/lang';
 import shallowPropertyComparisonMixin from '../../../src/mixins/shallowPropertyComparisonMixin';
+import createWidgetBase from './../../../src/createWidgetBase';
 
 registerSuite({
 	name: 'mixins/shallowPropertyComparisonMixin',
@@ -131,5 +132,22 @@ registerSuite({
 			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
 			assert.lengthOf(updatedKeys, 0);
+		},
+		'test compatibility with shallowPropertyComparisonMixin'() {
+			const properties = {
+				id: 'id',
+				items: [
+					{ foo: 'bar' }
+				]
+			};
+			const updatedProperties = deepAssign({}, properties);
+			updatedProperties.items[0].foo = 'foo';
+
+			const widgetBase = createWidgetBase.mixin(shallowPropertyComparisonMixin)({ properties });
+			widgetBase.properties = updatedProperties;
+			const updatedKeys = widgetBase.diffProperties(properties);
+			assert.lengthOf(updatedKeys, 1);
+			assert.deepEqual(updatedKeys, [ 'items' ]);
 		}
+
 });

--- a/tests/unit/mixins/shallowPropertyComparisonMixin.ts
+++ b/tests/unit/mixins/shallowPropertyComparisonMixin.ts
@@ -1,0 +1,135 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { deepAssign } from 'dojo-core/lang';
+import shallowPropertyComparisonMixin from '../../../src/mixins/shallowPropertyComparisonMixin';
+
+registerSuite({
+	name: 'mixins/shallowPropertyComparisonMixin',
+		'no updated properties'() {
+			(<any> shallowPropertyComparisonMixin.mixin).properties = { id: 'id', foo: 'bar' };
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' });
+			assert.lengthOf(updatedKeys, 0);
+		},
+		'updated properties'() {
+			(<any> shallowPropertyComparisonMixin.mixin).properties = { id: 'id', foo: 'baz' };
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' });
+			assert.lengthOf(updatedKeys, 1);
+		},
+		'new properties'() {
+			(<any> shallowPropertyComparisonMixin.mixin).properties = { id: 'id', foo: 'bar', bar: 'baz' };
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' });
+			assert.lengthOf(updatedKeys, 1);
+		},
+		'updated / new properties with falsy values'() {
+			(<any> shallowPropertyComparisonMixin.mixin).properties = { id: 'id', foo: null, bar: '', baz: 0, qux: false };
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' });
+			assert.lengthOf(updatedKeys, 4);
+			assert.deepEqual(updatedKeys, [ 'foo', 'bar', 'baz', 'qux']);
+		},
+		'update array item in property'() {
+			const properties = {
+				id: 'id',
+				items: [ 'a', 'b' ],
+				otherItems: [ 'c', 'd']
+			};
+			const updatedProperties = deepAssign({}, properties);
+			updatedProperties.items[1] = 'c';
+
+			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
+			assert.lengthOf(updatedKeys, 1);
+			assert.deepEqual(updatedKeys, [ 'items' ]);
+		},
+		'reordered array property'() {
+			const properties = {
+				id: 'id',
+				items: [ 'a', 'b' ],
+				otherItems: [ 'c', 'd']
+			};
+			const updatedProperties = deepAssign({}, properties);
+			updatedProperties.items = updatedProperties.items.reverse();
+
+			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
+			assert.lengthOf(updatedKeys, 1);
+			assert.deepEqual(updatedKeys, [ 'items' ]);
+		},
+		'array property with updated object item'() {
+			const properties = {
+				id: 'id',
+				items: [
+					{ foo: 'bar' }
+				]
+			};
+			const updatedProperties = deepAssign({}, properties);
+			updatedProperties.items[0].foo = 'foo';
+
+			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
+			assert.lengthOf(updatedKeys, 1);
+			assert.deepEqual(updatedKeys, [ 'items' ]);
+		},
+		'array property with new object item'() {
+			const properties: any = {
+				id: 'id',
+				items: [
+					{ foo: 'bar' }
+				]
+			};
+			const updatedProperties = deepAssign({}, properties);
+			updatedProperties.items[1] = { bar: 'foo' };
+
+			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
+			assert.lengthOf(updatedKeys, 1);
+			assert.deepEqual(updatedKeys, [ 'items' ]);
+		},
+		'updated value in property object'() {
+			const properties = {
+				id: 'id',
+				obj: {
+					foo: 'bar'
+				},
+				otherObj: {
+					baz: 'qux'
+				}
+			};
+			const updatedProperties = deepAssign({}, properties);
+			updatedProperties.obj.foo = 'foo';
+
+			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
+			assert.lengthOf(updatedKeys, 1);
+			assert.deepEqual(updatedKeys, [ 'obj' ]);
+		},
+		'new key in property object'() {
+			const properties: any = {
+				id: 'id',
+				obj: {
+					foo: 'bar'
+				},
+				otherObj: {
+					baz: 'qux'
+				}
+			};
+			const updatedProperties = deepAssign({}, properties);
+			updatedProperties.obj.bar = 'foo';
+
+			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
+			assert.lengthOf(updatedKeys, 1);
+			assert.deepEqual(updatedKeys, [ 'obj' ]);
+		},
+		'ignore functions'() {
+			const properties: any = {
+				id: 'id',
+				myFunc: () => {}
+			};
+			const updatedProperties = deepAssign({}, properties);
+			updatedProperties.myFunc = () => {};
+
+			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
+			assert.lengthOf(updatedKeys, 0);
+		}
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Provide a `mixin` that overrides the `diffProperties` function providing an enhanced algorithm to perform a "shallow" comparison for Array and Object attributes passed as `WidgetProperties`.

For Objects, `values` for all keys are compared against the equivalent key on the `previousProperties` attribute using `===`. If the key does not exists on the `previousProperties` attribute it is considered unequal.

For Arrays, each item is compared with the item in the equivalent index of the `previousProperties` attribute. If the item is an object then the object comparison described above is applied otherwise a simple `===` is used.

Usage:

```ts
const createMyCustomWidget = createWidgetBase.mixin(shallowPropertyComparisonMixin);
```

Resolves #187 
