### PR TITLE
Update the public widget api to require only WidgetProperties

### DIFF
--- a/src/FactoryRegistry.ts
+++ b/src/FactoryRegistry.ts
@@ -2,7 +2,7 @@ import { isComposeFactory } from 'dojo-compose/compose';
 import Promise from 'dojo-shim/Promise';
 import Map from 'dojo-shim/Map';
 import {
-	WidgetFactory,
+	WidgetBaseFactory,
 	FactoryRegistryInterface,
 	FactoryRegistryItem,
 	WidgetFactoryFunction
@@ -26,7 +26,7 @@ export default class FactoryRegistry implements FactoryRegistryInterface {
 		this.registry.set(factoryLabel, registryItem);
 	}
 
-	get(factoryLabel: string): WidgetFactory | Promise<WidgetFactory> | null {
+	get(factoryLabel: string): WidgetBaseFactory | Promise<WidgetBaseFactory> | null {
 		if (!this.has(factoryLabel)) {
 			return null;
 		}

--- a/src/components/button/createButton.ts
+++ b/src/components/button/createButton.ts
@@ -1,12 +1,7 @@
-import { ComposeFactory } from 'dojo-compose/compose';
 import { VNodeProperties } from 'dojo-interfaces/vdom';
 import createWidgetBase from '../../createWidgetBase';
-import { Widget, WidgetOptions, WidgetProperties, WidgetState } from './../../interfaces';
-import createFormFieldMixin, { FormFieldMixin, FormFieldMixinState, FormFieldMixinOptions } from '../../mixins/createFormFieldMixin';
-
-export interface ButtonState extends WidgetState, FormFieldMixinState<string> {
-	label?: string;
-}
+import { Widget, WidgetProperties, WidgetFactory } from './../../interfaces';
+import createFormFieldMixin, { FormFieldMixin } from '../../mixins/createFormFieldMixin';
 
 export interface ButtonProperties extends WidgetProperties {
 	label?: string;
@@ -14,13 +9,11 @@ export interface ButtonProperties extends WidgetProperties {
 	onClick?(event: MouseEvent): void;
 }
 
-export interface ButtonOptions extends WidgetOptions<ButtonState, ButtonProperties>, FormFieldMixinOptions<any, ButtonState> { }
-
-export type Button = Widget<ButtonState, ButtonProperties> & FormFieldMixin<string, ButtonState> & {
+export type Button = Widget<ButtonProperties> & FormFieldMixin<string, any> & {
 	onClick(event?: MouseEvent): void;
 };
 
-export interface ButtonFactory extends ComposeFactory<Button, ButtonOptions> { }
+export interface ButtonFactory extends WidgetFactory<Button, ButtonProperties> { }
 
 const createButton: ButtonFactory = createWidgetBase
 	.mixin(createFormFieldMixin)
@@ -31,7 +24,7 @@ const createButton: ButtonFactory = createWidgetBase
 			},
 			nodeAttributes: [
 				function(this: Button): VNodeProperties {
-					return { innerHTML: this.state.label, onclick: this.onClick };
+					return { innerHTML: this.properties.label, onclick: this.onClick };
 				}
 			],
 			tagName: 'button',

--- a/src/components/textinput/createTextInput.ts
+++ b/src/components/textinput/createTextInput.ts
@@ -1,23 +1,22 @@
-import { ComposeFactory } from 'dojo-compose/compose';
 import createWidgetBase from '../../createWidgetBase';
 import { VNodeProperties } from 'dojo-interfaces/vdom';
-import { Widget, WidgetOptions, WidgetState, WidgetProperties } from './../../interfaces';
-import createFormFieldMixin, { FormFieldMixin, FormFieldMixinState, FormFieldMixinOptions } from '../../mixins/createFormFieldMixin';
+import { Widget, WidgetProperties, WidgetFactory } from './../../interfaces';
+import createFormFieldMixin, { FormFieldMixin } from '../../mixins/createFormFieldMixin';
 
 /* TODO: I suspect this needs to go somewhere else */
 export interface TypedTargetEvent<T extends EventTarget> extends Event {
 	target: T;
 }
 
-export type TextInputState = WidgetState & FormFieldMixinState<string>
+export interface TextInputProperties extends WidgetProperties {
+	name?: string;
+}
 
-export type TextInputOptions = WidgetOptions<TextInputState, WidgetProperties> & FormFieldMixinOptions<string, TextInputState>;
-
-export type TextInput = Widget<TextInputState, WidgetProperties> & FormFieldMixin<string, TextInputState> & {
+export type TextInput = Widget<TextInputProperties> & FormFieldMixin<string, any> & {
 	onInput(event: TypedTargetEvent<HTMLInputElement>): void;
 };
 
-export interface TextInputFactory extends ComposeFactory<TextInput, TextInputOptions> { }
+export interface TextInputFactory extends WidgetFactory<TextInput, TextInputProperties> { }
 
 const createTextInput: TextInputFactory = createWidgetBase
 	.mixin(createFormFieldMixin)

--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -9,7 +9,7 @@ import {
 	WidgetState,
 	WidgetOptions,
 	WidgetProperties,
-	WidgetFactory,
+	WidgetBaseFactory,
 	FactoryRegistryItem
 } from './interfaces';
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
@@ -27,22 +27,22 @@ interface WidgetInternalState {
 	widgetClasses: string[];
 	cachedVNode?: VNode | string;
 	factoryRegistry: FactoryRegistry;
-	initializedFactoryMap: Map<string, Promise<WidgetFactory>>;
+	initializedFactoryMap: Map<string, Promise<WidgetBaseFactory>>;
 	previousProperties: WidgetProperties;
-	historicChildrenMap: Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState, WidgetProperties>>;
-	currentChildrenMap: Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState, WidgetProperties>>;
+	historicChildrenMap: Map<string | Promise<WidgetBaseFactory> | WidgetBaseFactory, Widget<WidgetProperties>>;
+	currentChildrenMap: Map<string | Promise<WidgetBaseFactory> | WidgetBaseFactory, Widget<WidgetProperties>>;
 };
 
 /**
  * Internal state map for widget instances
  */
-const widgetInternalStateMap = new WeakMap<Widget<WidgetState, WidgetProperties>, WidgetInternalState>();
+const widgetInternalStateMap = new WeakMap<Widget<WidgetProperties>, WidgetInternalState>();
 
 function isWNode(child: DNode): child is WNode {
 	return Boolean(child && (<WNode> child).factory !== undefined);
 }
 
-function getFromRegistry(instance: Widget<WidgetState, WidgetProperties>, factoryLabel: string): FactoryRegistryItem | null {
+function getFromRegistry(instance: Widget<WidgetProperties>, factoryLabel: string): FactoryRegistryItem | null {
 	if (instance.registry.has(factoryLabel)) {
 		return instance.registry.get(factoryLabel);
 	}
@@ -50,7 +50,7 @@ function getFromRegistry(instance: Widget<WidgetState, WidgetProperties>, factor
 	return registry.get(factoryLabel);
 }
 
-function dNodeToVNode(instance: Widget<WidgetState, WidgetProperties>, dNode: DNode): VNode | string | null {
+function dNodeToVNode(instance: Widget<WidgetProperties>, dNode: DNode): VNode | string | null {
 	const internalState = widgetInternalStateMap.get(instance);
 
 	if (typeof dNode === 'string' || dNode === null) {
@@ -62,17 +62,17 @@ function dNodeToVNode(instance: Widget<WidgetState, WidgetProperties>, dNode: DN
 		const { id } = properties;
 
 		let { factory } = dNode;
-		let child: Widget<WidgetState, WidgetProperties>;
+		let child: Widget<WidgetProperties>;
 
 		if (typeof factory === 'string') {
 			const item = getFromRegistry(instance, factory);
 
 			if (isComposeFactory(item)) {
-				factory = <WidgetFactory> item;
+				factory = <WidgetBaseFactory> item;
 			}
 			else {
 				if (item && !internalState.initializedFactoryMap.has(factory)) {
-					const promise = (<Promise<WidgetFactory>> item).then((factory) => {
+					const promise = (<Promise<WidgetBaseFactory>> item).then((factory) => {
 						instance.invalidate();
 						return factory;
 					});
@@ -120,7 +120,7 @@ function dNodeToVNode(instance: Widget<WidgetState, WidgetProperties>, dNode: DN
 	return dNode.render({ bind: instance });
 }
 
-function manageDetachedChildren(instance: Widget<WidgetState, WidgetProperties>): void {
+function manageDetachedChildren(instance: Widget<WidgetProperties>): void {
 	const internalState = widgetInternalStateMap.get(instance);
 
 	internalState.historicChildrenMap.forEach((child, key) => {
@@ -139,7 +139,7 @@ function formatTagNameAndClasses(tagName: string, classes: string[]) {
 	return tagName;
 }
 
-const createWidget: WidgetFactory = createStateful
+const createWidget: WidgetBaseFactory = createStateful
 	.mixin<WidgetMixin<WidgetProperties>, WidgetOptions<WidgetState, WidgetProperties>>({
 		mixin: {
 			properties: {},
@@ -151,7 +151,7 @@ const createWidget: WidgetFactory = createStateful
 				return v(tag, this.getNodeAttributes(), this.getChildrenNodes());
 			},
 
-			set children(this: Widget<WidgetState, WidgetProperties>, children: DNode[]) {
+			set children(this: Widget<WidgetProperties>, children: DNode[]) {
 				const internalState = widgetInternalStateMap.get(this);
 				internalState.children = children;
 				this.emit({
@@ -164,11 +164,11 @@ const createWidget: WidgetFactory = createStateful
 				return widgetInternalStateMap.get(this).children;
 			},
 
-			getChildrenNodes(this: Widget<WidgetState, WidgetProperties>): DNode[] {
+			getChildrenNodes(this: Widget<WidgetProperties>): DNode[] {
 				return this.children;
 			},
 
-			getNodeAttributes(this: Widget<WidgetState, WidgetProperties>, overrides?: VNodeProperties): VNodeProperties {
+			getNodeAttributes(this: Widget<WidgetProperties>, overrides?: VNodeProperties): VNodeProperties {
 				const props: VNodeProperties = {};
 
 				this.nodeAttributes.forEach((fn) => {
@@ -181,7 +181,7 @@ const createWidget: WidgetFactory = createStateful
 				return props;
 			},
 
-			invalidate(this: Widget<WidgetState, WidgetProperties>): void {
+			invalidate(this: Widget<WidgetProperties>): void {
 				const internalState = widgetInternalStateMap.get(this);
 				internalState.dirty = true;
 				this.emit({
@@ -190,11 +190,11 @@ const createWidget: WidgetFactory = createStateful
 				});
 			},
 
-			get id(this: Widget<WidgetState, WidgetProperties>): string | undefined {
+			get id(this: Widget<WidgetProperties>): string | undefined {
 				return this.properties.id;
 			},
 
-			setProperties(this: Widget<WidgetState, WidgetProperties>, properties: WidgetProperties) {
+			setProperties(this: Widget<WidgetProperties>, properties: WidgetProperties) {
 				const internalState = widgetInternalStateMap.get(this);
 				const changedPropertyKeys = this.diffProperties(internalState.previousProperties, properties);
 				this.properties = this.assignProperties(internalState.previousProperties, properties, changedPropertyKeys);
@@ -209,15 +209,15 @@ const createWidget: WidgetFactory = createStateful
 				internalState.previousProperties = this.properties;
 			},
 
-			diffProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: WidgetProperties, newProperties: WidgetProperties): string[] {
+			diffProperties(this: Widget<WidgetProperties>, previousProperties: WidgetProperties, newProperties: WidgetProperties): string[] {
 				return Object.keys(newProperties);
 			},
 
-			assignProperties(this: Widget<WidgetState, WidgetProperties>, previousProperties: WidgetProperties, newProperties: WidgetProperties, changedPropertyKeys: string[]): WidgetProperties {
+			assignProperties(this: Widget<WidgetProperties>, previousProperties: WidgetProperties, newProperties: WidgetProperties, changedPropertyKeys: string[]): WidgetProperties {
 				return assign({}, newProperties);
 			},
 
-			onPropertiesChanged: function(this: Widget<WidgetState, WidgetProperties>, properties: WidgetProperties, changedPropertyKeys: string[]): void {
+			onPropertiesChanged: function(this: Widget<WidgetProperties>, properties: WidgetProperties, changedPropertyKeys: string[]): void {
 				const state = changedPropertyKeys.reduce((state: any, key) => {
 					const property = (<any> properties)[key];
 					if (!(typeof property === 'function')) {
@@ -229,7 +229,7 @@ const createWidget: WidgetFactory = createStateful
 			},
 
 			nodeAttributes: [
-				function (this: Widget<WidgetState, WidgetProperties>): VNodeProperties {
+				function (this: Widget<WidgetProperties>): VNodeProperties {
 					const baseIdProp = this.state && this.state.id ? { 'data-widget-id': this.state.id } : {};
 					const { styles = {} } = this.state || {};
 					const classes: { [index: string]: boolean; } = {};
@@ -247,7 +247,7 @@ const createWidget: WidgetFactory = createStateful
 				}
 			],
 
-			__render__(this: Widget<WidgetState, WidgetProperties>): VNode | string | null {
+			__render__(this: Widget<WidgetProperties>): VNode | string | null {
 				const internalState = widgetInternalStateMap.get(this);
 				if (internalState.dirty || !internalState.cachedVNode) {
 					const widget = dNodeToVNode(this, this.getNode());
@@ -261,13 +261,13 @@ const createWidget: WidgetFactory = createStateful
 				return internalState.cachedVNode;
 			},
 
-			get registry(this: Widget<WidgetState, WidgetProperties>): FactoryRegistry {
+			get registry(this: Widget<WidgetProperties>): FactoryRegistry {
 				return widgetInternalStateMap.get(this).factoryRegistry;
 			},
 
 			tagName: 'div'
 		},
-		initialize(instance: Widget<WidgetState, WidgetProperties>, options: WidgetOptions<WidgetState, WidgetProperties> = {}) {
+		initialize(instance: Widget<WidgetProperties>, options: WidgetOptions<WidgetState, WidgetProperties> = {}) {
 			const { tagName, properties = {} } = options;
 
 			instance.tagName = tagName || instance.tagName;
@@ -277,13 +277,13 @@ const createWidget: WidgetFactory = createStateful
 				widgetClasses: [],
 				previousProperties: {},
 				factoryRegistry: new FactoryRegistry(),
-				initializedFactoryMap: new Map<string, Promise<WidgetFactory>>(),
-				historicChildrenMap: new Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState, WidgetProperties>>(),
-				currentChildrenMap: new Map<string | Promise<WidgetFactory> | WidgetFactory, Widget<WidgetState, WidgetProperties>>(),
+				initializedFactoryMap: new Map<string, Promise<WidgetBaseFactory>>(),
+				historicChildrenMap: new Map<string | Promise<WidgetBaseFactory> | WidgetBaseFactory, Widget<WidgetProperties>>(),
+				currentChildrenMap: new Map<string | Promise<WidgetBaseFactory> | WidgetBaseFactory, Widget<WidgetProperties>>(),
 				children: []
 			});
 
-			instance.own(instance.on('properties:changed', (evt: PropertiesChangeEvent<Widget<WidgetState, WidgetProperties>, WidgetProperties>) => {
+			instance.own(instance.on('properties:changed', (evt: PropertiesChangeEvent<Widget<WidgetProperties>, WidgetProperties>) => {
 				instance.onPropertiesChanged(evt.properties, evt.changedPropertyKeys);
 			}));
 

--- a/src/d.ts
+++ b/src/d.ts
@@ -1,4 +1,3 @@
-import { ComposeFactory } from 'dojo-compose/compose';
 import { assign } from 'dojo-core/lang';
 import { VNode, VNodeProperties } from 'dojo-interfaces/vdom';
 import { h } from 'maquette';
@@ -7,28 +6,16 @@ import {
 	HNode,
 	WNode,
 	Widget,
-	WidgetOptions,
-	WidgetState,
-	WidgetProperties
+	WidgetProperties,
+	WidgetFactory
 } from './interfaces';
 import FactoryRegistry from './FactoryRegistry';
 
 export const registry = new FactoryRegistry();
 
-export function w<P extends WidgetProperties, S extends WidgetState, W extends Widget<S, P>, O extends WidgetOptions<S, P>>(
-	factory: ComposeFactory<W, O> | string,
-	properties: P
-): WNode;
-export function w<P extends WidgetProperties, S extends WidgetState, W extends Widget<S, P>, O extends WidgetOptions<S, P>>(
-	factory: ComposeFactory<W, O> | string,
-	properties: P,
-	children?: DNode[]
-): WNode;
-export function w<P extends WidgetProperties, S extends WidgetState, W extends Widget<S, P>, O extends WidgetOptions<S, P>>(
-	factory: ComposeFactory<W, O> | string,
-	properties: P,
-	children: DNode[] = []
-): WNode {
+export function w<P extends WidgetProperties>(factory: WidgetFactory<Widget<P>, P> | string, properties: P): WNode;
+export function w<P extends WidgetProperties>(factory: WidgetFactory<Widget<P>, P> | string, properties: P, children?: DNode[]): WNode;
+export function w<P extends WidgetProperties>(factory: WidgetFactory<Widget<P>, P> | string, properties: P, children: DNode[] = []): WNode {
 
 	return {
 		children,

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -14,14 +14,14 @@ import { ComposeFactory } from 'dojo-compose/compose';
  * A function that is called to return top level node
  */
 export interface NodeFunction {
-	(this: Widget<WidgetState, WidgetProperties>): DNode;
+	(this: Widget<WidgetProperties>): DNode;
 }
 
 /**
  * A function that is called when collecting the children nodes on render.
  */
 export interface ChildNodeFunction {
-	(this: Widget<WidgetState, WidgetProperties>): DNode[];
+	(this: Widget<WidgetProperties>): DNode[];
 }
 
 /**
@@ -55,9 +55,9 @@ export interface NodeAttributeFunction<T> {
 	(this: T, attributes: VNodeProperties): VNodeProperties;
 }
 
-export type WidgetFactoryFunction = () => Promise<WidgetFactory>
+export type WidgetFactoryFunction = () => Promise<WidgetFactory<Widget<WidgetProperties>, WidgetProperties>>
 
-export type FactoryRegistryItem = WidgetFactory | Promise<WidgetFactory> | WidgetFactoryFunction
+export type FactoryRegistryItem = WidgetFactory<Widget<WidgetProperties>, WidgetProperties> | Promise<WidgetFactory<Widget<WidgetProperties>, WidgetProperties>> | WidgetFactoryFunction
 
 /**
  * Factory Registry
@@ -72,7 +72,7 @@ export interface FactoryRegistryInterface {
 	/**
 	 * Return the registered FactoryRegistryItem for the label.
 	 */
-	get(factoryLabel: string): WidgetFactory | Promise<WidgetFactory> | null;
+	get(factoryLabel: string): WidgetFactory<Widget<WidgetProperties>, WidgetProperties> | Promise<WidgetFactory<Widget<WidgetProperties>, WidgetProperties>> | null;
 
 	/**
 	 * Check if the factory label has already been used to define a FactoryRegistryItem.
@@ -89,14 +89,14 @@ export interface HNode {
 	/**
 	 * render function that wraps returns VNode
 	 */
-	render<T>(options?: { bind: T }): VNode;
+	render<T>(options?: { bind?: T }): VNode;
 }
 
 export interface WNode {
 	/**
 	 * Factory to create a widget
 	 */
-	factory: WidgetFactory | string;
+	factory: WidgetFactory<Widget<WidgetProperties>, WidgetProperties> | string;
 
 	/**
 	 * Options used to create factory a widget
@@ -111,9 +111,9 @@ export interface WNode {
 
 export type DNode = HNode | WNode | string | null;
 
-export type Widget<S extends WidgetState, P extends WidgetProperties> = Stateful<S> & WidgetMixin<P> & WidgetOverloads<P>
+export type Widget<P extends WidgetProperties> = Stateful<WidgetState> & WidgetMixin<P> & WidgetOverloads<P>
 
-export interface WidgetFactory extends ComposeFactory<Widget<WidgetState, WidgetProperties>, WidgetOptions<WidgetState, WidgetProperties>> {}
+export interface WidgetBaseFactory extends ComposeFactory<Widget<WidgetProperties>, WidgetOptions<WidgetState, WidgetProperties>> {}
 
 export interface WidgetOverloads<P extends WidgetProperties> {
 	/**
@@ -122,14 +122,14 @@ export interface WidgetOverloads<P extends WidgetProperties> {
 	 * @param type The event type to listen for
 	 * @param listener The listener to call when the event is emitted
 	 */
-	on(type: 'invalidated', listener: EventedListener<Widget<WidgetState, P>, EventTargettedObject<Widget<WidgetState, P>>>): Handle;
+	on(type: 'invalidated', listener: EventedListener<Widget<P>, EventTargettedObject<Widget<P>>>): Handle;
 	/**
 	 * Attach a listener to the properties changed event, which is emitted when a difference in properties passed occurs
 	 *
 	 * @param type The event type to listen for
 	 * @param listener The listener to call when the event is emitted
 	 */
-	on(type: 'properties:changed', listener: EventedListener<Widget<WidgetState, P>, PropertiesChangeEvent<Widget<WidgetState, P>, P>>): Handle;
+	on(type: 'properties:changed', listener: EventedListener<Widget<P>, PropertiesChangeEvent<Widget<P>, P>>): Handle;
 }
 
 export interface PropertyComparison<P extends WidgetProperties> {
@@ -183,12 +183,12 @@ export interface WidgetMixin<P extends WidgetProperties> extends PropertyCompari
 	/*
 	 * set properties on the widget
 	 */
-	setProperties(this: Widget<WidgetState, WidgetProperties>, properties: P): void;
+	setProperties(this: Widget<WidgetProperties>, properties: P): void;
 
 	/**
 	 * Called when the properties have changed
 	 */
-	onPropertiesChanged(this: Widget<WidgetState, WidgetProperties>, properties: P, changedPropertyKeys: string[]): void;
+	onPropertiesChanged(this: Widget<WidgetProperties>, properties: P, changedPropertyKeys: string[]): void;
 
 	/**
 	 * The ID of the widget, which gets automatically rendered in the VNode property `data-widget-id` when
@@ -210,7 +210,7 @@ export interface WidgetMixin<P extends WidgetProperties> extends PropertyCompari
 	 * making it easy for mixins to alter the behaviour of the render process without needing to override or aspect
 	 * the `getNodeAttributes` method.
 	 */
-	nodeAttributes: NodeAttributeFunction<Widget<WidgetState, WidgetProperties>>[];
+	nodeAttributes: NodeAttributeFunction<Widget<WidgetProperties>>[];
 
 	/**
 	 * Render the widget, returing the virtual DOM node that represents this widget.
@@ -251,6 +251,7 @@ export interface WidgetOptions<S extends WidgetState, P extends WidgetProperties
 export interface WidgetProperties {
 	id?: string;
 	classes?: string[];
+	preventDefaultBind?: boolean;
 }
 
 export interface WidgetState extends State {
@@ -271,3 +272,5 @@ export interface WidgetState extends State {
 	 */
 	styles?: StylesMap;
 }
+
+export interface WidgetFactory<W extends Widget<P>, P extends WidgetProperties> extends ComposeFactory<W, WidgetOptions<WidgetState, P>> {}

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -55,9 +55,9 @@ export interface NodeAttributeFunction<T> {
 	(this: T, attributes: VNodeProperties): VNodeProperties;
 }
 
-export type WidgetFactoryFunction = () => Promise<WidgetFactory<Widget<WidgetProperties>, WidgetProperties>>
+export type WidgetFactoryFunction = () => Promise<WidgetBaseFactory>
 
-export type FactoryRegistryItem = WidgetFactory<Widget<WidgetProperties>, WidgetProperties> | Promise<WidgetFactory<Widget<WidgetProperties>, WidgetProperties>> | WidgetFactoryFunction
+export type FactoryRegistryItem = WidgetBaseFactory | Promise<WidgetBaseFactory> | WidgetFactoryFunction
 
 /**
  * Factory Registry
@@ -72,7 +72,7 @@ export interface FactoryRegistryInterface {
 	/**
 	 * Return the registered FactoryRegistryItem for the label.
 	 */
-	get(factoryLabel: string): WidgetFactory<Widget<WidgetProperties>, WidgetProperties> | Promise<WidgetFactory<Widget<WidgetProperties>, WidgetProperties>> | null;
+	get(factoryLabel: string): WidgetBaseFactory | Promise<WidgetBaseFactory> | null;
 
 	/**
 	 * Check if the factory label has already been used to define a FactoryRegistryItem.
@@ -96,7 +96,7 @@ export interface WNode {
 	/**
 	 * Factory to create a widget
 	 */
-	factory: WidgetFactory<Widget<WidgetProperties>, WidgetProperties> | string;
+	factory: WidgetBaseFactory | string;
 
 	/**
 	 * Options used to create factory a widget

--- a/src/mixins/createI18nMixin.ts
+++ b/src/mixins/createI18nMixin.ts
@@ -55,7 +55,7 @@ interface I18nVNodeProperties extends VNodeProperties {
 	dir: string | null;
 }
 
-export type I18nWidget<M extends Messages, P extends I18nProperties> = I18nMixin<M> & Widget<WidgetState, I18nProperties>;
+export type I18nWidget<M extends Messages, P extends I18nProperties> = I18nMixin<M> & Widget<I18nProperties>;
 
 export type LocalizedMessages<T extends Messages> = T & {
 	/**

--- a/src/mixins/createProjectorMixin.ts
+++ b/src/mixins/createProjectorMixin.ts
@@ -96,7 +96,7 @@ interface ProjectorData {
 	afterCreate?: () => void;
 }
 
-export type Projector = Widget<WidgetState, WidgetProperties> & ProjectorMixin;
+export type Projector = Widget<WidgetProperties> & ProjectorMixin;
 
 export interface ProjectorMixinFactory extends ComposeFactory<ProjectorMixin, ProjectorOptions> {}
 

--- a/tests/unit/components/button/createButton.ts
+++ b/tests/unit/components/button/createButton.ts
@@ -13,9 +13,9 @@ registerSuite({
 				name: 'baz'
 			}
 		});
-		assert.strictEqual(button.state.id, 'foo');
-		assert.strictEqual(button.state.label, 'bar');
-		assert.strictEqual(button.state.name, 'baz');
+		assert.strictEqual(button.properties.id, 'foo');
+		assert.strictEqual(button.properties.label, 'bar');
+		assert.strictEqual(button.properties.name, 'baz');
 	},
 	render() {
 		const button = createButton({

--- a/tests/unit/components/textinput/createTextInput.ts
+++ b/tests/unit/components/textinput/createTextInput.ts
@@ -11,8 +11,8 @@ registerSuite({
 				name: 'baz'
 			}
 		});
-		assert.strictEqual(textInput.state.id, 'foo');
-		assert.strictEqual(textInput.state.name, 'baz');
+		assert.strictEqual(textInput.properties.id, 'foo');
+		assert.strictEqual(textInput.properties.name, 'baz');
 	},
 	nodeAttributes() {
 		const textInput = createTextInput();


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Abstract the details of `ComposeFactory`, `WidgetState` and `WidgetOptions` from consumers and widget authors, leaving `WidgetProperties` that should be used to provide a widgets public API.

Additionally a convenience interface `WidgetFactory` is now available from `src/interfaces` that abstracts `WidgetOptions` and `WidgetState` from consumers and should be preferred over using `ComposeFactory`. This also means widget authors will not need to import anything from `dojo-compose` in there code and hopefully will remove potential confusion. 

Resolves #229
