### PR TITLE
Added root class to slidepane root

### DIFF
--- a/src/slidepane/SlidePane.ts
+++ b/src/slidepane/SlidePane.ts
@@ -177,7 +177,8 @@ export default class SlidePane extends SlidePaneBase<SlidePaneProperties> {
 			onmouseup: this._onSwipeEnd,
 			ontouchend: this._onSwipeEnd,
 			ontouchmove: this._onSwipeMove,
-			ontouchstart: this._onSwipeStart
+			ontouchstart: this._onSwipeStart,
+			classes: this.classes(css.root)
 		}, [
 			open ? v('div', {
 				classes: this.classes(css.underlay).fixed(underlay ? css.underlayVisible : null),

--- a/src/slidepane/styles/slidePane.m.css
+++ b/src/slidepane/styles/slidePane.m.css
@@ -1,5 +1,7 @@
 @import '../../common/styles/variables.css';
 
+.root {}
+
 .underlay {
 	position: fixed;
 	top: 0;

--- a/src/slidepane/styles/slidePane.m.css.d.ts
+++ b/src/slidepane/styles/slidePane.m.css.d.ts
@@ -1,3 +1,4 @@
+export const root: string;
 export const underlay: string;
 export const underlayVisible: string;
 export const content: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Provides a means to target the root node for the slidepane. Useful for setting the`z-index` such that it appears above other elements.