### PR TITLE
textinput and textarea examples should be fully controlled

### DIFF
--- a/src/textarea/example/index.ts
+++ b/src/textarea/example/index.ts
@@ -7,18 +7,7 @@ import Textarea from '../../textarea/Textarea';
 
 export const AppBase = StatefulMixin(WidgetBase);
 export class App extends AppBase<WidgetProperties> {
-	onChange(event: Event) {
-		const value = (<HTMLInputElement> event.target).value;
-		this.setState({ inputValue: value });
-		this.setState({ invalid: value.trim().length === 0 });
-	}
-
 	render() {
-		const {
-			inputValue = '',
-			invalid
-		} = this.state;
-
 		return v('div', [
 			v('h1', {}, ['Textarea Example']),
 			w(Textarea, {
@@ -26,7 +15,9 @@ export class App extends AppBase<WidgetProperties> {
 				columns: 40,
 				rows: 8,
 				placeholder: 'Hello, World',
-				label: 'Type Something'
+				label: 'Type Something',
+				value: <string> this.state['value1'],
+				onChange: (event: Event) => this.setState({ 'value1': (<HTMLInputElement> event.target).value })
 			}),
 			v('h3', {}, ['Disabled Textarea']),
 			w(Textarea, {
@@ -44,9 +35,13 @@ export class App extends AppBase<WidgetProperties> {
 				rows: 8,
 				label: 'Required',
 				required: true,
-				value: <string> inputValue,
-				invalid: <boolean | undefined> invalid,
-				onChange: this.onChange
+				value: <string> this.state['value2'],
+				invalid: <boolean | undefined> this.state.invalid,
+				onChange: (event: Event) => {
+					const value = (<HTMLInputElement> event.target).value;
+					this.setState({ 'value2': value });
+					this.setState({ invalid: value.trim().length === 0 });
+				}
 			})
 		]);
 	}

--- a/src/textinput/example/index.ts
+++ b/src/textinput/example/index.ts
@@ -7,18 +7,7 @@ import TextInput, { TextInputType } from '../../textinput/TextInput';
 
 export const AppBase = StatefulMixin(WidgetBase);
 export class App extends AppBase<WidgetProperties> {
-	onChange(event: Event) {
-		const value = (<HTMLInputElement> event.target).value;
-		this.setState({ inputValue: value });
-		this.setState({ invalid: value.toLowerCase() !== 'foo' && value.toLowerCase() !== 'bar' });
-	}
-
 	render() {
-		const {
-			inputValue = '',
-			invalid
-		} = this.state;
-
 		return v('div', [
 			v('h1', {}, ['Text Input Examples']),
 			v('h3', {}, ['String label']),
@@ -26,7 +15,9 @@ export class App extends AppBase<WidgetProperties> {
 				key: 't1',
 				label: 'Name',
 				type: <TextInputType> 'text',
-				placeholder: 'Hello, World'
+				placeholder: 'Hello, World',
+				value: <string> this.state['value1'],
+				onChange: (event: Event) => this.setState({ 'value1': (<HTMLInputElement> event.target).value })
 			}),
 			v('h3', {}, ['Label before the input']),
 			w(TextInput, {
@@ -36,7 +27,9 @@ export class App extends AppBase<WidgetProperties> {
 					before: true,
 					content: 'Email (required)'
 				},
-				required: true
+				required: true,
+				value: <string> this.state['value2'],
+				onChange: (event: Event) => this.setState({ 'value2': (<HTMLInputElement> event.target).value })
 			}),
 			v('h3', {}, ['Hidden accessible label']),
 			w(TextInput, {
@@ -47,7 +40,9 @@ export class App extends AppBase<WidgetProperties> {
 					content: 'Try listening to me!',
 					before: false,
 					hidden: true
-				}
+				},
+				value: <string> this.state['value3'],
+				onChange: (event: Event) => this.setState({ 'value3': (<HTMLInputElement> event.target).value })
 			}),
 			v('h3', {}, ['Disabled text input']),
 			w(TextInput, {
@@ -63,9 +58,13 @@ export class App extends AppBase<WidgetProperties> {
 				key: 't5',
 				type: <TextInputType> 'text',
 				label: 'Type "foo" or "bar"',
-				value: <string> inputValue,
-				invalid: <boolean | undefined> invalid,
-				onChange: this.onChange
+				value: <string> this.state['value4'],
+				invalid: <boolean | undefined> this.state.invalid,
+				onChange: (event: Event) => {
+					const value = (<HTMLInputElement> event.target).value;
+					this.setState({ 'value4': value });
+					this.setState({ invalid: value.toLowerCase() !== 'foo' && value.toLowerCase() !== 'bar' });
+				}
 			})
 		]);
 	}


### PR DESCRIPTION
<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Updates textinput and textarea example pages to have all widgets be fully controlled by the parent
