### PR TITLE
Add aria-controls and aria-expanded to popup

### DIFF
--- a/src/button/Button.ts
+++ b/src/button/Button.ts
@@ -35,7 +35,7 @@ export interface ButtonProperties extends ThemeableProperties {
 	content?: string;
 	describedBy?: string;
 	disabled?: boolean;
-	hasPopup?: boolean;
+	popup?: { expanded?: boolean; id?: string; } | boolean;
 	name?: string;
 	pressed?: boolean;
 	type?: ButtonType;
@@ -70,11 +70,11 @@ export default class Button extends ButtonBase<ButtonProperties> {
 	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
 
 	render(): DNode {
-		const {
+		let {
 			content = '',
 			describedBy,
 			disabled,
-			hasPopup,
+			popup = false,
 			name,
 			pressed,
 			type,
@@ -83,16 +83,22 @@ export default class Button extends ButtonBase<ButtonProperties> {
 
 		const stateClasses = [
 			disabled ? css.disabled : null,
-			hasPopup ? css.popup : null,
+			popup ? css.popup : null,
 			pressed ? css.pressed : null
 		];
+
+		if (popup === true) {
+			popup = { expanded: false, id: '' };
+		}
 
 		return v('button', {
 			innerHTML: content,
 			classes: this.classes(css.button, ...stateClasses),
 			'aria-describedby': describedBy,
 			disabled,
-			'aria-haspopup': typeof hasPopup === 'boolean' ? hasPopup.toString() : null,
+			'aria-haspopup': popup ? 'true' : null,
+			'aria-controls': popup ? popup.id : null,
+			'aria-expanded': popup ? popup.expanded + '' : null,
 			name,
 			'aria-pressed': typeof pressed === 'boolean' ? pressed.toString() : null,
 			type,

--- a/src/button/Button.ts
+++ b/src/button/Button.ts
@@ -14,7 +14,7 @@ export type ButtonType = 'submit' | 'reset' | 'button' | 'menu';
  * @property content        Text content of button
  * @property describedBy    ID of element with descriptive text
  * @property disabled       Whether the button is disabled or clickable
- * @property hasPopup       Whether the button triggers a popup
+ * @property popup       		Controls aria-haspopup, aria-expanded, and aria-controls for popup buttons
  * @property name           The button's name attribute
  * @property pressed        Indicates status of a toggle button
  * @property type           Button type can be "submit", "reset", "button", or "menu"

--- a/src/button/example/index.ts
+++ b/src/button/example/index.ts
@@ -30,7 +30,7 @@ export class App extends AppBase<WidgetProperties> {
 				key: 'b2',
 				content: 'Open',
 				disabled: true,
-				hasPopup: true,
+				popup: { expanded: false, id: 'fakeId' },
 				type: <ButtonType> 'menu'
 			}),
 			v('p', {

--- a/src/button/tests/unit/Button.ts
+++ b/src/button/tests/unit/Button.ts
@@ -24,7 +24,7 @@ registerSuite({
 			disabled: true,
 			pressed: true,
 			describedBy: 'baz',
-			hasPopup: true
+			popup: true
 		});
 		const vnode = <VNode> button.__render__();
 		assert.strictEqual(vnode.vnodeSelector, 'button');
@@ -35,6 +35,8 @@ registerSuite({
 		assert.strictEqual(vnode.properties!['aria-pressed'], 'true');
 		assert.strictEqual(vnode.properties!['aria-describedby'], 'baz');
 		assert.strictEqual(vnode.properties!['aria-haspopup'], 'true');
+		assert.strictEqual(vnode.properties!['aria-controls'], '');
+		assert.strictEqual(vnode.properties!['aria-expanded'], 'false');
 		assert.lengthOf(vnode.children, 0);
 	},
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Switches `hasPopup` for `popup`, which also allows you to pass in information about the popup (current expanded/collapsed state and id).

Resolves #108 
