### PR TITLE
Move the function type check of properties to onPropertiesChanged

### DIFF
--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -220,10 +220,13 @@ const createWidget: WidgetFactory = createStateful
 			},
 
 			onPropertiesChanged: function(this: Widget<WidgetState, WidgetProperties>, properties: WidgetProperties, changedPropertyKeys: string[]): void {
-				const state = changedPropertyKeys.reduce((state, key) => {
-					(<any> state)[key] = (<any> properties)[key];
+				const state = changedPropertyKeys.reduce((state: any, key) => {
+					const property = (<any> properties)[key];
+					if (!(typeof property === 'function')) {
+						state[key] = property;
+					}
 					return state;
-				}, <WidgetProperties> {});
+				}, {});
 				this.setState(state);
 			},
 

--- a/src/mixins/shallowPropertyComparisonMixin.ts
+++ b/src/mixins/shallowPropertyComparisonMixin.ts
@@ -34,28 +34,26 @@ const shallowPropertyComparisonMixin: { mixin: PropertyComparison<WidgetProperti
 				let isEqual = true;
 				if (previousProperties.hasOwnProperty(key)) {
 					const previousValue = (<any> previousProperties)[key];
-					if (!(typeof value === 'function')) {
-						if (Array.isArray(value) && Array.isArray(previousValue)) {
-							if (value.length !== previousValue.length) {
-								isEqual = false;
-							}
-							else {
-								isEqual = value.every((item: any, index: number) => {
-									if (isObject(item)) {
-										return shallowCompare(item, previousValue[index]);
-									}
-									else {
-										return item === previousValue[index];
-									}
-								});
-							}
-						}
-						else if (isObject(value) && isObject(previousValue)) {
-							isEqual = shallowCompare(value, previousValue);
+					if (Array.isArray(value) && Array.isArray(previousValue)) {
+						if (value.length !== previousValue.length) {
+							isEqual = false;
 						}
 						else {
-							isEqual = value === previousValue;
+							isEqual = value.every((item: any, index: number) => {
+								if (isObject(item)) {
+									return shallowCompare(item, previousValue[index]);
+								}
+								else {
+									return item === previousValue[index];
+								}
+							});
 						}
+					}
+					else if (isObject(value) && isObject(previousValue)) {
+						isEqual = shallowCompare(value, previousValue);
+					}
+					else {
+						isEqual = value === previousValue;
 					}
 				}
 				else {

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -106,7 +106,7 @@ registerSuite({
 	},
 	onPropertiesChanged() {
 		const widgetBase = createWidgetBase();
-		widgetBase.onPropertiesChanged(<any> { foo: 'bar' }, [ 'foo' ]);
+		widgetBase.onPropertiesChanged(<any> { foo: 'bar', myFunction: () => {} }, [ 'foo', 'myFunction' ]);
 		assert.equal((<any> widgetBase.state).foo, 'bar');
 	},
 	getChildrenNodes: {

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -108,6 +108,7 @@ registerSuite({
 		const widgetBase = createWidgetBase();
 		widgetBase.onPropertiesChanged(<any> { foo: 'bar', myFunction: () => {} }, [ 'foo', 'myFunction' ]);
 		assert.equal((<any> widgetBase.state).foo, 'bar');
+		assert.isUndefined((<any> widgetBase.state).myFunction);
 	},
 	getChildrenNodes: {
 		'getChildrenNodes with no ChildNodeRenderers'() {

--- a/tests/unit/mixins/shallowPropertyComparisonMixin.ts
+++ b/tests/unit/mixins/shallowPropertyComparisonMixin.ts
@@ -128,7 +128,7 @@ registerSuite({
 			assert.lengthOf(updatedKeys, 1);
 			assert.deepEqual(updatedKeys, [ 'obj' ]);
 		},
-		'ignore functions'() {
+		'do not ignore functions'() {
 			const properties: any = {
 				id: 'id',
 				myFunc: () => {}
@@ -137,7 +137,7 @@ registerSuite({
 			(<any> updatedProperties).myFunc = () => {};
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 0);
+			assert.lengthOf(updatedKeys, 1);
 		},
 		'test compatibility with shallowPropertyComparisonMixin'() {
 			const properties = {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Move the property function type check to `onPropertiesChanged` instead of in the `diffProperties` implementation in `shallowPropertyComparisonMixin`.

Resolves #216
