### PR TITLE
Added root class to dialog

### DIFF
--- a/src/dialog/Dialog.ts
+++ b/src/dialog/Dialog.ts
@@ -74,7 +74,7 @@ export default class Dialog extends DialogBase<DialogProperties> {
 
 		this._wasOpen = open;
 
-		return v('div', open ? [
+		return v('div', { classes: this.classes(css.root) }, open ? [
 			v('div', {
 				classes: this.classes(underlay ? css.underlayVisible : null).fixed(css.underlay),
 				enterAnimation: animations.fadeIn,

--- a/src/dialog/styles/dialog.m.css
+++ b/src/dialog/styles/dialog.m.css
@@ -1,5 +1,7 @@
 @import '../../common/styles/variables.css';
 
+.root {}
+
 .main {
 	position: absolute;
 	top: 50%;

--- a/src/dialog/styles/dialog.m.css.d.ts
+++ b/src/dialog/styles/dialog.m.css.d.ts
@@ -1,3 +1,4 @@
+export const root: string;
 export const main: string;
 export const underlay: string;
 export const underlayVisible: string;

--- a/src/dialog/tests/unit/Dialog.ts
+++ b/src/dialog/tests/unit/Dialog.ts
@@ -2,6 +2,7 @@ import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import { VNode } from '@dojo/interfaces/vdom';
 import Dialog from '../../Dialog';
+import * as css from '../../styles/dialog.m.css';
 
 registerSuite({
 	name: 'Dialog',
@@ -36,6 +37,7 @@ registerSuite({
 		});
 		let vnode = <VNode> dialog.__render__();
 		assert.strictEqual(vnode.vnodeSelector, 'div', 'tagname should be div');
+		assert.property(vnode.properties!.classes!, css.root);
 		assert.lengthOf(vnode.children, 0);
 
 		dialog.__setProperties__({


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds `root` class to widgets that are missing it.
`Label` still missing root but can be added in PR that addresses the `classes` property label currently accepts.

Resolves #75 
