### PR TITLE
Button README

### DIFF
--- a/src/button/README.md
+++ b/src/button/README.md
@@ -1,1 +1,64 @@
-# Button widget
+# @dojo/widgets/button/Button widget
+
+Dojo 2's `Button` widget creates a `<button>` element
+
+
+## Features
+
+- Provides an API for valid `<button>` attributes
+- Can be used to create a toggle button (i.e. a button with an on/off state)
+- Provides an easy API to create a button controlling a popup
+
+### Accessibility Features
+
+- The basic button provides a strongly typed `type` property, as well as `describedBy` and `disabled`
+- Setting `pressed` to create a toggle button handles `aria-pressed`
+- Creating a popup button with `popup` sets `aria-haspopup`, `aria-controls`, and `aria-expanded`.
+
+## Example Usage
+
+```typescript
+// Basic usage
+w(Button, {
+	type: 'submit',
+	value: 'foo'
+}, [ 'Submit' ]);
+
+// Toggle button
+// pressed must be a boolean to correctly set aria-pressed
+w(Button, {
+	describedBy: 'instructions',
+	pressed: !!this.state.buttonPressed,
+	onClick: (event: MouseEvent) => {
+		this.setState({ buttonPressed: !this.state.buttonPressed });
+	}
+}, [ 'Click Me' ]),
+v('p', {
+	id: 'instructions'
+}, [ 'You can use this pattern to provide extra information, if necessary' ]);
+
+// Button that controls a popup (e.g. a modal or tooltip)
+w(Button, {
+	id: 'foo',
+	popup: {
+		id: 'bar',
+		expanded: this.state.popupOpen
+	},
+	onClick: () => {
+		this.setState({ popupOpen: !this.state.popupOpen });
+	}
+}, [ 'Open Popup' ]),
+v('div', {
+	id: 'bar',
+	...
+}, [ 'Popup Content' ])
+```
+
+## Theming
+
+The following CSS classes are available on the root node of the `Button` widget for use with custom themes:
+
+- `root`: Always available
+- `disabled`: Applied if `properties.disabled` is true
+- `popup`: Applied if `properties.popup` has a non-false value
+- `pressed`: Applied if `properties.pressed` is true

--- a/src/button/README.md
+++ b/src/button/README.md
@@ -13,7 +13,7 @@ Dojo 2's `Button` widget creates a `<button>` element
 
 - The basic button provides a strongly typed `type` property, as well as `describedBy` and `disabled`
 - Setting `pressed` to create a toggle button handles `aria-pressed`
-- Creating a popup button with `popup` sets `aria-haspopup`, `aria-controls`, and `aria-expanded`.
+- Creating a popup button with `popup` sets `aria-haspopup`, `aria-controls`, and `aria-expanded`
 
 ## Example Usage
 

--- a/src/button/example/index.ts
+++ b/src/button/example/index.ts
@@ -1,5 +1,5 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties } from '@dojo/widget-core/interfaces';
+import { WidgetProperties, TypedTargetEvent } from '@dojo/widget-core/interfaces';
 import { StatefulMixin } from '@dojo/widget-core/mixins/Stateful';
 import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { w, v } from '@dojo/widget-core/d';
@@ -10,8 +10,8 @@ export const AppBase = StatefulMixin(WidgetBase);
 export class App extends AppBase<WidgetProperties> {
 	private _theme: {};
 
-	themeChange(event: Event) {
-		const checked = (<HTMLInputElement> event.target).checked;
+	themeChange(event: TypedTargetEvent<HTMLInputElement>) {
+		const checked = event.target.checked;
 		this._theme = checked ? dojoTheme : {};
 		this.invalidate();
 	}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #180, adds Button README and fixes event typings on the example page. The content depends on the changes in #230