### PR TITLE
Provide default shallow property diffProperties/assign

### DIFF
--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -19,7 +19,6 @@ import Promise from '@dojo/shim/Promise';
 import Map from '@dojo/shim/Map';
 import { v, registry } from './d';
 import FactoryRegistry from './FactoryRegistry';
-import shallowPropertyComparisonMixin from './mixins/shallowPropertyComparisonMixin';
 
 interface WidgetInternalState {
 	children: DNode[];
@@ -210,7 +209,12 @@ const createWidget: WidgetBaseFactory = createStateful
 			},
 
 			diffProperties(this: Widget<WidgetProperties>, previousProperties: WidgetProperties, newProperties: WidgetProperties): string[] {
-				return Object.keys(newProperties);
+				return Object.keys(newProperties).reduce((changedPropertyKeys: string[], propertyKey: string): string[] => {
+					if (previousProperties[propertyKey] !== newProperties[propertyKey]) {
+						changedPropertyKeys.push(propertyKey);
+					}
+					return changedPropertyKeys;
+				}, []);
 			},
 
 			assignProperties(this: Widget<WidgetProperties>, previousProperties: WidgetProperties, newProperties: WidgetProperties, changedPropertyKeys: string[]): WidgetProperties {
@@ -293,7 +297,6 @@ const createWidget: WidgetBaseFactory = createStateful
 
 			instance.setProperties(properties);
 		}
-	})
-	.mixin(shallowPropertyComparisonMixin);
+	});
 
 export default createWidget;

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -70,25 +70,25 @@ registerSuite({
 		'no updated properties'() {
 			const properties = { id: 'id', foo: 'bar' };
 			const widgetBase = createWidgetBase();
-			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
+			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 0);
 		},
 		'updated properties'() {
 			const widgetBase = createWidgetBase();
 			const properties = { id: 'id', foo: 'baz' };
-			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
+			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 1);
 		},
 		'new properties'() {
 			const widgetBase = createWidgetBase();
 			const properties = { id: 'id', foo: 'bar', bar: 'baz' };
-			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
+			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 1);
 		},
 		'updated / new properties with falsy values'() {
 			const widgetBase = createWidgetBase();
 			const properties = { id: 'id', foo: '', bar: null, baz: 0, qux: false };
-			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
+			const updatedKeys = widgetBase.diffProperties({ id: 'id', foo: 'bar' }, properties);
 			assert.lengthOf(updatedKeys, 4);
 			assert.deepEqual(updatedKeys, [ 'foo', 'bar', 'baz', 'qux']);
 		}
@@ -480,10 +480,10 @@ registerSuite({
 			assert.deepEqual((<any> myWidget.state).items, [ 'a', 'b' ]);
 			properties.items.push('c');
 			myWidget.setProperties(properties);
-			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b', 'c' ]);
-			properties.items.push('d');
+			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b' ]);
+			properties.items = [...properties.items];
 			myWidget.setProperties(properties);
-			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b', 'c', 'd' ]);
+			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b', 'c' ]);
 		},
 		'__render__ with internally updated array state'() {
 			const properties = {

--- a/tests/unit/mixins/shallowPropertyComparisonMixin.ts
+++ b/tests/unit/mixins/shallowPropertyComparisonMixin.ts
@@ -5,140 +5,141 @@ import createWidgetBase from './../../../src/createWidgetBase';
 
 registerSuite({
 	name: 'mixins/shallowPropertyComparisonMixin',
-		'no updated properties'() {
-			const properties = { id: 'id', foo: 'bar' };
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
-			assert.lengthOf(updatedKeys, 0);
-		},
-		'updated properties'() {
-			const properties = { id: 'id', foo: 'baz' };
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
-			assert.lengthOf(updatedKeys, 1);
-		},
-		'new properties'() {
-			const properties = { id: 'id', foo: 'bar', bar: 'baz' };
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
-			assert.lengthOf(updatedKeys, 1);
-		},
-		'updated / new properties with falsy values'() {
-			const properties = { id: 'id', foo: null, bar: '', baz: 0, qux: false };
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, <any> properties);
-			assert.lengthOf(updatedKeys, 4);
-			assert.deepEqual(updatedKeys, [ 'foo', 'bar', 'baz', 'qux']);
-		},
-		'update array item in property'() {
-			const properties = {
-				id: 'id',
-				items: [ 'a', 'b' ],
-				otherItems: [ 'c', 'd']
-			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).items[1] = 'c';
+	'no updated properties'() {
+		const properties = { id: 'id', foo: 'bar' };
+		const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
+		assert.lengthOf(updatedKeys, 0);
+	},
+	'updated properties'() {
+		const properties = { id: 'id', foo: 'baz' };
+		const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
+		assert.lengthOf(updatedKeys, 1);
+	},
+	'new properties'() {
+		const properties = { id: 'id', foo: 'bar', bar: 'baz' };
+		const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
+		assert.lengthOf(updatedKeys, 1);
+	},
+	'updated / new properties with falsy values'() {
+		const properties = { id: 'id', foo: null, bar: '', baz: 0, qux: false };
+		const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, <any> properties);
+		assert.lengthOf(updatedKeys, 4);
+		assert.deepEqual(updatedKeys, [ 'foo', 'bar', 'baz', 'qux']);
+	},
+	'update array item in property'() {
+		const properties = {
+			id: 'id',
+			items: [ 'a', 'b' ],
+			otherItems: [ 'c', 'd']
+		};
+		const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+		(<any> updatedProperties).items[1] = 'c';
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'items' ]);
-		},
-		'reordered array property'() {
-			const properties = {
-				id: 'id',
-				items: [ 'a', 'b' ],
-				otherItems: [ 'c', 'd']
-			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).items.reverse();
+		const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
+		assert.lengthOf(updatedKeys, 1);
+		assert.deepEqual(updatedKeys, [ 'items' ]);
+	},
+	'reordered array property'() {
+		const properties = {
+			id: 'id',
+			items: [ 'a', 'b' ],
+			otherItems: [ 'c', 'd']
+		};
+		const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+		(<any> updatedProperties).items.reverse();
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'items' ]);
-		},
-		'array property with updated object item'() {
-			const properties = {
-				id: 'id',
-				items: [
-					{ foo: 'bar' }
-				]
-			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).items[0].foo = 'foo';
+		const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
+		assert.lengthOf(updatedKeys, 1);
+		assert.deepEqual(updatedKeys, [ 'items' ]);
+	},
+	'array property with updated object item'() {
+		const properties = {
+			id: 'id',
+			items: [
+				{ foo: 'bar' }
+			]
+		};
+		const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+		(<any> updatedProperties).items[0].foo = 'foo';
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'items' ]);
-		},
-		'array property updated to be empty'() {
-			const properties = {
-				id: 'id',
-				items: [
-					{ foo: 'bar' }
-				]
-			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).items.pop();
+		const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
+		assert.lengthOf(updatedKeys, 1);
+		assert.deepEqual(updatedKeys, [ 'items' ]);
+	},
+	'array property updated to be empty'() {
+		const properties = {
+			id: 'id',
+			items: [
+				{ foo: 'bar' }
+			]
+		};
+		const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+		(<any> updatedProperties).items.pop();
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'items' ]);
-		},
-		'array property with new object item'() {
-			const properties: any = {
-				id: 'id',
-				items: [
-					{ foo: 'bar' }
-				]
-			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).items[1] = { bar: 'foo' };
+		const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
+		assert.lengthOf(updatedKeys, 1);
+		assert.deepEqual(updatedKeys, [ 'items' ]);
+	},
+	'array property with new object item'() {
+		const properties: any = {
+			id: 'id',
+			items: [
+				{ foo: 'bar' }
+			]
+		};
+		const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+		(<any> updatedProperties).items[1] = { bar: 'foo' };
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'items' ]);
-		},
-		'updated value in property object'() {
-			const properties = {
-				id: 'id',
-				obj: {
-					foo: 'bar'
-				},
-				otherObj: {
-					baz: 'qux'
-				}
-			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).obj.foo = 'foo';
+		const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
+		assert.lengthOf(updatedKeys, 1);
+		assert.deepEqual(updatedKeys, [ 'items' ]);
+	},
+	'updated value in property object'() {
+		const properties = {
+			id: 'id',
+			obj: {
+				foo: 'bar'
+			},
+			otherObj: {
+				baz: 'qux'
+			}
+		};
+		const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+		(<any> updatedProperties).obj.foo = 'foo';
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'obj' ]);
-		},
-		'new key in property object'() {
-			const properties: any = {
-				id: 'id',
-				obj: {
-					foo: 'bar'
-				},
-				otherObj: {
-					baz: 'qux'
-				}
-			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).obj.bar = 'foo';
+		const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
+		assert.lengthOf(updatedKeys, 1);
+		assert.deepEqual(updatedKeys, [ 'obj' ]);
+	},
+	'new key in property object'() {
+		const properties: any = {
+			id: 'id',
+			obj: {
+				foo: 'bar'
+			},
+			otherObj: {
+				baz: 'qux'
+			}
+		};
+		const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+		(<any> updatedProperties).obj.bar = 'foo';
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'obj' ]);
-		},
-		'do not ignore functions'() {
-			const properties: any = {
-				id: 'id',
-				myFunc: () => {}
-			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).myFunc = () => {};
+		const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
+		assert.lengthOf(updatedKeys, 1);
+		assert.deepEqual(updatedKeys, [ 'obj' ]);
+	},
+	'do not ignore functions'() {
+		const properties: any = {
+			id: 'id',
+			myFunc: () => {}
+		};
+		const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+		(<any> updatedProperties).myFunc = () => {};
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-		},
+		const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
+		assert.lengthOf(updatedKeys, 1);
+	},
+	'intergration tests': {
 		'test compatibility with shallowPropertyComparisonMixin'() {
 			const properties = {
 				id: 'id',
@@ -153,6 +154,31 @@ registerSuite({
 			const updatedKeys = widgetBase.diffProperties(properties, updatedProperties);
 			assert.lengthOf(updatedKeys, 1);
 			assert.deepEqual(updatedKeys, [ 'items' ]);
+		},
+		'no updated properties'() {
+			const properties = { id: 'id', foo: 'bar' };
+			const widgetBase = createWidgetBase.mixin(shallowPropertyComparisonMixin)({ properties });
+			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
+			assert.lengthOf(updatedKeys, 0);
+		},
+		'updated properties'() {
+			const properties = { id: 'id', foo: 'baz' };
+			const widgetBase = createWidgetBase.mixin(shallowPropertyComparisonMixin)({ properties });
+			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
+			assert.lengthOf(updatedKeys, 1);
+		},
+		'new properties'() {
+			const properties = { id: 'id', foo: 'bar', bar: 'baz' };
+			const widgetBase = createWidgetBase.mixin(shallowPropertyComparisonMixin)({ properties });
+			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
+			assert.lengthOf(updatedKeys, 1);
+		},
+		'updated / new properties with falsy values'() {
+			const properties = { id: 'id', foo: '', bar: null, baz: 0, qux: false };
+			const widgetBase = createWidgetBase.mixin(shallowPropertyComparisonMixin)({ properties });
+			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
+			assert.lengthOf(updatedKeys, 4);
+			assert.deepEqual(updatedKeys, [ 'foo', 'bar', 'baz', 'qux']);
 		}
-
+	}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Default shallow `diffProperties` and `assign` for `createWidgetBase`

Resolves #214 
