### PR TITLE
Fix error in previous slider pr

### DIFF
--- a/src/slider/styles/slider.m.css
+++ b/src/slider/styles/slider.m.css
@@ -5,7 +5,7 @@
 }
 
 .rootFixed {
-	display: inline-block;
+	display: block;
 }
 
 .inputWrapper {


### PR DESCRIPTION
**Type:** bug

`display` should not have been set to `inline-block`. It needs to be `block` to fill the space it is provided with.