### PR TITLE
Revert to use safari 9.1

### DIFF
--- a/src/common/tests/intern.ts
+++ b/src/common/tests/intern.ts
@@ -23,7 +23,7 @@ export const environments = [
 	{ browserName: 'edge' },
 	{ browserName: 'firefox', platform: 'WINDOWS' },
 	{ browserName: 'chrome', platform: 'WINDOWS' },
-	{ browserName: 'safari', version: '10', platform: 'MAC' },
+	{ browserName: 'safari', version: '9.1', platform: 'MAC' },
 	{ browserName: 'iPhone', version: '9.1' }
 ];
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Revert to Safari 9.1 as Safari 10 is not working on browserstack
