### PR TITLE
Updated label classes type after removal of .get()

### DIFF
--- a/src/label/Label.ts
+++ b/src/label/Label.ts
@@ -1,6 +1,6 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { DNode } from '@dojo/widget-core/interfaces';
-import { ThemeableMixin, ThemeableProperties, theme, ClassNameFlags } from '@dojo/widget-core/mixins/Themeable';
+import { ThemeableMixin, ThemeableProperties, theme, ClassesFunctionChain } from '@dojo/widget-core/mixins/Themeable';
 import { v } from '@dojo/widget-core/d';
 import { assign } from '@dojo/core/lang';
 import * as baseCss from '../common/styles/base.css';
@@ -33,7 +33,7 @@ const labelDefaults = {
  * @property label		Label settings for form label text, position, and visibility
  */
 export interface LabelProperties extends ThemeableProperties {
-	classes?: ClassNameFlags;
+	classes?: ClassesFunctionChain;
 	formId?: string;
 	label: string | LabelOptions;
 }

--- a/src/label/example/index.ts
+++ b/src/label/example/index.ts
@@ -26,8 +26,7 @@ export class App extends AppBase<WidgetProperties> {
 					content: 'Can\'t read me!',
 					hidden: true,
 					before: false
-				},
-				classes: { 'test-class': true }
+				}
 			}, [
 				v('input', {
 					type: 'text',

--- a/src/label/tests/unit/Label.ts
+++ b/src/label/tests/unit/Label.ts
@@ -14,14 +14,14 @@ registerSuite({
 		label = new Label();
 		label.setProperties({
 			formId: 'foo',
-			classes: { 'bar': true },
+			classes: label.classes(baseCss.visuallyHidden),
 			label: 'baz'
 		});
 		const vnode = <VNode> label.__render__();
 
 		assert.strictEqual(vnode.vnodeSelector, 'label', 'tagname should be label');
 		assert.strictEqual(vnode.properties!.form, 'foo');
-		assert.isTrue(vnode.properties!.classes!['bar']);
+		assert.isTrue(vnode.properties!.classes![baseCss.visuallyHidden]);
 		assert.strictEqual(vnode.children![0].properties!.innerHTML, 'baz');
 	},
 


### PR DESCRIPTION
**Type:** bug

Since we're removing `this.classes().get()`, Label's `properties.classes` should be a `ClassesFunctionChain` instead of `ClassNameFlags`