### PR TITLE
Remove unnecessary type casting in examples

### DIFF
--- a/src/button/example/index.ts
+++ b/src/button/example/index.ts
@@ -3,7 +3,7 @@ import { WidgetProperties } from '@dojo/widget-core/interfaces';
 import { StatefulMixin } from '@dojo/widget-core/mixins/Stateful';
 import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { w, v } from '@dojo/widget-core/d';
-import Button, { ButtonType } from '../../button/Button';
+import Button from '../../button/Button';
 import dojoTheme from '../../themes/dojo/theme';
 
 export const AppBase = StatefulMixin(WidgetBase);
@@ -52,7 +52,7 @@ export class App extends AppBase<WidgetProperties> {
 					content: 'Open',
 					disabled: true,
 					popup: { expanded: false, id: 'fakeId' },
-					type: <ButtonType> 'menu'
+					type: 'menu'
 				})
 			]),
 			v('div', { id: 'example-3' }, [
@@ -63,7 +63,7 @@ export class App extends AppBase<WidgetProperties> {
 					key: 'b3',
 					theme: this._theme,
 					content: 'Button state',
-					pressed: <boolean> this.state.buttonPressed,
+					pressed: this.state.buttonPressed,
 					onClick: this.toggleButton
 				})
 			])

--- a/src/checkbox/example/index.ts
+++ b/src/checkbox/example/index.ts
@@ -47,7 +47,7 @@ export class App extends AppBase<WidgetProperties> {
 				v('div', { id: 'example-1' }, [
 					w(Checkbox, {
 						key: 'c1',
-						checked: <boolean> c1,
+						checked: c1,
 						label: 'Sample checkbox that starts checked',
 						value: 'c1',
 						onChange: this.onChange,
@@ -58,7 +58,7 @@ export class App extends AppBase<WidgetProperties> {
 				v('div', { id: 'example-2' }, [
 					w(Checkbox, {
 						key: 'c2',
-						checked: <boolean> c2,
+						checked: c2,
 						label: 'Sample disabled checkbox',
 						disabled: true,
 						value: 'c2',
@@ -70,7 +70,7 @@ export class App extends AppBase<WidgetProperties> {
 				v('div', { id: 'example-3' }, [
 					w(Checkbox, {
 						key: 'c3',
-						checked: <boolean> c3,
+						checked: c3,
 						label: 'Required checkbox',
 						required: true,
 						value: 'c3',
@@ -82,7 +82,7 @@ export class App extends AppBase<WidgetProperties> {
 				v('div', { id: 'example-4' }, [
 					w(Checkbox, {
 						key: 'c4',
-						checked: <boolean> c4,
+						checked: c4,
 						label: 'Checkbox in "toggle" mode',
 						mode: Mode.toggle,
 						value: 'c4',
@@ -94,7 +94,7 @@ export class App extends AppBase<WidgetProperties> {
 				v('div', { id: 'example-5' }, [
 					w(Checkbox, {
 						key: 'c5',
-						checked: <boolean> c5,
+						checked: c5,
 						label: 'Disabled toggle mode',
 						onLabel: 'On',
 						offLabel: 'Off',

--- a/src/combobox/example/index.ts
+++ b/src/combobox/example/index.ts
@@ -5,7 +5,7 @@ import { v, w } from '@dojo/widget-core/d';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { WidgetProperties } from '@dojo/widget-core/interfaces';
 import ComboBox from '../ComboBox';
-import ResultItem, { ResultItemProperties } from '../ResultItem';
+import ResultItem from '../ResultItem';
 import ResultMenu from '../ResultMenu';
 import dojoTheme from '../../themes/dojo/theme';
 
@@ -82,7 +82,7 @@ class CustomResultItem extends ResultItem {
 
 class CustomResultMenu extends ResultMenu {
 	renderResults(results: WNode[]) {
-		const items: any[] = [
+		const items: DNode[] = [
 			v('div', {
 				styles: {
 					fontWeight: 'bold',
@@ -94,8 +94,8 @@ class CustomResultMenu extends ResultMenu {
 
 		let lastLetter = 'a';
 
-		results.forEach(item => {
-			let state = (<ResultItemProperties> (<WNode> item).properties).result.value;
+		results.forEach((item: WNode<ResultItem>) => {
+			let state = item.properties.result.value;
 			let letter = state.charAt(0).toLowerCase();
 			if (letter !== lastLetter) {
 				items.push(v('div', {
@@ -147,10 +147,10 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 				key: '2',
 				clearable: true,
 				onChange: (value: string) => this.setState({ 'value2': value }),
-				getResultLabel: (result: any) => <string> result.value,
+				getResultLabel: (result: any) => result.value,
 				onRequestResults: this.onRequestResults,
-				results: <any[]> this.state['results'],
-				value: <string> this.state['value2'],
+				results: this.state.results,
+				value: this.state.value2,
 				inputProperties: {
 					placeholder: 'Enter a value'
 				},
@@ -161,10 +161,10 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 				key: '1',
 				openOnFocus: true,
 				onChange: (value: string) => this.setState({ 'value1': value }),
-				getResultLabel: (result: any) => <string> result.value,
+				getResultLabel: (result: any) => result.value,
 				onRequestResults: this.onRequestResults,
-				results: <any[]> this.state['results'],
-				value: <string> this.state['value1'],
+				results: this.state.results,
+				value: this.state.value1,
 				inputProperties: {
 					placeholder: 'Enter a value'
 				},
@@ -175,11 +175,11 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 				key: '3',
 				openOnFocus: true,
 				onChange: (value: string) => this.setState({ 'value3': value }),
-				getResultLabel: (result: any) => <string> result.value,
+				getResultLabel: (result: any) => result.value,
 				onRequestResults: this.onRequestResults,
 				customResultItem: CustomResultItem,
-				results: <any[]> this.state['results'],
-				value: <string> this.state['value3'],
+				results: this.state.results,
+				value: this.state.value3,
 				inputProperties: {
 					placeholder: 'Enter a value'
 				},
@@ -189,10 +189,10 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 			w(ComboBox, {
 				key: '4',
 				onChange: (value: string) => this.setState({ 'value4': value }),
-				getResultLabel: (result: any) => <string> result.value,
+				getResultLabel: (result: any) => result.value,
 				onRequestResults: this.onRequestResults,
-				results: <any[]> this.state['results'],
-				value: <string> this.state['value4'],
+				results: this.state.results,
+				value: this.state.value4,
 				customResultMenu: CustomResultMenu,
 				inputProperties: {
 					placeholder: 'Enter a value'
@@ -203,10 +203,10 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 			w(ComboBox, {
 				key: '5',
 				onChange: (value: string) => this.setState({ 'value5': value }),
-				getResultLabel: (result: any) => <string> result.value,
+				getResultLabel: (result: any) => result.value,
 				onRequestResults: this.onRequestResults,
-				results: <any[]> this.state['results'],
-				value: <string> this.state['value5'],
+				results: this.state.results,
+				value: this.state.value5,
 				isResultDisabled: (result: any) => result.value.length > 9,
 				inputProperties: {
 					placeholder: 'Enter a value'
@@ -235,10 +235,10 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 			w(ComboBox, {
 				key: '8',
 				onChange: (value: string) => this.setState({ 'value8': value }),
-				getResultLabel: (result: any) => <string> result.value,
+				getResultLabel: (result: any) => result.value,
 				onRequestResults: this.onRequestResults,
-				results: <any[]> this.state['results'],
-				value: <string> this.state['value8'],
+				results: this.state.results,
+				value: this.state.value8,
 				label: 'Enter a value',
 				theme: this._theme
 			}),
@@ -250,11 +250,11 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 					'value9': value,
 					invalid: value.trim().length === 0
 				}),
-				getResultLabel: (result: any) => <string> result.value,
+				getResultLabel: (result: any) => result.value,
 				onRequestResults: this.onRequestResults,
-				results: <any[]> this.state['results'],
-				value: <string> this.state['value9'],
-				invalid: <boolean> this.state.invalid,
+				results: this.state.results,
+				value: this.state.value9,
+				invalid: this.state.invalid,
 				inputProperties: {
 					placeholder: 'Enter a value'
 				},

--- a/src/combobox/example/index.ts
+++ b/src/combobox/example/index.ts
@@ -146,7 +146,9 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 			w(ComboBox, {
 				key: '2',
 				clearable: true,
-				onChange: (value: string) => this.setState({ 'value2': value }),
+				onChange: (value: string) => {
+					this.setState({ 'value2': value });
+				},
 				getResultLabel: (result: any) => result.value,
 				onRequestResults: this.onRequestResults,
 				results: this.state.results,
@@ -160,7 +162,9 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 			w(ComboBox, {
 				key: '1',
 				openOnFocus: true,
-				onChange: (value: string) => this.setState({ 'value1': value }),
+				onChange: (value: string) => {
+					this.setState({ 'value1': value });
+				},
 				getResultLabel: (result: any) => result.value,
 				onRequestResults: this.onRequestResults,
 				results: this.state.results,
@@ -174,7 +178,9 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 			w(ComboBox, {
 				key: '3',
 				openOnFocus: true,
-				onChange: (value: string) => this.setState({ 'value3': value }),
+				onChange: (value: string) => {
+					this.setState({ 'value3': value });
+				},
 				getResultLabel: (result: any) => result.value,
 				onRequestResults: this.onRequestResults,
 				customResultItem: CustomResultItem,
@@ -188,7 +194,9 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 			v('h3', ['Custom menu renderer']),
 			w(ComboBox, {
 				key: '4',
-				onChange: (value: string) => this.setState({ 'value4': value }),
+				onChange: (value: string) => {
+					this.setState({ 'value4': value });
+				},
 				getResultLabel: (result: any) => result.value,
 				onRequestResults: this.onRequestResults,
 				results: this.state.results,
@@ -202,7 +210,9 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 			v('h3', ['Disabled menu items']),
 			w(ComboBox, {
 				key: '5',
-				onChange: (value: string) => this.setState({ 'value5': value }),
+				onChange: (value: string) => {
+					this.setState({ 'value5': value });
+				},
 				getResultLabel: (result: any) => result.value,
 				onRequestResults: this.onRequestResults,
 				results: this.state.results,
@@ -234,7 +244,9 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 			v('h3', ['Label']),
 			w(ComboBox, {
 				key: '8',
-				onChange: (value: string) => this.setState({ 'value8': value }),
+				onChange: (value: string) => {
+					this.setState({ 'value8': value });
+				},
 				getResultLabel: (result: any) => result.value,
 				onRequestResults: this.onRequestResults,
 				results: this.state.results,
@@ -246,10 +258,12 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 			w(ComboBox, {
 				key: '9',
 				required: true,
-				onChange: (value: string) => this.setState({
-					'value9': value,
-					invalid: value.trim().length === 0
-				}),
+				onChange: (value: string) => {
+					this.setState({
+						'value9': value,
+						invalid: value.trim().length === 0
+					});
+				},
 				getResultLabel: (result: any) => result.value,
 				onRequestResults: this.onRequestResults,
 				results: this.state.results,

--- a/src/dialog/example/index.ts
+++ b/src/dialog/example/index.ts
@@ -41,7 +41,9 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 				modal: this.state.modal,
 				underlay: this.state.underlay,
 				closeable: this.state.closeable,
-				onRequestClose: () => this.setState({ open: false }),
+				onRequestClose: () => {
+					this.setState({ open: false });
+				},
 				theme: this._theme
 			}, [
 				`Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/src/dialog/example/index.ts
+++ b/src/dialog/example/index.ts
@@ -37,13 +37,11 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 			w(Dialog, {
 				key: 'dialog',
 				title: 'Dialog',
-				open: <boolean> this.state['open'],
-				modal: <boolean> this.state['modal'],
-				underlay: <boolean> this.state['underlay'],
-				closeable: <boolean> this.state['closeable'],
-				onRequestClose: () => {
-					this.setState({ open: false });
-				},
+				open: this.state.open,
+				modal: this.state.modal,
+				underlay: this.state.underlay,
+				closeable: this.state.closeable,
+				onRequestClose: () => this.setState({ open: false }),
 				theme: this._theme
 			}, [
 				`Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/src/select/example/index.ts
+++ b/src/select/example/index.ts
@@ -110,7 +110,9 @@ export class App extends AppBase<WidgetProperties> {
 				useNativeElement: true,
 				value: this.state.value1,
 				theme: this._theme,
-				onChange: (option: OptionData) => this.setState({ value1: option.value })
+				onChange: (option: OptionData) => {
+					this.setState({ value1: option.value });
+				}
 			}),
 			v('p', {
 				innerHTML: 'Result value: ' + this.state.value1
@@ -123,7 +125,9 @@ export class App extends AppBase<WidgetProperties> {
 				options: this._selectOptions,
 				value: this.state.value2,
 				theme: this._theme,
-				onChange: (option: OptionData) => this.setState({ value2: option.value })
+				onChange: (option: OptionData) => {
+					this.setState({ value2: option.value });
+				}
 			}),
 			v('h2', {}, [ 'Native multiselect widget' ]),
 			w(Select, {

--- a/src/select/example/index.ts
+++ b/src/select/example/index.ts
@@ -108,14 +108,12 @@ export class App extends AppBase<WidgetProperties> {
 				label: 'Try changing me',
 				options: this._selectOptions,
 				useNativeElement: true,
-				value: <string> this.state['value1'],
+				value: this.state.value1,
 				theme: this._theme,
-				onChange: (option: OptionData) => {
-					this.setState({ value1: option.value });
-				}
+				onChange: (option: OptionData) => this.setState({ value1: option.value })
 			}),
 			v('p', {
-				innerHTML: 'Result value: ' + this.state['value1']
+				innerHTML: 'Result value: ' + this.state.value1
 			}),
 			v('h2', {}, [ 'Custom Select Box, single select:' ]),
 			w(Select, {
@@ -123,11 +121,9 @@ export class App extends AppBase<WidgetProperties> {
 				customOption: CustomOption,
 				label: 'Custom box!',
 				options: this._selectOptions,
-				value: <string> this.state['value2'],
+				value: this.state.value2,
 				theme: this._theme,
-				onChange: (option: OptionData) => {
-					this.setState({ value2: option.value });
-				}
+				onChange: (option: OptionData) => this.setState({ value2: option.value })
 			}),
 			v('h2', {}, [ 'Native multiselect widget' ]),
 			w(Select, {
@@ -138,6 +134,7 @@ export class App extends AppBase<WidgetProperties> {
 				theme: this._theme,
 				onChange: (option: OptionData) => {
 					option.selected = !option.selected;
+					this.invalidate();
 				}
 			}),
 			v('h2', {}, [ 'Custom multiselect widget' ]),

--- a/src/slidepane/example/index.ts
+++ b/src/slidepane/example/index.ts
@@ -32,12 +32,10 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 		return v('div', [
 			w(SlidePane, {
 				key: 'pane',
-				open: <boolean> this.state['open'],
-				underlay: <boolean> this.state['underlay'],
-				align: <Align> this.state['align'],
-				onRequestClose: () => {
-					this.setState({ open: false });
-				},
+				open: this.state.open,
+				underlay: this.state.underlay,
+				align: this.state.align,
+				onRequestClose: () => this.setState({ open: false }),
 				theme: this._theme
 			}, [
 				`Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/src/slidepane/example/index.ts
+++ b/src/slidepane/example/index.ts
@@ -35,7 +35,9 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 				open: this.state.open,
 				underlay: this.state.underlay,
 				align: this.state.align,
-				onRequestClose: () => this.setState({ open: false }),
+				onRequestClose: () => {
+					this.setState({ open: false });
+				},
 				theme: this._theme
 			}, [
 				`Lorem ipsum dolor sit amet, consectetur adipiscing elit.

--- a/src/slider/example/index.ts
+++ b/src/slider/example/index.ts
@@ -58,7 +58,7 @@ export class App extends AppBase<WidgetProperties> {
 					else { return 'I permanently altered the ecology of a planet for my tribbles'; }
 				},
 				step: 1,
-				value: <number> tribbleValue,
+				value: tribbleValue,
 				onInput: this.onTribbleInput,
 				theme: this._theme
 			}),
@@ -66,9 +66,9 @@ export class App extends AppBase<WidgetProperties> {
 			w(Slider, {
 				key: 's2',
 				label: 'Vertical Slider with default properties. Anything over 50 is invalid:',
-				value: <number> verticalValue,
+				value: verticalValue,
 				vertical: true,
-				invalid: <boolean> verticalInvalid,
+				invalid: verticalInvalid,
 				output: (value: number) => {
 					return v('span', {
 						innerHTML: verticalInvalid ? value + ' !' : value + '',

--- a/src/splitpane/example/index.ts
+++ b/src/splitpane/example/index.ts
@@ -45,7 +45,7 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 					key: 'row',
 					direction: Direction.row,
 					onResize: (size: number) => this.setState({ rowSize: size }),
-					size: <number> this.state.rowSize,
+					size: this.state.rowSize,
 					theme: this._theme
 				})
 			]),
@@ -57,7 +57,7 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 					key: 'column',
 					direction: Direction.column,
 					onResize: (size: number) => this.setState({ columnSize: size }),
-					size: <number> this.state.columnSize,
+					size: this.state.columnSize,
 					theme: this._theme
 				})
 			]),
@@ -69,12 +69,12 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 					key: 'nested',
 					direction: Direction.row,
 					onResize: (size: number) => this.setState({ nestedSizeA: size }),
-					size: <number> this.state.nestedSizeA,
+					size: this.state.nestedSizeA,
 					theme: this._theme,
 					trailing: w(SplitPane, {
 						direction: Direction.column,
 						onResize: (size: number) => this.setState({ nestedSizeB: size }),
-						size: <number> this.state.nestedSizeB,
+						size: this.state.nestedSizeB,
 						theme: this._theme
 					})
 				})
@@ -87,12 +87,12 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 					key: 'verticalNested',
 					direction: Direction.row,
 					onResize: (size: number) => this.setState({ nestedSizeC: size }),
-					size: <number> this.state.nestedSizeC,
+					size: this.state.nestedSizeC,
 					theme: this._theme,
 					trailing: w(SplitPane, {
 						direction: Direction.row,
 						onResize: (size: number) => this.setState({ nestedSizeD: size }),
-						size: <number> this.state.nestedSizeD,
+						size: this.state.nestedSizeD,
 						theme: this._theme
 					})
 				})
@@ -105,12 +105,12 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 					key: 'horizontalNested',
 					direction: Direction.column,
 					onResize: (size: number) => this.setState({ nestedSizeE: size }),
-					size: <number> this.state.nestedSizeE,
+					size: this.state.nestedSizeE,
 					theme: this._theme,
 					trailing: w(SplitPane, {
 						direction: Direction.column,
 						onResize: (size: number) => this.setState({ nestedSizeF: size }),
-						size: <number> this.state.nestedSizeF,
+						size: this.state.nestedSizeF,
 						theme: this._theme
 					})
 				})
@@ -126,7 +126,7 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 						size = size > 300 ? 300 : size;
 						this.setState({ maxSize: size });
 					},
-					size: <number> this.state.maxSize,
+					size: this.state.maxSize,
 					theme: this._theme
 				})
 			]),
@@ -141,7 +141,7 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 						size = size < 100 ? 100 : size;
 						this.setState({ minSize: size });
 					},
-					size: <number> this.state.minSize,
+					size: this.state.minSize,
 					theme: this._theme
 				})
 			])

--- a/src/splitpane/example/index.ts
+++ b/src/splitpane/example/index.ts
@@ -44,7 +44,9 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 				w(SplitPane, {
 					key: 'row',
 					direction: Direction.row,
-					onResize: (size: number) => this.setState({ rowSize: size }),
+					onResize: (size: number) => {
+						this.setState({ rowSize: size });
+					},
 					size: this.state.rowSize,
 					theme: this._theme
 				})
@@ -56,7 +58,9 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 				w(SplitPane, {
 					key: 'column',
 					direction: Direction.column,
-					onResize: (size: number) => this.setState({ columnSize: size }),
+					onResize: (size: number) => {
+						this.setState({ columnSize: size });
+					},
 					size: this.state.columnSize,
 					theme: this._theme
 				})
@@ -68,12 +72,16 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 				w(SplitPane, {
 					key: 'nested',
 					direction: Direction.row,
-					onResize: (size: number) => this.setState({ nestedSizeA: size }),
+					onResize: (size: number) => {
+						this.setState({ nestedSizeA: size });
+					},
 					size: this.state.nestedSizeA,
 					theme: this._theme,
 					trailing: w(SplitPane, {
 						direction: Direction.column,
-						onResize: (size: number) => this.setState({ nestedSizeB: size }),
+						onResize: (size: number) => {
+							this.setState({ nestedSizeB: size });
+						},
 						size: this.state.nestedSizeB,
 						theme: this._theme
 					})
@@ -86,12 +94,16 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 				w(SplitPane, {
 					key: 'verticalNested',
 					direction: Direction.row,
-					onResize: (size: number) => this.setState({ nestedSizeC: size }),
+					onResize: (size: number) => {
+						this.setState({ nestedSizeC: size });
+					},
 					size: this.state.nestedSizeC,
 					theme: this._theme,
 					trailing: w(SplitPane, {
 						direction: Direction.row,
-						onResize: (size: number) => this.setState({ nestedSizeD: size }),
+						onResize: (size: number) => {
+							this.setState({ nestedSizeD: size });
+						},
 						size: this.state.nestedSizeD,
 						theme: this._theme
 					})
@@ -104,12 +116,16 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 				w(SplitPane, {
 					key: 'horizontalNested',
 					direction: Direction.column,
-					onResize: (size: number) => this.setState({ nestedSizeE: size }),
+					onResize: (size: number) => {
+						this.setState({ nestedSizeE: size });
+					},
 					size: this.state.nestedSizeE,
 					theme: this._theme,
 					trailing: w(SplitPane, {
 						direction: Direction.column,
-						onResize: (size: number) => this.setState({ nestedSizeF: size }),
+						onResize: (size: number) => {
+							this.setState({ nestedSizeF: size });
+						},
 						size: this.state.nestedSizeF,
 						theme: this._theme
 					})

--- a/src/tabpane/example/index.ts
+++ b/src/tabpane/example/index.ts
@@ -76,7 +76,9 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 				theme: this._theme,
 				activeIndex: activeIndex,
 				alignButtons: align,
-				onRequestTabClose: (index: number, key: string) => this.setState({ closedKeys: [...closedKeys, key] }),
+				onRequestTabClose: (index: number, key: string) => {
+					this.setState({ closedKeys: [...closedKeys, key] });
+				},
 				onRequestTabChange: (index: number, key: string) => {
 					refresh && refresh.cancel();
 					if (key === 'async') {
@@ -84,7 +86,9 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 							activeIndex: 2,
 							loading: true
 						});
-						refresh = refreshData().then(() => this.setState({ loading: false }));
+						refresh = refreshData().then(() => {
+							this.setState({ loading: false });
+						});
 					}
 					else {
 						this.setState({ activeIndex: index });

--- a/src/tabpane/example/index.ts
+++ b/src/tabpane/example/index.ts
@@ -74,8 +74,8 @@ export class App extends StatefulMixin(WidgetBase)<WidgetProperties> {
 			]),
 			w(TabPane, {
 				theme: this._theme,
-				activeIndex: <number> activeIndex,
-				alignButtons: <Align> align,
+				activeIndex: activeIndex,
+				alignButtons: align,
 				onRequestTabClose: (index: number, key: string) => this.setState({ closedKeys: [...closedKeys, key] }),
 				onRequestTabChange: (index: number, key: string) => {
 					refresh && refresh.cancel();

--- a/src/textarea/example/index.ts
+++ b/src/textarea/example/index.ts
@@ -33,7 +33,9 @@ export class App extends AppBase<WidgetProperties> {
 				placeholder: 'Hello, World',
 				label: 'Type Something',
 				value: this.state.value1,
-				onChange: (event: Event) => this.setState({ value1: (<HTMLInputElement> event.target).value }),
+				onChange: (event: Event) => {
+					this.setState({ value1: (<HTMLInputElement> event.target).value });
+				},
 				theme: this._theme
 			}),
 			v('h3', {}, ['Disabled Textarea']),

--- a/src/textarea/example/index.ts
+++ b/src/textarea/example/index.ts
@@ -32,8 +32,8 @@ export class App extends AppBase<WidgetProperties> {
 				rows: 8,
 				placeholder: 'Hello, World',
 				label: 'Type Something',
-				value: <string> this.state['value1'],
-				onChange: (event: Event) => this.setState({ 'value1': (<HTMLInputElement> event.target).value }),
+				value: this.state.value1,
+				onChange: (event: Event) => this.setState({ value1: (<HTMLInputElement> event.target).value }),
 				theme: this._theme
 			}),
 			v('h3', {}, ['Disabled Textarea']),
@@ -53,11 +53,11 @@ export class App extends AppBase<WidgetProperties> {
 				rows: 8,
 				label: 'Required',
 				required: true,
-				value: <string> this.state['value2'],
-				invalid: <boolean | undefined> this.state.invalid,
+				value: this.state.value2,
+				invalid: this.state.invalid,
 				onChange: (event: Event) => {
 					const value = (<HTMLInputElement> event.target).value;
-					this.setState({ 'value2': value });
+					this.setState({ value2: value });
 					this.setState({ invalid: value.trim().length === 0 });
 				},
 				theme: this._theme

--- a/src/textinput/example/index.ts
+++ b/src/textinput/example/index.ts
@@ -3,7 +3,7 @@ import { WidgetProperties } from '@dojo/widget-core/interfaces';
 import { StatefulMixin } from '@dojo/widget-core/mixins/Stateful';
 import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { v, w } from '@dojo/widget-core/d';
-import TextInput, { TextInputType } from '../../textinput/TextInput';
+import TextInput from '../../textinput/TextInput';
 import dojoTheme from '../../themes/dojo/theme';
 
 export const AppBase = StatefulMixin(WidgetBase);
@@ -31,10 +31,10 @@ export class App extends AppBase<WidgetProperties> {
 				w(TextInput, {
 					key: 't1',
 					label: 'Name',
-					type: <TextInputType> 'text',
+					type: 'text',
 					placeholder: 'Hello, World',
-					value: <string> this.state['value1'],
-					onChange: (event: Event) => this.setState({ 'value1': (<HTMLInputElement> event.target).value }),
+					value: this.state.value1,
+					onChange: (event: Event) => this.setState({ value1: (<HTMLInputElement> event.target).value }),
 					theme: this._theme
 				})
 			]),
@@ -42,14 +42,14 @@ export class App extends AppBase<WidgetProperties> {
 				v('h3', {}, ['Label before the input']),
 				w(TextInput, {
 					key: 't2',
-					type: <TextInputType> 'email',
+					type: 'email',
 					label: {
 						before: true,
 						content: 'Email (required)'
 					},
 					required: true,
-					value: <string> this.state['value2'],
-					onChange: (event: Event) => this.setState({ 'value2': (<HTMLInputElement> event.target).value }),
+					value: this.state.value2,
+					onChange: (event: Event) => this.setState({ value2: (<HTMLInputElement> event.target).value }),
 					theme: this._theme
 				})
 			]),
@@ -57,15 +57,15 @@ export class App extends AppBase<WidgetProperties> {
 				v('h3', {}, ['Hidden accessible label']),
 				w(TextInput, {
 					key: 't3',
-					type: <TextInputType> 'text',
+					type: 'text',
 					placeholder: 'Type something...',
 					label: {
 						content: 'Try listening to me!',
 						before: false,
 						hidden: true
 					},
-					value: <string> this.state['value3'],
-					onChange: (event: Event) => this.setState({ 'value3': (<HTMLInputElement> event.target).value }),
+					value: this.state.value3,
+					onChange: (event: Event) => this.setState({ value3: (<HTMLInputElement> event.target).value }),
 					theme: this._theme
 				})
 			]),
@@ -73,7 +73,7 @@ export class App extends AppBase<WidgetProperties> {
 				v('h3', {}, ['Disabled text input']),
 				w(TextInput, {
 					key: 't4',
-					type: <TextInputType> 'text',
+					type: 'text',
 					label: 'Can\'t type here',
 					value: 'Initial value',
 					disabled: true,
@@ -85,13 +85,13 @@ export class App extends AppBase<WidgetProperties> {
 				v('h3', {}, ['Validated Input']),
 				w(TextInput, {
 					key: 't5',
-					type: <TextInputType> 'text',
+					type: 'text',
 					label: 'Type "foo" or "bar"',
-					value: <string> this.state['value4'],
-					invalid: <boolean | undefined> this.state.invalid,
+					value: this.state.value4,
+					invalid: this.state.invalid,
 					onChange: (event: Event) => {
 						const value = (<HTMLInputElement> event.target).value;
-						this.setState({ 'value4': value });
+						this.setState({ value4: value });
 						this.setState({ invalid: value.toLowerCase() !== 'foo' && value.toLowerCase() !== 'bar' });
 					},
 					theme: this._theme

--- a/src/textinput/example/index.ts
+++ b/src/textinput/example/index.ts
@@ -34,7 +34,9 @@ export class App extends AppBase<WidgetProperties> {
 					type: 'text',
 					placeholder: 'Hello, World',
 					value: this.state.value1,
-					onChange: (event: Event) => this.setState({ value1: (<HTMLInputElement> event.target).value }),
+					onChange: (event: Event) => {
+						this.setState({ value1: (<HTMLInputElement> event.target).value });
+					},
 					theme: this._theme
 				})
 			]),
@@ -49,7 +51,9 @@ export class App extends AppBase<WidgetProperties> {
 					},
 					required: true,
 					value: this.state.value2,
-					onChange: (event: Event) => this.setState({ value2: (<HTMLInputElement> event.target).value }),
+					onChange: (event: Event) => {
+						this.setState({ value2: (<HTMLInputElement> event.target).value });
+					},
 					theme: this._theme
 				})
 			]),
@@ -65,7 +69,9 @@ export class App extends AppBase<WidgetProperties> {
 						hidden: true
 					},
 					value: this.state.value3,
-					onChange: (event: Event) => this.setState({ value3: (<HTMLInputElement> event.target).value }),
+					onChange: (event: Event) => {
+						this.setState({ value3: (<HTMLInputElement> event.target).value });
+					},
 					theme: this._theme
 				})
 			]),


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR removes once-necessary type casting from examples. The issue was evident when grabbing values from state and passing them to child components as properties.

Resolves #217 
