### PR TITLE
Remove bind references in v() and w() calls

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,8 +25,7 @@
     "@dojo/has": "beta1",
     "@dojo/i18n": "beta1",
     "@dojo/shim": "beta1",
-    "@dojo/widget-core": "beta1",
-    "maquette": "2.4.3"
+    "@dojo/widget-core": "beta1"
   },
   "devDependencies": {
     "@dojo/interfaces": "beta1",

--- a/src/checkbox/Checkbox.ts
+++ b/src/checkbox/Checkbox.ts
@@ -112,7 +112,6 @@ export default class Checkbox extends CheckboxBase<CheckboxProperties> {
 				mode === Mode.toggle ? v('div', { classes: this.classes(css.onLabel) }, [ onLabel || null ]) : null,
 				mode === Mode.toggle ? v('div', { classes: this.classes(css.offLabel) }, [ offLabel || null ]) : null,
 				v('input', {
-					bind: this,
 					classes: this.classes(css.input),
 					checked,
 					'aria-describedby': describedBy,

--- a/src/combobox/ComboBox.ts
+++ b/src/combobox/ComboBox.ts
@@ -384,7 +384,6 @@ export default class ComboBox extends ComboBoxBase<ComboBoxProperties> {
 			}),
 			clearable ? v('button', {
 				'aria-controls': menuId,
-				bind: this,
 				classes: this.classes(css.clear),
 				disabled,
 				readOnly,
@@ -393,7 +392,6 @@ export default class ComboBox extends ComboBoxBase<ComboBoxProperties> {
 			}) : null,
 			v('button', {
 				'aria-controls': menuId,
-				bind: this,
 				classes: this.classes(css.arrow),
 				disabled,
 				readOnly,
@@ -404,7 +402,6 @@ export default class ComboBox extends ComboBoxBase<ComboBoxProperties> {
 
 		if (label) {
 			controls = w(Label, {
-				bind: this,
 				formId,
 				label
 			}, [ controls ]);
@@ -415,7 +412,6 @@ export default class ComboBox extends ComboBoxBase<ComboBoxProperties> {
 			'aria-haspopup': 'true',
 			'aria-readonly': readOnly ? 'true' : 'false',
 			'aria-required': required ? 'true' : 'false',
-			bind: this,
 			classes: this.classes(css.root),
 			key: 'root',
 			role: 'combobox'

--- a/src/combobox/ComboBox.ts
+++ b/src/combobox/ComboBox.ts
@@ -327,8 +327,7 @@ export default class ComboBox extends ComboBoxBase<ComboBoxProperties> {
 			return null;
 		}
 
-		return w('result-menu', <ResultMenuProperties> {
-			bind: this,
+		return w<ResultMenu>('result-menu', {
 			id: uuid(),
 			registry: this._registry,
 			results,
@@ -367,7 +366,6 @@ export default class ComboBox extends ComboBoxBase<ComboBoxProperties> {
 		}, [
 			w(TextInput, {
 				...inputProperties,
-				bind: this,
 				classes: this.classes(clearable ? css.clearable : null),
 				controls: menuId,
 				disabled,

--- a/src/combobox/ResultMenu.ts
+++ b/src/combobox/ResultMenu.ts
@@ -3,7 +3,7 @@ import { ThemeableMixin, ThemeableProperties, theme } from '@dojo/widget-core/mi
 import { RegistryMixin, RegistryMixinProperties } from '@dojo/widget-core/mixins/Registry';
 import { v, w } from '@dojo/widget-core/d';
 import { DNode, WNode } from '@dojo/widget-core/interfaces';
-import { ResultItemProperties } from './ResultItem';
+import ResultItem from './ResultItem';
 
 import * as css from './styles/comboBox.m.css';
 
@@ -53,7 +53,7 @@ export default class ResultMenu extends ResultMenuBase<ResultMenuProperties> {
 			theme = {}
 		} = this.properties;
 
-		const resultElements = this.renderResults(results.map((result, i) => w('result-item', <ResultItemProperties> {
+		const resultElements = this.renderResults(results.map((result, i) => w<ResultItem>('result-item', {
 			index: i,
 			key: String(i),
 			result,

--- a/src/radio/Radio.ts
+++ b/src/radio/Radio.ts
@@ -91,7 +91,6 @@ export default class Radio extends RadioBase<RadioProperties> {
 
 		const radio = v('div', { classes: this.classes(css.inputWrapper) }, [
 			v('input', {
-				bind: this,
 				classes: this.classes(css.input),
 				checked,
 				'aria-describedby': describedBy,

--- a/src/select/Select.ts
+++ b/src/select/Select.ts
@@ -205,7 +205,6 @@ export default class Select extends SelectBase<SelectProperties> {
 		} = this.properties;
 
 		const optionNodes = options.map((option, i) => w<SelectOption>('select-option', {
-			bind: this,
 			focused: this._focusedIndex === i,
 			index: i,
 			key: i + '',
@@ -271,7 +270,6 @@ export default class Select extends SelectBase<SelectProperties> {
 
 		return v('div', { classes: this.classes(css.inputWrapper) }, [
 			v('select', {
-				bind: this,
 				classes: this.classes(css.input),
 				'aria-describedby': describedBy,
 				disabled,
@@ -309,7 +307,6 @@ export default class Select extends SelectBase<SelectProperties> {
 
 		return v('div', { classes: this.classes(css.inputWrapper) }, [
 			v('div', {
-				bind: this,
 				role: 'listbox',
 				classes: this.classes(css.input),
 				disabled,
@@ -351,7 +348,6 @@ export default class Select extends SelectBase<SelectProperties> {
 			classes: this.classes(css.inputWrapper, _open ? css.open : null)
 		}, [
 			v('button', {
-				bind: this,
 				classes: this.classes(css.trigger, css.input),
 				disabled,
 				'aria-controls': _selectId,
@@ -366,7 +362,6 @@ export default class Select extends SelectBase<SelectProperties> {
 				onkeydown: this._onListboxKeyDown
 			}, [ selectedOption ? selectedOption.label : '' ]),
 			v('div', {
-				bind: this,
 				role: 'listbox',
 				id: _selectId,
 				classes: this.classes(css.dropdown),

--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -130,7 +130,6 @@ export default class Slider extends SliderBase<SliderProperties> {
 			styles: vertical ? { height: verticalHeight } : {}
 		}, [
 			v('input', {
-				bind: this,
 				classes: this.classes(css.input).fixed(css.nativeInput),
 				'aria-describedby': describedBy,
 				disabled,

--- a/src/textarea/Textarea.ts
+++ b/src/textarea/Textarea.ts
@@ -117,7 +117,6 @@ export default class Textarea extends TextareaBase<TextareaProperties> {
 
 		const textarea = v('div', { classes: this.classes(css.inputWrapper) }, [
 			v('textarea', {
-				bind: this,
 				classes: this.classes(css.input),
 				cols: columns ? columns + '' : null,
 				'aria-describedby': describedBy,

--- a/src/textinput/TextInput.ts
+++ b/src/textinput/TextInput.ts
@@ -116,7 +116,6 @@ export default class TextInput extends TextInputBase<TextInputProperties> {
 
 		const textinput = v('div', { classes: this.classes(css.inputWrapper) }, [
 			v('input', {
-				bind: this,
 				classes: this.classes(css.input),
 				'aria-controls': controls,
 				'aria-describedby': describedBy,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Prepping for the next release of `widget-core` that removes `bind` from both the `v()` and `w()` property interfaces. `bind` will automatically be added to all nodes from a `render` call using an `afterRender` in `WidgetBase`.

This means there is no way to pass `bind` when trying to assert with test-extras, so https://github.com/dojo/test-extras/issues/38 will need to be addressed first.