### PR TITLE
Update Button to use `this.children`

### DIFF
--- a/src/button/Button.ts
+++ b/src/button/Button.ts
@@ -11,7 +11,6 @@ export type ButtonType = 'submit' | 'reset' | 'button' | 'menu';
  *
  * Properties that can be set on a Button component
  *
- * @property content        Text content of button
  * @property describedBy    ID of element with descriptive text
  * @property disabled       Whether the button is disabled or clickable
  * @property popup       		Controls aria-haspopup, aria-expanded, and aria-controls for popup buttons
@@ -32,7 +31,6 @@ export type ButtonType = 'submit' | 'reset' | 'button' | 'menu';
  * @property onTouchStart   Called on the button's touchstart event
  */
 export interface ButtonProperties extends ThemeableProperties {
-	content?: string;
 	describedBy?: string;
 	disabled?: boolean;
 	id?: string;
@@ -72,7 +70,6 @@ export default class Button extends ButtonBase<ButtonProperties> {
 
 	render(): DNode {
 		let {
-			content = '',
 			describedBy,
 			disabled,
 			id,
@@ -88,7 +85,6 @@ export default class Button extends ButtonBase<ButtonProperties> {
 		}
 
 		return v('button', {
-			innerHTML: content,
 			classes: this.classes(
 				css.root,
 				disabled ? css.disabled : null,
@@ -116,6 +112,6 @@ export default class Button extends ButtonBase<ButtonProperties> {
 			'aria-expanded': popup ? popup.expanded + '' : null,
 			'aria-pressed': typeof pressed === 'boolean' ? pressed.toString() : null,
 			'aria-describedby': describedBy
-		});
+		}, this.children);
 	}
 }

--- a/src/button/example/index.ts
+++ b/src/button/example/index.ts
@@ -22,9 +22,7 @@ export class App extends AppBase<WidgetProperties> {
 
 	render() {
 		return v('div', [
-			v('h2', {
-				innerHTML: 'Button Examples'
-			}),
+			v('h2', [ 'Button Examples' ]),
 			v('label', [
 				'Use Dojo Theme ',
 				v('input', {
@@ -33,39 +31,30 @@ export class App extends AppBase<WidgetProperties> {
 				})
 			]),
 			v('div', { id: 'example-1' }, [
-				v('p', {
-					innerHTML: 'Basic example:'
-				}),
+				v('p', [ 'Basic example:' ]),
 				w(Button, {
 					key: 'b1',
-					theme: this._theme,
-					content: 'Basic Button'
-				})
+					theme: this._theme
+				}, [ 'Basic Button' ])
 			]),
 			v('div', { id: 'example-2' }, [
-				v('p', {
-					innerHTML: 'Disabled menu button:'
-				}),
+				v('p', [ 'Disabled menu button:' ]),
 				w(Button, {
 					key: 'b2',
 					theme: this._theme,
-					content: 'Open',
 					disabled: true,
 					popup: { expanded: false, id: 'fakeId' },
 					type: 'menu'
-				})
+				}, [ 'Open' ])
 			]),
 			v('div', { id: 'example-3' }, [
-				v('p', {
-					innerHTML: 'Toggle Button'
-				}),
+				v('p', [ 'Toggle Button' ]),
 				w(Button, {
 					key: 'b3',
 					theme: this._theme,
-					content: 'Button state',
 					pressed: this.state.buttonPressed,
 					onClick: this.toggleButton
-				})
+				}, [ 'Button state' ])
 			])
 		]);
 	}

--- a/src/button/tests/unit/Button.ts
+++ b/src/button/tests/unit/Button.ts
@@ -13,7 +13,6 @@ let widget: Harness<ButtonProperties, typeof Button>;
 
 registerSuite({
 	name: 'Button',
-<<<<<<< HEAD
 
 	beforeEach() {
 		widget = harness(Button);
@@ -33,7 +32,6 @@ registerSuite({
 			classes: widget.classes(css.root),
 			disabled: undefined,
 			id: undefined,
-			innerHTML: '',
 			name: undefined,
 			onblur: widget.listener,
 			onclick: widget.listener,
@@ -53,20 +51,6 @@ registerSuite({
 
 	'properties and attributes'() {
 		const buttonProperties: ButtonProperties = {
-			content: 'foo',
-=======
-	construction() {
-		const button = new Button();
-		button.__setProperties__({
-			name: 'bar'
-		});
-		assert.strictEqual(button.properties.name, 'bar');
-	},
-
-	'correct node attributes'() {
-		const button = new Button();
-		button.__setProperties__({
->>>>>>> updated button content to use children
 			type: 'submit',
 			name: 'bar',
 			id: 'qux',
@@ -80,6 +64,7 @@ registerSuite({
 			value: 'value'
 		};
 		widget.setProperties(buttonProperties);
+		widget.setChildren(['foo']);
 
 		widget.expectRender(v('button', {
 			'aria-controls': (<any> buttonProperties.popup).id,
@@ -89,7 +74,6 @@ registerSuite({
 			'aria-pressed': String(buttonProperties.pressed),
 			classes: widget.classes(css.root, css.disabled, css.popup, css.pressed),
 			disabled: buttonProperties.disabled,
-			innerHTML: buttonProperties.content,
 			name: buttonProperties.name,
 			id: buttonProperties.id,
 			onblur: widget.listener,
@@ -105,14 +89,13 @@ registerSuite({
 			ontouchcancel: widget.listener,
 			type: buttonProperties.type,
 			value: buttonProperties.value
-		}));
+		}, [ 'foo' ]));
 	},
 
 	'popup = true'() {
 		widget.setProperties({
 			popup: true
 		});
-<<<<<<< HEAD
 
 		widget.expectRender(v('button', {
 			'aria-controls': '',
@@ -122,7 +105,6 @@ registerSuite({
 			'aria-pressed': null,
 			classes: widget.classes(css.root, css.popup),
 			disabled: undefined,
-			innerHTML: '',
 			name: undefined,
 			id: undefined,
 			onblur: widget.listener,
@@ -139,27 +121,6 @@ registerSuite({
 			type: undefined,
 			value: undefined
 		}));
-=======
-		button.__setChildren__([ 'foo' ]);
-		const vnode = <VNode> button.__render__();
-		assert.strictEqual(vnode.vnodeSelector, 'button');
-		assert.strictEqual(vnode.text, 'foo');
-		assert.strictEqual(vnode.properties!.type, 'submit');
-		assert.strictEqual(vnode.properties!.name, 'bar');
-		assert.strictEqual(vnode.properties!.id, 'qux');
-		assert.isTrue(vnode.properties!.disabled);
-		assert.strictEqual(vnode.properties!['aria-pressed'], 'true');
-		assert.strictEqual(vnode.properties!['aria-describedby'], 'baz');
-		assert.strictEqual(vnode.properties!['aria-haspopup'], 'true');
-		assert.strictEqual(vnode.properties!['aria-controls'], '');
-		assert.strictEqual(vnode.properties!['aria-expanded'], 'false');
-	},
-
-	'button without popup'() {
-		const button = new Button();
-		const vnode = <VNode> button.__render__();
-		assert.strictEqual(vnode.properties!['aria-haspopup'], null);
->>>>>>> updated button content to use children
 	},
 
 	events() {

--- a/src/button/tests/unit/Button.ts
+++ b/src/button/tests/unit/Button.ts
@@ -13,6 +13,7 @@ let widget: Harness<ButtonProperties, typeof Button>;
 
 registerSuite({
 	name: 'Button',
+<<<<<<< HEAD
 
 	beforeEach() {
 		widget = harness(Button);
@@ -53,6 +54,19 @@ registerSuite({
 	'properties and attributes'() {
 		const buttonProperties: ButtonProperties = {
 			content: 'foo',
+=======
+	construction() {
+		const button = new Button();
+		button.__setProperties__({
+			name: 'bar'
+		});
+		assert.strictEqual(button.properties.name, 'bar');
+	},
+
+	'correct node attributes'() {
+		const button = new Button();
+		button.__setProperties__({
+>>>>>>> updated button content to use children
 			type: 'submit',
 			name: 'bar',
 			id: 'qux',
@@ -98,6 +112,7 @@ registerSuite({
 		widget.setProperties({
 			popup: true
 		});
+<<<<<<< HEAD
 
 		widget.expectRender(v('button', {
 			'aria-controls': '',
@@ -124,6 +139,27 @@ registerSuite({
 			type: undefined,
 			value: undefined
 		}));
+=======
+		button.__setChildren__([ 'foo' ]);
+		const vnode = <VNode> button.__render__();
+		assert.strictEqual(vnode.vnodeSelector, 'button');
+		assert.strictEqual(vnode.text, 'foo');
+		assert.strictEqual(vnode.properties!.type, 'submit');
+		assert.strictEqual(vnode.properties!.name, 'bar');
+		assert.strictEqual(vnode.properties!.id, 'qux');
+		assert.isTrue(vnode.properties!.disabled);
+		assert.strictEqual(vnode.properties!['aria-pressed'], 'true');
+		assert.strictEqual(vnode.properties!['aria-describedby'], 'baz');
+		assert.strictEqual(vnode.properties!['aria-haspopup'], 'true');
+		assert.strictEqual(vnode.properties!['aria-controls'], '');
+		assert.strictEqual(vnode.properties!['aria-expanded'], 'false');
+	},
+
+	'button without popup'() {
+		const button = new Button();
+		const vnode = <VNode> button.__render__();
+		assert.strictEqual(vnode.properties!['aria-haspopup'], null);
+>>>>>>> updated button content to use children
 	},
 
 	events() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Button had been using a `content` property to set `innerHTML`, but this approach is limiting and outdated. I would prefer to use `this.children`, which is more in line with our other widgets and will make things like adding icons much easier.
