### PR TITLE
Allow setting a single DNode for children

### DIFF
--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -105,7 +105,7 @@ function dNodeToVNode(instance: Widget<WidgetProperties>, dNode: DNode): VNode |
 			instance.emit({ type: 'error', target: instance, error: new Error(errorMsg) });
 		}
 
-		child.children = children;
+		child.setChildren(children);
 		internalState.currentChildrenMap.set(childrenMapKey, child);
 
 		return child.__render__();
@@ -151,17 +151,17 @@ const createWidget: WidgetBaseFactory = createStateful
 				return v(tag, this.getNodeAttributes(), this.getChildrenNodes());
 			},
 
-			set children(this: Widget<WidgetProperties>, children: DNode[]) {
+			get children(this: Widget<WidgetProperties>) {
+				return widgetInternalStateMap.get(this).children;
+			},
+
+			setChildren(this: Widget<WidgetProperties>, children: DNode | DNode[]): void {
 				const internalState = widgetInternalStateMap.get(this);
-				internalState.children = children;
+				internalState.children = Array.isArray(children) ? children : [ children ];
 				this.emit({
 					type: 'widget:children',
 					target: this
 				});
-			},
-
-			get children() {
-				return widgetInternalStateMap.get(this).children;
 			},
 
 			getChildrenNodes(this: Widget<WidgetProperties>): DNode[] {

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -155,7 +155,12 @@ export interface WidgetMixin<P extends WidgetProperties> extends PropertyCompari
 	/**
 	 * An array of children `DNode`s returned via `getChildrenNodes`
 	 */
-	children: DNode[];
+	readonly children: DNode[];
+
+	/**
+	 * Set children
+	 */
+	setChildren(children: DNode | DNode[]): void;
 
 	/**
 	 * Get the top level node and children when rendering the widget.

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -25,7 +25,7 @@ registerSuite({
 		});
 
 		assert.lengthOf(widget.children, 0);
-		widget.children = [ expectedChild ];
+		widget.setChildren(expectedChild);
 		assert.lengthOf(widget.children, 1);
 		assert.strictEqual(widget.children[0], expectedChild);
 		assert.isTrue(childrenEventEmitted);

--- a/tests/unit/mixins/createProjectorMixin.ts
+++ b/tests/unit/mixins/createProjectorMixin.ts
@@ -69,7 +69,7 @@ registerSuite({
 			const childNodeLength = document.body.childNodes.length;
 			const projector = createTestWidget();
 
-			projector.children = [ v('h2', [ 'foo' ] ) ];
+			projector.setChildren([ v('h2', [ 'foo' ] ) ]);
 
 			return projector.append().then((attachHandle) => {
 				assert.strictEqual(document.body.childNodes.length, childNodeLength + 1, 'child should have been added');
@@ -84,7 +84,7 @@ registerSuite({
 				tagName: 'body'
 			});
 
-			projector.children = [ v('h2', [ 'foo' ] ) ];
+			projector.setChildren(v('h2', [ 'foo' ] ));
 
 			return projector.replace().then((attachHandle) => {
 				assert.strictEqual(document.body.childNodes.length, 1, 'child should have been added');
@@ -97,7 +97,7 @@ registerSuite({
 			const childNodeLength = document.body.childNodes.length;
 			const projector = createTestWidget();
 
-			projector.children = [ v('h2', [ 'foo' ] ) ];
+			projector.setChildren([ v('h2', [ 'foo' ] ) ]);
 
 			return projector.merge().then((attachHandle) => {
 				assert.strictEqual(document.body.childNodes.length, childNodeLength + 1, 'child should have been added');
@@ -114,7 +114,7 @@ registerSuite({
 			root
 		});
 
-		projector.children = [ v('h2', [ 'foo' ] ) ];
+		projector.setChildren([ v('h2', [ 'foo' ] ) ]);
 
 		assert.strictEqual(root.childNodes.length, 0, 'there should be no children');
 		let eventFired = false;
@@ -172,7 +172,7 @@ registerSuite({
 			called = true;
 		});
 
-		projector.children = [ v('div') ];
+		projector.setChildren(v('div'));
 
 		assert.isTrue(called);
 	},


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Add `setChildren(children: DNode | DNode[])` api to replace the overridden property setter that can consume a single `DNode` as well as an array of `DNode`s

Resolves #157
