### PR TITLE
Add `SlidePane` functional tests.

### DIFF
--- a/src/common/tests/functional/all.ts
+++ b/src/common/tests/functional/all.ts
@@ -1,0 +1,1 @@
+import '../../../slidepane/tests/functional/SlidePane';

--- a/src/common/tests/intern.ts
+++ b/src/common/tests/intern.ts
@@ -66,7 +66,7 @@ export const loaderOptions = {
 export const suites = [ 'src/common/tests/unit/all' ];
 
 // Functional test suite(s) to run in each browser once non-functional tests are completed
-export const functionalSuites = [];
+export const functionalSuites = [ 'src/common/tests/functional/all' ];
 
 // A regular expression matching URLs to files that should not be included in code coverage analysis
 export const excludeInstrumentation = /(?:node_modules|bower_components|tests|styles|themes|example|.+Element\.)/;

--- a/src/slidepane/tests/functional/SlidePane.ts
+++ b/src/slidepane/tests/functional/SlidePane.ts
@@ -128,6 +128,7 @@ registerSuite({
 		}
 
 		if (browserName.toLowerCase() === 'microsoftedge') {
+			// TODO: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11469232/
 			this.skip('Edge driver does not handle mouse movements correctly.');
 		}
 
@@ -152,6 +153,7 @@ registerSuite({
 		}
 
 		if (browserName.toLowerCase() === 'microsoftedge') {
+			// TODO: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11469232/
 			this.skip('Edge driver does not handle mouse movements correctly.');
 		}
 
@@ -179,6 +181,7 @@ registerSuite({
 		}
 
 		if (browserName.toLowerCase() === 'microsoftedge') {
+			// TODO: https://developer.microsoft.com/en-us/microsoft-edge/platform/issues/11469232/
 			this.skip('Edge driver does not handle mouse movements correctly.');
 		}
 

--- a/src/slidepane/tests/functional/SlidePane.ts
+++ b/src/slidepane/tests/functional/SlidePane.ts
@@ -1,0 +1,192 @@
+import * as registerSuite from 'intern!object';
+import * as assert from 'intern/chai!assert';
+
+const DELAY = 400;
+const SLIDEPANE_SELECTOR = 'div > div > :last-child';
+const UNDERLAY_SELECTOR = 'div > div > :first-child';
+
+function openSlidePane(remote: any, alignRight?: boolean) {
+	let promise = remote
+		.get('http://localhost:9000/_build/common/example/?module=slidepane')
+		.setFindTimeout(5000)
+		.findById('underlay')
+			.click()
+			.end();
+
+	if (alignRight) {
+		promise = promise
+			.findById('alignRight')
+				.click()
+				.end();
+	}
+
+	return promise
+		.findById('button')
+			.click()
+			.end()
+		.sleep(DELAY);
+}
+
+function clickUnderlay(remote: any) {
+	const { mouseEnabled } = remote.environmentType;
+	const underlay = openSlidePane(remote);
+
+	if (mouseEnabled) {
+		return underlay
+			.moveMouseTo(null, 300, 10)
+			.clickMouseButton()
+			.sleep(DELAY)
+			.end();
+	}
+
+	return underlay
+		.findByCssSelector(UNDERLAY_SELECTOR)
+			.click()
+			.sleep(DELAY)
+			.end();
+}
+
+function swipeSlidePane(remote: any, distance = 250, alignRight?: boolean) {
+	const { mouseEnabled } = remote.environmentType;
+	const initialX = alignRight ? 10 : 300;
+
+	if (mouseEnabled) {
+		const finalX = alignRight ? distance : -distance;
+		return openSlidePane(remote, alignRight)
+			.moveMouseTo(null, initialX, 10)
+			.pressMouseButton()
+			.moveMouseTo(null, finalX, 0)
+			.releaseMouseButton()
+			.sleep(DELAY);
+	}
+
+	const finalX = alignRight ? initialX + distance : initialX - distance;
+	return openSlidePane(remote, alignRight)
+		.pressFinger(initialX, 10)
+		.moveFinger(finalX, 10)
+		.releaseFinger(finalX, 10)
+		.sleep(DELAY);
+}
+
+registerSuite({
+	name: 'SlidePane',
+
+	'the underlay should cover the screen'(this: any) {
+		let viewportSize: { height: number; width: number; };
+
+		return openSlidePane(this.remote)
+			.getWindowSize()
+				.then(({ height, width }: { height: number; width: number; }) => {
+					viewportSize = { height, width };
+				})
+			.findByCssSelector(UNDERLAY_SELECTOR)
+				.getSize()
+				.then(({ height, width }: { height: number; width: number; }) => {
+					assert.closeTo(height, viewportSize.height, viewportSize.height * 0.2);
+					assert.closeTo(width, viewportSize.width, viewportSize.width * 0.2);
+				});
+	},
+
+	'the underlay should be destroyed when the slidepane is hidden'(this: any) {
+		return clickUnderlay(this.remote)
+			.findByCssSelector(UNDERLAY_SELECTOR)
+				.getAttribute('class')
+				.then((className: string) => {
+					assert.match(className, /slidePane-m__content/, 'the underlay should be removed.');
+				});
+	},
+
+	'the underlay should not be destroyed when the slidepane is clicked'(this: any) {
+		return openSlidePane(this.remote)
+			.findByCssSelector(SLIDEPANE_SELECTOR)
+				.click()
+				.end()
+			.sleep(DELAY)
+			.findByCssSelector(UNDERLAY_SELECTOR)
+				.getAttribute('class')
+				.then((className: string) => {
+					assert.match(className, /slidePane-m__underlay/, 'the underlay should not be removed.');
+				});
+	},
+
+	'the slidepane should not be hidden when it is clicked'(this: any) {
+		return openSlidePane(this.remote)
+			.findByCssSelector(SLIDEPANE_SELECTOR)
+				.click()
+				.sleep(DELAY)
+				.getPosition()
+					.then(({ x }: { x: number; }) => {
+						assert.strictEqual(x, 0, 'The slidepane should be visible.');
+					});
+	},
+
+	'a left-aligned slidepane should close when swiping from right to left'(this: any) {
+		const { browserName, mouseEnabled, touchEnabled } = this.remote.environmentType;
+
+		if (!mouseEnabled && !touchEnabled) {
+			this.skip('Test requires mouse or touch interactions.');
+		}
+
+		if (browserName.toLowerCase() === 'microsoftedge') {
+			this.skip('Edge driver does not handle mouse movements correctly.');
+		}
+
+		let width = 0;
+		return swipeSlidePane(this.remote)
+			.findByCssSelector(SLIDEPANE_SELECTOR)
+				.getSize()
+					.then((size: { width: number; }) => {
+						width = size.width;
+					})
+				.getPosition()
+					.then(({ x }: { x: number; }) => {
+						assert.closeTo(x, -width, 15);
+					});
+	},
+
+	'a right-aligned slidepane should close when swiping from left to right'(this: any) {
+		const { browserName, mouseEnabled, touchEnabled } = this.remote.environmentType;
+
+		if (!mouseEnabled && !touchEnabled) {
+			this.skip('Test requires mouse or touch interactions.');
+		}
+
+		if (browserName.toLowerCase() === 'microsoftedge') {
+			this.skip('Edge driver does not handle mouse movements correctly.');
+		}
+
+		let viewportWidth = 0;
+		return swipeSlidePane(this.remote, undefined, true)
+			.getWindowSize()
+				.then(({ width }: { width: number }) => {
+					viewportWidth = width;
+				})
+			.findByCssSelector(SLIDEPANE_SELECTOR)
+				.getPosition()
+				.then(({ x }: { x: number; }) => {
+					// Edge/IE11/Chrome on Windows visually hide the slidepane correctly, but the position
+					// is slightly less than the expected (the viewport width).
+					const expected = viewportWidth * 0.95;
+					assert.isAtLeast(x, expected, 'The slidepane should be hidden off to the right.');
+				});
+	},
+
+	'minor swipe movements should not close the slidepane'(this: any) {
+		const { browserName, mouseEnabled, touchEnabled } = this.remote.environmentType;
+
+		if (!mouseEnabled && !touchEnabled) {
+			this.skip('Test requires mouse or touch interactions.');
+		}
+
+		if (browserName.toLowerCase() === 'microsoftedge') {
+			this.skip('Edge driver does not handle mouse movements correctly.');
+		}
+
+		return swipeSlidePane(this.remote, 50)
+			.findByCssSelector(SLIDEPANE_SELECTOR)
+				.getPosition()
+					.then(({ x }: { x: number; }) => {
+						assert.strictEqual(x, 0, 'The slidepane should be open.');
+					});
+	}
+});

--- a/src/slidepane/tests/functional/SlidePane.ts
+++ b/src/slidepane/tests/functional/SlidePane.ts
@@ -1,9 +1,8 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as css from '../../styles/slidePane.m.css';
 
 const DELAY = 400;
-const SLIDEPANE_SELECTOR = 'div > div > :last-child';
-const UNDERLAY_SELECTOR = 'div > div > :first-child';
 
 function openSlidePane(remote: any, alignRight?: boolean) {
 	let promise = remote
@@ -40,7 +39,7 @@ function clickUnderlay(remote: any) {
 	}
 
 	return underlay
-		.findByCssSelector(UNDERLAY_SELECTOR)
+		.findByCssSelector(`.${css.underlay}`)
 			.click()
 			.sleep(DELAY)
 			.end();
@@ -79,7 +78,7 @@ registerSuite({
 				.then(({ height, width }: { height: number; width: number; }) => {
 					viewportSize = { height, width };
 				})
-			.findByCssSelector(UNDERLAY_SELECTOR)
+			.findByCssSelector(`.${css.underlay}`)
 				.getSize()
 				.then(({ height, width }: { height: number; width: number; }) => {
 					assert.closeTo(height, viewportSize.height, viewportSize.height * 0.2);
@@ -89,20 +88,20 @@ registerSuite({
 
 	'the underlay should be destroyed when the slidepane is hidden'(this: any) {
 		return clickUnderlay(this.remote)
-			.findByCssSelector(UNDERLAY_SELECTOR)
-				.getAttribute('class')
-				.then((className: string) => {
-					assert.match(className, /slidePane-m__content/, 'the underlay should be removed.');
+			.findByCssSelector(`.${css.root}`)
+				.getProperty('children')
+				.then((children: any[]) => {
+					assert.lengthOf(children, 1, 'the underlay should be removed.');
 				});
 	},
 
 	'the underlay should not be destroyed when the slidepane is clicked'(this: any) {
 		return openSlidePane(this.remote)
-			.findByCssSelector(SLIDEPANE_SELECTOR)
+			.findByCssSelector(`.${css.content}`)
 				.click()
 				.end()
 			.sleep(DELAY)
-			.findByCssSelector(UNDERLAY_SELECTOR)
+			.findByCssSelector(`.${css.underlay}`)
 				.getAttribute('class')
 				.then((className: string) => {
 					assert.match(className, /slidePane-m__underlay/, 'the underlay should not be removed.');
@@ -111,7 +110,7 @@ registerSuite({
 
 	'the slidepane should not be hidden when it is clicked'(this: any) {
 		return openSlidePane(this.remote)
-			.findByCssSelector(SLIDEPANE_SELECTOR)
+			.findByCssSelector(`.${css.content}`)
 				.click()
 				.sleep(DELAY)
 				.getPosition()
@@ -134,7 +133,7 @@ registerSuite({
 
 		let width = 0;
 		return swipeSlidePane(this.remote)
-			.findByCssSelector(SLIDEPANE_SELECTOR)
+			.findByCssSelector(`.${css.content}`)
 				.getSize()
 					.then((size: { width: number; }) => {
 						width = size.width;
@@ -163,11 +162,11 @@ registerSuite({
 				.then(({ width }: { width: number }) => {
 					viewportWidth = width;
 				})
-			.findByCssSelector(SLIDEPANE_SELECTOR)
+			.findByCssSelector(`.${css.content}`)
 				.getPosition()
 				.then(({ x }: { x: number; }) => {
 					// Edge/IE11/Chrome on Windows visually hide the slidepane correctly, but the position
-					// is slightly less than the expected (the viewport width).
+					// is slightly less than expected (the viewport width).
 					const expected = viewportWidth * 0.95;
 					assert.isAtLeast(x, expected, 'The slidepane should be hidden off to the right.');
 				});
@@ -186,7 +185,7 @@ registerSuite({
 		}
 
 		return swipeSlidePane(this.remote, 50)
-			.findByCssSelector(SLIDEPANE_SELECTOR)
+			.findByCssSelector(`.${css.content}`)
 				.getPosition()
 					.then(({ x }: { x: number; }) => {
 						assert.strictEqual(x, 0, 'The slidepane should be open.');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds functional tests for `SlidePane`. Swipe tests are skipped for both Firefox and Edge since the FirefoxDriver is extremely limited, and since the MS Edge driver does not handle mouse movements correctly (in multiple independent tests I verified that Edge reports different `MouseEvent#pageX` values then those passed to the `moveMouseTo` methods).

Resolves #157 
