### PR TITLE
Refine properties lifecycle, add public setProperties()

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/jsdom": "2.0.*",
     "@types/sinon": "^1.16.31",
     "codecov.io": "0.1.6",
-    "dojo-interfaces": "2.0.0-alpha.9",
+    "dojo-interfaces": ">=2.0.0-alpha.9",
     "dojo-loader": ">=2.0.0-beta.7",
     "dts-generator": "~1.7.0",
     "glob": "^7.0.6",

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "@types/jsdom": "2.0.*",
     "@types/sinon": "^1.16.31",
     "codecov.io": "0.1.6",
-    "dojo-interfaces": "^2.0.0-alpha.4",
+    "dojo-interfaces": "2.0.0-alpha.9",
     "dojo-loader": ">=2.0.0-beta.7",
     "dts-generator": "~1.7.0",
     "glob": "^7.0.6",

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -201,7 +201,6 @@ const createWidget: WidgetFactory = createStateful
 				this.properties = this.assignProperties(internalState.previousProperties, properties, changedPropertyKeys);
 				this.applyProperties(this.properties, changedPropertyKeys);
 				internalState.previousProperties = this.properties;
-				this.invalidate();
 			},
 
 			diffProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: WidgetProperties, newProperties: WidgetProperties): string[] {

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -213,8 +213,12 @@ const createWidget: WidgetFactory = createStateful
 			},
 
 			applyProperties: function(this: Widget<WidgetState, WidgetProperties>, properties: WidgetProperties, changedPropertyKeys: string[]): void {
-				if (Object.keys(properties).length) {
-					this.setState(properties);
+				if (changedPropertyKeys.length) {
+					const state = changedPropertyKeys.reduce((state, key) => {
+						(<any> state)[key] = (<any> properties)[key];
+						return state;
+					}, <WidgetProperties> {});
+					this.setState(state);
 				}
 			},
 

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -216,7 +216,7 @@ const createWidget: WidgetFactory = createStateful
 			},
 
 			assignProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: WidgetProperties, newProperties: WidgetProperties, changedPropertyKeys: string[]): WidgetProperties {
-				return assign({}, newProperties, { id: this.id });
+				return assign({}, newProperties);
 			},
 
 			onPropertiesChanged: function(this: Widget<WidgetState, WidgetProperties>, properties: WidgetProperties, changedPropertyKeys: string[]): void {

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -2,6 +2,7 @@ import { isComposeFactory } from 'dojo-compose/compose';
 import createStateful from 'dojo-compose/bases/createStateful';
 import {
 	DNode,
+	PropertiesChangeEvent,
 	WNode,
 	Widget,
 	WidgetMixin,
@@ -281,7 +282,7 @@ const createWidget: WidgetFactory = createStateful
 				children: []
 			});
 
-			instance.own(instance.on('properties:changed', (evt: any) => {
+			instance.own(instance.on('properties:changed', (evt: PropertiesChangeEvent<Widget<WidgetState, WidgetProperties>>) => {
 				instance.onPropertiesChanged(evt.properties, evt.changedPropertyKeys);
 			}));
 

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -282,7 +282,7 @@ const createWidget: WidgetFactory = createStateful
 				children: []
 			});
 
-			instance.own(instance.on('properties:changed', (evt: PropertiesChangeEvent<Widget<WidgetState, WidgetProperties>>) => {
+			instance.own(instance.on('properties:changed', (evt: PropertiesChangeEvent<Widget<WidgetState, WidgetProperties>, WidgetProperties>) => {
 				instance.onPropertiesChanged(evt.properties, evt.changedPropertyKeys);
 			}));
 

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -155,9 +155,9 @@ export interface WidgetMixin<P extends WidgetProperties> {
 	assignProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: P, newProperties: P, changedPropertyKeys: string[]): P;
 
 	/**
-	 * apply properties
+	 * Called when the properties have changed
 	 */
-	applyProperties(this: Widget<WidgetState, WidgetProperties>, properties: Partial<P>, changedPropertyKeys: string[]): void;
+	onPropertiesChanged(this: Widget<WidgetState, WidgetProperties>, properties: Partial<P>, changedPropertyKeys: string[]): void;
 
 	/**
 	 * The ID of the widget, which gets automatically rendered in the VNode property `data-widget-id` when

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -145,15 +145,19 @@ export interface WidgetMixin<P extends WidgetProperties> {
 	 */
 	properties: P;
 
+	setProperties(this: Widget<WidgetState, WidgetProperties>, properties: P): void;
+
 	/**
 	 * Determine changed or new property keys on render.
 	 */
-	diffProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: P): string[];
+	diffProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: P, newProperties: P): string[];
+
+	assignProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: P, newProperties: P, changedPropertyKeys: string[]): P;
 
 	/**
-	 * apply change in properties
+	 * apply properties
 	 */
-	applyChangedProperties(previousProperties: Partial<P>, currentProperties: Partial<P>): void;
+	applyProperties(this: Widget<WidgetState, WidgetProperties>, properties: Partial<P>, changedPropertyKeys: string[]): void;
 
 	/**
 	 * The ID of the widget, which gets automatically rendered in the VNode property `data-widget-id` when

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -25,9 +25,21 @@ export interface ChildNodeFunction {
 	(this: Widget<WidgetState, WidgetProperties>): DNode[];
 }
 
+/**
+ * the event emitted on properties:changed
+ */
 export interface PropertiesChangeEvent<T, P extends WidgetProperties> extends EventTypedObject<'properties:changed'> {
+	/**
+	 * the full set of properties
+	 */
 	properties: P;
+	/**
+	 * the changed properties between setProperty calls
+	 */
 	changedPropertyKeys: string[];
+	/**
+	 * the target (this)
+	 */
 	target: T;
 }
 

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -112,6 +112,12 @@ export interface WidgetOverloads<P extends WidgetProperties> {
 	 * @param listener The listener to call when the event is emitted
 	 */
 	on(type: 'invalidated', listener: EventedListener<Widget<WidgetState, P>, EventTargettedObject<Widget<WidgetState, P>>>): Handle;
+	/**
+	 * Attach a listener to the properties changed event, which is emitted when a difference in properties passed occurs
+	 *
+	 * @param type The event type to listen for
+	 * @param listener The listener to call when the event is emitted
+	 */
 	on(type: 'properties:changed', listener: EventedListener<Widget<WidgetState, P>, PropertiesChangeEvent<Widget<WidgetState, P>, P>>): Handle;
 }
 
@@ -119,11 +125,11 @@ export interface PropertyComparison<P extends WidgetProperties> {
 	/**
 	 * Determine changed or new property keys on setProperties
 	 */
-	diffProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: P, newProperties: P): string[];
+	diffProperties<S>(this: S, previousProperties: P, newProperties: P): string[];
 	/**
 	 * Construct properties object for this.properties
 	 */
-	assignProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: P, newProperties: P, changedPropertyKeys: string[]): P;
+	assignProperties<S>(this: S, previousProperties: P, newProperties: P, changedPropertyKeys: string[]): P;
 }
 
 export interface WidgetMixin<P extends WidgetProperties> extends PropertyComparison<P> {

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -6,7 +6,7 @@
  */
 import Promise from 'dojo-shim/Promise';
 import { EventedListener, Stateful, StatefulOptions } from 'dojo-interfaces/bases';
-import { EventTargettedObject, Handle, StylesMap } from 'dojo-interfaces/core';
+import { EventTargettedObject, EventTypedObject, Handle, StylesMap } from 'dojo-interfaces/core';
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
 import { ComposeFactory } from 'dojo-compose/compose';
 import { VNodeEvented, VNodeEventedOptions } from './mixins/createVNodeEvented';
@@ -23,6 +23,12 @@ export interface NodeFunction {
  */
 export interface ChildNodeFunction {
 	(this: Widget<WidgetState, WidgetProperties>): DNode[];
+}
+
+export interface PropertiesChangeEvent<T> extends EventTypedObject<'properties:changed'> {
+	properties: WidgetProperties;
+	changedPropertyKeys: string[];
+	target: T;
 }
 
 /**

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -163,7 +163,7 @@ export interface WidgetMixin<P extends WidgetProperties> {
 	/**
 	 * Called when the properties have changed
 	 */
-	onPropertiesChanged(this: Widget<WidgetState, WidgetProperties>, properties: Partial<P>, changedPropertyKeys: string[]): void;
+	onPropertiesChanged(this: Widget<WidgetState, WidgetProperties>, properties: P, changedPropertyKeys: string[]): void;
 
 	/**
 	 * The ID of the widget, which gets automatically rendered in the VNode property `data-widget-id` when

--- a/src/mixins/shallowPropertyComparisonMixin.ts
+++ b/src/mixins/shallowPropertyComparisonMixin.ts
@@ -1,11 +1,13 @@
 import { entries } from 'dojo-shim/object';
 import { WidgetProperties } from './../interfaces';
+import { deepAssign } from 'dojo-core/lang';
 
 /**
  * Interface for `diffProperties`
  */
 export interface ShallowPropertyComparisonMixin {
-	diffProperties<T>(previousProperties: T): string[];
+	diffProperties<T>(previousProperties: T, newProperties: T): string[];
+	assignProperties<T>(previousProperties: T, newProperties: T, changedPropertyKeys: string[]): T;
 }
 
 /**
@@ -33,13 +35,13 @@ function shallowCompare(from: any, to: any) {
  */
 const shallowPropertyComparisonMixin: { mixin: ShallowPropertyComparisonMixin } = {
 	mixin: {
-		diffProperties<T extends WidgetProperties & { [index: string]: any }>(this: { properties: T }, previousProperties: T): string[] {
+		diffProperties<T extends WidgetProperties>(this: { properties: T }, previousProperties: T, newProperties: T): string[] {
 			const changedPropertyKeys: string[] = [];
 
-			entries(this.properties).forEach(([key, value]) => {
+			entries(newProperties).forEach(([key, value]) => {
 				let isEqual = true;
 				if (previousProperties.hasOwnProperty(key)) {
-					const previousValue = previousProperties[key];
+					const previousValue = (<any> previousProperties)[key];
 					if (!(typeof value === 'function')) {
 						if (Array.isArray(value) && Array.isArray(previousValue)) {
 							if (value.length !== previousValue.length) {
@@ -72,6 +74,9 @@ const shallowPropertyComparisonMixin: { mixin: ShallowPropertyComparisonMixin } 
 				}
 			});
 			return changedPropertyKeys;
+		},
+		assignProperties<T extends WidgetProperties>(this: { id: string, properties: T }, previousProperties: T, newProperties: T, changedPropertyKeys: string[]): T {
+			return deepAssign({}, newProperties);
 		}
 	}
 };

--- a/src/mixins/shallowPropertyComparisonMixin.ts
+++ b/src/mixins/shallowPropertyComparisonMixin.ts
@@ -76,7 +76,7 @@ const shallowPropertyComparisonMixin: { mixin: ShallowPropertyComparisonMixin } 
 			return changedPropertyKeys;
 		},
 		assignProperties<T extends WidgetProperties>(this: { id: string, properties: T }, previousProperties: T, newProperties: T, changedPropertyKeys: string[]): T {
-			return deepAssign({}, newProperties);
+			return deepAssign({}, newProperties, { id: this.id });
 		}
 	}
 };

--- a/src/mixins/shallowPropertyComparisonMixin.ts
+++ b/src/mixins/shallowPropertyComparisonMixin.ts
@@ -76,7 +76,7 @@ const shallowPropertyComparisonMixin: { mixin: ShallowPropertyComparisonMixin } 
 			return changedPropertyKeys;
 		},
 		assignProperties<T extends WidgetProperties>(this: { id: string, properties: T }, previousProperties: T, newProperties: T, changedPropertyKeys: string[]): T {
-			return deepAssign({}, newProperties, { id: this.id });
+			return deepAssign({}, newProperties);
 		}
 	}
 };

--- a/src/mixins/shallowPropertyComparisonMixin.ts
+++ b/src/mixins/shallowPropertyComparisonMixin.ts
@@ -1,14 +1,6 @@
 import { entries } from 'dojo-shim/object';
-import { WidgetProperties } from './../interfaces';
+import { WidgetProperties, PropertyComparison } from './../interfaces';
 import { deepAssign } from 'dojo-core/lang';
-
-/**
- * Interface for `diffProperties`
- */
-export interface ShallowPropertyComparisonMixin {
-	diffProperties<T>(previousProperties: T, newProperties: T): string[];
-	assignProperties<T>(previousProperties: T, newProperties: T, changedPropertyKeys: string[]): T;
-}
 
 /**
  * Determine if the value is an Object
@@ -33,9 +25,9 @@ function shallowCompare(from: any, to: any) {
  * For Arrays, each `item` is compared with the `item` in the equivalent `index` of the `previousProperties` attribute.
  * If the `item` is an `object` then the object comparison described above is applied otherwise a simple `===` is used.
  */
-const shallowPropertyComparisonMixin: { mixin: ShallowPropertyComparisonMixin } = {
+const shallowPropertyComparisonMixin: { mixin: PropertyComparison<WidgetProperties> } = {
 	mixin: {
-		diffProperties<T extends WidgetProperties>(this: { properties: T }, previousProperties: T, newProperties: T): string[] {
+		diffProperties<S>(this: S, previousProperties: WidgetProperties, newProperties: WidgetProperties): string[] {
 			const changedPropertyKeys: string[] = [];
 
 			entries(newProperties).forEach(([key, value]) => {
@@ -75,7 +67,7 @@ const shallowPropertyComparisonMixin: { mixin: ShallowPropertyComparisonMixin } 
 			});
 			return changedPropertyKeys;
 		},
-		assignProperties<T extends WidgetProperties>(this: { id: string, properties: T }, previousProperties: T, newProperties: T, changedPropertyKeys: string[]): T {
+		assignProperties<S>(this: S, previousProperties: WidgetProperties, newProperties: WidgetProperties, changedPropertyKeys: string[]): WidgetProperties {
 			return deepAssign({}, newProperties);
 		}
 	}

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -483,15 +483,12 @@ registerSuite({
 			};
 
 			const myWidget = createWidgetBase({ properties });
-			myWidget.__render__();
 			assert.deepEqual((<any> myWidget.state).items, [ 'a', 'b' ]);
 			properties.items.push('c');
 			myWidget.setProperties(properties);
-			myWidget.__render__();
 			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b', 'c' ]);
 			properties.items.push('d');
 			myWidget.setProperties(properties);
-			myWidget.__render__();
 			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b', 'c', 'd' ]);
 		},
 		'__render__ with internally updated array state'() {

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -103,9 +103,9 @@ registerSuite({
 			assert.deepEqual(updatedKeys, [ 'foo', 'bar', 'baz', 'qux']);
 		}
 	},
-	applyProperties() {
+	onPropertiesChanged() {
 		const widgetBase = createWidgetBase({ id: 'id' });
-		widgetBase.applyProperties({ foo: 'bar' }, [ 'foo' ]);
+		widgetBase.onPropertiesChanged({ foo: 'bar' }, [ 'foo' ]);
 		assert.equal((<any> widgetBase.state).foo, 'bar');
 	},
 	getChildrenNodes: {

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -79,33 +79,34 @@ registerSuite({
 	},
 	diffProperties: {
 		'no updated properties'() {
-			const widgetBase = createWidgetBase({ properties: <any> { id: 'id', foo: 'bar' }});
-			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' });
+			const properties = { id: 'id', foo: 'bar' };
+			const widgetBase = createWidgetBase();
+			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 0);
 		},
 		'updated properties'() {
 			const widgetBase = createWidgetBase();
 			const properties = { id: 'id', foo: 'baz' };
-			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' }, properties);
+			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 1);
 		},
 		'new properties'() {
 			const widgetBase = createWidgetBase();
 			const properties = { id: 'id', foo: 'bar', bar: 'baz' };
-			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' }, properties);
+			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 1);
 		},
 		'updated / new properties with falsy values'() {
 			const widgetBase = createWidgetBase();
 			const properties = { id: 'id', foo: '', bar: null, baz: 0, qux: false };
-			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' }, properties);
+			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 4);
 			assert.deepEqual(updatedKeys, [ 'foo', 'bar', 'baz', 'qux']);
 		}
 	},
 	onPropertiesChanged() {
 		const widgetBase = createWidgetBase({ id: 'id' });
-		widgetBase.onPropertiesChanged({ foo: 'bar' }, [ 'foo' ]);
+		widgetBase.onPropertiesChanged(<any> { foo: 'bar' }, [ 'foo' ]);
 		assert.equal((<any> widgetBase.state).foo, 'bar');
 	},
 	getChildrenNodes: {

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -105,7 +105,7 @@ registerSuite({
 		}
 	},
 	onPropertiesChanged() {
-		const widgetBase = createWidgetBase({ id: 'id' });
+		const widgetBase = createWidgetBase();
 		widgetBase.onPropertiesChanged(<any> { foo: 'bar' }, [ 'foo' ]);
 		assert.equal((<any> widgetBase.state).foo, 'bar');
 	},

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -55,7 +55,6 @@ registerSuite({
 			clickCalled = true;
 		};
 
-		console.log('------>');
 		const widgetBase = createWidgetBase({
 			properties: { id: 'foo', classes: [ 'bar' ] },
 			listeners: {

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -55,6 +55,7 @@ registerSuite({
 			clickCalled = true;
 		};
 
+		console.log('------>');
 		const widgetBase = createWidgetBase({
 			properties: { id: 'foo', classes: [ 'bar' ] },
 			listeners: {
@@ -84,30 +85,29 @@ registerSuite({
 			assert.lengthOf(updatedKeys, 0);
 		},
 		'updated properties'() {
-			const widgetBase = createWidgetBase({ properties: <any> { id: 'id', foo: 'bar' }});
-			widgetBase.properties = <any> { id: 'id', foo: 'baz' };
-			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' });
+			const widgetBase = createWidgetBase();
+			const properties = { id: 'id', foo: 'baz' };
+			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 1);
 		},
 		'new properties'() {
-			const widgetBase = createWidgetBase({ properties: <any> { id: 'id', foo: 'bar' }});
-			widgetBase.properties = <any> { id: 'id', foo: 'bar', bar: 'baz' };
-			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' });
+			const widgetBase = createWidgetBase();
+			const properties = { id: 'id', foo: 'bar', bar: 'baz' };
+			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 1);
 		},
 		'updated / new properties with falsy values'() {
-			const widgetBase = createWidgetBase({ properties: <any> { id: 'id', foo: 'bar' }});
-			widgetBase.properties = <any> { id: 'id', foo: '', bar: null, baz: 0, qux: false };
-			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' });
+			const widgetBase = createWidgetBase();
+			const properties = { id: 'id', foo: '', bar: null, baz: 0, qux: false };
+			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 4);
 			assert.deepEqual(updatedKeys, [ 'foo', 'bar', 'baz', 'qux']);
 		}
 	},
-	applyChangedProperties() {
-		const widgetBase = createWidgetBase({ properties: { id: 'id' } });
-		widgetBase.applyChangedProperties({}, <any> { foo: 'bar' });
+	applyProperties() {
+		const widgetBase = createWidgetBase({ id: 'id' });
+		widgetBase.applyProperties({ foo: 'bar' }, [ 'foo' ]);
 		assert.equal((<any> widgetBase.state).foo, 'bar');
-		assert.equal(widgetBase.state.id, 'id');
 	},
 	getChildrenNodes: {
 		'getChildrenNodes with no ChildNodeRenderers'() {
@@ -487,13 +487,11 @@ registerSuite({
 			myWidget.__render__();
 			assert.deepEqual((<any> myWidget.state).items, [ 'a', 'b' ]);
 			properties.items.push('c');
-			myWidget.properties = properties;
-			myWidget.invalidate();
+			myWidget.setProperties(properties);
 			myWidget.__render__();
 			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b', 'c' ]);
 			properties.items.push('d');
-			myWidget.properties = properties;
-			myWidget.invalidate();
+			myWidget.setProperties(properties);
 			myWidget.__render__();
 			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b', 'c', 'd' ]);
 		},

--- a/tests/unit/mixins/shallowPropertyComparisonMixin.ts
+++ b/tests/unit/mixins/shallowPropertyComparisonMixin.ts
@@ -1,6 +1,5 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
-import { deepAssign } from 'dojo-core/lang';
 import shallowPropertyComparisonMixin from '../../../src/mixins/shallowPropertyComparisonMixin';
 import createWidgetBase from './../../../src/createWidgetBase';
 
@@ -33,8 +32,8 @@ registerSuite({
 				items: [ 'a', 'b' ],
 				otherItems: [ 'c', 'd']
 			};
-			const updatedProperties = deepAssign({}, properties);
-			updatedProperties.items[1] = 'c';
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			(<any> updatedProperties).items[1] = 'c';
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
@@ -46,8 +45,8 @@ registerSuite({
 				items: [ 'a', 'b' ],
 				otherItems: [ 'c', 'd']
 			};
-			const updatedProperties = deepAssign({}, properties);
-			updatedProperties.items = updatedProperties.items.reverse();
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			(<any> updatedProperties).items.reverse();
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
@@ -60,8 +59,8 @@ registerSuite({
 					{ foo: 'bar' }
 				]
 			};
-			const updatedProperties = deepAssign({}, properties);
-			updatedProperties.items[0].foo = 'foo';
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			(<any> updatedProperties).items[0].foo = 'foo';
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
@@ -74,8 +73,8 @@ registerSuite({
 					{ foo: 'bar' }
 				]
 			};
-			const updatedProperties = deepAssign({}, properties);
-			updatedProperties.items.pop();
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			(<any> updatedProperties).items.pop();
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
@@ -88,8 +87,8 @@ registerSuite({
 					{ foo: 'bar' }
 				]
 			};
-			const updatedProperties = deepAssign({}, properties);
-			updatedProperties.items[1] = { bar: 'foo' };
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			(<any> updatedProperties).items[1] = { bar: 'foo' };
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
@@ -105,8 +104,8 @@ registerSuite({
 					baz: 'qux'
 				}
 			};
-			const updatedProperties = deepAssign({}, properties);
-			updatedProperties.obj.foo = 'foo';
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			(<any> updatedProperties).obj.foo = 'foo';
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
@@ -122,8 +121,8 @@ registerSuite({
 					baz: 'qux'
 				}
 			};
-			const updatedProperties = deepAssign({}, properties);
-			updatedProperties.obj.bar = 'foo';
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			(<any> updatedProperties).obj.bar = 'foo';
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
@@ -134,8 +133,8 @@ registerSuite({
 				id: 'id',
 				myFunc: () => {}
 			};
-			const updatedProperties = deepAssign({}, properties);
-			updatedProperties.myFunc = () => {};
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			(<any> updatedProperties).myFunc = () => {};
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 0);
@@ -147,8 +146,8 @@ registerSuite({
 					{ foo: 'bar' }
 				]
 			};
-			const updatedProperties = deepAssign({}, properties);
-			updatedProperties.items[0].foo = 'foo';
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			(<any> updatedProperties).items[0].foo = 'foo';
 
 			const widgetBase = createWidgetBase.mixin(shallowPropertyComparisonMixin)({ properties });
 			const updatedKeys = widgetBase.diffProperties(properties, updatedProperties);

--- a/tests/unit/mixins/shallowPropertyComparisonMixin.ts
+++ b/tests/unit/mixins/shallowPropertyComparisonMixin.ts
@@ -7,22 +7,22 @@ registerSuite({
 	name: 'mixins/shallowPropertyComparisonMixin',
 		'no updated properties'() {
 			const properties = { id: 'id', foo: 'bar' };
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' }, properties);
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 0);
 		},
 		'updated properties'() {
 			const properties = { id: 'id', foo: 'baz' };
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' }, properties);
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 1);
 		},
 		'new properties'() {
 			const properties = { id: 'id', foo: 'bar', bar: 'baz' };
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' }, properties);
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 1);
 		},
 		'updated / new properties with falsy values'() {
 			const properties = { id: 'id', foo: null, bar: '', baz: 0, qux: false };
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' }, <any> properties);
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, <any> properties);
 			assert.lengthOf(updatedKeys, 4);
 			assert.deepEqual(updatedKeys, [ 'foo', 'bar', 'baz', 'qux']);
 		},

--- a/tests/unit/mixins/shallowPropertyComparisonMixin.ts
+++ b/tests/unit/mixins/shallowPropertyComparisonMixin.ts
@@ -7,23 +7,23 @@ import createWidgetBase from './../../../src/createWidgetBase';
 registerSuite({
 	name: 'mixins/shallowPropertyComparisonMixin',
 		'no updated properties'() {
-			(<any> shallowPropertyComparisonMixin.mixin).properties = { id: 'id', foo: 'bar' };
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' });
+			const properties = { id: 'id', foo: 'bar' };
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 0);
 		},
 		'updated properties'() {
-			(<any> shallowPropertyComparisonMixin.mixin).properties = { id: 'id', foo: 'baz' };
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' });
+			const properties = { id: 'id', foo: 'baz' };
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 1);
 		},
 		'new properties'() {
-			(<any> shallowPropertyComparisonMixin.mixin).properties = { id: 'id', foo: 'bar', bar: 'baz' };
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' });
+			const properties = { id: 'id', foo: 'bar', bar: 'baz' };
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 1);
 		},
 		'updated / new properties with falsy values'() {
-			(<any> shallowPropertyComparisonMixin.mixin).properties = { id: 'id', foo: null, bar: '', baz: 0, qux: false };
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' });
+			const properties = { id: 'id', foo: null, bar: '', baz: 0, qux: false };
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties({ id: 'id', foo: 'bar' }, <any> properties);
 			assert.lengthOf(updatedKeys, 4);
 			assert.deepEqual(updatedKeys, [ 'foo', 'bar', 'baz', 'qux']);
 		},
@@ -36,8 +36,7 @@ registerSuite({
 			const updatedProperties = deepAssign({}, properties);
 			updatedProperties.items[1] = 'c';
 
-			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
 			assert.deepEqual(updatedKeys, [ 'items' ]);
 		},
@@ -50,8 +49,7 @@ registerSuite({
 			const updatedProperties = deepAssign({}, properties);
 			updatedProperties.items = updatedProperties.items.reverse();
 
-			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
 			assert.deepEqual(updatedKeys, [ 'items' ]);
 		},
@@ -65,8 +63,7 @@ registerSuite({
 			const updatedProperties = deepAssign({}, properties);
 			updatedProperties.items[0].foo = 'foo';
 
-			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
 			assert.deepEqual(updatedKeys, [ 'items' ]);
 		},
@@ -80,8 +77,7 @@ registerSuite({
 			const updatedProperties = deepAssign({}, properties);
 			updatedProperties.items.pop();
 
-			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
 			assert.deepEqual(updatedKeys, [ 'items' ]);
 		},
@@ -95,8 +91,7 @@ registerSuite({
 			const updatedProperties = deepAssign({}, properties);
 			updatedProperties.items[1] = { bar: 'foo' };
 
-			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
 			assert.deepEqual(updatedKeys, [ 'items' ]);
 		},
@@ -113,8 +108,7 @@ registerSuite({
 			const updatedProperties = deepAssign({}, properties);
 			updatedProperties.obj.foo = 'foo';
 
-			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
 			assert.deepEqual(updatedKeys, [ 'obj' ]);
 		},
@@ -131,8 +125,7 @@ registerSuite({
 			const updatedProperties = deepAssign({}, properties);
 			updatedProperties.obj.bar = 'foo';
 
-			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
 			assert.deepEqual(updatedKeys, [ 'obj' ]);
 		},
@@ -144,8 +137,7 @@ registerSuite({
 			const updatedProperties = deepAssign({}, properties);
 			updatedProperties.myFunc = () => {};
 
-			(<any> shallowPropertyComparisonMixin.mixin).properties = updatedProperties;
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties);
+			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 0);
 		},
 		'test compatibility with shallowPropertyComparisonMixin'() {
@@ -159,8 +151,7 @@ registerSuite({
 			updatedProperties.items[0].foo = 'foo';
 
 			const widgetBase = createWidgetBase.mixin(shallowPropertyComparisonMixin)({ properties });
-			widgetBase.properties = updatedProperties;
-			const updatedKeys = widgetBase.diffProperties(properties);
+			const updatedKeys = widgetBase.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
 			assert.deepEqual(updatedKeys, [ 'items' ]);
 		}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Resolves #207, #202 

This refines the property lifecycle for widgets. The lifecycle is itself now triggered by a `setProperties` call rather than the `__render__` call.

The new lifecycle is as follows:
```ts
diffProperties(previousProperties: P, newProperties: P): string[];
assignProperties(previousProperties: P, newProperties: P, changedPropertyKeys: string[]): P;
```

`diffProperties` is responsible for diffing the previous and new properties - returning an array of property keys that have changed.
`assignProperties` returns a set of properties to be assigned to `this.properties` for usage later.

If `diffProperties` returns an array of length > 0 an event of `properties:changed` is triggered, as well as `onPropertiesChanged` being called.

These new lifecycle methods and events should give control of property diffing and assignment, as well as reacting to changes.

Notes: there are a few any hammers due to the issues with TS that will be resolved in 2.1.5.

