### PR TITLE
Dialog component

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -1,5 +1,25 @@
 module.exports = function (grunt) {
+
+	var staticExampleFiles = [ 'src/examples/**', '!src/examples/**/*.js' ];
+
 	require('grunt-dojo2').initConfig(grunt, {
-		/* any custom configuration goes here */
+		copy: {
+			staticExampleFiles: {
+				expand: true,
+				cwd: '.',
+				src: staticExampleFiles,
+				dest: '<%= devDirectory %>'
+			}
+		}
 	});
+
+	grunt.registerTask('dev', [
+		'clean:typings',
+		'typings',
+		'tslint',
+		'clean:dev',
+		'ts:dev',
+		'copy:staticTestFiles',
+		'copy:staticExampleFiles'
+	]);
 };

--- a/src/components/dialog/createDialog.ts
+++ b/src/components/dialog/createDialog.ts
@@ -5,9 +5,9 @@ import createWidgetBase from '../../createWidgetBase';
 import { v } from '../../d';
 
 export interface DialogState extends WidgetState {
-	title?: string;
-	open?: boolean;
 	modal?: boolean;
+	open?: boolean;
+	title?: string;
 	underlay?: boolean;
 };
 
@@ -24,7 +24,7 @@ export interface DialogOptions extends WidgetOptions<DialogState, DialogProperti
 
 export type Dialog = Widget<DialogState, DialogProperties> & {
 	onCloseClick?(): void;
-	onContentClick?(): void;
+	onContentClick?(event: MouseEvent): void;
 	onUnderlayClick?(): void;
 };
 
@@ -37,7 +37,7 @@ const createDialogWidget: DialogFactory = createWidgetBase
 				this.properties.onRequestClose && this.properties.onRequestClose.call(this);
 			},
 
-			onContentClick: function (this: Dialog, event: MouseEvent) {
+			onContentClick: function (event: MouseEvent) {
 				event.stopPropagation();
 			},
 

--- a/src/components/dialog/createDialog.ts
+++ b/src/components/dialog/createDialog.ts
@@ -57,16 +57,15 @@ const createDialogWidget: DialogFactory = createWidgetBase
 					exitAnimation = 'hide'
 				} = this.properties;
 
-				const dialogChildren: DNode[] = [
-					v('div.title', { innerHTML: this.state.title }),
-					v('div.content', this.children)
-				];
-
-				closeable && dialogChildren.push(v('div.close', { innerHTML: '✖', onclick: this.onCloseClick }));
-
 				const children: DNode[] = [
 					v('div.underlay', { enterAnimation: 'show', exitAnimation: 'hide', onclick: this.onUnderlayClick }),
-					v('div.main', { enterAnimation: enterAnimation, exitAnimation: exitAnimation }, dialogChildren)
+					v('div.main', { enterAnimation: enterAnimation, exitAnimation: exitAnimation }, [
+						v('div.title', [
+							this.state.title,
+							closeable ? v('div.close', { innerHTML: '✕', onclick: this.onCloseClick }) : null
+						]),
+						v('div.content', this.children)
+					])
 				];
 
 				return this.state.open ? children : [];

--- a/src/components/dialog/createDialog.ts
+++ b/src/components/dialog/createDialog.ts
@@ -8,14 +8,16 @@ export interface DialogState extends WidgetState {
 	title?: string;
 	open?: boolean;
 	modal?: boolean;
+	underlay?: boolean;
 };
 
 export interface DialogProperties extends WidgetProperties {
-	title?: string;
-	open?: boolean;
 	modal?: boolean;
-	onRequestClose?(): void;
+	open?: boolean;
+	title?: string;
+	underlay?: boolean;
 	onOpen?(): void;
+	onRequestClose?(): void;
 };
 
 export interface DialogOptions extends WidgetOptions<DialogState, DialogProperties> { };
@@ -45,17 +47,13 @@ const createDialogWidget: DialogFactory = createWidgetBase
 
 			getChildrenNodes: function (this: Dialog): DNode[] {
 				const children: DNode[] = [
-					// TODO: CSS modules
 					v('div.title', { innerHTML: this.state.title }),
-					// TODO: CSS modules
 					v('div.close', {
 						innerHTML: '✖',
 						onclick: this.onCloseClick
 					}),
-					// TODO: CSS modules
 					v('div.content', this.children)
 				];
-				// TODO: CSS modules
 				const content: DNode = v('div.content', { onclick: this.onContentClick }, children);
 				return [ content ];
 			},
@@ -66,12 +64,11 @@ const createDialogWidget: DialogFactory = createWidgetBase
 					return {
 						onclick: this.onUnderlayClick,
 						'data-open': this.state.open ? 'true' : 'false',
-						'data-modal': this.state.modal ? 'true' : 'false'
+						'data-underlay': this.state.underlay ? 'true' : 'false'
 					};
 				}
 			],
 
-			// TODO: CSS modules
 			classes: [ 'dialog' ]
 		}
 	});

--- a/src/components/dialog/createDialog.ts
+++ b/src/components/dialog/createDialog.ts
@@ -58,11 +58,21 @@ const createDialogWidget: DialogFactory = createWidgetBase
 				} = this.properties;
 
 				const children: DNode[] = [
-					v('div.underlay', { enterAnimation: 'show', exitAnimation: 'hide', onclick: this.onUnderlayClick }),
-					v('div.main', { enterAnimation: enterAnimation, exitAnimation: exitAnimation }, [
+					v('div.underlay', {
+						enterAnimation: 'show',
+						exitAnimation: 'hide',
+						onclick: this.onUnderlayClick
+					}),
+					v('div.main', {
+						enterAnimation: enterAnimation,
+						exitAnimation: exitAnimation
+					}, [
 						v('div.title', [
 							this.state.title,
-							closeable ? v('div.close', { innerHTML: '✕', onclick: this.onCloseClick }) : null
+							closeable ? v('div.close', {
+								innerHTML: '✕',
+								onclick: this.onCloseClick
+							}) : null
 						]),
 						v('div.content', this.children)
 					])

--- a/src/components/dialog/createDialog.ts
+++ b/src/components/dialog/createDialog.ts
@@ -5,6 +5,7 @@ import createWidgetBase from '../../createWidgetBase';
 import { v } from '../../d';
 
 export interface DialogState extends WidgetState {
+	closeable?: boolean;
 	modal?: boolean;
 	open?: boolean;
 	title?: string;
@@ -12,6 +13,7 @@ export interface DialogState extends WidgetState {
 };
 
 export interface DialogProperties extends WidgetProperties {
+	closeable?: boolean;
 	modal?: boolean;
 	open?: boolean;
 	title?: string;
@@ -34,7 +36,8 @@ const createDialogWidget: DialogFactory = createWidgetBase
 	.mixin({
 		mixin: {
 			onCloseClick: function (this: Dialog) {
-				this.properties.onRequestClose && this.properties.onRequestClose.call(this);
+				const closeable = this.state.closeable || typeof this.state.closeable === 'undefined';
+				closeable && this.properties.onRequestClose && this.properties.onRequestClose.call(this);
 			},
 
 			onContentClick: function (event: MouseEvent) {
@@ -46,14 +49,15 @@ const createDialogWidget: DialogFactory = createWidgetBase
 			},
 
 			getChildrenNodes: function (this: Dialog): DNode[] {
-				const children: DNode[] = [
-					v('div.title', { innerHTML: this.state.title }),
-					v('div.close', {
+				const children: DNode[] = [ v('div.title', { innerHTML: this.state.title }) ];
+				// TODO: Properly default closeable property to `true`
+				if (this.state.closeable || typeof this.state.closeable === 'undefined') {
+					children.push(v('div.close', {
 						innerHTML: '✖',
 						onclick: this.onCloseClick
-					}),
-					v('div.content', this.children)
-				];
+					}));
+				}
+				children.push(v('div.content', this.children));
 				const content: DNode = v('div.content', { onclick: this.onContentClick }, children);
 				return [ content ];
 			},

--- a/src/components/dialog/createDialog.ts
+++ b/src/components/dialog/createDialog.ts
@@ -1,0 +1,81 @@
+import { ComposeFactory } from 'dojo-compose/compose';
+import { VNodeProperties } from 'dojo-interfaces/vdom';
+import { DNode, Widget, WidgetOptions, WidgetProperties, WidgetState } from '../../interfaces';
+import createWidgetBase from '../../createWidgetBase';
+import { v } from '../../d';
+
+export interface DialogState extends WidgetState {
+	title?: string;
+	open?: boolean;
+	modal?: boolean;
+}
+
+export interface DialogProperties extends WidgetProperties {
+	title?: string;
+	open?: boolean;
+	modal?: boolean;
+	onopen?(): void;
+	onclose?(): void;
+}
+
+export interface DialogOptions extends WidgetOptions<DialogState, DialogProperties> { }
+
+export type Dialog = Widget<DialogState, DialogProperties>;
+
+export interface DialogFactory extends ComposeFactory<Dialog, DialogOptions> { };
+
+function onCloseClick(this: Dialog) {
+	this.setState({ open: false });
+}
+
+function onContentClick(this: Dialog, event: MouseEvent) {
+	event.stopPropagation();
+}
+
+function onUnderlayClick(this: Dialog, event: MouseEvent) {
+	if (this.state.modal) {
+		return;
+	}
+
+	this.setState({ open: false });
+}
+
+const createDialogWidget: DialogFactory = createWidgetBase
+	.mixin({
+		mixin: {
+			getChildrenNodes: function (this: Dialog): DNode[] {
+				const children: DNode[] = [
+					// TODO: CSS modules
+					v('div.title', { innerHTML: this.state.title }),
+					// TODO: CSS modules
+					v('div.close', {
+						innerHTML: '✖',
+						onclick: onCloseClick
+					}),
+					// TODO: CSS modules
+					v('div.content', this.children)
+				];
+				// TODO: CSS modules
+				const content: DNode = v('div.content', { onclick: onContentClick }, children);
+				return [ content ];
+			},
+
+			nodeAttributes: [
+				function(this: Dialog): VNodeProperties {
+					this.state.open && this.properties.onopen && this.properties.onopen();
+					!this.state.open && this.properties.onclose && this.properties.onclose();
+					return { 'data-open': this.state.open ? 'true' : 'false' };
+				},
+				function(this: Dialog): VNodeProperties {
+					return { 'data-modal': this.state.modal ? 'true' : 'false' };
+				}
+			],
+
+			listeners: { onclick: onUnderlayClick },
+
+			// TODO: CSS modules
+			classes: [ 'dialog' ]
+		}
+	});
+
+export default createDialogWidget;

--- a/src/components/dialog/createDialog.ts
+++ b/src/components/dialog/createDialog.ts
@@ -28,11 +28,10 @@ export interface DialogOptions extends WidgetOptions<DialogState, DialogProperti
 
 export type Dialog = Widget<DialogState, DialogProperties> & {
 	onCloseClick?(): void;
-	onContentClick?(event: MouseEvent): void;
 	onUnderlayClick?(): void;
 };
 
-export interface DialogFactory extends ComposeFactory<Dialog, DialogOptions> { }
+export interface DialogFactory extends ComposeFactory<Dialog, DialogOptions> { };
 
 const createDialogWidget: DialogFactory = createWidgetBase
 	.mixin({
@@ -40,10 +39,6 @@ const createDialogWidget: DialogFactory = createWidgetBase
 			onCloseClick: function (this: Dialog) {
 				const closeable = this.state.closeable || typeof this.state.closeable === 'undefined';
 				closeable && this.properties.onRequestClose && this.properties.onRequestClose.call(this);
-			},
-
-			onContentClick: function (event: MouseEvent) {
-				event.stopPropagation();
 			},
 
 			onUnderlayClick: function (this: Dialog) {
@@ -68,7 +63,7 @@ const createDialogWidget: DialogFactory = createWidgetBase
 						exitAnimation: exitAnimation
 					}, [
 						v('div.title', [
-							this.state.title,
+							this.state.title ? this.state.title : null,
 							closeable ? v('div.close', {
 								innerHTML: '✕',
 								onclick: this.onCloseClick

--- a/src/examples/boot.ts
+++ b/src/examples/boot.ts
@@ -1,0 +1,52 @@
+import { DNode, Widget, WidgetState, WidgetProperties } from '../interfaces';
+import { w } from '../d';
+import createProjector, { ProjectorMixin } from '../createProjector';
+import createButton from '../components/button/createButton';
+import createDialog from '../components/dialog/createDialog';
+
+interface RootState extends WidgetState {
+	dialogOpen?: boolean;
+	modalDialogOpen?: boolean;
+}
+
+type Root = Widget<RootState, WidgetProperties> & ProjectorMixin;
+
+const createApp = createProjector.mixin({
+	mixin: {
+		getChildrenNodes: function(this: Root): DNode[] {
+			console.log('a', this.state.dialogOpen);
+			const self: Root = this;
+			return [
+				w(createDialog, {
+					id: 'dialog',
+					properties: {
+						title: 'Dialog',
+						open: this.state.dialogOpen,
+						onclose: () => {
+							console.log('b', this.state.dialogOpen);
+							self.setState({ dialogOpen: false });
+							console.log('c', this.state.dialogOpen);
+						}
+					}
+				}),
+				w(createButton, {
+					id: 'button',
+					properties: { label: 'open dialog' },
+					listeners: {
+						click: () => {
+							this.setState({ dialogOpen: true });
+						}
+					}
+				})
+			];
+		},
+		classes: [ 'main-app' ],
+		tagName: 'main'
+	}
+});
+
+const app = createApp();
+
+app.append().then(() => {
+	console.log('projector is attached');
+});

--- a/src/examples/boot.ts
+++ b/src/examples/boot.ts
@@ -14,18 +14,25 @@ type Root = Widget<RootState, WidgetProperties> & ProjectorMixin;
 const createApp = createProjector.mixin({
 	mixin: {
 		getChildrenNodes: function(this: Root): DNode[] {
-			console.log('a', this.state.dialogOpen);
-			const self: Root = this;
 			return [
 				w(createDialog, {
 					id: 'dialog',
 					properties: {
 						title: 'Dialog',
 						open: this.state.dialogOpen,
-						onclose: () => {
-							console.log('b', this.state.dialogOpen);
-							self.setState({ dialogOpen: false });
-							console.log('c', this.state.dialogOpen);
+						onRequestClose: () => {
+							this.setState({ dialogOpen: false });
+						}
+					}
+				}),
+				w(createDialog, {
+					id: 'modal-dialog',
+					properties: {
+						title: 'Modal Dialog',
+						modal: true,
+						open: this.state.modalDialogOpen,
+						onRequestClose: () => {
+							this.setState({ modalDialogOpen: false });
 						}
 					}
 				}),
@@ -35,6 +42,15 @@ const createApp = createProjector.mixin({
 					listeners: {
 						click: () => {
 							this.setState({ dialogOpen: true });
+						}
+					}
+				}),
+				w(createButton, {
+					id: 'modal-button',
+					properties: { label: 'open modal dialog' },
+					listeners: {
+						click: () => {
+							this.setState({ modalDialogOpen: true });
 						}
 					}
 				})

--- a/src/examples/boot.ts
+++ b/src/examples/boot.ts
@@ -1,15 +1,24 @@
 import { DNode, Widget, WidgetState, WidgetProperties } from '../interfaces';
-import { w } from '../d';
+import { w, v } from '../d';
 import createProjector, { ProjectorMixin } from '../createProjector';
 import createButton from '../components/button/createButton';
 import createDialog from '../components/dialog/createDialog';
 
 interface RootState extends WidgetState {
-	dialogOpen?: boolean;
-	modalDialogOpen?: boolean;
+	open?: boolean;
+	modal?: boolean;
+	underlay?: boolean;
 }
 
 type Root = Widget<RootState, WidgetProperties> & ProjectorMixin;
+
+function toggleModal(this: Root, event: Event) {
+	this.setState({ modal: (<HTMLInputElement> event.target).checked });
+}
+
+function toggleUnderlay(this: Root, event: Event) {
+	this.setState({ underlay: (<HTMLInputElement> event.target).checked });
+}
 
 const createApp = createProjector.mixin({
 	mixin: {
@@ -19,20 +28,11 @@ const createApp = createProjector.mixin({
 					id: 'dialog',
 					properties: {
 						title: 'Dialog',
-						open: this.state.dialogOpen,
+						open: this.state.open,
+						modal: this.state.modal,
+						underlay: this.state.underlay,
 						onRequestClose: () => {
-							this.setState({ dialogOpen: false });
-						}
-					}
-				}),
-				w(createDialog, {
-					id: 'modal-dialog',
-					properties: {
-						title: 'Modal Dialog',
-						modal: true,
-						open: this.state.modalDialogOpen,
-						onRequestClose: () => {
-							this.setState({ modalDialogOpen: false });
+							this.setState({ open: false });
 						}
 					}
 				}),
@@ -41,18 +41,27 @@ const createApp = createProjector.mixin({
 					properties: { label: 'open dialog' },
 					listeners: {
 						click: () => {
-							this.setState({ dialogOpen: true });
+							this.setState({ open: true });
 						}
 					}
 				}),
-				w(createButton, {
-					id: 'modal-button',
-					properties: { label: 'open modal dialog' },
-					listeners: {
-						click: () => {
-							this.setState({ modalDialogOpen: true });
-						}
-					}
+				v('label', {
+					for: 'modal',
+					innerHTML: 'modal'
+				}),
+				v('input', {
+					type: 'checkbox',
+					id: 'modal',
+					onchange: toggleModal
+				}),
+				v('label', {
+					for: 'underlay',
+					innerHTML: 'underlay'
+				}),
+				v('input', {
+					type: 'checkbox',
+					id: 'underlay',
+					onchange: toggleUnderlay
 				})
 			];
 		},

--- a/src/examples/dialog/index.html
+++ b/src/examples/dialog/index.html
@@ -12,10 +12,37 @@
 			left: 50%;
 			transform: translate(-50%, -50%);
 			background: #FFF;
+			min-width: 450px;
+			min-height: 250px;
+			box-shadow: 0 0 7px 0px rgba(0, 0, 0, 0.25);
+			border-radius: 2px;
+			overflow: hidden;
+			font-family: sans-serif;
+		}
+
+		.dialog .main .title {
+			background-color: #34495e;
+			font-size: 20px;
+			color: #FFF;
+			padding: 14px 35px;
+			position: relative;
+		}
+
+		.dialog .main .title .close {
+			position: absolute;
+			top: 50%;
+			transform: translateY(-50%);
+			right: 35px;
+			cursor: pointer;
+			line-height: 1;
+		}
+
+		.dialog .content {
+			padding: 14px 35px;
 		}
 
 		.show {
-			transition: opacity .5s;
+			transition: opacity .2s;
 			opacity: 0;
 		}
 
@@ -24,7 +51,7 @@
 		}
 
 		.hide {
-			transition: opacity .5s;
+			transition: opacity .2s;
 			opacity: 1;
 		}
 
@@ -41,12 +68,12 @@
 		}
 
 		.dialog[data-underlay="true"] .underlay {
-			background: rgba(0, 0, 0, 0.5);
+			background: rgba(0, 0, 0, 0.3);
 		}
 
 		.slideIn {
-			transition: top .5s;
-			top: -100px !important;
+			transition: top .2s;
+			top: -150px !important;
 		}
 
 		.slideIn-active {
@@ -54,12 +81,12 @@
 		}
 
 		.slideOut {
-			transition: top .5s;
+			transition: top .2s;
 			top: 50% !important;
 		}
 
 		.slideOut-active {
-			top: -100px !important;
+			top: -150px !important;
 		}
 
 		button {

--- a/src/examples/dialog/index.html
+++ b/src/examples/dialog/index.html
@@ -42,21 +42,21 @@
 			padding: 14px 35px;
 		}
 
-		.show {
+		.dialog .show {
 			transition: opacity .2s;
 			opacity: 0;
 		}
 
-		.show-active {
+		.dialog .show-active {
 			opacity: 1;
 		}
 
-		.hide {
+		.dialog .hide {
 			transition: opacity .2s;
 			opacity: 1;
 		}
 
-		.hide-active {
+		.dialog .hide-active {
 			opacity: 0;
 		}
 

--- a/src/examples/dialog/index.html
+++ b/src/examples/dialog/index.html
@@ -30,6 +30,15 @@
 		.dialog[data-underlay="true"] {
 			background: rgba(0, 0, 0, 0.5);
 		}
+
+
+		button {
+			margin-bottom: 50px;
+		}
+
+		.option {
+			margin-bottom: 10px;
+		}
 	</style>
 	<script>
 		require.config({

--- a/src/examples/dialog/index.html
+++ b/src/examples/dialog/index.html
@@ -1,10 +1,10 @@
 <!DOCTYPE html>
 <html>
 <head>
-	<title>dojo-widget Examples</title>
+	<title>Dialog Examples</title>
 </head>
 <body>
-	<script src="../../../node_modules/dojo-loader/loader.min.js"></script>
+	<script src="../../../../node_modules/dojo-loader/loader.min.js"></script>
 	<style>
 		.dialog {
 			width: 100%;
@@ -33,7 +33,7 @@
 	</style>
 	<script>
 		require.config({
-			baseUrl: '../../..',
+			baseUrl: '../../../..',
 			packages: [
 				{ name: 'src', location: '_build/src' },
 				{ name: 'dojo-actions', location: 'node_modules/dojo-actions' },
@@ -49,7 +49,7 @@
 		});
 
 		/* Requiring in the main module */
-		require([ 'src/examples/boot' ], function () {});
+		require([ 'src/examples/dialog/index' ], function () {});
 	</script>
 </body>
 </html>

--- a/src/examples/dialog/index.html
+++ b/src/examples/dialog/index.html
@@ -12,12 +12,13 @@
 			left: 50%;
 			transform: translate(-50%, -50%);
 			background: #FFF;
-			min-width: 450px;
+			width: 450px;
 			min-height: 250px;
 			box-shadow: 0 0 7px 0px rgba(0, 0, 0, 0.25);
 			border-radius: 2px;
 			overflow: hidden;
 			font-family: sans-serif;
+			max-width: calc(100% - 30px);
 		}
 
 		.dialog .main .title {

--- a/src/examples/dialog/index.html
+++ b/src/examples/dialog/index.html
@@ -6,20 +6,7 @@
 <body>
 	<script src="../../../../node_modules/dojo-loader/loader.min.js"></script>
 	<style>
-		.dialog {
-			width: 100%;
-			height: 100%;
-			position: fixed;
-			top: 0;
-			left: 0;
-			display: none;
-		}
-
-		.dialog[data-open="true"] {
-			display: block;
-		}
-
-		.dialog .content {
+		.dialog .main {
 			position: absolute;
 			top: 50%;
 			left: 50%;
@@ -27,10 +14,53 @@
 			background: #FFF;
 		}
 
-		.dialog[data-underlay="true"] {
+		.show {
+			transition: opacity .5s;
+			opacity: 0;
+		}
+
+		.show-active {
+			opacity: 1;
+		}
+
+		.hide {
+			transition: opacity .5s;
+			opacity: 1;
+		}
+
+		.hide-active {
+			opacity: 0;
+		}
+
+		.dialog .underlay {
+			width: 100%;
+			position: fixed;
+			top: 0;
+			left: 0;
+			height: 100%;
+		}
+
+		.dialog[data-underlay="true"] .underlay {
 			background: rgba(0, 0, 0, 0.5);
 		}
 
+		.slideIn {
+			transition: top .5s;
+			top: -100px !important;
+		}
+
+		.slideIn-active {
+			top: 50% !important;
+		}
+
+		.slideOut {
+			transition: top .5s;
+			top: 50% !important;
+		}
+
+		.slideOut-active {
+			top: -100px !important;
+		}
 
 		button {
 			margin-bottom: 50px;
@@ -40,6 +70,7 @@
 			margin-bottom: 10px;
 		}
 	</style>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/maquette/2.4.2/css-transitions.min.js"></script>
 	<script>
 		require.config({
 			baseUrl: '../../../..',

--- a/src/examples/dialog/index.ts
+++ b/src/examples/dialog/index.ts
@@ -49,11 +49,11 @@ const createApp = createProjector.mixin({
 		cssTransitions: true,
 		getChildrenNodes: function(this: Root): DNode[] {
 			return [
-				this.state.open ? w(createDialog, {
+				w(createDialog, {
 					id: 'dialog',
 					properties: {
 						title: 'Dialog',
-						open: true,
+						open: this.state.open,
 						modal: this.state.modal,
 						underlay: this.state.underlay,
 						closeable: this.state.closeable,
@@ -63,7 +63,9 @@ const createApp = createProjector.mixin({
 							this.setState({ open: false });
 						}
 					}
-				}) : null,
+				}, [
+					'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+				]),
 				w(createButton, {
 					id: 'button',
 					properties: { label: 'open dialog' },

--- a/src/examples/dialog/index.ts
+++ b/src/examples/dialog/index.ts
@@ -8,9 +8,17 @@ interface RootState extends WidgetState {
 	open?: boolean;
 	modal?: boolean;
 	underlay?: boolean;
+	closeable?: boolean;
 }
 
-type Root = Widget<RootState, WidgetProperties> & ProjectorMixin;
+interface RootProperties extends WidgetProperties {
+	open?: boolean;
+	modal?: boolean;
+	underlay?: boolean;
+	closeable?: boolean;
+};
+
+type Root = Widget<RootState, RootProperties> & ProjectorMixin;
 
 function toggleModal(this: Root, event: Event) {
 	this.setState({ modal: (<HTMLInputElement> event.target).checked });
@@ -18,6 +26,10 @@ function toggleModal(this: Root, event: Event) {
 
 function toggleUnderlay(this: Root, event: Event) {
 	this.setState({ underlay: (<HTMLInputElement> event.target).checked });
+}
+
+function toggleCloseable(this: Root, event: Event) {
+	this.setState({ closeable: (<HTMLInputElement> event.target).checked });
 }
 
 const createApp = createProjector.mixin({
@@ -31,6 +43,7 @@ const createApp = createProjector.mixin({
 						open: this.state.open,
 						modal: this.state.modal,
 						underlay: this.state.underlay,
+						closeable: this.state.closeable,
 						onRequestClose: () => {
 							this.setState({ open: false });
 						}
@@ -45,24 +58,40 @@ const createApp = createProjector.mixin({
 						}
 					}
 				}),
-				v('label', {
-					for: 'modal',
-					innerHTML: 'modal'
-				}),
-				v('input', {
-					type: 'checkbox',
-					id: 'modal',
-					onchange: toggleModal
-				}),
-				v('label', {
-					for: 'underlay',
-					innerHTML: 'underlay'
-				}),
-				v('input', {
-					type: 'checkbox',
-					id: 'underlay',
-					onchange: toggleUnderlay
-				})
+				v('div', { classes: { option: true }}, [
+					v('input', {
+						type: 'checkbox',
+						id: 'modal',
+						onchange: toggleModal
+					}),
+					v('label', {
+						for: 'modal',
+						innerHTML: 'modal'
+					})
+				]),
+				v('div', { classes: { option: true }}, [
+					v('input', {
+						type: 'checkbox',
+						id: 'underlay',
+						onchange: toggleUnderlay
+					}),
+					v('label', {
+						for: 'underlay',
+						innerHTML: 'underlay'
+					})
+				]),
+				v('div', { classes: { option: true }}, [
+					v('input', {
+						type: 'checkbox',
+						id: 'closeable',
+						onchange: toggleCloseable,
+						checked: true
+					}),
+					v('label', {
+						for: 'closeable',
+						innerHTML: 'closeable'
+					})
+				])
 			];
 		},
 		classes: [ 'main-app' ],
@@ -70,7 +99,11 @@ const createApp = createProjector.mixin({
 	}
 });
 
-const app = createApp();
+const app = createApp({
+	properties: {
+		closeable: true
+	}
+});
 
 app.append().then(() => {
 	console.log('projector is attached');

--- a/src/examples/dialog/index.ts
+++ b/src/examples/dialog/index.ts
@@ -1,8 +1,8 @@
-import { DNode, Widget, WidgetState, WidgetProperties } from '../interfaces';
-import { w, v } from '../d';
-import createProjector, { ProjectorMixin } from '../createProjector';
-import createButton from '../components/button/createButton';
-import createDialog from '../components/dialog/createDialog';
+import { DNode, Widget, WidgetState, WidgetProperties } from '../../interfaces';
+import { w, v } from '../../d';
+import createProjector, { ProjectorMixin } from '../../createProjector';
+import createButton from '../../components/button/createButton';
+import createDialog from '../../components/dialog/createDialog';
 
 interface RootState extends WidgetState {
 	open?: boolean;

--- a/src/examples/dialog/index.ts
+++ b/src/examples/dialog/index.ts
@@ -64,7 +64,9 @@ const createApp = createProjector.mixin({
 						}
 					}
 				}, [
-					'Lorem ipsum dolor sit amet, consectetur adipiscing elit.'
+					`Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+					Quisque id purus ipsum. Aenean ac purus purus.
+					Nam sollicitudin varius augue, sed lacinia felis tempor in.`
 				]),
 				w(createButton, {
 					id: 'button',

--- a/src/examples/dialog/index.ts
+++ b/src/examples/dialog/index.ts
@@ -9,6 +9,8 @@ interface RootState extends WidgetState {
 	modal?: boolean;
 	underlay?: boolean;
 	closeable?: boolean;
+	enterAnimation?: string;
+	exitAnimation?: string;
 }
 
 interface RootProperties extends WidgetProperties {
@@ -16,6 +18,8 @@ interface RootProperties extends WidgetProperties {
 	modal?: boolean;
 	underlay?: boolean;
 	closeable?: boolean;
+	enterAnimation?: string;
+	exitAnimation?: string;
 };
 
 type Root = Widget<RootState, RootProperties> & ProjectorMixin;
@@ -32,23 +36,34 @@ function toggleCloseable(this: Root, event: Event) {
 	this.setState({ closeable: (<HTMLInputElement> event.target).checked });
 }
 
+function toggleEnterAnimation(this: Root, event: Event) {
+	this.setState({ enterAnimation: (<HTMLInputElement> event.target).checked ? 'slideIn' : undefined });
+}
+
+function toggleExitAnimation(this: Root, event: Event) {
+	this.setState({ exitAnimation: (<HTMLInputElement> event.target).checked ? 'slideOut' : undefined });
+}
+
 const createApp = createProjector.mixin({
 	mixin: {
+		cssTransitions: true,
 		getChildrenNodes: function(this: Root): DNode[] {
 			return [
-				w(createDialog, {
+				this.state.open ? w(createDialog, {
 					id: 'dialog',
 					properties: {
 						title: 'Dialog',
-						open: this.state.open,
+						open: true,
 						modal: this.state.modal,
 						underlay: this.state.underlay,
 						closeable: this.state.closeable,
+						enterAnimation: this.state.enterAnimation,
+						exitAnimation: this.state.exitAnimation,
 						onRequestClose: () => {
 							this.setState({ open: false });
 						}
 					}
-				}),
+				}) : null,
 				w(createButton, {
 					id: 'button',
 					properties: { label: 'open dialog' },
@@ -91,6 +106,28 @@ const createApp = createProjector.mixin({
 						for: 'closeable',
 						innerHTML: 'closeable'
 					})
+				]),
+				v('div', { classes: { option: true }}, [
+					v('input', {
+						type: 'checkbox',
+						id: 'enterAnimation',
+						onchange: toggleEnterAnimation
+					}),
+					v('label', {
+						for: 'enterAnimation',
+						innerHTML: 'enterAnimation'
+					})
+				]),
+				v('div', { classes: { option: true }}, [
+					v('input', {
+						type: 'checkbox',
+						id: 'exitAnimation',
+						onchange: toggleExitAnimation
+					}),
+					v('label', {
+						for: 'exitAnimation',
+						innerHTML: 'exitAnimation'
+					})
 				])
 			];
 		},
@@ -100,6 +137,7 @@ const createApp = createProjector.mixin({
 });
 
 const app = createApp({
+	cssTransitions: true,
 	properties: {
 		closeable: true
 	}

--- a/src/examples/index.html
+++ b/src/examples/index.html
@@ -19,7 +19,12 @@
 			display: block;
 		}
 
-		
+		.dialog .content {
+			position: absolute;
+			top: 50%;
+			left: 50%;
+			transform: translate(-50%, -50%);
+		}
 	</style>
 	<script>
 		require.config({

--- a/src/examples/index.html
+++ b/src/examples/index.html
@@ -1,0 +1,45 @@
+<!DOCTYPE html>
+<html>
+<head>
+	<title>dojo-widget Examples</title>
+</head>
+<body>
+	<script src="../../../node_modules/dojo-loader/loader.min.js"></script>
+	<style>
+		.dialog {
+			width: 100%;
+			height: 100%;
+			position: fixed;
+			top: 0;
+			left: 0;
+			display: none;
+		}
+
+		.dialog[data-open="true"] {
+			display: block;
+		}
+
+		
+	</style>
+	<script>
+		require.config({
+			baseUrl: '../../..',
+			packages: [
+				{ name: 'src', location: '_build/src' },
+				{ name: 'dojo-actions', location: 'node_modules/dojo-actions' },
+				{ name: 'dojo-compose', location: 'node_modules/dojo-compose' },
+				{ name: 'dojo-core', location: 'node_modules/dojo-core' },
+				{ name: 'dojo-has', location: 'node_modules/dojo-has' },
+				{ name: 'dojo-shim', location: 'node_modules/dojo-shim' },
+				{ name: 'dojo-stores', location: 'node_modules/dojo-stores'},
+				{ name: 'immutable', location: 'node_modules/immutable/dist', main: 'immutable' },
+				{ name: 'maquette', location: 'node_modules/maquette/dist', main: 'maquette' },
+				{ name: 'rxjs', location: 'node_modules/@reactivex/rxjs/dist/amd' }
+			]
+		});
+
+		/* Requiring in the main module */
+		require([ 'src/examples/boot' ], function () {});
+	</script>
+</body>
+</html>

--- a/src/examples/index.html
+++ b/src/examples/index.html
@@ -24,6 +24,11 @@
 			top: 50%;
 			left: 50%;
 			transform: translate(-50%, -50%);
+			background: #FFF;
+		}
+
+		.dialog[data-underlay="true"] {
+			background: rgba(0, 0, 0, 0.5);
 		}
 	</style>
 	<script>

--- a/tests/unit/components/all.ts
+++ b/tests/unit/components/all.ts
@@ -1,2 +1,3 @@
 import './button/createButton';
 import './textinput/createTextInput';
+import './dialog/createDialog';

--- a/tests/unit/components/dialog/createDialog.ts
+++ b/tests/unit/components/dialog/createDialog.ts
@@ -92,7 +92,6 @@ registerSuite({
 			}
 		});
 
-		dialog.onContentClick && dialog.onContentClick(<MouseEvent> { stopPropagation: () => { }});
 		dialog.onUnderlayClick && dialog.onUnderlayClick();
 		assert.isTrue(dialog.state.open);
 	},

--- a/tests/unit/components/dialog/createDialog.ts
+++ b/tests/unit/components/dialog/createDialog.ts
@@ -1,0 +1,93 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import { VNode } from 'dojo-interfaces/vdom';
+import createDialog from '../../../../src/components/dialog/createDialog';
+import createProjector from '../../../../src/createProjector';
+import { w } from '../../../../src/d';
+
+registerSuite({
+	name: 'createDialog',
+
+	construction() {
+		const dialog = createDialog({
+			properties: {
+				id: 'foo',
+				modal: true,
+				open: false,
+				title: 'dialog',
+				underlay: true
+			}
+		});
+		assert.strictEqual(dialog.state.id, 'foo');
+		assert.isTrue(dialog.state.modal);
+		assert.isFalse(dialog.state.open);
+		assert.strictEqual(dialog.state.title, 'dialog');
+		assert.isTrue(dialog.state.underlay);
+	},
+
+	render() {
+		const dialog = createDialog({
+			properties: {
+				id: 'foo',
+				open: true,
+				underlay: true
+			}
+		});
+		const vnode = <VNode> dialog.__render__();
+		assert.strictEqual(vnode.vnodeSelector, 'div.dialog');
+		assert.strictEqual(vnode.properties!['data-widget-id'], 'foo');
+		assert.strictEqual(vnode.properties!['data-underlay'], 'true');
+		assert.strictEqual(vnode.properties!['data-open'], 'true');
+		assert.lengthOf(vnode.children, 1);
+	},
+
+	'onRequestClose'() {
+		const dialog = createDialog({
+			properties: {
+				open: true,
+				onRequestClose: () => {
+					dialog.setState({ open: false });
+				}
+			}
+		});
+
+		dialog.onCloseClick && dialog.onCloseClick();
+		assert.isFalse(dialog.state.open);
+	},
+
+	'onOpen'(this: any) {
+		let dfd = this.async(1000, 1);
+
+		function onOpen(): void {
+			let func = dfd.callback(() => { });
+			func.call();
+		}
+
+		const dialog = w(createDialog, {
+			properties: {
+				open: true,
+				onOpen: onOpen
+			}
+		});
+
+		const projector = createProjector();
+		projector.children = [ dialog ];
+		projector.append();
+	},
+
+	'modal'() {
+		const dialog = createDialog({
+			properties: {
+				open: true,
+				modal: true,
+				onRequestClose: () => {
+					dialog.setState({ open: false });
+				}
+			}
+		});
+
+		dialog.onContentClick && dialog.onContentClick(<MouseEvent> { stopPropagation: () => { }});
+		dialog.onUnderlayClick && dialog.onUnderlayClick();
+		assert.isTrue(dialog.state.open);
+	}
+});

--- a/tests/unit/components/dialog/createDialog.ts
+++ b/tests/unit/components/dialog/createDialog.ts
@@ -15,7 +15,8 @@ registerSuite({
 				modal: true,
 				open: false,
 				title: 'dialog',
-				underlay: true
+				underlay: true,
+				closeable: true
 			}
 		});
 		assert.strictEqual(dialog.state.id, 'foo');
@@ -23,6 +24,7 @@ registerSuite({
 		assert.isFalse(dialog.state.open);
 		assert.strictEqual(dialog.state.title, 'dialog');
 		assert.isTrue(dialog.state.underlay);
+		assert.isTrue(dialog.state.closeable);
 	},
 
 	render() {
@@ -41,7 +43,7 @@ registerSuite({
 		assert.lengthOf(vnode.children, 1);
 	},
 
-	'onRequestClose'() {
+	onRequestClose() {
 		const dialog = createDialog({
 			properties: {
 				open: true,
@@ -55,7 +57,7 @@ registerSuite({
 		assert.isFalse(dialog.state.open);
 	},
 
-	'onOpen'(this: any) {
+	onOpen(this: any) {
 		let dfd = this.async(1000, 1);
 
 		function onOpen(): void {
@@ -75,7 +77,7 @@ registerSuite({
 		projector.append();
 	},
 
-	'modal'() {
+	modal() {
 		const dialog = createDialog({
 			properties: {
 				open: true,
@@ -88,6 +90,18 @@ registerSuite({
 
 		dialog.onContentClick && dialog.onContentClick(<MouseEvent> { stopPropagation: () => { }});
 		dialog.onUnderlayClick && dialog.onUnderlayClick();
+		assert.isTrue(dialog.state.open);
+	},
+
+	closeable() {
+		const dialog = createDialog({
+			properties: {
+				closeable: false,
+				open: true
+			}
+		});
+
+		dialog.onCloseClick && dialog.onCloseClick();
 		assert.isTrue(dialog.state.open);
 	}
 });

--- a/tests/unit/components/dialog/createDialog.ts
+++ b/tests/unit/components/dialog/createDialog.ts
@@ -32,7 +32,9 @@ registerSuite({
 			properties: {
 				id: 'foo',
 				open: true,
-				underlay: true
+				underlay: true,
+				enterAnimation: 'enter',
+				exitAnimation: 'exit'
 			}
 		});
 		const vnode = <VNode> dialog.__render__();
@@ -40,7 +42,9 @@ registerSuite({
 		assert.strictEqual(vnode.properties!['data-widget-id'], 'foo');
 		assert.strictEqual(vnode.properties!['data-underlay'], 'true');
 		assert.strictEqual(vnode.properties!['data-open'], 'true');
-		assert.lengthOf(vnode.children, 1);
+		vnode.children && assert.strictEqual(vnode.children[1].properties!['enterAnimation'], 'enter');
+		vnode.children && assert.strictEqual(vnode.children[1].properties!['exitAnimation'], 'exit');
+		assert.lengthOf(vnode.children, 2);
 	},
 
 	onRequestClose() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

This PR introduces a Dialog component. The API is fairly minimal. Properties to control alignment, positioning, and sizing of the dialog were omitted in favor of embracing CSS. I'm expecting to add to the API as necessary features are identified through use. This PR also adds an `examples` folder with a per-widget example structure. Note that because component CSS hasn't been solidified, base structural styles have been temporarily included on the example dialog page itself.

Initial API:

```ts
closeable?: boolean;
enterAnimation?: string;
exitAnimation?: string;
modal?: boolean;
open?: boolean;
title?: string;
underlay?: boolean;
onOpen?(): void;
onRequestClose?(): void;
```

Resolves #197
