### PR TITLE
Fix: clear SlidePane transform on reopen.

### DIFF
--- a/src/slidepane/SlidePane.ts
+++ b/src/slidepane/SlidePane.ts
@@ -148,7 +148,6 @@ export default class SlidePane extends SlidePaneBase<SlidePaneProperties> {
 			this._slideIn || (open && !this._wasOpen) ? css.slideIn : null,
 			!open && this._wasOpen ? css.slideOut : null
 		];
-		this._slideIn = false;
 
 		const contentStyles: {[key: string]: any} = {
 			transform: '',
@@ -159,9 +158,13 @@ export default class SlidePane extends SlidePaneBase<SlidePaneProperties> {
 			// If pane is closing because of swipe
 			contentStyles['transform'] = `translateX(${ align === Align.left ? '-' : '' }${ this._transform }%)`;
 		}
+		else if (this._slideIn && this._content) {
+			this._content.style.transform = '';
+		}
 
 		open && !this._wasOpen && onOpen && onOpen();
 		this._wasOpen = open;
+		this._slideIn = false;
 
 		return v('div', {
 			onmousedown: this._onSwipeStart,


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

After reopening a `SlidePane`, the CSS `transform` property should be reset to avoid interfering with animations.