### PR TITLE
Readme changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We also provide a suite of pre-built widgets to use in your applications: [(@doj
         - [Event Handling](#event-handling)
         - [Widget Registry](#widget-registry)
         - [Theming](#theming)
-        - [Internationalization](#Internationalizationi18n)
+        - [Internationalization](#internationalizationi18n)
     - [Key Principles](#key-principles)
     - [Examples](#examples)
         - [Example Label Widget](#example-label-widget)

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We also provide a suite of pre-built widgets to use in your applications: [(@doj
         - [Event Handling](#event-handling)
         - [Widget Registry](#widget-registry)
         - [Theming](#theming)
-        - [Internationalization](#internationalizationi18n)
+        - [Internationalization](#internationalization-i18n)
     - [Key Principles](#key-principles)
     - [Examples](#examples)
         - [Example Label Widget](#example-label-widget)

--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@ We also provide a suite of pre-built widgets to use in your applications: [(@doj
 - [Usage](#usage)
 - [Features](#features)
     - [Overview](#overview)
-        - [`v` & `w`](#v--w)
-            - [`v`](#v)
-            - [`w`](#w)
-        - [Writing custom widgets](#writing-custom-widgets)
-            -[Public API](#public-api)
+    - [`v` & `w`](#v--w)
+        - [`v`](#v)
+        - [`w`](#w)
+    - [Writing custom widgets](#writing-custom-widgets)
+        - [Public API](#public-api)
         - [The 'properties' and 'render' lifecycles](#the-properties-and-render-lifecycles)
-            -[Custom property diff control](#custom-property-diff-control)
+            - [Custom property diff control](#custom-property-diff-control)
         - [Projector](#projector)
         - [Event Handling](#event-handling)
         - [Widget Registry](#widget-registry)
@@ -85,7 +85,7 @@ We also make use of a VirtualDOM (VDOM) in Dojo 2.
 In order to interact with our VDOM, you need to pass it [HyperScript](https://github.com/dominictarr/hyperscript).
 In Dojo 2 we provide 2 functions that make interacting with the VDOM, easy and intuitive:
 
-#### `v` & `w`
+### `v` & `w`
 
 The `v` & `w` functions are available from the `@dojo/widgets/d` package.
 
@@ -108,7 +108,7 @@ The argument and return types for `v` and `w` are available from `@dojo/widgets/
 import { DNode, HNode, WNode } from '@dojo/widgets/interfaces';
 ```
 
-##### `v`
+#### `v`
 
 The following code creates an element with the specified `tag`
 
@@ -145,7 +145,7 @@ v(tag: string, properties: VNodeProperties, children?: (DNode | null)[]): HNode[
 
 As well as interacting with the VDOM by passing it HyperScript, you can also pass it Dojo 2 Widgets or Custom Widgets using the `w` function.
 
-##### `w`
+#### `w`
 
 The following code creates a widget using the `factory` and `properties`.
 
@@ -171,7 +171,7 @@ w('my-factory', properties, children);
 The example above that uses a string for the `factory`, is taking advantage of our [widget registry](#widget-registry) functionality.
 The widget registry allows you to lazy instantiate widgets.
 
-#### Writing Custom Widgets
+### Writing Custom Widgets
 
 The `createWidgetBase` class provides the functionality needed to create Custom Widgets.
 This functionality includes caching and widget lifecycle management.
@@ -184,7 +184,7 @@ import { createWidgetBase } from '@dojo/widgets/createWidgetBase';
 
 **All** widgets should extend from this class.
 
-##### Pubic API
+#### Pubic API
 
 |Function|Description|Default Behaviour|
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![codecov](https://codecov.io/gh/dojo/widgets/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/widgets)
 [![npm version](https://badge.fury.io/js/%40dojo%2Fwidgets.svg)](https://badge.fury.io/js/%40dojo%2Fwidgets)
 
-This repo provides users with the ability to write their own widgets.
+This repo provides users with the ability to write their own Dojo 2 widgets.
 
 We also provide a suite of pre-built widgets to use in your applications: [(@dojo/widgets)](https://github.com/dojo/widgets).
 
@@ -28,8 +28,8 @@ We also provide a suite of pre-built widgets to use in your applications: [(@doj
         - [Internationalization](#internationalization)
     - [Key Principles](#key-principles)
     - [Examples](#examples)
-        - [Sample Label Widget](#sample-label-widget)
-        - [Sample List Widget](#sample-list-widget)
+        - [Example Label Widget](#example-label-widget)
+        - [Example List Widget](#example-list-widget)
     - [API](#api)
 - [How Do I Contribute?](#how-do-i-contribute)
     - [Installation](#installation)
@@ -450,7 +450,7 @@ These are some of the **important** principles to keep in mind when creating and
 
 ### Examples
 
-#### Sample Label Widget
+#### Example Label Widget
 
 A simple widget with no children, such as a `label` widget, can be created like this:
 
@@ -481,7 +481,7 @@ const createLabelWidget: LabelFactory = createWidgetBase.mixin({
 export default createLabelWidget;
 ```
 
-#### Sample List Widget
+#### Example List Widget
 
 To create structured widgets, override the `getChildrenNodes` function:
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ The depth of the returned diff is equal to the depth used during the equality co
 ##### Custom property diff control
 
 Included in `createWidgetBase` is functionality to support targeting a specific property with a custom comparison function.
-This is done by adding a function to the widget class with `diffProperty` suffixed to the property name.
+This is done by adding a function to the widget class with `diffProperty` prefixed to the property name.
  
 e.g. for a property `foo` you would add a function called `diffPropertyFoo`
 (the casing of the comparison function name is unimportant).
@@ -232,7 +232,7 @@ const createMyWidget = createWidgetBase.mixin({
 });
 ```
 
-If a property has a custom diff function then that property is excluded from those passed to the catch all `diffProperties` implementation.
+If a property has a custom diff function then that property is excluded from those passed to the `diffProperties` function.
 
 ##### The 'properties:changed' event 
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ We also provide a suite of pre-built widgets to use in your applications: [(@doj
         - [Public API](#public-api)
         - [The 'properties' and 'render' lifecycles](#the-properties-and-render-lifecycles)
             - [Custom property diff control](#custom-property-diff-control)
+            - [The `properties:changed` event](#the-properties-changed-event)
         - [Projector](#projector)
         - [Event Handling](#event-handling)
         - [Widget Registry](#widget-registry)
@@ -233,6 +234,8 @@ const createMyWidget = createWidgetBase.mixin({
 
 If a property has a custom diff function then that property is excluded from those passed to the catch all `diffProperties` implementation.
 
+##### The 'properties:changed' event 
+
 When `diffProperties` has completed, the results are used to update the properties on the widget instance.
 If any properties were changed, then the `properties:changed` event is emitted.
 
@@ -288,11 +291,11 @@ createWidgetProjector().append(() => {
 
 #### Event Handling
 
-The recommended pattern for event listeners is to declare them on the widget class, referencing the function using `this`.
+The recommended pattern for custom event handlers is to declare them on the widget class and reference the function using `this`.
 Event handlers are most commonly called from the `getChildrenNodes` function or a `nodeAttributes` function.
 
-Event listeners can be internal logic encapsulated within a widget or delegate to a function passed via `properties`.
-For convenience event listeners are automatically bound to the scope of their enclosing widget.
+Event handlers can be internal logic encapsulated within a widget or delegate to a function passed into the widget via `properties`.
+For convenience event handlers are automatically bound to the scope of their enclosing widget.
 
 *internally defined handler*
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@
 [![codecov](https://codecov.io/gh/dojo/widgets/branch/master/graph/badge.svg)](https://codecov.io/gh/dojo/widgets)
 [![npm version](https://badge.fury.io/js/%40dojo%2Fwidgets.svg)](https://badge.fury.io/js/%40dojo%2Fwidgets)
 
-Provides Dojo 2 core widget and mixin functionality for creating custom widgets. For Dojo 2 widgets please see [@dojo/widgets](https://github.com/dojo/widgets).
+This repo provides users with the ability to write their own widgets.
+
+We also provide a suite of pre-built widgets to use in your applications [here (@dojo/widgets)](https://github.com/dojo/widgets).
 
 **WARNING** This is *alpha* software. It is not yet production ready, so you should use at your own risk.
 
@@ -31,7 +33,7 @@ Provides Dojo 2 core widget and mixin functionality for creating custom widgets.
 
 ## Usage
 
-To use @dojo/widgets install the package along with the required peer dependencies.
+To use @dojo/widgets, install the package along with its required peer dependencies.
 
 ```shell
 npm install @dojo/widgets
@@ -45,12 +47,11 @@ npm install @dojo/i18n
 npm install maquette
 ```
 
-Use the [@dojo/cli](https://github.com/dojo/cli) to create a complete Dojo 2 skeleton application with the [@dojo/cli-create-app](https://github.com/dojo/cli-create-app) command.
+You can also use the [dojo cli](https://github.com/dojo/cli) to create a complete Dojo 2 skeleton application.
 
 ## Features
 
-Dojo 2 widgets are built using the [@dojo/compose](https://github.com/dojo/compose) composition library that promotes traits and mixins over inheritence.
-
+Constructing your own widgets (Custom widgets) is simple and straightforward.
 The smallest `@dojo/widgets` example looks like this:
 
 ```ts
@@ -66,23 +67,38 @@ const createMyWidget = createWidgetBase.extend({
 createMyWidget.mixin(createProjectorMixin)().append();
 ```
 
-It renders a `h1` element saying "Hello, Dojo!" on the page.
+This code renders a `h1` element onto the page, that says "Hello, Dojo!".
 
 ### Overview
 
-Dojo 2 widgets is designed using key reactive architecture concepts. These include unidirectional data flow, inversion of control and property passing.
+All widgets in Dojo 2 are designed using key reactive architecture concepts.
+These concepts include unidirectional data flow, inversion of control and property passing.
 
-<!-- needs more details-->
+Dojo 2's  widget suite is built using the [@dojo/compose](https://github.com/dojo/compose) composition library.
+This library provides the ability to construct and manipulate traits and mixins.
+
+We also make use of a VirtualDOM (VDOM) in Dojo 2.
+In order to interact with our VDOM, you need to pass it [HyperScript](https://github.com/dominictarr/hyperscript).
+In Dojo 2 we provide 2 functions that make interacting with the VDOM, easy and intuitive:
 
 #### `v` & `w`
 
-`v` & `w` are abstractions used to express structures that will be reflected in the DOM. `v` is used to create nodes that represent DOM tags, for example `div`, `header` etc. and allows Dojo 2 to manage lazy hyperscript creation and element caching. `w` is used to create Dojo or custom widget nodes enabling support for lazy widget instantiation, instance management and caching.
+The `v` & `w` functions are available from the `@dojo/widgets/d` package.
 
 ```ts
 import { v, w } from '@dojo/widgets/d';
 ```
 
-The argument and return types are available from `@dojo/widgets/interfaces` as follows:
+These functions express structures that will be passed to the VDOM.
+
+`v` creates nodes that represent DOM tags, e.g. `div`, `header` etc.
+This function allows Dojo 2 to manage lazy hyperscript creation and element caching.
+  
+ `w` creates Dojo 2 widgets or custom widget.
+This function provides support for lazy widget instantiation, instance management and caching.
+
+
+The argument and return types for `v` and `w` are available from `@dojo/widgets/interfaces`, and are as follows:
 
 ```ts
 import { DNode, HNode, WNode } from '@dojo/widgets/interfaces';
@@ -90,7 +106,7 @@ import { DNode, HNode, WNode } from '@dojo/widgets/interfaces';
 
 ##### `v`
 
-Creates an element with the specified `tag`
+The following code creates an element with the specified `tag`
 
 ```ts
 v(tag: string): HNode[];
@@ -98,45 +114,42 @@ v(tag: string): HNode[];
 
 where `tag` is in the form: element.className(s)#id, e.g.
 
-h2
-h2.foo
-h2.foo.bar
-h2.foo.bar#baz
-h2#baz
-
-`classNames` should be delimited by a period (`.`). **Please note**, both the `classes` and `id` portions of the `tag` are optional.
-
-The results of the invocations above are:
-
 ```
-h2                  (<h2></h2>)
-h2.foo              (<h2 class="foo"></h2>)
-h2.foo.bar          (<h2 class="foo bar"></h2>)
-h2.foo.bar#baz      (<h2 class="foo bar" id="baz"></h2>)
-h2#baz              (<h2 id="baz"></h2>)
+h2                  (produces <h2></h2>)
+h2.foo              (produces <h2 class="foo"></h2>)
+h2.foo.bar          (produces <h2 class="foo bar"></h2>)
+h2.foo.bar#baz      (produces <h2 class="foo bar" id="baz"></h2>)
+h2#baz              (produces <h2 id="baz"></h2>)
 ```
 
-Renders an element with the `tag` and `children`.
+`classNames` should be delimited by a period (`.`).
+
+**Please note**, both the `classes` and `id` portions of the `tag` are optional.
+
+
+The following code renders an element with the `tag` and `children`.
 
 ```ts
 v(tag: string, children: (DNode | null)[]): HNode[];
 ```
 
-Renders an element with the `tag`, `properties` and `children`.
+The following code renders an element with the `tag`, `properties` and `children`.
 
 ```ts
 v(tag: string, properties: VNodeProperties, children?: (DNode | null)[]): HNode[];
 ```
 
+As well as interacting with the VDOM by passing it HyperScript, you can also pass it Dojo 2 Widgets or Custom Widgets using the `w` function.
+
 ##### `w`
 
-Creates a widget using the `factory` and `properties`.
+The following code creates a widget using the `factory` and `properties`.
 
 ```ts
 w<P extends WidgetProperties>(factory: string | WidgetFactory<Widget<P>, P>, properties: P): WNode[];
 ```
 
-Creates a widget using the `factory`, `properties` and `children`
+The following code creates a widget using the `factory`, `properties` and `children`
 
 ```ts
 w<P extends WidgetProperties>(factory: string | WidgetFactory<Widget<P>, P>, properties: P, children: (DNode | null)[]): WNode[];
@@ -151,9 +164,21 @@ w('my-factory', properties);
 w('my-factory', properties, children);
 ```
 
-#### `createWidgetBase`
+The example above that uses a string for the `factory`, is taking advantage of our [widget registry](####Widget Registry) functionality.
+The widget registry allows you to lazy instantiate widgets.
 
-The class `createWidgetBase` provides key base functionality including caching and widget lifecycle management which **all** widgets should extend from.
+#### Writing Custom Widgets
+
+The `createWidgetBase` class provides the functionality needed to create Custom Widgets.
+This functionality includes caching and widget lifecycle management.
+
+The `createWidgetBase` class is available from the `@dojo/widgets/createWidgetBase` package.
+
+```ts
+import { createWidgetBase } from '@dojo/widgets/createWidgetBase';
+```
+
+**All** widgets should extend from this class.
 
 ##### Pubic API
 
@@ -164,9 +189,52 @@ The class `createWidgetBase` provides key base functionality including caching a
 |nodeAttributes|An array of functions that return VNodeProperties to be applied to the top level node|Returns attributes for `data-widget-id`, `classes` and `styles` using the widget's specified `properties` (`id`, `classes`, `styles`) at the time of render|
 |diffProperties|Diffs the current properties against the previous properties and returns an object with the changed keys and new properties|Performs a shallow comparison previous and current properties, copies the properties using `Object.assign` and returns the resulting `PropertiesChangeRecord`.|
 
+#### The Properties and Render lifecycles
+
+The widget's properties lifecycle occurs before its render lifecycle.
+
+Properties passed to the `w` function represent the public API for a widget.
+
+The properties lifecycle starts when properties are passed to the widget.
+The properties lifecycle is performed in the widgets `setProperties` function.
+This function uses the widget instance's `diffProperties` function to determine whether any of the properties have changed since the last render cycle.
+By default `diffProperties` provides a shallow comparison of the previous properties and new properties. 
+
+**Note** If a widget's properties contain complex data structures that you need to diff, then the `diffProperties` function will need to be overridden.
+
+The `diffProperties` function is also responsible for creating a copy (the default implementation uses`Object.assign({}, newProperties)` of all changed properties.
+The depth of the returned diff is equal to the depth used during the equality comparison.
+
+<!-- example of depth -->
+
+##### Finer property diff control
+
+Included in `createWidgetBase` is functionality to support targeting a specific property with a custom comparison function.
+This is done by adding a function to the widget class with `diffProperty` suffixed to the property name.
+ 
+e.g. for a property `foo` you would add a function called `diffPropertyFoo`.
+(note that casing of the comparison function name is unimportant).
+
+```ts
+
+const createMyWidget = createWidgetBase.mixin({
+	mixin: {
+		diffPropertyFoo(this: MyWidget, previousProperty: MyComplexObject, newProperty: MyComplexObject) {
+			// can perfom complex comparison logic here between the two property values
+			// or even use externally stored state to assist the comparison.
+		}
+	}
+});
+```
+
+If a property has a custom diff function then that property is excluded from those passed to the catch all `diffProperties` implementation.
+
+When `diffProperties` has completed, the results are used to update the properties on the widget instance.
+If any properties were changed, then the `properties:changed` event is emitted.
+
 ##### Events
 
-`properties:changed` - The event is emitted when `dffProperties` detected changed keys. The event can be attached to by any extending widget.
+`properties:changed`
 
 *Attaching*
 
@@ -187,47 +255,22 @@ this.on('properties:changed', (evt: PropertiesChangedEvent<MyWidget, MyPropertie
 }
 ```
 
-#### Properties Lifecycle
+Finally once all the attached events have been processed, the properties lifecycle is complete and the finalized widget properties are available during the render cycle functions.
 
-Properties are passed to the `w` function and represent the public API for a widget. The properties lifecycle occurs as the properties that are passed are `set` onto a widget, this is prior to the widgets render cycle.
-
-The property lifecyle is performed in the widgets `setProperties` function and uses the instances' `diffProperties` function to determine whether any of the properties have changed since the last render. By default `diffProperties` provides a shallow comparison of the previous properties and new properties. 
-
-**Note** If a widgets properties contain complex data structures, the `diffProperties` function will need to be overridden to prevent returning incorrect changed properties.
-
-The `diffProperties` function is also responsible for creating a copy (the default implementation uses`Object.assign({}, newProperties)` of all changed properties to the depth that is considered during the equality comparison.
-
-When `diffProperties` has completed the results are used to update the properties on the widget instance and if changed properties were returned then the `properties:changed` event is emitted. Finally once all the attached events have been processed the lifecycle is complete and the finalized widget properties are available during the render cycle functions.
-
-##### Finer property diff control
-
-Included in `createWidgetBase` is functionality to support targetting a specific property with a custom comparison function. This is done by adding a function to the widget class with `diffProperty` prefixed to the property name e.g. `diffPropertyFoo`.
-
-```ts
-
-const createMyWidget = createWidgetBase.mixin({
-	mixin: {
-		diffPropertyFoo(this: MyWidget, previousProperty: MyComplexObject, newProperty: MyComplexObject) {
-			// can perfom complex comparison logic here between the two property values
-			// or even use externally stored state to assist the comparison.
-		}
-	}
-});
-```
-
-If a property has a custom diff function then it is excluded from the normal catch all `diffProperties` implementation.
+<!-- bit about render lifecycle -->
 
 #### Projector
 
-Projector is a term used to describe a widget that will be attached to a DOM element, also known as a root widget. Any widget can be converted into a projector simply by mixing in the `createProjectorMixin` mixin.
+Projector is a term used to describe a widget that will be attached to a DOM element, also known as a root widget.
+Any widget can be converted into a projector simply by mixing in the `createProjectorMixin` mixin.
 
 ```ts
 createMyWidget.mixin(createProjectorMixin)
 ```
 
-Projectors operate as any widget **except** that they need to be manually instantiated and managed outside of the standard widget lifecycle. 
+Projectors behave in the same way as any other widget **except** that they need to be manually instantiated and managed outside of the standard widget lifecycle. 
 
-There are 3 ways that a projector widget can be added to the DOM - `.append`, `.merge` or `.replace` depending on the type of attachment required.
+There are 3 ways that a projector widget can be added to the DOM - `.append`, `.merge` or `.replace`, depending on the type of attachment required.
 
  - append  - Creates the widget as a child to the projector's `root` node
  - merge   - Merges the widget with the projector's `root` node
@@ -243,9 +286,11 @@ createWidgetProjector().append(() => {
 
 #### Event Handling
 
-The recommended pattern for event listeners is to declare them on the widget class, referencing the function using `this`, most commonly within `getChildrenNodes` or a `nodeAttributes` function.
+The recommended pattern for event listeners is to declare them on the widget class, referencing the function using `this`.
+Event handlers are most commonly called from the `getChildrenNodes` function or a `nodeAttributes` function.
 
-Event listeners can be internal logic encapsulated within a widget or delegate to a function passed via `properties`. For convenience event listeners are automatically bound to the scope of their enclosing widget.
+Event listeners can be internal logic encapsulated within a widget or delegate to a function passed via `properties`.
+For convenience event listeners are automatically bound to the scope of their enclosing widget.
 
 *internally defined handler*
 
@@ -297,7 +342,7 @@ const createMyWidget: MyWidgetFactory = createWidgetBase.mixin({
 });
 ```
 
-#### Widget Registry
+####Widget Registry
 
 The registry provides the ability to define a label against a `WidgetFactory`, a `Promise<WidgetFactory>` or a function that when executed returns a `Promise<WidgetFactory>`.
 
@@ -320,7 +365,7 @@ registry.define('my-widget-2', Promise.resolve(createMyWidget));
 registry.define('my-widget-3', () => Promise.resolve(createMyWidget));
 ```
 
-It's recommended to use the factory registry when defining widgets with [`w`](#w--d) to support lazy factory resolution. 
+It is recommended to use the factory registry when defining widgets with [`w`](#w--d) to support lazy factory resolution. 
 
 Example of registering a function that returns a `Promise` that resolves to a `Factory`.
 
@@ -333,13 +378,19 @@ registry.define('my-widget', () => {
 });
 ```
 
-#### Theming
+#### Themeing
 
 // talk about the css and theming support
 
-#### Internationalization
+#### Internationalization (i18n)
 
-Widgets can be internationalized by mixing in `@dojo/widgets/mixins/createI18nMixin`. [Message bundles](https://github.com/dojo/i18n) are localized by passing them to `localizeBundle`. If the bundle supports the widget's current locale, but those locale-specific messages have not yet been loaded, then the default messages are returned and the widget will be invalidated once the locale-specific messages have been loaded. Each widget can have its own locale by setting its `state.locale`; if no locale is set, then the default locale as set by [`@dojo/i18n`](https://github.com/dojo/i18n) is assumed.
+Widgets can be internationalized by mixing in `@dojo/widgets/mixins/createI18nMixin`.
+[Message bundles](https://github.com/dojo/i18n) are localized by passing them to `localizeBundle`. 
+
+If the bundle supports the widget's current locale, but those locale-specific messages have not yet been loaded, then the default messages are returned and the widget will be invalidated once the locale-specific messages have been loaded.
+
+Each widget can have its own locale by setting its `state.locale`. 
+If no locale is set, then the default locale, as set by [`@dojo/i18n`](https://github.com/dojo/i18n), is assumed.
 
 ```ts
 const createI18nWidget = createWidgetBase
@@ -395,7 +446,7 @@ These are some of the **important** principles to keep in mind when creating and
 
 #### Sample Label Widget
 
-A simple widget with no children such as a `label` widget can be created like this:
+A simple widget with no children, such as a `label` widget, can be created like this:
 
 ```ts
 import { VNodeProperties } from '@dojo/interfaces/vdom';
@@ -426,7 +477,7 @@ export default createLabelWidget;
 
 #### Sample List Widget
 
-To create structured widgets override the `getChildrenNodes` function.
+To create structured widgets, override the `getChildrenNodes` function:
 
 ```ts
 import { DNode, Widget, WidgetFactory, WidgetProperties } from '@dojo/widgets/interfaces';
@@ -507,4 +558,4 @@ or
 
 ## Licensing Information
 
-© 2016 [JS Foundation](https://js.foundation/). [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.
+© 2017 [JS Foundation](https://js.foundation/). [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We also provide a suite of pre-built widgets to use in your applications: [(@doj
         - [Event Handling](#event-handling)
         - [Widget Registry](#widget-registry)
         - [Theming](#theming)
-        - [Internationalization](#internationalization)
+        - [Internationalization](#Internationalizationi18n)
     - [Key Principles](#key-principles)
     - [Examples](#examples)
         - [Example Label Widget](#example-label-widget)
@@ -380,7 +380,7 @@ registry.define('my-widget', () => {
 });
 ```
 
-#### Themeing
+#### Theming
 
 // talk about the css and theming support
 

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ We also provide a suite of pre-built widgets to use in your applications: [(@doj
         - [`w`](#w)
     - [Writing custom widgets](#writing-custom-widgets)
         - [Public API](#public-api)
-        - [The 'properties' and 'render' lifecycles](#the-'properties'-and-'render'-lifecycles)
+        - [The 'properties' and 'render' lifecycles](#the-properties-and-render-lifecycles)
             - [Custom property diff control](#custom-property-diff-control)
-            - [The `properties:changed` event](#the-'properties:changed'-event)
+            - [The `properties:changed` event](#the-propertieschanged-event)
         - [Projector](#projector)
         - [Event Handling](#event-handling)
         - [Widget Registry](#widget-registry)
@@ -184,7 +184,7 @@ import { createWidgetBase } from '@dojo/widgets/createWidgetBase';
 
 **All** widgets should extend from this class.
 
-#### Pubic API
+#### Public API
 
 |Function|Description|Default Behaviour|
 |---|---|---|

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ We also provide a suite of pre-built widgets to use in your applications: [(@doj
         - [`w`](#w)
     - [Writing custom widgets](#writing-custom-widgets)
         - [Public API](#public-api)
-        - [The 'properties' and 'render' lifecycles](#the-properties-and-render-lifecycles)
+        - [The 'properties' and 'render' lifecycles](#the-'properties'-and-'render'-lifecycles)
             - [Custom property diff control](#custom-property-diff-control)
-            - [The `properties:changed` event](#the-properties-changed-event)
+            - [The `properties:changed` event](#the-'properties:changed'-event)
         - [Projector](#projector)
         - [Event Handling](#event-handling)
         - [Widget Registry](#widget-registry)
@@ -88,12 +88,6 @@ In Dojo 2 we provide 2 functions that make interacting with the VDOM, easy and i
 
 ### `v` & `w`
 
-The `v` & `w` functions are available from the `@dojo/widgets/d` package.
-
-```ts
-import { v, w } from '@dojo/widgets/d';
-```
-
 These functions express structures that will be passed to the VDOM.
 
 `v` creates nodes that represent DOM tags, e.g. `div`, `header` etc.
@@ -102,6 +96,11 @@ This function allows Dojo 2 to manage lazy hyperscript creation and element cach
  `w` creates Dojo 2 widgets or custom widget.
 This function provides support for lazy widget instantiation, instance management and caching.
 
+The `v` & `w` functions are available from the `@dojo/widgets/d` package.
+
+```ts
+import { v, w } from '@dojo/widgets/d';
+```
 
 The argument and return types for `v` and `w` are available from `@dojo/widgets/interfaces`, and are as follows:
 

--- a/README.md
+++ b/README.md
@@ -6,25 +6,29 @@
 
 This repo provides users with the ability to write their own widgets.
 
-We also provide a suite of pre-built widgets to use in your applications [here (@dojo/widgets)](https://github.com/dojo/widgets).
+We also provide a suite of pre-built widgets to use in your applications: [(@dojo/widgets)](https://github.com/dojo/widgets).
 
 **WARNING** This is *alpha* software. It is not yet production ready, so you should use at your own risk.
 
 - [Usage](#usage)
 - [Features](#features)
     - [Overview](#overview)
-    	- [`v` & `w`](#v--w)
-    	- [createWidgetBase](#createwidgetbase)
-    	- [Properties Lifecycle](#properties-lifecycle)
-    	- [Projector](#projector)
-    	- [Event Handling](#event-handling)
-    	- [Widget Registry](#widget-registry)
-    	- [Theming](#theming)
-    	- [Internationalization](#internationalization)
+        - [`v` & `w`](#v--w)
+            - [`v`](#v)
+            - [`w`](#w)
+        - [Writing custom widgets](#writing-custom-widgets)
+            -[Public API](#public-api)
+        - [The 'properties' and 'render' lifecycles](#the-properties-and-render-lifecycles)
+            -[Custom property diff control](#custom-property-diff-control)
+        - [Projector](#projector)
+        - [Event Handling](#event-handling)
+        - [Widget Registry](#widget-registry)
+        - [Theming](#theming)
+        - [Internationalization](#internationalization)
     - [Key Principles](#key-principles)
     - [Examples](#examples)
-    	- [Sample Label Widget](#sample-label-widget)
-    	- [Sample List Widget](#sample-list-widget)
+        - [Sample Label Widget](#sample-label-widget)
+        - [Sample List Widget](#sample-list-widget)
     - [API](#api)
 - [How Do I Contribute?](#how-do-i-contribute)
     - [Installation](#installation)
@@ -164,7 +168,7 @@ w('my-factory', properties);
 w('my-factory', properties, children);
 ```
 
-The example above that uses a string for the `factory`, is taking advantage of our [widget registry](####Widget Registry) functionality.
+The example above that uses a string for the `factory`, is taking advantage of our [widget registry](#widget-registry) functionality.
 The widget registry allows you to lazy instantiate widgets.
 
 #### Writing Custom Widgets
@@ -189,7 +193,7 @@ import { createWidgetBase } from '@dojo/widgets/createWidgetBase';
 |nodeAttributes|An array of functions that return VNodeProperties to be applied to the top level node|Returns attributes for `data-widget-id`, `classes` and `styles` using the widget's specified `properties` (`id`, `classes`, `styles`) at the time of render|
 |diffProperties|Diffs the current properties against the previous properties and returns an object with the changed keys and new properties|Performs a shallow comparison previous and current properties, copies the properties using `Object.assign` and returns the resulting `PropertiesChangeRecord`.|
 
-#### The Properties and Render lifecycles
+#### The 'properties' and 'render' lifecycles
 
 The widget's properties lifecycle occurs before its render lifecycle.
 
@@ -205,9 +209,9 @@ By default `diffProperties` provides a shallow comparison of the previous proper
 The `diffProperties` function is also responsible for creating a copy (the default implementation uses`Object.assign({}, newProperties)` of all changed properties.
 The depth of the returned diff is equal to the depth used during the equality comparison.
 
-<!-- example of depth -->
+// example of depth
 
-##### Finer property diff control
+##### Custom property diff control
 
 Included in `createWidgetBase` is functionality to support targeting a specific property with a custom comparison function.
 This is done by adding a function to the widget class with `diffProperty` suffixed to the property name.
@@ -232,9 +236,7 @@ If a property has a custom diff function then that property is excluded from tho
 When `diffProperties` has completed, the results are used to update the properties on the widget instance.
 If any properties were changed, then the `properties:changed` event is emitted.
 
-##### Events
-
-`properties:changed`
+Event: `properties:changed`
 
 *Attaching*
 
@@ -244,7 +246,7 @@ this.on('properties:changed', (evt: PropertiesChangedEvent<MyWidget, MyPropertie
 });
 ```
 
-*Example Payload*
+*Example event payload*
 
 ```ts
 {
@@ -257,7 +259,7 @@ this.on('properties:changed', (evt: PropertiesChangedEvent<MyWidget, MyPropertie
 
 Finally once all the attached events have been processed, the properties lifecycle is complete and the finalized widget properties are available during the render cycle functions.
 
-<!-- bit about render lifecycle -->
+// bit about render lifecycle
 
 #### Projector
 
@@ -342,7 +344,7 @@ const createMyWidget: MyWidgetFactory = createWidgetBase.mixin({
 });
 ```
 
-####Widget Registry
+#### Widget Registry
 
 The registry provides the ability to define a label against a `WidgetFactory`, a `Promise<WidgetFactory>` or a function that when executed returns a `Promise<WidgetFactory>`.
 
@@ -365,7 +367,7 @@ registry.define('my-widget-2', Promise.resolve(createMyWidget));
 registry.define('my-widget-3', () => Promise.resolve(createMyWidget));
 ```
 
-It is recommended to use the factory registry when defining widgets with [`w`](#w--d) to support lazy factory resolution. 
+It is recommended to use the factory registry when defining widgets with [`w`](#w--d), to support lazy factory resolution. 
 
 Example of registering a function that returns a `Promise` that resolves to a `Factory`.
 
@@ -387,7 +389,8 @@ registry.define('my-widget', () => {
 Widgets can be internationalized by mixing in `@dojo/widgets/mixins/createI18nMixin`.
 [Message bundles](https://github.com/dojo/i18n) are localized by passing them to `localizeBundle`. 
 
-If the bundle supports the widget's current locale, but those locale-specific messages have not yet been loaded, then the default messages are returned and the widget will be invalidated once the locale-specific messages have been loaded.
+If the bundle supports the widget's current locale, but those locale-specific messages have not yet been loaded, then the default messages are returned.
+The widget will be invalidated once the locale-specific messages have been loaded.
 
 Each widget can have its own locale by setting its `state.locale`. 
 If no locale is set, then the default locale, as set by [`@dojo/i18n`](https://github.com/dojo/i18n), is assumed.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ We also provide a suite of pre-built widgets to use in your applications: [(@doj
         - [`w`](#w)
     - [Writing custom widgets](#writing-custom-widgets)
         - [Public API](#public-api)
-        - [The 'properties' and 'render' lifecycles](#the-properties-and-render-lifecycles)
+        - [The 'properties' lifecycle](#the-properties-lifecycle)
             - [Custom property diff control](#custom-property-diff-control)
             - [The `properties:changed` event](#the-propertieschanged-event)
         - [Projector](#projector)
@@ -79,7 +79,7 @@ This code renders a `h1` element onto the page, that says "Hello, Dojo!".
 All widgets in Dojo 2 are designed using key reactive architecture concepts.
 These concepts include unidirectional data flow, inversion of control and property passing.
 
-Dojo 2's  widget suite is built using the [@dojo/compose](https://github.com/dojo/compose) composition library.
+Dojo 2's widget suite is built using the [@dojo/compose](https://github.com/dojo/compose) composition library.
 This library provides the ability to construct and manipulate traits and mixins.
 
 We also make use of a VirtualDOM (VDOM) in Dojo 2.
@@ -193,7 +193,7 @@ import { createWidgetBase } from '@dojo/widgets/createWidgetBase';
 |nodeAttributes|An array of functions that return VNodeProperties to be applied to the top level node|Returns attributes for `data-widget-id`, `classes` and `styles` using the widget's specified `properties` (`id`, `classes`, `styles`) at the time of render|
 |diffProperties|Diffs the current properties against the previous properties and returns an object with the changed keys and new properties|Performs a shallow comparison previous and current properties, copies the properties using `Object.assign` and returns the resulting `PropertiesChangeRecord`.|
 
-#### The 'properties' and 'render' lifecycles
+#### The 'properties' lifecycle
 
 The widget's properties lifecycle occurs before its render lifecycle.
 
@@ -207,7 +207,7 @@ By default `diffProperties` provides a shallow comparison of the previous proper
 The `diffProperties` function is also responsible for creating a copy (the default implementation uses`Object.assign({}, newProperties)` of all changed properties.
 The depth of the returned diff is equal to the depth used during the equality comparison.
 
-// example of depth
+<!-- add example of 'depth' -->
 
 **Note** If a widget's properties contain complex data structures that you need to diff, then the `diffProperties` function will need to be overridden.
 
@@ -259,7 +259,7 @@ this.on('properties:changed', (evt: PropertiesChangedEvent<MyWidget, MyPropertie
 
 Finally once all the attached events have been processed, the properties lifecycle is complete and the finalized widget properties are available during the render cycle functions.
 
-// bit about render lifecycle
+<!-- render lifecycle goes here -->
 
 #### Projector
 
@@ -382,7 +382,7 @@ registry.define('my-widget', () => {
 
 #### Theming
 
-// talk about the css and theming support
+// To be completed
 
 #### Internationalization (i18n)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ We also provide a suite of pre-built widgets to use in your applications: [(@doj
 
 ## Usage
 
-To use @dojo/widgets, install the package along with its required peer dependencies.
+To use @dojo/widgets, install the package along with its required peer dependencies:
 
 ```shell
 npm install @dojo/widgets
@@ -84,7 +84,7 @@ This library provides the ability to construct and manipulate traits and mixins.
 
 We also make use of a VirtualDOM (VDOM) in Dojo 2.
 In order to interact with our VDOM, you need to pass it [HyperScript](https://github.com/dominictarr/hyperscript).
-In Dojo 2 we provide 2 functions that make interacting with the VDOM, easy and intuitive:
+In Dojo 2 we provide 2 functions that make interacting with the VDOM, easy and intuitive: `v` and `w`.
 
 ### `v` & `w`
 
@@ -205,20 +205,20 @@ The properties lifecycle is performed in the widgets `setProperties` function.
 This function uses the widget instance's `diffProperties` function to determine whether any of the properties have changed since the last render cycle.
 By default `diffProperties` provides a shallow comparison of the previous properties and new properties. 
 
-**Note** If a widget's properties contain complex data structures that you need to diff, then the `diffProperties` function will need to be overridden.
-
 The `diffProperties` function is also responsible for creating a copy (the default implementation uses`Object.assign({}, newProperties)` of all changed properties.
 The depth of the returned diff is equal to the depth used during the equality comparison.
 
 // example of depth
+
+**Note** If a widget's properties contain complex data structures that you need to diff, then the `diffProperties` function will need to be overridden.
 
 ##### Custom property diff control
 
 Included in `createWidgetBase` is functionality to support targeting a specific property with a custom comparison function.
 This is done by adding a function to the widget class with `diffProperty` suffixed to the property name.
  
-e.g. for a property `foo` you would add a function called `diffPropertyFoo`.
-(note that casing of the comparison function name is unimportant).
+e.g. for a property `foo` you would add a function called `diffPropertyFoo`
+(the casing of the comparison function name is unimportant).
 
 ```ts
 
@@ -238,8 +238,6 @@ If a property has a custom diff function then that property is excluded from tho
 
 When `diffProperties` has completed, the results are used to update the properties on the widget instance.
 If any properties were changed, then the `properties:changed` event is emitted.
-
-Event: `properties:changed`
 
 *Attaching*
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Updated the readme.
Fixed typos and missing punctuation.
Split sentences where there were conjunctions - to make easier to read if english is not your first language.
Made naming consistent, e.g. example and sample
Re ordered to adhere to the rule that if you introduce a concept, then it needs to be explained in the next paragraph.
We no longer have a `pubic API` 😉 
