### PR TITLE
Fix slidepane animations with custom theme.

### DIFF
--- a/src/common/styles/widgets.css.d.ts
+++ b/src/common/styles/widgets.css.d.ts
@@ -1,0 +1,1 @@
+export default {};

--- a/src/common/styles/widgets.css.d.ts
+++ b/src/common/styles/widgets.css.d.ts
@@ -1,1 +1,0 @@
-export default {};

--- a/src/slidepane/SlidePane.ts
+++ b/src/slidepane/SlidePane.ts
@@ -93,7 +93,7 @@ export default class SlidePane extends SlidePaneBase<SlidePaneProperties> {
 	}
 
 	private _onSwipeEnd(event: MouseEvent & TouchEvent) {
-		const { target, type } = event;
+		const { changedTouches, pageX, target, type } = event;
 		this._swiping = false;
 
 		const {
@@ -103,7 +103,7 @@ export default class SlidePane extends SlidePaneBase<SlidePaneProperties> {
 		} = this.properties;
 
 		// Current pointer position
-		const currentX = type === 'touchend' ? event.changedTouches[0].screenX : event.pageX;
+		const currentX = type === 'touchend' ? changedTouches[0].screenX : pageX;
 		// Difference between current and initial pointer position
 		const delta = align === Align.right ? currentX - this._initialX : this._initialX - currentX;
 

--- a/src/slidepane/SlidePane.ts
+++ b/src/slidepane/SlidePane.ts
@@ -173,7 +173,7 @@ export default class SlidePane extends SlidePaneBase<SlidePaneProperties> {
 			classes: this.classes(css.root)
 		}, [
 			open ? v('div', {
-				classes: this.classes(css.underlay, underlay ? css.underlayVisible : null),
+				classes: this.classes(underlay ? css.underlayVisible : null).fixed(css.underlay),
 				enterAnimation: animations.fadeIn,
 				exitAnimation: animations.fadeOut,
 				key: 'underlay'

--- a/src/slidepane/tests/unit/SlidePane.ts
+++ b/src/slidepane/tests/unit/SlidePane.ts
@@ -65,6 +65,7 @@ registerSuite({
 				afterUpdate: widget.listener,
 				classes: widget.classes(css.content, css.left, css.open, css.slideIn),
 				styles: {
+					transform: '',
 					width: '256px'
 				}
 			}, [ GREEKING ])
@@ -93,6 +94,7 @@ registerSuite({
 				afterUpdate: widget.listener,
 				classes: widget.classes(css.content, css.left),
 				styles: {
+					transform: '',
 					width: '256px'
 				}
 			}, [])
@@ -142,6 +144,7 @@ registerSuite({
 				afterUpdate: widget.listener,
 				classes: widget.classes(css.content, css.left, css.open, css.slideIn),
 				styles: {
+					transform: '',
 					width: '256px'
 				}
 			}, [])
@@ -167,6 +170,7 @@ registerSuite({
 				afterUpdate: widget.listener,
 				classes: widget.classes(css.content, css.left, css.slideOut),
 				styles: {
+					transform: '',
 					width: '256px'
 				}
 			}, [])
@@ -410,25 +414,77 @@ registerSuite({
 		assert(!((<HTMLElement> widget.getDom().lastChild).style.transform));
 	},
 
-	'classes and transform removed after transition'() {
+	'classes removed after transition'() {
 		widget.setProperties({
 			open: true
 		});
 
-		const content = <HTMLElement> widget.getDom().lastChild;
+		widget.setChildren([ GREEKING ]);
 
-		assert.isTrue(content.classList.contains(css.slideIn), 'should have css.slideIn');
-		content.classList.add(css.slideOut);
-		assert.isTrue(content.classList.contains(css.slideOut), 'should have css.slideOut');
-		content.style.transform = 'translateX(1%)';
+		const expected = v('div', {
+			onmousedown: widget.listener,
+			onmousemove: widget.listener,
+			onmouseup: widget.listener,
+			ontouchend: widget.listener,
+			ontouchmove: widget.listener,
+			ontouchstart: widget.listener,
+			classes: widget.classes(css.root)
+		}, [
+			v('div', {
+				afterCreate: widget.listener,
+				afterUpdate: widget.listener,
+				classes: widget.classes(css.underlay),
+				enterAnimation: animations.fadeIn,
+				exitAnimation: animations.fadeOut,
+				key: 'underlay'
+			}),
+			v('div', {
+				key: 'content',
+				afterCreate: widget.listener,
+				afterUpdate: widget.listener,
+				classes: widget.classes(css.content, css.left, css.open, css.slideIn),
+				styles: {
+					transform: '',
+					width: '256px'
+				}
+			}, [ GREEKING ])
+		]);
+
+		widget.expectRender(expected);
 
 		widget.sendEvent('transitionend', {
 			selector: ':last-child'
 		});
 
-		assert.isFalse(content.classList.contains(css.slideIn), 'should not have css.slideIn');
-		assert.isFalse(content.classList.contains(css.slideOut), 'should not have css.slideOut');
-		assert.strictEqual(content.style.transform, '', 'transform should be removed');
+		assignChildProperties(expected, 0, {
+			classes: widget.classes(css.underlay)
+		});
+		assignChildProperties(expected, 1, {
+			classes: widget.classes(css.content, css.left, css.open)
+		});
+		assignProperties(expected, { classes: widget.classes(css.root) });
+		widget.expectRender(expected, '`css.slideIn` should be removed when the animation ends.');
+
+		widget.setProperties({
+			open: false
+		});
+
+		replaceChild(expected, 0, null);
+		assignChildProperties(expected, 1, {
+			classes: widget.classes(css.content, css.left, css.slideOut)
+		});
+		assignProperties(expected, { classes: widget.classes(css.root) });
+		widget.expectRender(expected);
+
+		widget.sendEvent('transitionend', {
+			selector: ':last-child'
+		});
+
+		assignChildProperties(expected, 1, {
+			classes: widget.classes(css.content, css.left)
+		});
+		assignProperties(expected, { classes: widget.classes(css.root) });
+		widget.expectRender(expected, '`css.slideOut` should be removed when the animation ends.');
 	},
 
 	'last transform is applied on next render if being swiped closed'() {
@@ -461,6 +517,7 @@ registerSuite({
 				afterUpdate: widget.listener,
 				classes: widget.classes(css.content, css.left, css.open, css.slideIn),
 				styles: {
+					transform: '',
 					width: '256px'
 				}
 			}, [ GREEKING ])
@@ -536,6 +593,7 @@ registerSuite({
 				afterUpdate: widget.listener,
 				classes: widget.classes(css.content, css.right, css.open, css.slideIn),
 				styles: {
+					transform: '',
 					width: '256px'
 				}
 			}, [ GREEKING ])

--- a/src/themes/dojo/slidePane.m.css
+++ b/src/themes/dojo/slidePane.m.css
@@ -1,13 +1,5 @@
 @import './variables.css';
 
-.underlay {
-	position: fixed;
-	top: 0;
-	left: 0;
-	width: 100%;
-	height: 100%;
-}
-
 .underlayVisible {
 	background: var(--underlay-bg);
 }

--- a/src/themes/dojo/slidePane.m.css.d.ts
+++ b/src/themes/dojo/slidePane.m.css.d.ts
@@ -1,4 +1,3 @@
-export const underlay: string;
 export const underlayVisible: string;
 export const content: string;
 export const left: string;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Remove direct DOM manipulation from `SlidePane` so that its animations and functionality do not depend directly on `src/slidepane/styles/slidePane.m.css`.

Previously, `SlidePane` treated the `open`, `left`, and `right` CSS classes as fixed classes. However, this made it impossible for themes to specify combinations like `left.slideIn`, since the corresponding `left` class in the generated CSS is different than the fixed class actually applied to the DOM node. As such, `open`, `left`, and `right` were downgraded to normal classes.

Resolves #129 
