### PR TITLE
widgets.css -> example.css

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -47,7 +47,7 @@ module.exports = function (grunt) {
 			distStyles: {
 				expand: true,
 				cwd: 'src',
-				src: ['**/widgets.css', '**/example.css'],
+				src: '**/widgets.css',
 				dest: '<%= distDirectory %>'
 			}
 		},

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -41,13 +41,13 @@ module.exports = function (grunt) {
 			devStyles: {
 				expand: true,
 				cwd: 'src',
-				src: '**/widgets.css',
+				src: ['**/widgets.css', '**/example.css'],
 				dest: '<%= devDirectory %>'
 			},
 			distStyles: {
 				expand: true,
 				cwd: 'src',
-				src: '**/widgets.css',
+				src: ['**/widgets.css', '**/example.css'],
 				dest: '<%= distDirectory %>'
 			}
 		},

--- a/src/common/example/example.css
+++ b/src/common/example/example.css
@@ -1,6 +1,6 @@
-@import 'animations.m.css';
-@import 'base.m.css';
-@import 'icons.m.css';
+@import '../styles/animations.m.css';
+@import '../styles/base.m.css';
+@import '../styles/icons.m.css';
 @import '../../button/styles/button.m.css';
 @import '../../calendar/styles/calendar.m.css';
 @import '../../checkbox/styles/checkbox.m.css';

--- a/src/common/example/index.html
+++ b/src/common/example/index.html
@@ -14,7 +14,7 @@
 <body>
 	<script src="../../../node_modules/@dojo/loader/loader.min.js"></script>
 	<script src="../../../node_modules/maquette/dist/css-transitions.min.js"></script>
-	<link rel="stylesheet" href="../styles/widgets.css">
+	<link rel="stylesheet" href="./example.css">
 	<link rel="stylesheet" href="../../themes/dojo/widgets.css">
 	<script>
 		require.config({

--- a/src/tabpane/TabButton.ts
+++ b/src/tabpane/TabButton.ts
@@ -12,7 +12,7 @@ import * as css from './styles/tabPane.m.css';
  * Properties that can be set on a TabButton component
  *
  * @property active             Determines whether this tab button is active
- * @property callFocus        Used to immediately call focus on the cell
+ * @property callFocus          Used to immediately call focus on the cell
  * @property closeable          Determines whether this tab can be closed
  * @property controls           ID of the DOM element this tab button controls
  * @property disabled           Determines whether this tab can become active
@@ -22,7 +22,7 @@ import * as css from './styles/tabPane.m.css';
  * @property onCloseClick       Called when this tab button's close icon is clicked
  * @property onDownArrowPress   Called when the down arrow button is pressed
  * @property onEndPress         Called when the end button is pressed
- * @property onFocusCalled    Callback function when the cell receives focus
+ * @property onFocusCalled      Callback function when the cell receives focus
  * @property onHomePress        Called when the home button is pressed
  * @property onLeftArrowPress   Called when the left arrow button is pressed
  * @property onRightArrowPress  Called when the right arrow button is pressed

--- a/src/timepicker/TimePicker.ts
+++ b/src/timepicker/TimePicker.ts
@@ -226,7 +226,7 @@ export class TimePicker extends TimePickerBase<TimePickerProperties> {
 		}
 	}
 
-	protected renderNativeInput() {
+	protected renderNativeInput(): DNode {
 		const {
 			disabled,
 			end,
@@ -270,7 +270,7 @@ export class TimePicker extends TimePickerBase<TimePickerProperties> {
 		});
 	}
 
-	protected renderCustomInput() {
+	protected renderCustomInput(): DNode {
 		const {
 			autoBlur,
 			clearable,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR moves removes `common/styles/widgets.css` and adds a new `common/example/example.css` file, the name and location of which more clearly denote that this pattern should not be followed. As per @kitsonk and @tomdye, we should eventually consider moving examples out of widgets entirely, as they're a unrealistic example of Dojo 2 application code.

Resolves #240
