### PR TITLE
Dialog readme and i18n update

### DIFF
--- a/src/dialog/Dialog.ts
+++ b/src/dialog/Dialog.ts
@@ -18,6 +18,7 @@ export type RoleType = 'dialog' | 'alertdialog';
  * Properties that can be set on a Dialog component
  *
  * @property closeable          Determines whether the dialog can be closed
+ * @property closeText          Hidden text used by screen readers to display for the close button
  * @property enterAnimation     CSS class to apply to the dialog when opened
  * @property exitAnimation      CSS class to apply to the dialog when closed
  * @property modal              Determines whether the dialog can be closed by clicking outside its content
@@ -30,6 +31,7 @@ export type RoleType = 'dialog' | 'alertdialog';
  */
 export interface DialogProperties extends ThemeableProperties {
 	closeable?: boolean;
+	closeText?: string;
 	enterAnimation?: string;
 	exitAnimation?: string;
 	modal?: boolean;
@@ -60,13 +62,14 @@ export default class Dialog extends DialogBase<DialogProperties> {
 	render(): DNode {
 		const {
 			closeable = true,
+			closeText = 'close dialog',
 			enterAnimation = animations.fadeIn,
 			exitAnimation = animations.fadeOut,
 			onOpen,
 			open = false,
 			role = 'dialog',
 			title = '',
-			underlay = false
+			underlay
 		} = this.properties;
 
 		open && !this._wasOpen && onOpen && onOpen();
@@ -97,7 +100,7 @@ export default class Dialog extends DialogBase<DialogProperties> {
 					title,
 					closeable ? v('button', {
 						classes: this.classes(css.close),
-						innerHTML: 'close dialog',
+						innerHTML: closeText,
 						onclick: this._onCloseClick
 					}) : null
 				]),

--- a/src/dialog/README.md
+++ b/src/dialog/README.md
@@ -1,11 +1,17 @@
 # @dojo/widgets/dialog/Dialog widget
-Dojo 2's `Dialog` component can be used to show content inside of a window over top of application content. It provides default styling for a titlebar, content area, underlay, and a close button, and will respond to different screen sizes responsively.
+
+Dojo 2's `Dialog` component can be used to show content inside a window over top the application content. It provides default styling for a titlebar, content area, underlay, and a close button, and will respond to different screen sizes responsively.
 
 ## Features
+
+- Can be used as a modal window or classic dialog
+- Possible to show a semi-transparent underlay
+- Custom CSS animations can be provided
 
 ![Image of basic dialog](http://placekitten.com/450/300)
 
 ### Accessibility Features
+
 - The titlebar and content have screen-reader-accessible labels and instructions
 - The close button is a `<button>` with screen-reader-accessible instructive text
 

--- a/src/dialog/README.md
+++ b/src/dialog/README.md
@@ -1,1 +1,55 @@
-# Dialog widget
+# @dojo/widgets/dialog/Dialog widget
+Dojo 2's `Dialog` component can be used to show content inside of a window over top of application content. It provides default styling for a titlebar, content area, underlay, and a close button, and will respond to different screen sizes responsively.
+
+## Features
+
+![Image of basic dialog](http://placekitten.com/450/300)
+
+### Accessibility Features
+- The titlebar and content have screen-reader-accessible labels and instructions
+- The close button is a `<button>` with screen-reader-accessible instructive text
+
+### i18n Features
+- A localized version of the close button instructive text can be passed in via the `closeText` property.
+
+## Example Usage
+
+*Basic Example*
+```js
+w(Dialog, {
+	title: 'My Dialog',
+	open: this.state.open,
+	onRequestClose: () => this.setState({ open: false })
+}, [ 'My dialog content...' ])
+```
+
+*Modal with underlay*
+```js
+w(Dialog, {
+	title: 'My Dialog',
+	open: this.state.open,
+	modal: true,
+	underlay: true,
+	onRequestClose: () => this.setState({ open: false })
+}, [ 'My dialog content...' ])
+```
+
+*Custom animations*
+```js
+w(Dialog, {
+	title: 'My Dialog',
+	open: this.state.open,
+	enterAnimation: 'fly-in',
+	exitAnimation: 'fly-out',
+	onRequestClose: () => this.setState({ open: false })
+}, [ 'My dialog content...' ])
+```
+
+*Dialog that can't be closed*
+```js
+w(Dialog, {
+	title: 'My Dialog',
+	open: this.state.open,
+	closeable: false
+}, [ 'My dialog content...' ])
+```

--- a/src/dialog/README.md
+++ b/src/dialog/README.md
@@ -18,6 +18,17 @@ Dojo 2's `Dialog` component can be used to show content inside a window over top
 ### i18n Features
 - A localized version of the close button instructive text can be passed in via the `closeText` property.
 
+## Themeing
+
+The following CSS classes are used to style the `Dialog` widget and should be provided by custom themes:
+
+- `close`: Applied to the close button in the titlebar.
+- `content`: Applied to content of the dialog window.
+- `main`: Applied to dialog window itself that includes both the titlebar and the content window.
+- `root`: Applied to the top-level wrapper node.
+- `title`: Applied to the titlebar of the dialog window.
+- `underlayVisible`: Applied to the application mask behind a dialog with an underlay.
+
 ## Example Usage
 
 *Basic Example*

--- a/src/dialog/README.md
+++ b/src/dialog/README.md
@@ -21,7 +21,10 @@ Dojo 2's `Dialog` component can be used to show content inside a window over top
 ## Example Usage
 
 *Basic Example*
-```js
+```typescript
+import Dialog from '@dojo/widgets/dialog/Dialog';
+import { w } from '@dojo/widget-core/d';
+
 w(Dialog, {
 	title: 'My Dialog',
 	open: this.state.open,
@@ -30,7 +33,10 @@ w(Dialog, {
 ```
 
 *Modal with underlay*
-```js
+```typescript
+import Dialog from '@dojo/widgets/dialog/Dialog';
+import { w } from '@dojo/widget-core/d';
+
 w(Dialog, {
 	title: 'My Dialog',
 	open: this.state.open,
@@ -41,7 +47,10 @@ w(Dialog, {
 ```
 
 *Custom animations*
-```js
+```typescript
+import Dialog from '@dojo/widgets/dialog/Dialog';
+import { w } from '@dojo/widget-core/d';
+
 w(Dialog, {
 	title: 'My Dialog',
 	open: this.state.open,
@@ -52,7 +61,10 @@ w(Dialog, {
 ```
 
 *Dialog that can't be closed*
-```js
+```typescript
+import Dialog from '@dojo/widgets/dialog/Dialog';
+import { w } from '@dojo/widget-core/d';
+
 w(Dialog, {
 	title: 'My Dialog',
 	open: this.state.open,

--- a/src/dialog/createDialogElement.ts
+++ b/src/dialog/createDialogElement.ts
@@ -14,6 +14,10 @@ export default function createDialogElement(): CustomElementDescriptor {
 				value: value => value === 'false' || value === '0' ? false : true
 			},
 			{
+				attributeName: 'closetext',
+				propertyName: 'closeText'
+			},
+			{
 				attributeName: 'enteranimation',
 				propertyName: 'enterAnimation'
 			},

--- a/src/dialog/tests/unit/Dialog.ts
+++ b/src/dialog/tests/unit/Dialog.ts
@@ -16,6 +16,7 @@ registerSuite({
 			title: 'dialog',
 			underlay: true,
 			closeable: true,
+			closeText: 'foo',
 			role: 'dialog'
 		});
 
@@ -25,6 +26,7 @@ registerSuite({
 		assert.strictEqual(dialog.properties.title, 'dialog');
 		assert.isTrue(dialog.properties.underlay);
 		assert.isTrue(dialog.properties.closeable);
+		assert.strictEqual(dialog.properties.closeText, 'foo');
 		assert.strictEqual(dialog.properties.role, 'dialog');
 	},
 
@@ -33,7 +35,8 @@ registerSuite({
 		dialog.__setProperties__({
 			enterAnimation: 'enter',
 			exitAnimation: 'exit',
-			role: 'dialog'
+			role: 'dialog',
+			closeText: 'foo'
 		});
 		let vnode = <VNode> dialog.__render__();
 		assert.strictEqual(vnode.vnodeSelector, 'div', 'tagname should be div');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

This PR adds an initial readme for the Dialog based on Andy's template. The aim was to include a general description, pertinent a11y and i18n information, and to show common example uses, while avoiding API documentation. This PR also adds one property to the Dialog for i18n, a shortcoming discovered during the readme authoring.

Resolves #183 
