### PR TITLE
Use mapped type to ensure the properties object is readonly

### DIFF
--- a/src/interfaces.d.ts
+++ b/src/interfaces.d.ts
@@ -205,7 +205,7 @@ export interface WidgetMixin<P extends WidgetProperties> extends PropertyCompari
 	/**
 	 * Properties passed to affect state
 	 */
-	readonly properties: Partial<P>;
+	readonly properties: Readonly<Partial<P>>;
 
 	/*
 	 * set properties on the widget


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Ensure that `properties` are readonly.

Resolves #238 
