### PR TITLE
Shallowly assign values in shallowPropertyComparisonMixin

### DIFF
--- a/src/mixins/shallowPropertyComparisonMixin.ts
+++ b/src/mixins/shallowPropertyComparisonMixin.ts
@@ -1,5 +1,6 @@
 import { entries } from '@dojo/shim/object';
 import { WidgetProperties, PropertyComparison } from './../interfaces';
+import { assign } from '@dojo/core/lang';
 
 /**
  * Determine if the value is an Object
@@ -69,11 +70,11 @@ const shallowPropertyComparisonMixin: { mixin: PropertyComparison<WidgetProperti
 				const newValue = newProperties[key];
 				if (Array.isArray(newValue)) {
 					properties[key] = newValue.map((value: any) => {
-						return isObject(value) ? Object.assign({}, value) : value;
+						return isObject(value) ? assign({}, value) : value;
 					});
 				}
 				else {
-					properties[key] = isObject(newValue) ? Object.assign({}, newValue) : newValue;
+					properties[key] = isObject(newValue) ? assign({}, newValue) : newValue;
 				}
 				return properties;
 			}, <WidgetProperties> {});

--- a/src/mixins/shallowPropertyComparisonMixin.ts
+++ b/src/mixins/shallowPropertyComparisonMixin.ts
@@ -1,6 +1,5 @@
 import { entries } from '@dojo/shim/object';
 import { WidgetProperties, PropertyComparison } from './../interfaces';
-import { deepAssign } from '@dojo/core/lang';
 
 /**
  * Determine if the value is an Object
@@ -30,7 +29,7 @@ const shallowPropertyComparisonMixin: { mixin: PropertyComparison<WidgetProperti
 		diffProperties<S>(this: S, previousProperties: WidgetProperties, newProperties: WidgetProperties): string[] {
 			const changedPropertyKeys: string[] = [];
 
-			entries(newProperties).forEach(([key, value]) => {
+			entries(newProperties).forEach(([ key, value ]) => {
 				let isEqual = true;
 				if (previousProperties.hasOwnProperty(key)) {
 					const previousValue = (<any> previousProperties)[key];
@@ -66,7 +65,18 @@ const shallowPropertyComparisonMixin: { mixin: PropertyComparison<WidgetProperti
 			return changedPropertyKeys;
 		},
 		assignProperties<S>(this: S, previousProperties: WidgetProperties, newProperties: WidgetProperties, changedPropertyKeys: string[]): WidgetProperties {
-			return deepAssign({}, newProperties);
+			return Object.keys(newProperties).reduce((properties, key) => {
+				const newValue = newProperties[key];
+				if (Array.isArray(newValue)) {
+					properties[key] = newValue.map((value: any) => {
+						return isObject(value) ? Object.assign({}, value) : value;
+					});
+				}
+				else {
+					properties[key] = isObject(newValue) ? Object.assign({}, newValue) : newValue;
+				}
+				return properties;
+			}, <WidgetProperties> {});
 		}
 	}
 };

--- a/tests/unit/components/button/createButton.ts
+++ b/tests/unit/components/button/createButton.ts
@@ -64,10 +64,10 @@ registerSuite({
 		const onClick = function() {
 			onClickCount++;
 		};
-		const button = createButton({ properties: { onClick }});
+		const button = createButton({ properties: { onClick } });
 		button.onClick();
 		assert.equal(onClickCount, 1);
-		button.setProperties({});
+		button.setProperties({ onClick: () => {} });
 		button.onClick();
 		assert.equal(onClickCount, 1);
 	}

--- a/tests/unit/mixins/shallowPropertyComparisonMixin.ts
+++ b/tests/unit/mixins/shallowPropertyComparisonMixin.ts
@@ -32,7 +32,7 @@ registerSuite({
 				items: [ 'a', 'b' ],
 				otherItems: [ 'c', 'd']
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, Object.keys(properties));
 			(<any> updatedProperties).items[1] = 'c';
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
@@ -45,7 +45,7 @@ registerSuite({
 				items: [ 'a', 'b' ],
 				otherItems: [ 'c', 'd']
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, Object.keys(properties));
 			(<any> updatedProperties).items.reverse();
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
@@ -59,7 +59,7 @@ registerSuite({
 					{ foo: 'bar' }
 				]
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, Object.keys(properties));
 			(<any> updatedProperties).items[0].foo = 'foo';
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
@@ -73,7 +73,7 @@ registerSuite({
 					{ foo: 'bar' }
 				]
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, Object.keys(properties));
 			(<any> updatedProperties).items.pop();
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
@@ -87,7 +87,7 @@ registerSuite({
 					{ foo: 'bar' }
 				]
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, Object.keys(properties));
 			(<any> updatedProperties).items[1] = { bar: 'foo' };
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
@@ -104,7 +104,7 @@ registerSuite({
 					baz: 'qux'
 				}
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, Object.keys(properties));
 			(<any> updatedProperties).obj.foo = 'foo';
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
@@ -121,7 +121,7 @@ registerSuite({
 					baz: 'qux'
 				}
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, Object.keys(properties));
 			(<any> updatedProperties).obj.bar = 'foo';
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
@@ -133,7 +133,7 @@ registerSuite({
 				id: 'id',
 				myFunc: () => {}
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, Object.keys(properties));
 			(<any> updatedProperties).myFunc = () => {};
 
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
@@ -146,7 +146,7 @@ registerSuite({
 					{ foo: 'bar' }
 				]
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
+			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, Object.keys(properties));
 			(<any> updatedProperties).items[0].foo = 'foo';
 
 			const widgetBase = createWidgetBase.mixin(shallowPropertyComparisonMixin)({ properties });


### PR DESCRIPTION
**Type:** feature

This implements the required assigns needed for the `diff` part of the mixin. Which should give some performance enhancements over using `deepAssign`, by only copying to the levels it needs to.