### PR TITLE
Aria cleanup

### DIFF
--- a/src/checkbox/Checkbox.ts
+++ b/src/checkbox/Checkbox.ts
@@ -117,7 +117,7 @@ export default class Checkbox extends CheckboxBase<CheckboxProperties> {
 					checked,
 					'aria-describedby': describedBy,
 					disabled,
-					'aria-invalid': invalid + '',
+					'aria-invalid': invalid ? 'true' : null,
 					name,
 					readOnly,
 					'aria-readonly': readOnly ? 'true' : null,

--- a/src/radio/Radio.ts
+++ b/src/radio/Radio.ts
@@ -96,7 +96,7 @@ export default class Radio extends RadioBase<RadioProperties> {
 				checked,
 				'aria-describedby': describedBy,
 				disabled,
-				'aria-invalid': invalid + '',
+				'aria-invalid': invalid ? 'true' : null,
 				name,
 				readOnly,
 				'aria-readonly': readOnly ? 'true' : null,

--- a/src/select/Select.ts
+++ b/src/select/Select.ts
@@ -242,9 +242,9 @@ export default class Select extends SelectBase<SelectProperties> {
 
 		// add ids to options for use with aria-activedescendant
 		if (includes(evt.changedPropertyKeys, 'options')) {
-			for (let option of options) {
+			options.forEach((option) => {
 				option.id = option.id || uuid();
-			}
+			});
 		}
 	}
 

--- a/src/select/Select.ts
+++ b/src/select/Select.ts
@@ -218,7 +218,7 @@ export default class Select extends SelectBase<SelectProperties> {
 			index: i,
 			key: i + '',
 			optionData: assign({}, option, <any> {
-				id: option.id || uuid() + '',
+				id: option.id,
 				selected: multiple ? option.selected : value === option.value
 			}),
 			onMouseDown: this._onOptionMouseDown,
@@ -231,11 +231,20 @@ export default class Select extends SelectBase<SelectProperties> {
 	@onPropertiesChanged()
 	protected onPropertiesChanged(evt: PropertiesChangeEvent<this, SelectProperties>) {
 		const {
-			customOption = SelectOption
+			customOption = SelectOption,
+			options = []
 		} = this.properties;
 
+		// update custom option registry
 		if ( !this.registry || includes(evt.changedPropertyKeys, 'customOption')) {
 			this.registry = this._createRegistry(customOption);
+		}
+
+		// add ids to options for use with aria-activedescendant
+		if (includes(evt.changedPropertyKeys, 'options')) {
+			for (let option of options) {
+				option.id = option.id || uuid() + '';
+			}
 		}
 	}
 

--- a/src/select/Select.ts
+++ b/src/select/Select.ts
@@ -243,7 +243,7 @@ export default class Select extends SelectBase<SelectProperties> {
 		// add ids to options for use with aria-activedescendant
 		if (includes(evt.changedPropertyKeys, 'options')) {
 			for (let option of options) {
-				option.id = option.id || uuid() + '';
+				option.id = option.id || uuid();
 			}
 		}
 	}

--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -135,7 +135,7 @@ export default class Slider extends SliderBase<SliderProperties> {
 				'aria-describedby': describedBy,
 				disabled,
 				id: inputId,
-				'aria-invalid': invalid + '',
+				'aria-invalid': invalid ? 'true' : null,
 				max: max + '',
 				min: min + '',
 				name,

--- a/src/textarea/Textarea.ts
+++ b/src/textarea/Textarea.ts
@@ -122,7 +122,7 @@ export default class Textarea extends TextareaBase<TextareaProperties> {
 				cols: columns ? columns + '' : null,
 				'aria-describedby': describedBy,
 				disabled,
-				'aria-invalid': invalid + '',
+				'aria-invalid': invalid ? 'true' : null,
 				maxlength: maxLength ? maxLength + '' : null,
 				minlength: minLength ? minLength + '' : null,
 				name,

--- a/src/textinput/TextInput.ts
+++ b/src/textinput/TextInput.ts
@@ -121,7 +121,7 @@ export default class TextInput extends TextInputBase<TextInputProperties> {
 				'aria-controls': controls,
 				'aria-describedby': describedBy,
 				disabled,
-				'aria-invalid': invalid + '',
+				'aria-invalid': invalid ? 'true' : null,
 				maxlength: maxLength ? maxLength + '' : null,
 				minlength: minLength ? minLength + '' : null,
 				name,


### PR DESCRIPTION
**Type:** bug
The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

- Updates widgets that use `aria-invalid` to only show the property when it is set to `true`. Previously, widgets were displaying `aria-invalid="undefined"`.
- Also updates Select option id's to be correctly referenced in `aria-activedescendant`.