### PR TITLE
Add Dialog functional tests

### DIFF
--- a/src/common/tests/functional/all.ts
+++ b/src/common/tests/functional/all.ts
@@ -1,1 +1,2 @@
+import '../../../dialog/tests/functional/Dialog';
 import '../../../slidepane/tests/functional/SlidePane';

--- a/src/dialog/tests/functional/Dialog.ts
+++ b/src/dialog/tests/functional/Dialog.ts
@@ -1,0 +1,149 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+
+interface Options {
+	closeable?: boolean;
+	modal?: boolean;
+	underlay?: boolean;
+}
+
+const CONTAINER_SELECTOR = 'div > div';
+const DELAY = 400;
+const DIALOG_SELECTOR = 'div > div > :last-child';
+const UNDERLAY_SELECTOR = 'div > div > :first-child';
+
+function openDialog(remote: any, options: Options = {}) {
+	const { closeable = true, modal, underlay } = options;
+	let promise = remote
+		.get('http://localhost:9000/_build/common/example/?module=dialog')
+		.setFindTimeout(5000);
+
+	if (!closeable) {
+		promise = promise
+			.findById('closeable')
+				.click()
+				.end();
+	}
+
+	if (modal) {
+		promise = promise
+			.findById('modal')
+				.click()
+				.end();
+	}
+
+	if (underlay) {
+		promise = promise
+			.findById('underlay')
+				.click()
+				.end();
+	}
+
+	return promise
+		.findById('button')
+			.click()
+			.end();
+}
+
+function clickUnderlay(remote: any, options: Options = { underlay: true }) {
+	const { mouseEnabled, touchEnabled } = remote.environmentType;
+	const promise = openDialog(remote, options);
+
+	if (touchEnabled) {
+		return promise
+			.moveFinger(0, 0)
+			.pressFinger(0, 0)
+			.releaseFinger(0, 0)
+			.end();
+	}
+
+	if (mouseEnabled) {
+		// `click` clicks the center of the element, which in this case is where the dialog node is.
+		return promise
+			.moveMouseTo(null, 0, 0)
+			.clickMouseButton()
+			.end();
+	}
+
+	return promise
+		.findByCssSelector(UNDERLAY_SELECTOR)
+			.click()
+			.end();
+}
+
+registerSuite({
+	name: 'Dialog',
+
+	'The dialog should be visibly centered by default'(this: any) {
+		let dialogSize: { height: number; width: number };
+		let viewportSize: { height: number; width: number };
+
+		return openDialog(this.remote)
+			.sleep(DELAY)
+			.getWindowSize()
+				.then(({ height, width }: { height: number; width: number; }) => {
+					viewportSize = { height, width };
+				})
+			.findByCssSelector(DIALOG_SELECTOR)
+				.getSize()
+					.then(({ height, width }: { height: number; width: number; }) => {
+						dialogSize = { height, width };
+					})
+				.getPosition()
+					.then(({ x, y }: { x: number; y: number; }) => {
+						const expectedX = (viewportSize.width - dialogSize.width) / 2;
+						const expectedY = (viewportSize.height - dialogSize.height) / 2;
+
+						assert.closeTo(x, expectedX, expectedX * 0.2);
+						assert.closeTo(y, expectedY, expectedY * 0.2);
+					});
+	},
+
+	'The underlay should cover the entire visible screen'(this: any) {
+		let viewportSize: { height: number; width: number };
+
+		return openDialog(this.remote, { underlay: true })
+			.getWindowSize()
+				.then(({ height, width }: { height: number; width: number; }) => {
+					viewportSize = { height, width };
+				})
+				.end()
+			.sleep(DELAY)
+			.findByCssSelector(UNDERLAY_SELECTOR)
+				.getSize()
+				.then(({ height, width }: { height: number; width: number; }) => {
+					assert.isAtLeast(height, viewportSize.height * 0.8);
+					assert.isAtLeast(width, viewportSize.width * 0.9);
+				});
+	},
+
+	'Clicking the underlay should destroy the dialog'(this: any) {
+		return clickUnderlay(this.remote)
+			.sleep(DELAY)
+			.findByCssSelector(CONTAINER_SELECTOR)
+				.getProperty('children')
+				.then((children: HTMLElement[]) => {
+					assert.lengthOf(children, 0);
+				});
+	},
+
+	'Clicking the underlay should not destroy the dialog when "modal" is true'(this: any) {
+		return clickUnderlay(this.remote, { underlay: true, modal: true })
+			.sleep(DELAY)
+			.findByCssSelector(CONTAINER_SELECTOR)
+				.getProperty('children')
+				.then((children: HTMLElement[]) => {
+					assert.lengthOf(children, 2);
+				});
+	},
+
+	'The dialog should not be closeable when "closeable" is false'(this: any) {
+		return clickUnderlay(this.remote, { underlay: true, closeable: false })
+			.sleep(DELAY)
+			.findByCssSelector(CONTAINER_SELECTOR)
+				.getProperty('children')
+				.then((children: HTMLElement[]) => {
+					assert.lengthOf(children, 2, 'The dialog should not be destroyed when the underlay is clicked.');
+				});
+	}
+});

--- a/src/dialog/tests/functional/Dialog.ts
+++ b/src/dialog/tests/functional/Dialog.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as keys from 'leadfoot/keys';
 import * as css from '../../styles/dialog.m.css';
 
 interface Options {
@@ -145,6 +146,45 @@ registerSuite({
 				.getProperty('children')
 				.then((children: HTMLElement[]) => {
 					assert.lengthOf(children, 2, 'The dialog should not be destroyed when the underlay is clicked.');
+				});
+	},
+
+	'The dialog should be hidden when the close button is clicked'(this: any) {
+		return openDialog(this.remote)
+			.findByCssSelector(`.${css.close}`)
+				.click()
+				.sleep(DELAY)
+				.end()
+			.findByCssSelector(`.${css.root}`)
+				.getProperty('children')
+				.then((children: HTMLElement[]) => {
+					assert.lengthOf(children, 0);
+				});
+	},
+
+	'The dialog should be hidden when the close button is activated with the enter key'(this: any) {
+		if (this.remote.session.capabilities.browserName === 'safari') {
+			// TODO: https://github.com/seleniumhq/selenium-google-code-issue-archive/issues/5403
+			this.skip('SafariDriver does not move focus with tab key.');
+		}
+
+		// The number of tab presses required to highlight the close button.
+		const tabCount = 6;
+		const tabKeys: string[] = [];
+		for (let i = 0; i < tabCount; i++) {
+			tabKeys.push(keys.TAB);
+		}
+
+		return openDialog(this.remote)
+			.pressKeys(tabKeys)
+			.findByCssSelector(`.${css.close}`)
+				.pressKeys(keys.ENTER)
+				.sleep(DELAY)
+				.end()
+			.findByCssSelector(`.${css.root}`)
+				.getProperty('children')
+				.then((children: HTMLElement[]) => {
+					assert.lengthOf(children, 0);
 				});
 	}
 });

--- a/src/dialog/tests/functional/Dialog.ts
+++ b/src/dialog/tests/functional/Dialog.ts
@@ -45,7 +45,7 @@ function openDialog(remote: any, options: Options = {}) {
 }
 
 function clickUnderlay(remote: any, options: Options = { underlay: true }) {
-	const { mouseEnabled, touchEnabled } = remote.environmentType;
+	const { browser, touchEnabled } = remote.session.capabilities;
 	const promise = openDialog(remote, options);
 
 	if (touchEnabled) {
@@ -56,18 +56,20 @@ function clickUnderlay(remote: any, options: Options = { underlay: true }) {
 			.end();
 	}
 
-	if (mouseEnabled) {
-		// `click` clicks the center of the element, which in this case is where the dialog node is.
+	// TODO: The iPhone driver does not support touch events:
+	// https://github.com/theintern/intern/issues/602
+	if (browser && browser.toLowerCase() === 'iphone') {
 		return promise
-			.moveMouseTo(null, 0, 0)
-			.clickMouseButton()
-			.end();
+			.findByCssSelector(`.${css.underlay}`)
+				.click()
+				.end();
 	}
 
+	// `click` clicks the center of the element, which in this case is where the dialog node is.
 	return promise
-		.findByCssSelector(`.${css.underlay}`)
-			.click()
-			.end();
+		.moveMouseTo(null, 0, 0)
+		.clickMouseButton()
+		.end();
 }
 
 registerSuite({

--- a/src/dialog/tests/functional/Dialog.ts
+++ b/src/dialog/tests/functional/Dialog.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as css from '../../styles/dialog.m.css';
 
 interface Options {
 	closeable?: boolean;
@@ -9,8 +10,6 @@ interface Options {
 
 const CONTAINER_SELECTOR = 'div > div';
 const DELAY = 400;
-const DIALOG_SELECTOR = 'div > div > :last-child';
-const UNDERLAY_SELECTOR = 'div > div > :first-child';
 
 function openDialog(remote: any, options: Options = {}) {
 	const { closeable = true, modal, underlay } = options;
@@ -66,7 +65,7 @@ function clickUnderlay(remote: any, options: Options = { underlay: true }) {
 	}
 
 	return promise
-		.findByCssSelector(UNDERLAY_SELECTOR)
+		.findByCssSelector(`.${css.underlay}`)
 			.click()
 			.end();
 }
@@ -84,7 +83,7 @@ registerSuite({
 				.then(({ height, width }: { height: number; width: number; }) => {
 					viewportSize = { height, width };
 				})
-			.findByCssSelector(DIALOG_SELECTOR)
+			.findByCssSelector(`.${css.main}`)
 				.getSize()
 					.then(({ height, width }: { height: number; width: number; }) => {
 						dialogSize = { height, width };
@@ -109,7 +108,7 @@ registerSuite({
 				})
 				.end()
 			.sleep(DELAY)
-			.findByCssSelector(UNDERLAY_SELECTOR)
+			.findByCssSelector(`.${css.underlay}`)
 				.getSize()
 				.then(({ height, width }: { height: number; width: number; }) => {
 					assert.isAtLeast(height, viewportSize.height * 0.8);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds basic functional tests for `Dialog`.

It should be noted that I have not been able to figure out how to get a consistent read on the window/dialog dimensions. In Chrome, for example, the registered height of the underlay is always ~60px less than the window height, even though during the tests themselves the underlay clearly occupies the entire screen. As such, rather liberal estimates have to be used to determine whether the underlay spans the entire screen, and whether the dialog is actually centered. If anyone has ideas for getting a more accurate reading, I would greatly appreciate the input.