### PR TITLE
Allow non optional properties

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -140,7 +140,7 @@ export interface PropertyComparison<P extends WidgetProperties> {
 	/**
 	 * Construct properties object for this.properties
 	 */
-	assignProperties<S>(this: S, previousProperties: P, newProperties: P, changedPropertyKeys: string[]): P;
+	assignProperties<S>(this: S, previousProperties: P, newProperties: P, changedPropertyKeys: string[]): Partial<P>;
 }
 
 export interface WidgetMixin<P extends WidgetProperties> extends PropertyComparison<P> {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Attributes should be able to be defined as mandatory for `WidgetProperties`
