### PR TITLE
Add symbol type to WNode and HNode

### DIFF
--- a/src/createWidgetBase.ts
+++ b/src/createWidgetBase.ts
@@ -3,7 +3,6 @@ import createStateful from '@dojo/compose/bases/createStateful';
 import {
 	DNode,
 	PropertiesChangeEvent,
-	WNode,
 	Widget,
 	WidgetMixin,
 	WidgetState,
@@ -19,7 +18,7 @@ import { assign } from '@dojo/core/lang';
 import WeakMap from '@dojo/shim/WeakMap';
 import Promise from '@dojo/shim/Promise';
 import Map from '@dojo/shim/Map';
-import { v, registry } from './d';
+import { v, registry, isWNode } from './d';
 import FactoryRegistry from './FactoryRegistry';
 import shallowPropertyComparisonMixin from './mixins/shallowPropertyComparisonMixin';
 
@@ -43,10 +42,6 @@ interface WidgetInternalState {
 const widgetInternalStateMap = new WeakMap<Widget<WidgetProperties>, WidgetInternalState>();
 
 const propertyFunctionNameRegex = /^diffProperty(.*)/;
-
-function isWNode(child: DNode): child is WNode {
-	return Boolean(child && (<WNode> child).factory !== undefined);
-}
 
 function getFromRegistry(instance: Widget<WidgetProperties>, factoryLabel: string): FactoryRegistryItem | null {
 	if (instance.registry.has(factoryLabel)) {

--- a/src/d.ts
+++ b/src/d.ts
@@ -12,7 +12,14 @@ import {
 } from './interfaces';
 import FactoryRegistry from './FactoryRegistry';
 
+/**
+ * The symbol intifier for a WNode type
+ */
 export const WNODE = Symbol('Identifier for a WNode.');
+
+/**
+ * The symbol intifier for a HNode type
+ */
 export const HNODE = Symbol('Identifier for a HNode.');
 
 /**

--- a/src/d.ts
+++ b/src/d.ts
@@ -15,8 +15,18 @@ import FactoryRegistry from './FactoryRegistry';
 export const WNODE = Symbol('Identifier for a WNode.');
 export const HNODE = Symbol('Identifier for a HNode.');
 
+/**
+ * Helper function that returns true if the `DNode` is a `WNode` using the `type` property
+ */
 export function isWNode(child: DNode): child is WNode {
 	return Boolean(child && (typeof child !== 'string') && child.type === WNODE);
+}
+
+/**
+ * Helper function that returns true if the `DNode` is a `Node` using the `type` property
+ */
+export function isHNode(child: DNode): child is HNode {
+	return Boolean(child && (typeof child !== 'string') && child.type === HNODE);
 }
 
 export const registry = new FactoryRegistry();

--- a/src/d.ts
+++ b/src/d.ts
@@ -1,5 +1,6 @@
 import { assign } from '@dojo/core/lang';
 import { VNode, VNodeProperties } from '@dojo/interfaces/vdom';
+import Symbol from '@dojo/shim/Symbol';
 import { h } from 'maquette';
 import {
 	DNode,
@@ -11,6 +12,13 @@ import {
 } from './interfaces';
 import FactoryRegistry from './FactoryRegistry';
 
+export const WNODE = Symbol('Identifier for a WNode.');
+export const HNODE = Symbol('Identifier for a HNode.');
+
+export function isWNode(child: DNode): child is WNode {
+	return Boolean(child && (typeof child !== 'string') && child.type === WNODE);
+}
+
 export const registry = new FactoryRegistry();
 
 export function w<P extends WidgetProperties>(factory: WidgetFactory<Widget<P>, P> | string, properties: P): WNode;
@@ -20,7 +28,8 @@ export function w<P extends WidgetProperties>(factory: WidgetFactory<Widget<P>, 
 	return {
 		children,
 		factory,
-		properties
+		properties,
+		type: WNODE
 	};
 }
 
@@ -38,6 +47,7 @@ export function v(tag: string, propertiesOrChildren: VNodeProperties = {}, child
 			children,
 			render<T>(this: { children: VNode[] }, options: { bind?: T } = { }) {
 				return h(tag, assign(options, propertiesOrChildren), this.children);
-			}
+			},
+			type: HNODE
 		};
 }

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -90,6 +90,8 @@ export interface HNode {
 	 * render function that wraps returns VNode
 	 */
 	render<T>(options?: { bind?: T }): VNode;
+
+	type: symbol;
 }
 
 export interface WNode {
@@ -107,6 +109,8 @@ export interface WNode {
 	 * DNode children
 	 */
 	children: DNode[];
+
+	type: symbol;
 }
 
 export type DNode = HNode | WNode | string | null;

--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -91,6 +91,9 @@ export interface HNode {
 	 */
 	render<T>(options?: { bind?: T }): VNode;
 
+	/**
+	 * The type of node
+	 */
 	type: symbol;
 }
 
@@ -110,6 +113,9 @@ export interface WNode {
 	 */
 	children: DNode[];
 
+	/**
+	 * The type of node
+	 */
 	type: symbol;
 }
 

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -2,7 +2,7 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { WidgetProperties } from './../../src/interfaces';
 import createWidgetBase from '../../src/createWidgetBase';
-import { v, w, registry } from '../../src/d';
+import { v, w, registry, WNODE, HNODE } from '../../src/d';
 import FactoryRegistry from './../../src/FactoryRegistry';
 
 class TestFactoryRegistry extends FactoryRegistry {
@@ -22,6 +22,7 @@ registerSuite({
 			const dNode = w(createWidgetBase, properties);
 			assert.deepEqual(dNode.factory, createWidgetBase);
 			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]});
+			assert.equal(dNode.type, WNODE);
 		},
 		'create WNode wrapper using a factory label'() {
 			registry.define('my-widget', createWidgetBase);
@@ -29,6 +30,7 @@ registerSuite({
 			const dNode = w('my-widget', properties);
 			assert.deepEqual(dNode.factory, 'my-widget');
 			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ] });
+			assert.equal(dNode.type, WNODE);
 		},
 		'create WNode wrapper with children'() {
 			const properties: WidgetProperties = { id: 'id', classes: [ 'world' ] };
@@ -36,6 +38,7 @@ registerSuite({
 			assert.deepEqual(dNode.factory, createWidgetBase);
 			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ] });
 			assert.lengthOf(dNode.children, 1);
+			assert.equal(dNode.type, WNODE);
 		}
 	},
 	v: {
@@ -43,6 +46,7 @@ registerSuite({
 			const hNode = v('div');
 			assert.isFunction(hNode.render);
 			assert.lengthOf(hNode.children, 0);
+			assert.equal(hNode.type, HNODE);
 		},
 		'create HNode wrapper with options'() {
 			const hNode = v('div', { innerHTML: 'Hello World' });
@@ -51,21 +55,25 @@ registerSuite({
 			const render = hNode.render();
 			assert.equal(render.vnodeSelector, 'div');
 			assert.equal(render.properties && render.properties.innerHTML, 'Hello World');
+			assert.equal(hNode.type, HNODE);
 		},
 		'create HNode wrapper with children'() {
 			const hNode = v('div', {}, [ v('div'), v('div') ]);
 			assert.isFunction(hNode.render);
 			assert.lengthOf(hNode.children, 2);
+			assert.equal(hNode.type, HNODE);
 		},
 		'create HNode wrapper with children as options param'() {
 			const hNode = v('div', [ v('div'), v('div') ]);
 			assert.isFunction(hNode.render);
 			assert.lengthOf(hNode.children, 2);
+			assert.equal(hNode.type, HNODE);
 		},
 		'create HNode wrapper with text node children'() {
 			const hNode = v('div', {}, [ 'This Text Node', 'That Text Node' ]);
 			assert.isFunction(hNode.render);
 			assert.lengthOf(hNode.children, 2);
+			assert.equal(hNode.type, HNODE);
 		}
 	}
 });

--- a/tests/unit/d.ts
+++ b/tests/unit/d.ts
@@ -2,7 +2,7 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { WidgetProperties } from './../../src/interfaces';
 import createWidgetBase from '../../src/createWidgetBase';
-import { v, w, registry, WNODE, HNODE } from '../../src/d';
+import { v, w, registry, WNODE, HNODE, isWNode, isHNode } from '../../src/d';
 import FactoryRegistry from './../../src/FactoryRegistry';
 
 class TestFactoryRegistry extends FactoryRegistry {
@@ -23,6 +23,8 @@ registerSuite({
 			assert.deepEqual(dNode.factory, createWidgetBase);
 			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ]});
 			assert.equal(dNode.type, WNODE);
+			assert.isTrue(isWNode(dNode));
+			assert.isFalse(isHNode(dNode));
 		},
 		'create WNode wrapper using a factory label'() {
 			registry.define('my-widget', createWidgetBase);
@@ -31,6 +33,8 @@ registerSuite({
 			assert.deepEqual(dNode.factory, 'my-widget');
 			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ] });
 			assert.equal(dNode.type, WNODE);
+			assert.isTrue(isWNode(dNode));
+			assert.isFalse(isHNode(dNode));
 		},
 		'create WNode wrapper with children'() {
 			const properties: WidgetProperties = { id: 'id', classes: [ 'world' ] };
@@ -39,6 +43,8 @@ registerSuite({
 			assert.deepEqual(dNode.properties, { id: 'id', classes: [ 'world' ] });
 			assert.lengthOf(dNode.children, 1);
 			assert.equal(dNode.type, WNODE);
+			assert.isTrue(isWNode(dNode));
+			assert.isFalse(isHNode(dNode));
 		}
 	},
 	v: {
@@ -47,6 +53,8 @@ registerSuite({
 			assert.isFunction(hNode.render);
 			assert.lengthOf(hNode.children, 0);
 			assert.equal(hNode.type, HNODE);
+			assert.isTrue(isHNode(hNode));
+			assert.isFalse(isWNode(hNode));
 		},
 		'create HNode wrapper with options'() {
 			const hNode = v('div', { innerHTML: 'Hello World' });
@@ -56,24 +64,46 @@ registerSuite({
 			assert.equal(render.vnodeSelector, 'div');
 			assert.equal(render.properties && render.properties.innerHTML, 'Hello World');
 			assert.equal(hNode.type, HNODE);
+			assert.isTrue(isHNode(hNode));
+			assert.isFalse(isWNode(hNode));
 		},
 		'create HNode wrapper with children'() {
 			const hNode = v('div', {}, [ v('div'), v('div') ]);
 			assert.isFunction(hNode.render);
 			assert.lengthOf(hNode.children, 2);
 			assert.equal(hNode.type, HNODE);
+			assert.isTrue(isHNode(hNode));
+			assert.isFalse(isWNode(hNode));
 		},
 		'create HNode wrapper with children as options param'() {
 			const hNode = v('div', [ v('div'), v('div') ]);
 			assert.isFunction(hNode.render);
 			assert.lengthOf(hNode.children, 2);
 			assert.equal(hNode.type, HNODE);
+			assert.isTrue(isHNode(hNode));
+			assert.isFalse(isWNode(hNode));
 		},
 		'create HNode wrapper with text node children'() {
 			const hNode = v('div', {}, [ 'This Text Node', 'That Text Node' ]);
 			assert.isFunction(hNode.render);
 			assert.lengthOf(hNode.children, 2);
 			assert.equal(hNode.type, HNODE);
+			assert.isTrue(isHNode(hNode));
+			assert.isFalse(isWNode(hNode));
+		}
+	},
+	util: {
+		'isWNode returns false for null'() {
+			assert.isFalse(isWNode(null));
+		},
+		'isWNode returns false for a string'() {
+			assert.isFalse(isWNode('string'));
+		},
+		'isHNode returns false for null'() {
+			assert.isFalse(isHNode(null));
+		},
+		'isHNode returns false for a string'() {
+			assert.isFalse(isHNode('string'));
 		}
 	}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Add type to `HNode` and `WNode` and helper `isWNode` and `isHNode` functions.

Resolves #236
