### PR TITLE
Skip theme `css.js` files for coverage

### DIFF
--- a/src/common/tests/intern.ts
+++ b/src/common/tests/intern.ts
@@ -69,4 +69,4 @@ export const suites = [ 'src/common/tests/unit/all' ];
 export const functionalSuites = [];
 
 // A regular expression matching URLs to files that should not be included in code coverage analysis
-export const excludeInstrumentation = /(?:node_modules|bower_components|tests|styles|example|.+Element\.)/;
+export const excludeInstrumentation = /(?:node_modules|bower_components|tests|styles|themes|example|.+Element\.)/;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Should skip the generated `css.js` themes files for coverage.
