### PR TITLE
Internal state mixin

### DIFF
--- a/src/components/button/createButton.ts
+++ b/src/components/button/createButton.ts
@@ -1,22 +1,21 @@
 import { VNodeProperties } from '@dojo/interfaces/vdom';
 import createWidgetBase from '../../createWidgetBase';
 import { Widget, WidgetProperties, WidgetFactory } from './../../interfaces';
-import createFormFieldMixin, { FormFieldMixin } from '../../mixins/createFormFieldMixin';
 
 export interface ButtonProperties extends WidgetProperties {
 	label?: string;
 	name?: string;
+	disabled?: boolean;
 	onClick?(event: MouseEvent): void;
 }
 
-export type Button = Widget<ButtonProperties> & FormFieldMixin<string, any> & {
+export type Button = Widget<ButtonProperties> & {
 	onClick(event?: MouseEvent): void;
 };
 
 export interface ButtonFactory extends WidgetFactory<Button, ButtonProperties> { }
 
 const createButton: ButtonFactory = createWidgetBase
-	.mixin(createFormFieldMixin)
 	.mixin({
 		mixin: {
 			onClick(this: Button, event: MouseEvent) {
@@ -24,7 +23,8 @@ const createButton: ButtonFactory = createWidgetBase
 			},
 			nodeAttributes: [
 				function(this: Button): VNodeProperties {
-					return { innerHTML: this.properties.label, onclick: this.onClick };
+					const { type, properties: { label, name, disabled } } = this;
+					return { type, innerHTML: label, onclick: this.onClick, name, disabled: Boolean(disabled) };
 				}
 			],
 			tagName: 'button',

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -5,8 +5,8 @@
  * bases.
  */
 import Promise from '@dojo/shim/Promise';
-import { EventedListener, Stateful, StatefulOptions, State } from '@dojo/interfaces/bases';
-import { EventTargettedObject, EventTypedObject, Handle, StylesMap } from '@dojo/interfaces/core';
+import { EventedListener, Evented, EventedOptions } from '@dojo/interfaces/bases';
+import { EventTargettedObject, EventTypedObject, Handle } from '@dojo/interfaces/core';
 import { VNode, VNodeProperties } from '@dojo/interfaces/vdom';
 import { ComposeFactory } from '@dojo/compose/compose';
 
@@ -126,9 +126,9 @@ export interface PropertyChangeRecord {
 	value: any;
 }
 
-export type Widget<P extends WidgetProperties> = Stateful<WidgetState> & WidgetMixin<P> & WidgetOverloads<P>
+export type Widget<P extends WidgetProperties> = Evented & WidgetMixin<P> & WidgetOverloads<P>
 
-export interface WidgetBaseFactory extends ComposeFactory<Widget<WidgetProperties>, WidgetOptions<WidgetState, WidgetProperties>> {}
+export interface WidgetBaseFactory extends ComposeFactory<Widget<WidgetProperties>, WidgetOptions<WidgetProperties>> { }
 
 export interface WidgetOverloads<P extends WidgetProperties> {
 	/**
@@ -213,11 +213,6 @@ export interface WidgetMixin<P extends WidgetProperties> extends PropertyCompari
 	setProperties(this: Widget<WidgetProperties>, properties: P): void;
 
 	/**
-	 * Called when the properties have changed
-	 */
-	onPropertiesChanged(this: Widget<WidgetProperties>, properties: P, changedPropertyKeys: string[]): void;
-
-	/**
 	 * The ID of the widget, which gets automatically rendered in the VNode property `data-widget-id` when
 	 * rendered.
 	 */
@@ -266,7 +261,7 @@ export interface WidgetMixin<P extends WidgetProperties> extends PropertyCompari
 	registry: FactoryRegistryInterface | undefined;
 }
 
-export interface WidgetOptions<S extends WidgetState, P extends WidgetProperties> extends StatefulOptions<S> {
+export interface WidgetOptions<P extends WidgetProperties> extends EventedOptions {
 	/**
 	 * Properties used to affect internal widget state
 	 */
@@ -281,23 +276,4 @@ export interface WidgetProperties {
 	classes?: string[];
 }
 
-export interface WidgetState extends State {
-	/**
-	 * Any classes that should be mixed into the widget's VNode upon render.
-	 *
-	 * Any classes expressed in state will be additive to those provided in the widget's `.classes` property
-	 */
-	classes?: string[];
-
-	/**
-	 * The ID of the widget
-	 */
-	id?: string;
-
-	/**
-	 * Any inline styles which should be mixed into the widget's VNode upon render.
-	 */
-	styles?: StylesMap;
-}
-
-export interface WidgetFactory<W extends Widget<P>, P extends WidgetProperties> extends ComposeFactory<W, WidgetOptions<WidgetState, P>> {}
+export interface WidgetFactory<W extends Widget<P>, P extends WidgetProperties> extends ComposeFactory<W, WidgetOptions<P>> {}

--- a/src/mixins/createI18nMixin.ts
+++ b/src/mixins/createI18nMixin.ts
@@ -3,7 +3,7 @@ import compose, { ComposeFactory } from '@dojo/compose/compose';
 import { assign } from '@dojo/core/lang';
 import i18n, { Bundle, formatMessage, getCachedMessages, Messages, observeLocale } from '@dojo/i18n/i18n';
 import { VNodeProperties } from 'maquette';
-import { NodeAttributeFunction, Widget, WidgetOptions, WidgetProperties, WidgetState } from '../interfaces';
+import { NodeAttributeFunction, Widget, WidgetOptions, WidgetProperties } from '../interfaces';
 
 export interface I18nMixin<M extends Messages> {
 	/**
@@ -28,7 +28,7 @@ export interface I18nMixin<M extends Messages> {
 	localizeBundle(bundle: Bundle<M>): LocalizedMessages<M>;
 }
 
-export interface I18nFactory extends ComposeFactory<I18nMixin<Messages>, WidgetOptions<WidgetState, I18nProperties>> {}
+export interface I18nFactory extends ComposeFactory<I18nMixin<Messages>, WidgetOptions<I18nProperties>> {}
 
 export interface I18nProperties extends WidgetProperties {
 	/**
@@ -101,7 +101,7 @@ function getLocaleMessages(instance: I18nWidget<Messages, I18nProperties>, bundl
 	});
 }
 
-const createI18nMixin: I18nFactory = compose<I18nMixin<Messages>, WidgetOptions<WidgetState, I18nProperties>>({
+const createI18nMixin: I18nFactory = compose<I18nMixin<Messages>, WidgetOptions<I18nProperties>>({
 	nodeAttributes: [
 		function (this: I18nWidget<Messages, I18nProperties>, attributes: VNodeProperties): VNodeProperties {
 			const vNodeProperties = {

--- a/src/mixins/createProjectorMixin.ts
+++ b/src/mixins/createProjectorMixin.ts
@@ -5,7 +5,7 @@ import { VNode, VNodeProperties } from '@dojo/interfaces/vdom';
 import Promise from '@dojo/shim/Promise';
 import WeakMap from '@dojo/shim/WeakMap';
 import { createProjector as createMaquetteProjector, Projector as MaquetteProjector } from 'maquette';
-import { Widget, WidgetState, WidgetOptions, WidgetProperties } from '../interfaces';
+import { Widget, WidgetOptions, WidgetProperties } from '../interfaces';
 /**
  * Represents the state of the projector
  */
@@ -35,7 +35,7 @@ export interface AttachOptions {
 /**
  * Projector interface
  */
-export interface ProjectorOptions extends WidgetOptions<WidgetState, WidgetProperties> {
+export interface ProjectorOptions extends WidgetOptions<WidgetProperties> {
 
 	/**
 	 * An optional root of the projector

--- a/src/mixins/internalState.ts
+++ b/src/mixins/internalState.ts
@@ -1,0 +1,19 @@
+import { State, Stateful, StatefulOptions } from '@dojo/interfaces/bases';
+import createStateful from '@dojo/compose/bases/createStateful';
+import { ComposeFactory } from '@dojo/compose/compose';
+
+export type InternalState = Stateful<State> & {
+	invalidate(): void;
+}
+
+export interface InternalStateFactory extends ComposeFactory<Stateful<State>, StatefulOptions<State>> {}
+
+const internalStateFactory: InternalStateFactory = createStateful.mixin({
+	initialize(instance: InternalState) {
+		instance.own(instance.on('state:changed', () => {
+			instance.invalidate();
+		}));
+	}
+});
+
+export default internalStateFactory;

--- a/tests/unit/components/button/createButton.ts
+++ b/tests/unit/components/button/createButton.ts
@@ -53,7 +53,10 @@ registerSuite({
 		});
 		let vnode = <VNode> button.__render__();
 		assert.isFalse(vnode.properties!['disabled']);
-		button.setState({
+		button.setProperties({
+			id: 'foo',
+			label: 'bar',
+			name: 'baz',
 			disabled: true
 		});
 		vnode = <VNode> button.__render__();

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -61,7 +61,7 @@ registerSuite({
 		assert.deepEqual(nodeAttributes.classes, { bar: true });
 		assert.strictEqual(Object.keys(nodeAttributes).length, 4);
 
-		widgetBase.setState({ 'id': 'foo', classes: ['foo'] });
+		widgetBase.setProperties({ 'id': 'foo', classes: ['foo'] });
 
 		nodeAttributes = widgetBase.getNodeAttributes();
 
@@ -152,12 +152,6 @@ registerSuite({
 
 			widgetBase.setProperties({ foo: 'baz' });
 		}
-	},
-	onPropertiesChanged() {
-		const widgetBase = createWidgetBase();
-		widgetBase.onPropertiesChanged(<any> { foo: 'bar', myFunction: () => {} }, [ 'foo', 'myFunction' ]);
-		assert.equal((<any> widgetBase.state).foo, 'bar');
-		assert.isUndefined((<any> widgetBase.state).myFunction);
 	},
 	getChildrenNodes: {
 		'getChildrenNodes with no ChildNodeRenderers'() {
@@ -418,9 +412,9 @@ registerSuite({
 				.mixin({
 					mixin: {
 						getChildrenNodes: function(this: any): (DNode | null)[] {
-							const properties: WidgetProperties = this.state.classes ? { classes: this.state.classes } : {};
+							const properties: WidgetProperties = this.properties.classes ? { classes: this.properties.classes } : {};
 							return [
-								this.state.hide ? null : w(testChildWidget, properties)
+								this.properties.hide ? null : w(testChildWidget, properties)
 							];
 						}
 					}
@@ -442,7 +436,7 @@ registerSuite({
 			const secondRenderChild: any = secondRenderResult.children && secondRenderResult.children[0];
 			assert.strictEqual(secondRenderChild.vnodeSelector, 'footer');
 
-			widgetBase.setState({ 'classes': ['test-class'] });
+			widgetBase.setProperties({ 'classes': ['test-class'] });
 			widgetBase.invalidate();
 			const thirdRenderResult = <VNode> widgetBase.__render__();
 			assert.strictEqual(countWidgetCreated, 1);
@@ -452,7 +446,7 @@ registerSuite({
 			assert.strictEqual(thirdRenderChild.vnodeSelector, 'footer');
 			assert.isTrue(thirdRenderChild.properties.classes['test-class']);
 
-			widgetBase.setState(<any> { hide: true });
+			widgetBase.setProperties(<any> { hide: true });
 			widgetBase.invalidate();
 
 			const forthRenderResult = <VNode> widgetBase.__render__();
@@ -460,7 +454,7 @@ registerSuite({
 			assert.strictEqual(countWidgetDestroyed, 1);
 			assert.lengthOf(forthRenderResult.children, 0);
 
-			widgetBase.setState(<any> { hide: false });
+			widgetBase.setProperties(<any> { hide: false });
 			widgetBase.invalidate();
 
 			const lastRenderResult = <VNode> widgetBase.__render__();
@@ -494,7 +488,7 @@ registerSuite({
 				mixin: {
 					nodeAttributes: [
 						function(this: any): any {
-							const { state: { foo, bar } } = this;
+							const { properties: { foo, bar } } = this;
 
 							return { foo, bar };
 						}
@@ -538,13 +532,13 @@ registerSuite({
 			};
 
 			const myWidget = createWidgetBase({ properties });
-			assert.deepEqual((<any> myWidget.state).items, [ 'a', 'b' ]);
+			assert.deepEqual((<any> myWidget.properties).items, [ 'a', 'b' ]);
 			properties.items.push('c');
 			myWidget.setProperties(properties);
-			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b' ]);
+			assert.deepEqual((<any> myWidget.properties).items , [ 'a', 'b' ]);
 			properties.items = [...properties.items];
 			myWidget.setProperties(properties);
-			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b', 'c' ]);
+			assert.deepEqual((<any> myWidget.properties).items , [ 'a', 'b', 'c' ]);
 		},
 		'__render__ with internally updated array state'() {
 			const properties = {
@@ -555,10 +549,10 @@ registerSuite({
 
 			const myWidget = createWidgetBase({ properties });
 			myWidget.__render__();
-			assert.deepEqual((<any> myWidget.state).items, [ 'a', 'b' ]);
-			myWidget.setState(<any> { items: [ 'a', 'b', 'c'] });
+			assert.deepEqual((<any> myWidget.properties).items, [ 'a', 'b' ]);
+			myWidget.setProperties(<any> { items: [ 'a', 'b', 'c'] });
 			myWidget.__render__();
-			assert.deepEqual((<any> myWidget.state).items , [ 'a', 'b', 'c' ]);
+			assert.deepEqual((<any> myWidget.properties).items , [ 'a', 'b', 'c' ]);
 		},
 		'__render__() and invalidate()'() {
 			const widgetBase = createWidgetBase({
@@ -568,7 +562,6 @@ registerSuite({
 			const result2 = <VNode> widgetBase.__render__();
 			widgetBase.invalidate();
 			widgetBase.invalidate();
-			widgetBase.setState({});
 			const result3 = widgetBase.__render__();
 			const result4 = widgetBase.__render__();
 			assert.strictEqual(result1, result2);

--- a/tests/unit/createWidgetBase.ts
+++ b/tests/unit/createWidgetBase.ts
@@ -535,10 +535,10 @@ registerSuite({
 			assert.deepEqual((<any> myWidget.properties).items, [ 'a', 'b' ]);
 			properties.items.push('c');
 			myWidget.setProperties(properties);
-			assert.deepEqual((<any> myWidget.properties).items , [ 'a', 'b' ]);
-			properties.items = [...properties.items];
-			myWidget.setProperties(properties);
 			assert.deepEqual((<any> myWidget.properties).items , [ 'a', 'b', 'c' ]);
+			properties.items.push('d');
+			myWidget.setProperties(properties);
+			assert.deepEqual((<any> myWidget.properties).items , [ 'a', 'b', 'c', 'd' ]);
 		},
 		'__render__ with internally updated array state'() {
 			const properties = {

--- a/tests/unit/mixins/all.ts
+++ b/tests/unit/mixins/all.ts
@@ -6,3 +6,4 @@ import './shallowPropertyComparisonMixin';
 import './externalState';
 import './themeable';
 import './registryMixin';
+import './internalState';

--- a/tests/unit/mixins/internalState.ts
+++ b/tests/unit/mixins/internalState.ts
@@ -1,0 +1,20 @@
+import compose from '@dojo/compose/compose';
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+import internalState from '../../../src/mixins/internalState';
+
+const createTestInternalState = compose({
+	invalidateCalled: false,
+	invalidate(this: any) {
+		this.invalidateCalled = true;
+	}
+}).mixin(internalState);
+
+registerSuite({
+	name: 'mixins/internalState',
+	'invalidate is called on state change'() {
+		const testInternalState = createTestInternalState();
+		testInternalState.setState({});
+		assert.isTrue(testInternalState.invalidateCalled);
+	}
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Split the default stateful behaviour from `createWidgetBase` into a mixin - `internalState`. 

This changed also removes the `createWidgetBase#onPropertiesChanged` API  that was previously wired to the `properties:changed` event and coverts all references of `state` to `properties`. 

By default `createWidgetBase` now wires `createWidgetBase#invalidate` to the event.

Resolves #213 
