### PR TITLE
Combine diffProperties and assignProperties API

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -132,15 +132,16 @@ export interface WidgetOverloads<P extends WidgetProperties> {
 	on(type: 'properties:changed', listener: EventedListener<Widget<P>, PropertiesChangeEvent<Widget<P>, P>>): Handle;
 }
 
+export interface PropertiesChangedRecord<P extends WidgetProperties> {
+	changedKeys: string[];
+	properties: P;
+}
+
 export interface PropertyComparison<P extends WidgetProperties> {
 	/**
-	 * Determine changed or new property keys on setProperties
+	 * Determine changed or new property keys on setProperties and assign them on return.
 	 */
-	diffProperties<S>(this: S, previousProperties: P, newProperties: P): string[];
-	/**
-	 * Construct properties object for this.properties
-	 */
-	assignProperties<S>(this: S, previousProperties: P, newProperties: P, changedPropertyKeys: string[]): Partial<P>;
+	diffProperties<S>(this: S, previousProperties: P, newProperties: P): PropertiesChangedRecord<P>;
 }
 
 export interface WidgetMixin<P extends WidgetProperties> extends PropertyComparison<P> {

--- a/src/mixins/shallowPropertyComparisonMixin.ts
+++ b/src/mixins/shallowPropertyComparisonMixin.ts
@@ -1,5 +1,5 @@
 import { entries } from '@dojo/shim/object';
-import { WidgetProperties, PropertyComparison } from './../interfaces';
+import { WidgetProperties, PropertyComparison, PropertiesChangedRecord } from './../interfaces';
 import { deepAssign } from '@dojo/core/lang';
 
 /**
@@ -17,7 +17,8 @@ function shallowCompare(from: any, to: any) {
 }
 
 /**
- * Mixin that overrides the `diffProperties` method providing a shallow comparison of attributes.
+ * Mixin that overrides the `processProperties` method providing a comparison of attributes that goes a level deeper for
+ * arrays and objects.
  *
  * For Objects, values for all `keys` are compared against the equivalent `key` on the `previousProperties`
  * attribute using `===`. If the `key` does not exists on the `previousProperties` attribute it is considered unequal.
@@ -27,8 +28,8 @@ function shallowCompare(from: any, to: any) {
  */
 const shallowPropertyComparisonMixin: { mixin: PropertyComparison<WidgetProperties> } = {
 	mixin: {
-		diffProperties<S>(this: S, previousProperties: WidgetProperties, newProperties: WidgetProperties): string[] {
-			const changedPropertyKeys: string[] = [];
+		diffProperties<S>(this: S, previousProperties: WidgetProperties, newProperties: WidgetProperties): PropertiesChangedRecord<WidgetProperties> {
+			const changedKeys: string[] = [];
 
 			entries(newProperties).forEach(([key, value]) => {
 				let isEqual = true;
@@ -60,13 +61,13 @@ const shallowPropertyComparisonMixin: { mixin: PropertyComparison<WidgetProperti
 					isEqual = false;
 				}
 				if (!isEqual) {
-					changedPropertyKeys.push(key);
+					changedKeys.push(key);
 				}
 			});
-			return changedPropertyKeys;
-		},
-		assignProperties<S>(this: S, previousProperties: WidgetProperties, newProperties: WidgetProperties, changedPropertyKeys: string[]): WidgetProperties {
-			return deepAssign({}, newProperties);
+			return {
+				changedKeys,
+				properties: deepAssign({}, newProperties)
+			};
 		}
 	}
 };

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -70,27 +70,27 @@ registerSuite({
 		'no updated properties'() {
 			const properties = { id: 'id', foo: 'bar' };
 			const widgetBase = createWidgetBase();
-			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
-			assert.lengthOf(updatedKeys, 0);
+			const result = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
+			assert.lengthOf(result.changedKeys, 0);
 		},
 		'updated properties'() {
 			const widgetBase = createWidgetBase();
 			const properties = { id: 'id', foo: 'baz' };
-			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
-			assert.lengthOf(updatedKeys, 1);
+			const result = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
+			assert.lengthOf(result.changedKeys, 1);
 		},
 		'new properties'() {
 			const widgetBase = createWidgetBase();
 			const properties = { id: 'id', foo: 'bar', bar: 'baz' };
-			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
-			assert.lengthOf(updatedKeys, 1);
+			const result = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
+			assert.lengthOf(result.changedKeys, 1);
 		},
 		'updated / new properties with falsy values'() {
 			const widgetBase = createWidgetBase();
 			const properties = { id: 'id', foo: '', bar: null, baz: 0, qux: false };
-			const updatedKeys = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
-			assert.lengthOf(updatedKeys, 4);
-			assert.deepEqual(updatedKeys, [ 'foo', 'bar', 'baz', 'qux']);
+			const result = widgetBase.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
+			assert.lengthOf(result.changedKeys, 4);
+			assert.deepEqual(result.changedKeys, [ 'foo', 'bar', 'baz', 'qux']);
 		}
 	},
 	onPropertiesChanged() {

--- a/tests/unit/mixins/shallowPropertyComparisonMixin.ts
+++ b/tests/unit/mixins/shallowPropertyComparisonMixin.ts
@@ -1,30 +1,35 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import { PropertiesChangedRecord, WidgetProperties } from '../../../src/interfaces';
 import shallowPropertyComparisonMixin from '../../../src/mixins/shallowPropertyComparisonMixin';
 import createWidgetBase from './../../../src/createWidgetBase';
+
+interface TestProperties extends WidgetProperties {
+	items?: { foo: string }[];
+}
 
 registerSuite({
 	name: 'mixins/shallowPropertyComparisonMixin',
 		'no updated properties'() {
 			const properties = { id: 'id', foo: 'bar' };
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
-			assert.lengthOf(updatedKeys, 0);
+			assert.lengthOf(updatedKeys.changedKeys, 0);
 		},
 		'updated properties'() {
 			const properties = { id: 'id', foo: 'baz' };
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
-			assert.lengthOf(updatedKeys, 1);
+			assert.lengthOf(updatedKeys.changedKeys, 1);
 		},
 		'new properties'() {
 			const properties = { id: 'id', foo: 'bar', bar: 'baz' };
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, properties);
-			assert.lengthOf(updatedKeys, 1);
+			assert.lengthOf(updatedKeys.changedKeys, 1);
 		},
 		'updated / new properties with falsy values'() {
 			const properties = { id: 'id', foo: null, bar: '', baz: 0, qux: false };
 			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(<any> { id: 'id', foo: 'bar' }, <any> properties);
-			assert.lengthOf(updatedKeys, 4);
-			assert.deepEqual(updatedKeys, [ 'foo', 'bar', 'baz', 'qux']);
+			assert.lengthOf(updatedKeys.changedKeys, 4);
+			assert.deepEqual(updatedKeys.changedKeys, [ 'foo', 'bar', 'baz', 'qux']);
 		},
 		'update array item in property'() {
 			const properties = {
@@ -32,12 +37,15 @@ registerSuite({
 				items: [ 'a', 'b' ],
 				otherItems: [ 'c', 'd']
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).items[1] = 'c';
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'items' ]);
+			let propertiesChanged: PropertiesChangedRecord<TestProperties> = shallowPropertyComparisonMixin.mixin.diffProperties({}, properties);
+			assert.lengthOf(propertiesChanged.changedKeys, 3);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'id', 'items', 'otherItems' ]);
+			properties.items[1] = 'c';
+
+			propertiesChanged = shallowPropertyComparisonMixin.mixin.diffProperties(propertiesChanged.properties, properties);
+			assert.lengthOf(propertiesChanged.changedKeys, 1);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'items' ]);
 		},
 		'reordered array property'() {
 			const properties = {
@@ -45,12 +53,15 @@ registerSuite({
 				items: [ 'a', 'b' ],
 				otherItems: [ 'c', 'd']
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).items.reverse();
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'items' ]);
+			let propertiesChanged: PropertiesChangedRecord<TestProperties> = shallowPropertyComparisonMixin.mixin.diffProperties({}, properties);
+			assert.lengthOf(propertiesChanged.changedKeys, 3);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'id', 'items', 'otherItems' ]);
+			properties.items.reverse();
+
+			propertiesChanged = shallowPropertyComparisonMixin.mixin.diffProperties(propertiesChanged.properties, properties);
+			assert.lengthOf(propertiesChanged.changedKeys, 1);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'items' ]);
 		},
 		'array property with updated object item'() {
 			const properties = {
@@ -59,26 +70,32 @@ registerSuite({
 					{ foo: 'bar' }
 				]
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).items[0].foo = 'foo';
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'items' ]);
+			let propertiesChanged: PropertiesChangedRecord<TestProperties> = shallowPropertyComparisonMixin.mixin.diffProperties({}, properties);
+			assert.lengthOf(propertiesChanged.changedKeys, 2);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'id', 'items' ]);
+			properties.items[0].foo = 'foo';
+
+			propertiesChanged = shallowPropertyComparisonMixin.mixin.diffProperties(propertiesChanged.properties, properties);
+			assert.lengthOf(propertiesChanged.changedKeys, 1);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'items' ]);
 		},
 		'array property updated to be empty'() {
-			const properties = {
+			const properties: TestProperties = {
 				id: 'id',
 				items: [
 					{ foo: 'bar' }
 				]
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).items.pop();
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'items' ]);
+			let propertiesChanged: PropertiesChangedRecord<TestProperties> = shallowPropertyComparisonMixin.mixin.diffProperties({}, properties);
+			assert.lengthOf(propertiesChanged.changedKeys, 2);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'id', 'items' ]);
+			properties.items!.pop();
+
+			propertiesChanged = shallowPropertyComparisonMixin.mixin.diffProperties(propertiesChanged.properties, properties);
+			assert.lengthOf(propertiesChanged.changedKeys, 1);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'items' ]);
 		},
 		'array property with new object item'() {
 			const properties: any = {
@@ -87,12 +104,16 @@ registerSuite({
 					{ foo: 'bar' }
 				]
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).items[1] = { bar: 'foo' };
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'items' ]);
+			let propertiesChanged: PropertiesChangedRecord<TestProperties> = shallowPropertyComparisonMixin.mixin.diffProperties({}, properties);
+			assert.lengthOf(propertiesChanged.changedKeys, 2);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'id', 'items' ]);
+			properties.items[1] = { bar: 'foo' };
+
+			propertiesChanged = shallowPropertyComparisonMixin.mixin.diffProperties(propertiesChanged.properties, properties);
+
+			assert.lengthOf(propertiesChanged.changedKeys, 1);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'items' ]);
 		},
 		'updated value in property object'() {
 			const properties = {
@@ -104,12 +125,16 @@ registerSuite({
 					baz: 'qux'
 				}
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).obj.foo = 'foo';
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'obj' ]);
+			let propertiesChanged: PropertiesChangedRecord<TestProperties> = shallowPropertyComparisonMixin.mixin.diffProperties({}, properties);
+			assert.lengthOf(propertiesChanged.changedKeys, 3);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'id', 'obj', 'otherObj' ]);
+			properties.obj.foo = 'foo';
+
+			propertiesChanged = shallowPropertyComparisonMixin.mixin.diffProperties(propertiesChanged.properties, properties);
+
+			assert.lengthOf(propertiesChanged.changedKeys, 1);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'obj' ]);
 		},
 		'new key in property object'() {
 			const properties: any = {
@@ -121,23 +146,32 @@ registerSuite({
 					baz: 'qux'
 				}
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).obj.bar = 'foo';
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'obj' ]);
+			let propertiesChanged: PropertiesChangedRecord<TestProperties> = shallowPropertyComparisonMixin.mixin.diffProperties({}, properties);
+			assert.lengthOf(propertiesChanged.changedKeys, 3);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'id', 'obj', 'otherObj' ]);
+			properties.obj.bar = 'foo';
+
+			propertiesChanged = shallowPropertyComparisonMixin.mixin.diffProperties(propertiesChanged.properties, properties);
+
+			assert.lengthOf(propertiesChanged.changedKeys, 1);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'obj' ]);
 		},
 		'do not ignore functions'() {
 			const properties: any = {
 				id: 'id',
 				myFunc: () => {}
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).myFunc = () => {};
 
-			const updatedKeys = shallowPropertyComparisonMixin.mixin.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
+			let propertiesChanged: PropertiesChangedRecord<TestProperties> = shallowPropertyComparisonMixin.mixin.diffProperties({}, properties);
+			assert.lengthOf(propertiesChanged.changedKeys, 2);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'id', 'myFunc' ]);
+			properties.myFunc = () => {};
+
+			propertiesChanged = shallowPropertyComparisonMixin.mixin.diffProperties(propertiesChanged.properties, properties);
+
+			assert.lengthOf(propertiesChanged.changedKeys, 1);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'myFunc' ]);
 		},
 		'test compatibility with shallowPropertyComparisonMixin'() {
 			const properties = {
@@ -146,13 +180,16 @@ registerSuite({
 					{ foo: 'bar' }
 				]
 			};
-			const updatedProperties = shallowPropertyComparisonMixin.mixin.assignProperties({}, properties, []);
-			(<any> updatedProperties).items[0].foo = 'foo';
+
+			let propertiesChanged: PropertiesChangedRecord<TestProperties> = shallowPropertyComparisonMixin.mixin.diffProperties({}, properties);
+			assert.lengthOf(propertiesChanged.changedKeys, 2);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'id', 'items' ]);
+			properties.items[0].foo = 'foo';
 
 			const widgetBase = createWidgetBase.mixin(shallowPropertyComparisonMixin)({ properties });
-			const updatedKeys = widgetBase.diffProperties(properties, updatedProperties);
-			assert.lengthOf(updatedKeys, 1);
-			assert.deepEqual(updatedKeys, [ 'items' ]);
-		}
+			propertiesChanged = widgetBase.diffProperties(propertiesChanged.properties, properties);
 
+			assert.lengthOf(propertiesChanged.changedKeys, 1);
+			assert.deepEqual(propertiesChanged.changedKeys, [ 'items' ]);
+		}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Combine the existing `diffProperties` and `assignProperties` into a single `diffProperties`

Resolves #247