### PR TITLE
Enhancement: External State Mixin

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "codecov.io": "0.1.6",
     "dojo-interfaces": ">=2.0.0-alpha.9",
     "dojo-loader": ">=2.0.0-beta.7",
+    "dojo-stores": "^2.0.0-alpha.7",
     "dts-generator": "~1.7.0",
     "glob": "^7.0.6",
     "grunt": "^1.0.1",

--- a/src/mixins/externalState.ts
+++ b/src/mixins/externalState.ts
@@ -1,6 +1,7 @@
 import { Handle } from 'dojo-interfaces/core';
 import { ObservablePatchableStore } from 'dojo-interfaces/abilities';
 import WeakMap from 'dojo-shim/WeakMap';
+import { includes } from 'dojo-shim/array';
 import { assign } from 'dojo-core/lang';
 import { PropertiesChangeEvent } from './../interfaces';
 import { State, StatefulMixin } from 'dojo-interfaces/bases';
@@ -77,7 +78,7 @@ function replaceState(instance: ExternalState, state: State) {
 function onPropertiesChanged(instance: ExternalState, properties: ExternalStateProperties, changedPropertyKeys: string[]) {
 	const internalState = internalStateMap.get(instance);
 	if (internalState) {
-		if (changedPropertyKeys.indexOf('externalState') !== -1 || changedPropertyKeys.indexOf('id') !== -1) {
+		if (includes(changedPropertyKeys, 'externalState') || includes(changedPropertyKeys, 'id')) {
 			internalState.handle.destroy();
 		}
 	}

--- a/src/mixins/externalState.ts
+++ b/src/mixins/externalState.ts
@@ -2,6 +2,7 @@ import { Handle } from 'dojo-interfaces/core';
 import { ObservablePatchableStore } from 'dojo-interfaces/abilities';
 import WeakMap from 'dojo-shim/WeakMap';
 import { assign } from 'dojo-core/lang';
+import { PropertiesChangeEvent } from './../interfaces';
 import { State, StatefulMixin } from 'dojo-interfaces/bases';
 import createEvented from 'dojo-compose/bases/createEvented';
 import { ComposeFactory } from 'dojo-compose/compose';
@@ -129,21 +130,21 @@ const externalStateFactory: ExternalStateFactory = createEvented.mixin({
 		before: {
 			diffProperties(this: ExternalState, ...args: any[]): any[] {
 				const internalState = internalStateMap.get(this);
-				const { properties: { id, externalState } } = this;
-				const [ previousProperties ] = args;
+				const [ previousProperties, newProperties ] = args;
 
 				if (internalState) {
-					if (externalState !== previousProperties.externalState || id !== previousProperties.id) {
+					if (newProperties.externalState !== previousProperties.externalState || newProperties.id !== previousProperties.id) {
 						internalState.handle.destroy();
 					}
 				}
 				return args;
-			},
-			applyChangedProperties(this: ExternalStateMixin, ...args: any[]) {
-				this.observe();
-				return args;
 			}
 		}
+	},
+	initialize(instance: ExternalStateMixin) {
+		instance.own(instance.on('properties:changed', (evt: PropertiesChangeEvent<ExternalStateMixin, ExternalStateProperties>) => {
+			instance.observe();
+		}));
 	}
 });
 

--- a/src/mixins/externalState.ts
+++ b/src/mixins/externalState.ts
@@ -1,0 +1,150 @@
+import { Handle } from 'dojo-interfaces/core';
+import { ObservablePatchableStore } from 'dojo-interfaces/abilities';
+import WeakMap from 'dojo-shim/WeakMap';
+import { assign } from 'dojo-core/lang';
+import { State, StatefulMixin } from 'dojo-interfaces/bases';
+import createEvented from 'dojo-compose/bases/createEvented';
+import { ComposeFactory } from 'dojo-compose/compose';
+
+/**
+ * Properties required for the external state mixin
+ */
+export interface ExternalStateProperties {
+	id: string;
+	externalState: ObservablePatchableStore<State>;
+}
+
+/**
+ * External State Options
+ */
+export interface ExternalStateOptions {
+	properties: ExternalStateProperties;
+}
+
+/**
+ * External State Mixin
+ */
+export interface ExternalStateMixin extends StatefulMixin<State> {
+	/**
+	 * Observe the state using the id and stateFrom in the instances properties
+	 */
+	observe(): void;
+}
+
+/**
+ * External State
+ */
+export interface ExternalState extends ExternalStateMixin {
+	properties: ExternalStateProperties;
+}
+
+/**
+ * Compose External State Factory interface
+ */
+export interface ExternalStateFactory extends ComposeFactory<ExternalStateMixin, ExternalStateOptions> {}
+
+/**
+ * internal state for the `ExternalStateMixin`
+ */
+interface InternalState {
+	id: string;
+	state: State;
+	handle: Handle;
+}
+
+/**
+ * Private map for external state.
+ */
+const internalStateMap = new WeakMap<ExternalStateMixin, InternalState>();
+
+/**
+ * state changed event type
+ */
+const stateChangedEventType = 'state:changed';
+
+function replaceState(instance: ExternalState, state: State) {
+	const internalState = internalStateMap.get(instance);
+	internalState.state = state;
+	const eventObject = {
+		type: stateChangedEventType,
+		state,
+		target: instance
+	};
+	instance.emit(eventObject);
+}
+
+/**
+ * ExternalState Factory
+ */
+const externalStateFactory: ExternalStateFactory = createEvented.mixin({
+	className: 'ExternalStateMixin',
+	mixin: {
+		get state(this: ExternalState) {
+			return internalStateMap.get(this).state;
+		},
+		observe(this: ExternalState): void {
+			const internalState = internalStateMap.get(this);
+			const { properties: { id, externalState } } = this;
+			if (!id || !externalState) {
+				throw new Error('id and stateFrom are required to observe state');
+			}
+
+			if (internalState) {
+				if (internalState.id === id) {
+					return;
+				}
+				throw new Error('Unable to observe state for a different id');
+			}
+
+			const subscription = externalState
+			.observe(id)
+			.subscribe(
+				(state) => {
+					replaceState(this, state);
+				},
+				(err) => {
+					throw err;
+				}
+			);
+
+			const handle = {
+				destroy: () => {
+					subscription.unsubscribe();
+					internalStateMap.delete(this);
+				}
+			};
+			internalStateMap.set(this, { id, handle, state: Object.create(null) });
+			this.own(handle);
+		},
+		setState(this: ExternalState, newState: Partial<State>): void {
+			const { properties: { externalState, id } } = this;
+			externalState.patch(assign( { id }, newState))
+			.then(() => externalState.get(id))
+			.then((state: State) => {
+				replaceState(this, state);
+			});
+		}
+	},
+	aspectAdvice: {
+		before: {
+			diffProperties(this: ExternalState, ...args: any[]): any[] {
+				const internalState = internalStateMap.get(this);
+				const { properties: { id, externalState } } = this;
+				const [ previousProperties ] = args;
+
+				if (internalState) {
+					if (externalState !== previousProperties.externalState || id !== previousProperties.id) {
+						internalState.handle.destroy();
+					}
+				}
+				return args;
+			},
+			applyChangedProperties(this: ExternalStateMixin, ...args: any[]) {
+				this.observe();
+				return args;
+			}
+		}
+	}
+});
+
+export default externalStateFactory;

--- a/src/mixins/externalState.ts
+++ b/src/mixins/externalState.ts
@@ -87,7 +87,7 @@ const externalStateFactory: ExternalStateFactory = createEvented.mixin({
 			const internalState = internalStateMap.get(this);
 			const { properties: { id, externalState } } = this;
 			if (!id || !externalState) {
-				throw new Error('id and stateFrom are required to observe state');
+				throw new Error('id and externalState are required to observe state');
 			}
 
 			if (internalState) {

--- a/src/mixins/externalState.ts
+++ b/src/mixins/externalState.ts
@@ -119,10 +119,10 @@ const externalStateFactory: ExternalStateFactory = createEvented.mixin({
 		setState(this: ExternalState, newState: Partial<State>): void {
 			const { properties: { externalState, id } } = this;
 			externalState.patch(assign( { id }, newState))
-			.then(() => externalState.get(id))
-			.then((state: State) => {
-				replaceState(this, state);
-			});
+				.then(() => externalState.get(id))
+				.then((state: State) => {
+					replaceState(this, state);
+				});
 		}
 	},
 	aspectAdvice: {

--- a/tests/intern.ts
+++ b/tests/intern.ts
@@ -66,6 +66,7 @@ export const loaderOptions = {
 		{ name: 'dojo-compose', location: 'node_modules/dojo-compose' },
 		{ name: 'dojo-core', location: 'node_modules/dojo-core' },
 		{ name: 'dojo-has', location: 'node_modules/dojo-has' },
+		{ name: 'dojo-stores', location: 'node_modules/dojo-stores' },
 		{ name: 'dojo-i18n', location: 'node_modules/dojo-i18n' },
 		{ name: 'dojo-shim', location: 'node_modules/dojo-shim' },
 		{ name: 'globalize', location: 'node_modules/globalize/dist' },

--- a/tests/unit/mixins/all.ts
+++ b/tests/unit/mixins/all.ts
@@ -2,3 +2,4 @@ import './createCssTransitionMixin';
 import './createFormFieldMixin';
 import './createI18nMixin';
 import './shallowPropertyComparisonMixin';
+import './externalState';

--- a/tests/unit/mixins/externalState.ts
+++ b/tests/unit/mixins/externalState.ts
@@ -1,0 +1,230 @@
+import compose from 'dojo-compose/compose';
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import externalState from '../../../src/mixins/externalState';
+import { createObservableStore, ObservableStore } from 'dojo-stores/store/mixins/createObservableStoreMixin';
+
+let store: ObservableStore<{}, {}, any>;
+
+const externalStateWithProperties = compose({
+	properties: <any> {},
+	diffProperties(this: any, previousProperties: any) { },
+	applyChangedProperties(this: any) { }
+}).mixin(externalState);
+
+registerSuite({
+	name: 'mixins/externalStateMixin',
+	beforeEach() {
+		store = createObservableStore({
+			data: [
+				{ id: '1', foo: 'bar' },
+				{ id: '2', foo: 'bar' }
+			]
+		});
+	},
+	observe: {
+		'throw error if `id` property is not passed'() {
+			const externalStateMixin = externalStateWithProperties();
+
+			externalStateMixin.properties = {
+				externalState: store
+			};
+			assert.throws(() => externalStateMixin.observe(), Error);
+		},
+		'throw error if `externalState` property is not passed'() {
+			const externalStateMixin = externalStateWithProperties();
+
+			externalStateMixin.properties = {
+				id: '1'
+			};
+			assert.throws(() => externalStateMixin.observe(), Error);
+		},
+		observe() {
+			const externalStateMixin = externalStateWithProperties();
+
+			externalStateMixin.properties = {
+				id: '1',
+				externalState: store
+			};
+
+			const promise = new Promise((resolve, reject) => {
+				externalStateMixin.on('state:changed', ({ state }: any) => {
+					try {
+						assert.deepEqual(state, { id: '1', foo: 'bar'});
+						resolve();
+					} catch (err) {
+						reject(err);
+					}
+				});
+			});
+
+			externalStateMixin.observe();
+			externalStateMixin.observe();
+			return promise;
+		},
+		'throws error if observe called with a different id'() {
+			const externalStateMixin = externalStateWithProperties();
+
+			externalStateMixin.properties = {
+				id: '1',
+				externalState: store
+			};
+
+			externalStateMixin.observe();
+			externalStateMixin.properties.id = '2';
+			assert.throws(() => externalStateMixin.observe(), Error);
+
+		}
+	},
+	getState() {
+		const externalStateMixin = externalStateWithProperties();
+
+		externalStateMixin.properties = {
+			id: '1',
+			externalState: store
+		};
+
+		const promise = new Promise((resolve, reject) => {
+			externalStateMixin.on('state:changed', () => {
+				try {
+					assert.deepEqual(externalStateMixin.state, { id: '1', foo: 'bar'});
+					resolve();
+				} catch (err) {
+					reject(err);
+				}
+			});
+		});
+
+		externalStateMixin.observe();
+		assert.deepEqual(externalStateMixin.state, Object.create(null));
+		return promise;
+	},
+	setState() {
+		const externalStateMixin = externalStateWithProperties();
+		let intialStateChange = true;
+
+		externalStateMixin.properties = {
+			id: '1',
+			externalState: store
+		};
+
+		const promise = new Promise((resolve, reject) => {
+			externalStateMixin.on('state:changed', () => {
+				try {
+					if (intialStateChange) {
+						intialStateChange = false;
+						assert.deepEqual(externalStateMixin.state, { id: '1', foo: 'bar'});
+					}
+					else {
+						assert.deepEqual(externalStateMixin.state, { id: '1', foo: 'baz', baz: 'qux' });
+						resolve();
+					}
+				} catch (err) {
+					reject(err);
+				}
+			});
+		});
+
+		externalStateMixin.observe();
+		assert.deepEqual(externalStateMixin.state, Object.create(null));
+		externalStateMixin.setState({ id: '1', foo: 'baz', baz: 'qux' });
+		return promise;
+	},
+	diffProperties: {
+		'call destroy on observe handle if externalState has been updated.'() {
+			const externalStateMixin = externalStateWithProperties();
+			const newStore = createObservableStore({ data: [ { id: '1', foo: 'bar' } ]});
+			let intialStateChange = true;
+			const initialProperties = {
+				id: '1',
+				externalState: store
+			};
+
+			externalStateMixin.properties = initialProperties;
+
+			const promise = new Promise((resolve, reject) => {
+				externalStateMixin.on('state:changed', ({ target }: any) => {
+					try {
+						if (intialStateChange) {
+							intialStateChange = false;
+							assert.equal(target.properties.externalState, store);
+							externalStateMixin.properties = {
+								externalState: newStore,
+								id: '1'
+							};
+							externalStateMixin.diffProperties(initialProperties);
+							externalStateMixin.observe();
+						}
+						else {
+							assert.equal(target.properties.externalState, newStore);
+							resolve();
+						}
+					} catch (err) {
+						reject(err);
+					}
+				});
+			});
+
+			externalStateMixin.observe();
+			return promise;
+		},
+		'call destroy on observe handle if id has been updated.'() {
+			const externalStateMixin = externalStateWithProperties();
+			let intialStateChange = true;
+			const initialProperties = {
+				id: '1',
+				externalState: store
+			};
+
+			externalStateMixin.properties = initialProperties;
+
+			const promise = new Promise((resolve, reject) => {
+				externalStateMixin.on('state:changed', ({ target }: any) => {
+					try {
+						if (intialStateChange) {
+							intialStateChange = false;
+							assert.equal(target.properties.id, '1');
+							externalStateMixin.properties = {
+								externalState: store,
+								id: '2'
+							};
+							externalStateMixin.diffProperties(initialProperties);
+							externalStateMixin.observe();
+						}
+						else {
+							assert.equal(target.properties.id, '2');
+							resolve();
+						}
+					} catch (err) {
+						reject(err);
+					}
+				});
+			});
+
+			externalStateMixin.observe();
+			return promise;
+		}
+	},
+	applyChangedPropertie() {
+		const externalStateMixin = externalStateWithProperties();
+
+		externalStateMixin.properties = {
+			id: '1',
+			externalState: store
+		};
+
+		const promise = new Promise((resolve, reject) => {
+			externalStateMixin.on('state:changed', () => {
+				try {
+					assert.deepEqual(externalStateMixin.state, { id: '1', foo: 'bar' });
+					resolve();
+				} catch (err) {
+					reject(err);
+				}
+			});
+		});
+
+		externalStateMixin.applyChangedProperties();
+		return promise;
+	}
+});

--- a/tests/unit/mixins/externalState.ts
+++ b/tests/unit/mixins/externalState.ts
@@ -135,7 +135,32 @@ registerSuite({
 		externalStateMixin.setState({ id: '1', foo: 'baz', baz: 'qux' });
 		return promise;
 	},
-	diffProperties: {
+	'on "properties:changed" event': {
+		'initial properties'() {
+			const externalStateMixin = externalStateWithProperties();
+
+			externalStateMixin.properties = {
+				id: '1',
+				externalState: store
+			};
+
+			const promise = new Promise((resolve, reject) => {
+				externalStateMixin.on('state:changed', () => {
+					try {
+						assert.deepEqual(externalStateMixin.state, { id: '1', foo: 'bar' });
+						resolve();
+					} catch (err) {
+						reject(err);
+					}
+				});
+			});
+
+			externalStateMixin.emit({
+				type: 'properties:changed'
+			});
+			return promise;
+		},
+
 		'call destroy on observe handle if externalState has been updated.'() {
 			const externalStateMixin = externalStateWithProperties();
 			const newStore = createObservableStore({ data: [ { id: '1', foo: 'bar' } ]});
@@ -158,8 +183,12 @@ registerSuite({
 								id: '1'
 							};
 							externalStateMixin.properties = updatedProperties;
-							externalStateMixin.diffProperties(initialProperties, updatedProperties);
-							externalStateMixin.observe();
+							externalStateMixin.emit({
+								type: 'properties:changed',
+								target: externalStateMixin,
+								properties: updatedProperties,
+								changedPropertyKeys: [ 'externalState' ]
+							});
 						}
 						else {
 							assert.equal(target.properties.externalState, newStore);
@@ -171,7 +200,13 @@ registerSuite({
 				});
 			});
 
-			externalStateMixin.observe();
+			externalStateMixin.emit({
+				type: 'properties:changed',
+				target: externalStateMixin,
+				properties: initialProperties,
+				changedPropertyKeys: [ 'externalState', 'id' ]
+			});
+
 			return promise;
 		},
 		'call destroy on observe handle if id has been updated.'() {
@@ -195,8 +230,12 @@ registerSuite({
 								id: '2'
 							};
 							externalStateMixin.properties = updatedProperties;
-							externalStateMixin.diffProperties(initialProperties, updatedProperties);
-							externalStateMixin.observe();
+							externalStateMixin.emit({
+								type: 'properties:changed',
+								target: externalStateMixin,
+								properties: updatedProperties,
+								changedPropertyKeys: [ 'id' ]
+							});
 						}
 						else {
 							assert.equal(target.properties.id, '2');
@@ -208,32 +247,14 @@ registerSuite({
 				});
 			});
 
-			externalStateMixin.observe();
+			externalStateMixin.emit({
+				type: 'properties:changed',
+				target: externalStateMixin,
+				properties: initialProperties,
+				changedPropertyKeys: [ 'externalState', 'id' ]
+			});
+
 			return promise;
 		}
-	},
-	'on "properties:changed" event'() {
-		const externalStateMixin = externalStateWithProperties();
-
-		externalStateMixin.properties = {
-			id: '1',
-			externalState: store
-		};
-
-		const promise = new Promise((resolve, reject) => {
-			externalStateMixin.on('state:changed', () => {
-				try {
-					assert.deepEqual(externalStateMixin.state, { id: '1', foo: 'bar' });
-					resolve();
-				} catch (err) {
-					reject(err);
-				}
-			});
-		});
-
-		externalStateMixin.emit({
-			type: 'properties:changed'
-		});
-		return promise;
 	}
 });

--- a/tests/unit/mixins/externalState.ts
+++ b/tests/unit/mixins/externalState.ts
@@ -42,15 +42,18 @@ registerSuite({
 		},
 		observe() {
 			const externalStateMixin = externalStateWithProperties();
-
-			externalStateMixin.properties = {
+			let stateChangeCount = 0;
+			const properties = {
 				id: '1',
 				externalState: store
 			};
+			externalStateMixin.properties = properties;
 
 			const promise = new Promise((resolve, reject) => {
 				externalStateMixin.on('state:changed', ({ state }: any) => {
+					stateChangeCount++;
 					try {
+						assert.equal(stateChangeCount, 1);
 						assert.deepEqual(state, { id: '1', foo: 'bar'});
 						resolve();
 					} catch (err) {
@@ -59,6 +62,7 @@ registerSuite({
 				});
 			});
 
+			externalStateMixin.diffProperties({}, properties);
 			externalStateMixin.observe();
 			externalStateMixin.observe();
 			return promise;

--- a/tests/unit/mixins/externalState.ts
+++ b/tests/unit/mixins/externalState.ts
@@ -8,7 +8,7 @@ let store: ObservableStore<{}, {}, any>;
 
 const externalStateWithProperties = compose({
 	properties: <any> {},
-	diffProperties(this: any, previousProperties: any) { },
+	diffProperties(this: any, previousProperties: any, newProperties: any) { },
 	applyChangedProperties(this: any) { }
 }).mixin(externalState);
 
@@ -148,11 +148,12 @@ registerSuite({
 						if (intialStateChange) {
 							intialStateChange = false;
 							assert.equal(target.properties.externalState, store);
-							externalStateMixin.properties = {
+							const updatedProperties = {
 								externalState: newStore,
 								id: '1'
 							};
-							externalStateMixin.diffProperties(initialProperties);
+							externalStateMixin.properties = updatedProperties;
+							externalStateMixin.diffProperties(initialProperties, updatedProperties);
 							externalStateMixin.observe();
 						}
 						else {
@@ -184,11 +185,12 @@ registerSuite({
 						if (intialStateChange) {
 							intialStateChange = false;
 							assert.equal(target.properties.id, '1');
-							externalStateMixin.properties = {
+							const updatedProperties = {
 								externalState: store,
 								id: '2'
 							};
-							externalStateMixin.diffProperties(initialProperties);
+							externalStateMixin.properties = updatedProperties;
+							externalStateMixin.diffProperties(initialProperties, updatedProperties);
 							externalStateMixin.observe();
 						}
 						else {
@@ -205,7 +207,7 @@ registerSuite({
 			return promise;
 		}
 	},
-	applyChangedPropertie() {
+	'on "properties:changed" event'() {
 		const externalStateMixin = externalStateWithProperties();
 
 		externalStateMixin.properties = {
@@ -224,7 +226,9 @@ registerSuite({
 			});
 		});
 
-		externalStateMixin.applyChangedProperties();
+		externalStateMixin.emit({
+			type: 'properties:changed'
+		});
 		return promise;
 	}
 });

--- a/tests/unit/mixins/externalState.ts
+++ b/tests/unit/mixins/externalState.ts
@@ -1,5 +1,6 @@
 import compose from 'dojo-compose/compose';
 import * as registerSuite from 'intern!object';
+import Promise from 'dojo-shim/Promise';
 import * as assert from 'intern/chai!assert';
 import externalState from '../../../src/mixins/externalState';
 import { createObservableStore, ObservableStore } from 'dojo-stores/store/mixins/createObservableStoreMixin';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds a mixin to support backing widgets with external state.

Resolves #205
