### PR TITLE
Dialog "role"

### DIFF
--- a/src/dialog/Dialog.ts
+++ b/src/dialog/Dialog.ts
@@ -10,10 +10,7 @@ import * as animations from '../common/styles/animations.css';
 /**
  * Enum for dialog / alertdialog role
  */
-export const enum Role {
-	dialog,
-	alertdialog
-};
+export type Role = 'dialog' | 'alertdialog';
 
 /**
  * @type DialogProperties
@@ -64,7 +61,7 @@ export default class Dialog extends DialogBase<DialogProperties> {
 			exitAnimation = animations.fadeOut,
 			title = '',
 			open = false,
-			role = Role.dialog,
+			role = 'dialog',
 			underlay = false,
 			onOpen
 		} = this.properties;

--- a/src/dialog/Dialog.ts
+++ b/src/dialog/Dialog.ts
@@ -8,7 +8,7 @@ import * as css from './styles/dialog.css';
 import * as animations from '../common/styles/animations.css';
 
 /**
- * Enum for dialog / alertdialog role
+ * The role of this dialog, used for accessibility
  */
 export type Role = 'dialog' | 'alertdialog';
 

--- a/src/dialog/tests/unit/Dialog.ts
+++ b/src/dialog/tests/unit/Dialog.ts
@@ -1,7 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { VNode } from '@dojo/interfaces/vdom';
-import Dialog, { Role } from '../../Dialog';
+import Dialog from '../../Dialog';
 
 registerSuite({
 	name: 'Dialog',
@@ -15,7 +15,7 @@ registerSuite({
 			title: 'dialog',
 			underlay: true,
 			closeable: true,
-			role: Role.dialog
+			role: 'dialog'
 		});
 
 		assert.strictEqual(dialog.properties.key, 'foo');
@@ -24,7 +24,7 @@ registerSuite({
 		assert.strictEqual(dialog.properties.title, 'dialog');
 		assert.isTrue(dialog.properties.underlay);
 		assert.isTrue(dialog.properties.closeable);
-		assert.strictEqual(dialog.properties.role, Role.dialog);
+		assert.strictEqual(dialog.properties.role, 'dialog');
 	},
 
 	'Render correct children'() {
@@ -32,7 +32,7 @@ registerSuite({
 		dialog.setProperties({
 			enterAnimation: 'enter',
 			exitAnimation: 'exit',
-			role: Role.dialog
+			role: 'dialog'
 		});
 		let vnode = <VNode> dialog.__render__();
 		assert.strictEqual(vnode.vnodeSelector, 'div', 'tagname should be div');
@@ -41,7 +41,7 @@ registerSuite({
 		dialog.setProperties({
 			open: true,
 			underlay: true,
-			role: Role.alertdialog
+			role: 'dialog'
 		});
 		vnode = <VNode> dialog.__render__();
 		assert.lengthOf(vnode.children, 2);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

This PR fixes an issue with the Dialog and it's `role` property. It exported an enum to use, but it should've exported a string literal (which also provides intellisense.)

Resolves #69 
