### PR TITLE
Use sinon throughout unit tests

### DIFF
--- a/src/button/tests/unit/Button.ts
+++ b/src/button/tests/unit/Button.ts
@@ -1,6 +1,7 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
 import * as Test from 'intern/lib/Test';
+import * as sinon from 'sinon';
 
 import has from '@dojo/has/has';
 import harness, { Harness } from '@dojo/test-extras/harness';
@@ -124,42 +125,42 @@ registerSuite({
 	},
 
 	events() {
-		let blurred = false;
-		let clicked = false;
-		let focused = false;
-		let keydown = false;
-		let keypress = false;
-		let keyup = false;
-		let mousedown = false;
-		let mouseup = false;
+		const onBlur = sinon.spy();
+		const onClick = sinon.spy();
+		const onFocus = sinon.spy();
+		const onKeyDown = sinon.spy();
+		const onKeyPress = sinon.spy();
+		const onKeyUp = sinon.spy();
+		const onMouseDown = sinon.spy();
+		const onMouseUp = sinon.spy();
 
 		widget.setProperties({
-			onBlur: () => { blurred = true; },
-			onClick: () => { clicked = true; },
-			onFocus: () => { focused = true; },
-			onKeyDown: () => { keydown = true; },
-			onKeyPress: () => { keypress = true; },
-			onKeyUp: () => { keyup = true; },
-			onMouseDown: () => { mousedown = true; },
-			onMouseUp: () => { mouseup = true; }
+			onBlur,
+			onClick,
+			onFocus,
+			onKeyDown,
+			onKeyPress,
+			onKeyUp,
+			onMouseDown,
+			onMouseUp
 		});
 
 		widget.sendEvent('blur');
-		assert.isTrue(blurred);
+		assert.isTrue(onBlur.called);
 		widget.sendEvent('click');
-		assert.isTrue(clicked);
+		assert.isTrue(onClick.called);
 		widget.sendEvent('focus');
-		assert.isTrue(focused);
+		assert.isTrue(onFocus.called);
 		widget.sendEvent('keydown');
-		assert.isTrue(keydown);
+		assert.isTrue(onKeyDown.called);
 		widget.sendEvent('keypress');
-		assert.isTrue(keypress);
+		assert.isTrue(onKeyPress.called);
 		widget.sendEvent('keyup');
-		assert.isTrue(keyup);
+		assert.isTrue(onKeyUp.called);
 		widget.sendEvent('mousedown');
-		assert.isTrue(mousedown);
+		assert.isTrue(onMouseDown.called);
 		widget.sendEvent('mouseup');
-		assert.isTrue(mouseup);
+		assert.isTrue(onMouseUp.called);
 	},
 
 	'touch events'(this: Test) {
@@ -171,21 +172,21 @@ registerSuite({
 			this.skip('Touch events not supported');
 		}
 
-		let touchstart = false;
-		let touchend = false;
-		let touchcancel = false;
+		const onTouchStart = sinon.spy();
+		const onTouchEnd = sinon.spy();
+		const onTouchCancel = sinon.spy();
 
 		widget.setProperties({
-			onTouchStart: () => { touchstart = true; },
-			onTouchEnd: () => { touchend = true; },
-			onTouchCancel: () => { touchcancel = true; }
+			onTouchStart,
+			onTouchEnd,
+			onTouchCancel
 		});
 
 		widget.sendEvent('touchstart');
-		assert.isTrue(touchstart);
+		assert.isTrue(onTouchStart.called);
 		widget.sendEvent('touchend');
-		assert.isTrue(touchend);
+		assert.isTrue(onTouchEnd.called);
 		widget.sendEvent('touchcancel');
-		assert.isTrue(touchcancel);
+		assert.isTrue(onTouchCancel.called);
 	}
 });

--- a/src/calendar/tests/unit/CalendarCell.ts
+++ b/src/calendar/tests/unit/CalendarCell.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import harness, { Harness } from '@dojo/test-extras/harness';
 import { v } from '@dojo/widget-core/d';
 
@@ -91,41 +92,31 @@ registerSuite({
 	},
 
 	'Keydown handler called'() {
-		let called = false;
+		const onKeyDown = sinon.spy();
 		widget.setProperties({
 			date: 1,
-			onKeyDown: () => {
-				called = true;
-			}
+			onKeyDown
 		});
 		widget.sendEvent('keydown');
-
-		assert.isTrue(called);
+		assert.isTrue(onKeyDown.called);
 	},
 
 	'Focus is set with callback'() {
-		let callFocus = true;
+		const onFocusCalled = sinon.spy();
 		widget.setProperties({
-			callFocus,
+			callFocus: true,
 			date: 1,
-			onFocusCalled: () => {
-				callFocus = false;
-			}
+			onFocusCalled
 		});
 		widget.getRender();
+		assert.isTrue(onFocusCalled.called);
 
-		assert.isFalse(callFocus, 'Focus callback should set callFocus to false in onElementCreated');
-
-		callFocus = true;
 		widget.setProperties({
-			callFocus,
+			callFocus: true,
 			date: 2,
-			onFocusCalled: () => {
-				callFocus = false;
-			}
+			onFocusCalled
 		});
 		widget.getRender();
-
-		assert.isFalse(callFocus, 'Focus callback should set callFocus to false in onElementUpdated');
+		assert.isTrue(onFocusCalled.calledTwice);
 	}
 });

--- a/src/calendar/tests/unit/MonthPicker.ts
+++ b/src/calendar/tests/unit/MonthPicker.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import harness, { Harness } from '@dojo/test-extras/harness';
 import { compareProperty, assignChildProperties, replaceChild } from '@dojo/test-extras/support/d';
 import { v } from '@dojo/widget-core/d';
@@ -306,11 +307,11 @@ registerSuite({
 
 	'Change month radios'() {
 		let currentMonth = testDate.getMonth();
-		let closed = false;
+		const onRequestClose = sinon.spy();
 		widget.setProperties({
 			...requiredProps,
-			open: !closed,
-			onRequestClose: () => { closed = true; },
+			open: true,
+			onRequestClose,
 			onRequestMonthChange: (month: number) => { currentMonth = month; }
 		});
 
@@ -323,7 +324,7 @@ registerSuite({
 		widget.sendEvent('mouseup', {
 			selector: `.${css.monthRadio}:nth-of-type(7) input`
 		});
-		assert.isTrue(closed, 'Clicking radios closes popup');
+		assert.isTrue(onRequestClose.called, 'Clicking radios closes popup');
 	},
 
 	'Previous/next month buttons'() {

--- a/src/checkbox/tests/unit/Checkbox.ts
+++ b/src/checkbox/tests/unit/Checkbox.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import { VNode } from '@dojo/interfaces/vdom';
 import Checkbox, { Mode } from '../../Checkbox';
 import * as css from '../../styles/checkbox.m.css';
@@ -106,46 +107,46 @@ registerSuite({
 	},
 
 	events() {
-		let blurred = false,
-				changed = false,
-				clicked = false,
-				focused = false,
-				mousedown = false,
-				mouseup = false,
-				touchstart = false,
-				touchend = false,
-				touchcancel = false;
+		const onBlur = sinon.spy();
+		const onChange = sinon.spy();
+		const onClick = sinon.spy();
+		const onFocus = sinon.spy();
+		const onMouseDown = sinon.spy();
+		const onMouseUp = sinon.spy();
+		const onTouchStart = sinon.spy();
+		const onTouchEnd = sinon.spy();
+		const onTouchCancel = sinon.spy();
 
 		const checkbox = new Checkbox();
 		checkbox.__setProperties__({
-			onBlur: () => { blurred = true; },
-			onChange: () => { changed = true; },
-			onClick: () => { clicked = true; },
-			onFocus: () => { focused = true; },
-			onMouseDown: () => { mousedown = true; },
-			onMouseUp: () => { mouseup = true; },
-			onTouchStart: () => { touchstart = true; },
-			onTouchEnd: () => { touchend = true; },
-			onTouchCancel: () => { touchcancel = true; }
+			onBlur,
+			onChange,
+			onClick,
+			onFocus,
+			onMouseDown,
+			onMouseUp,
+			onTouchStart,
+			onTouchEnd,
+			onTouchCancel
 		});
 
 		(<any> checkbox)._onBlur(<FocusEvent> {});
-		assert.isTrue(blurred);
+		assert.isTrue(onBlur.called);
 		(<any> checkbox)._onChange(<Event> {});
-		assert.isTrue(changed);
+		assert.isTrue(onChange.called);
 		(<any> checkbox)._onClick(<MouseEvent> {});
-		assert.isTrue(clicked);
+		assert.isTrue(onClick.called);
 		(<any> checkbox)._onFocus(<FocusEvent> {});
-		assert.isTrue(focused);
+		assert.isTrue(onFocus.called);
 		(<any> checkbox)._onMouseDown(<MouseEvent> {});
-		assert.isTrue(mousedown);
+		assert.isTrue(onMouseDown.called);
 		(<any> checkbox)._onMouseUp(<MouseEvent> {});
-		assert.isTrue(mouseup);
+		assert.isTrue(onMouseUp.called);
 		(<any> checkbox)._onTouchStart(<TouchEvent> {});
-		assert.isTrue(touchstart);
+		assert.isTrue(onTouchStart.called);
 		(<any> checkbox)._onTouchEnd(<TouchEvent> {});
-		assert.isTrue(touchend);
+		assert.isTrue(onTouchEnd.called);
 		(<any> checkbox)._onTouchCancel(<TouchEvent> {});
-		assert.isTrue(touchcancel);
+		assert.isTrue(onTouchCancel.called);
 	}
 });

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import { VNode } from '@dojo/interfaces/vdom';
 import ComboBox from '../../ComboBox';
 import ResultItem from '../../ResultItem';
@@ -106,7 +107,7 @@ registerSuite({
 
 	'Blur should be ignored when clicking result'() {
 		const comboBox = new ComboBox();
-		let called = false;
+		const onBlur = sinon.spy();
 		comboBox.__setProperties__({
 			results: ['a', 'b']
 		});
@@ -117,14 +118,14 @@ registerSuite({
 			customResultMenu: ResultMenu
 		});
 		comboBox.__setProperties__({
-			onBlur: () => called = true
+			onBlur
 		});
 
 		(<any> comboBox)._onArrowClick();
 		(<any> comboBox)._onResultMouseEnter(event(), 0);
 		(<any> comboBox)._onResultMouseDown();
 		(<any> comboBox)._onInputBlur(event());
-		assert.isFalse(called);
+		assert.isFalse(onBlur.called);
 	},
 
 	'Down arrow should change selected result if open'() {
@@ -207,9 +208,9 @@ registerSuite({
 	},
 
 	'Input should blur if autoBlur is true'() {
-		let blurred = false;
+		const onBlur = sinon.spy();
 		const input = inputElement();
-		input.blur = () => blurred = true;
+		input.blur = onBlur;
 		const parent = parentElement(input);
 		const comboBox = new ComboBox();
 		comboBox.__setProperties__({
@@ -222,7 +223,7 @@ registerSuite({
 		(<any> comboBox)._selectIndex(0);
 		(<any> comboBox).onElementUpdated();
 		(<any> comboBox).onElementUpdated(parent, 'root');
-		assert.isTrue(blurred);
+		assert.isTrue(onBlur.called);
 	},
 
 	'Clearable should render clear button and allow input to be cleared'() {
@@ -274,52 +275,52 @@ registerSuite({
 	},
 
 	'onBlur should be called'() {
-		let called = false;
+		const onBlur = sinon.spy();
 		const comboBox = new ComboBox();
 		comboBox.__setProperties__({
-			onBlur: () => called = true
+			onBlur
 		});
 
 		(<any> comboBox)._onInputBlur(event());
-		assert.isTrue(called);
+		assert.isTrue(onBlur.called);
 	},
 
 	'onChange should be called'() {
-		let called = 0;
+		const onChange = sinon.spy();
 		const comboBox = new ComboBox();
 		(<any> comboBox)._selectIndex(0);
 		comboBox.__setProperties__({
 			results: ['abc'],
 			getResultLabel: value => value,
-			onChange: () => called++
+			onChange
 		});
 
 		(<any> comboBox)._onInput(event());
 		(<any> comboBox)._onClearClick();
 		(<any> comboBox)._selectIndex(0);
-		assert.strictEqual(called, 3);
+		assert.isTrue(onChange.calledThrice);
 	},
 
 	'onFocus should be called'() {
-		let called = false;
+		const onFocus = sinon.spy();
 		const parent = parentElement();
 		const comboBox = new ComboBox();
 		comboBox.__setProperties__({
-			onFocus: () => called = true
+			onFocus
 		});
 
 		(<any> comboBox)._onInputFocus(event());
 		(<any> comboBox).onElementCreated(parent, 'root');
 		parent.querySelector = () => null;
 		(<any> comboBox).onElementUpdated(parent, 'root');
-		assert.isTrue(called);
+		assert.isTrue(onFocus.called);
 	},
 
 	'onRequestResults should be called'() {
-		let called = 0;
+		const onRequestResults = sinon.spy();
 		const comboBox = new ComboBox();
 		comboBox.__setProperties__({
-			onRequestResults: () => called++,
+			onRequestResults,
 			openOnFocus: true
 		});
 
@@ -327,22 +328,22 @@ registerSuite({
 		(<any> comboBox)._onInput(event());
 		(<any> comboBox)._onInputFocus(event());
 		(<any> comboBox)._onArrowClick();
-		assert.strictEqual(called, 3);
+		assert.isTrue(onRequestResults.calledThrice);
 	},
 
 	'onMenuChange should be called'() {
-		let called = 0;
+		const onMenuChange = sinon.spy();
 		const comboBox = new ComboBox();
 		comboBox.__setProperties__({
 			results: ['a'],
-			onMenuChange: () => called++
+			onMenuChange
 		});
 
 		(<any> comboBox)._onInput(parentElement());
 		<VNode> comboBox.__render__();
 		(<any> comboBox)._onInputBlur(parentElement());
 		<VNode> comboBox.__render__();
-		assert.strictEqual(called, 2);
+		assert.isTrue(onMenuChange.calledTwice);
 	},
 
 	'Clicking arrow should not open menu if disabled'() {

--- a/src/combobox/tests/unit/ResultItem.ts
+++ b/src/combobox/tests/unit/ResultItem.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import { VNode } from '@dojo/interfaces/vdom';
 import ResultItem from '../../ResultItem';
 import * as css from '../../styles/comboBox.m.css';
@@ -45,26 +46,26 @@ registerSuite({
 	},
 
 	'onMouseEnter should be called'() {
-		let called = 0;
+		const onMouseEnter = sinon.spy();
 		const resultItem = new ResultItem();
-		resultItem.__setProperties__(props({ onMouseEnter: () => called++ }));
+		resultItem.__setProperties__(props({ onMouseEnter }));
 		(<any> resultItem)._onMouseEnter();
-		assert.strictEqual(called, 1);
+		assert.isTrue(onMouseEnter.called);
 	},
 
 	'onMouseDown should be called'() {
-		let called = 0;
+		const onMouseDown = sinon.spy();
 		const resultItem = new ResultItem();
-		resultItem.__setProperties__(props({ onMouseDown: () => called++ }));
+		resultItem.__setProperties__(props({ onMouseDown }));
 		(<any> resultItem)._onMouseDown(<any> {});
-		assert.strictEqual(called, 1);
+		assert.isTrue(onMouseDown.called);
 	},
 
 	'onMouseUp should be called'() {
-		let called = 0;
+		const onMouseUp = sinon.spy();
 		const resultItem = new ResultItem();
-		resultItem.__setProperties__(props({ onMouseUp: () => called++ }));
+		resultItem.__setProperties__(props({ onMouseUp }));
 		(<any> resultItem)._onMouseUp(<any> {});
-		assert.strictEqual(called, 1);
+		assert.isTrue(onMouseUp.called);
 	}
 });

--- a/src/combobox/tests/unit/ResultMenu.ts
+++ b/src/combobox/tests/unit/ResultMenu.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import { VNode } from '@dojo/interfaces/vdom';
 import ResultMenu from '../../ResultMenu';
 import { assign } from '@dojo/core/lang';
@@ -33,14 +34,11 @@ registerSuite({
 	},
 
 	'renderResults should be called'() {
-		let called = false;
+		const renderResults = sinon.spy();
 		const resultMenu = new ResultMenu();
 		resultMenu.__setProperties__(props());
-		resultMenu.renderResults = results => {
-			called = true;
-			return results;
-		};
+		resultMenu.renderResults = renderResults;
 		<VNode> resultMenu.__render__();
-		assert.isTrue(called);
+		assert.isTrue(renderResults.called);
 	}
 });

--- a/src/dialog/tests/unit/Dialog.ts
+++ b/src/dialog/tests/unit/Dialog.ts
@@ -1,4 +1,5 @@
 import * as registerSuite from 'intern!object';
+import * as sinon from 'sinon';
 import * as assert from 'intern/chai!assert';
 import { VNode } from '@dojo/interfaces/vdom';
 import Dialog from '../../Dialog';
@@ -66,18 +67,16 @@ registerSuite({
 	},
 
 	onOpen() {
-		let called = false;
+		const onOpen = sinon.spy();
 
 		const dialog = new Dialog();
 		dialog.__setProperties__({
 			open: true,
-			onOpen: () => {
-				called = true;
-			}
+			onOpen
 		});
 		<VNode> dialog.__render__();
 
-		assert.isTrue(called, 'onOpen should be called');
+		assert.isTrue(onOpen.called, 'onOpen should be called');
 	},
 
 	modal() {

--- a/src/radio/tests/unit/Radio.ts
+++ b/src/radio/tests/unit/Radio.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import { VNode } from '@dojo/interfaces/vdom';
 import Radio from '../../Radio';
 import * as css from '../../styles/radio.m.css';
@@ -99,46 +100,46 @@ registerSuite({
 	},
 
 	events() {
-		let blurred = false,
-				changed = false,
-				clicked = false,
-				focused = false,
-				mousedown = false,
-				mouseup = false,
-				touchstart = false,
-				touchend = false,
-				touchcancel = false;
+		const onBlur = sinon.spy();
+		const onChange = sinon.spy();
+		const onClick = sinon.spy();
+		const onFocus = sinon.spy();
+		const onMouseDown = sinon.spy();
+		const onMouseUp = sinon.spy();
+		const onTouchStart = sinon.spy();
+		const onTouchEnd = sinon.spy();
+		const onTouchCancel = sinon.spy();
 
 		const radio = new Radio();
 		radio.__setProperties__({
-			onBlur: () => { blurred = true; },
-			onChange: () => { changed = true; },
-			onClick: () => { clicked = true; },
-			onFocus: () => { focused = true; },
-			onMouseDown: () => { mousedown = true; },
-			onMouseUp: () => { mouseup = true; },
-			onTouchStart: () => { touchstart = true; },
-			onTouchEnd: () => { touchend = true; },
-			onTouchCancel: () => { touchcancel = true; }
+			onBlur,
+			onChange,
+			onClick,
+			onFocus,
+			onMouseDown,
+			onMouseUp,
+			onTouchStart,
+			onTouchEnd,
+			onTouchCancel
 		});
 
 		(<any> radio)._onBlur(<FocusEvent> {});
-		assert.isTrue(blurred);
+		assert.isTrue(onBlur.called);
 		(<any> radio)._onChange(<Event> {});
-		assert.isTrue(changed);
+		assert.isTrue(onChange.called);
 		(<any> radio)._onClick(<MouseEvent> {});
-		assert.isTrue(clicked);
+		assert.isTrue(onClick.called);
 		(<any> radio)._onFocus(<FocusEvent> {});
-		assert.isTrue(focused);
+		assert.isTrue(onFocus.called);
 		(<any> radio)._onMouseDown(<MouseEvent> {});
-		assert.isTrue(mousedown);
+		assert.isTrue(onMouseDown.called);
 		(<any> radio)._onMouseUp(<MouseEvent> {});
-		assert.isTrue(mouseup);
+		assert.isTrue(onMouseUp.called);
 		(<any> radio)._onTouchStart(<TouchEvent> {});
-		assert.isTrue(touchstart);
+		assert.isTrue(onTouchStart.called);
 		(<any> radio)._onTouchEnd(<TouchEvent> {});
-		assert.isTrue(touchend);
+		assert.isTrue(onTouchEnd.called);
 		(<any> radio)._onTouchCancel(<TouchEvent> {});
-		assert.isTrue(touchcancel);
+		assert.isTrue(onTouchCancel.called);
 	}
 });

--- a/src/select/tests/unit/Select.ts
+++ b/src/select/tests/unit/Select.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import { VNode } from '@dojo/interfaces/vdom';
 import Select from '../../Select';
 import SelectOption, { OptionData } from '../../SelectOption';
@@ -107,28 +108,28 @@ registerSuite({
 		},
 
 		'basic events'() {
-			let blurred = false,
-					clicked = false,
-					focused = false,
-					keydown = false;
+			const onBlur = sinon.spy();
+			const onClick = sinon.spy();
+			const onFocus = sinon.spy();
+			const onKeyDown = sinon.spy();
 
 			const select = new Select();
 			select.__setProperties__({
 				useNativeElement: true,
-				onBlur: () => { blurred = true; },
-				onClick: () => { clicked = true; },
-				onFocus: () => { focused = true; },
-				onKeyDown: () => { keydown = true; }
+				onBlur,
+				onClick,
+				onFocus,
+				onKeyDown
 			});
 
 			(<any> select)._onBlur(<FocusEvent> {});
-			assert.isTrue(blurred);
+			assert.isTrue(onBlur.called);
 			(<any> select)._onClick(<MouseEvent> {});
-			assert.isTrue(clicked);
+			assert.isTrue(onClick.called);
 			(<any> select)._onFocus(<FocusEvent> {});
-			assert.isTrue(focused);
+			assert.isTrue(onFocus.called);
 			(<any> select)._onKeyDown(<KeyboardEvent> {});
-			assert.isTrue(keydown);
+			assert.isTrue(onKeyDown.called);
 		},
 
 		'onChange called with correct option'() {
@@ -224,16 +225,16 @@ registerSuite({
 
 		'Disabled option click'() {
 			const select = new Select();
-			let clicked = false;
+			const onClick = sinon.spy();
 			let changedOption;
 			select.__setProperties__({
 				options: testOptions,
-				onClick: () => clicked = true,
+				onClick,
 				onChange: (option: OptionData) => changedOption = option.value
 			});
 			(<any> select)._onOptionClick(event(), 1);
 
-			assert.isTrue(clicked, 'properties.onClick called');
+			assert.isTrue(onClick.called, 'properties.onClick called');
 			assert.strictEqual(changedOption, 'two', 'onChange called with second option');
 
 			(<any> select)._onOptionClick(event(), 2);
@@ -243,17 +244,17 @@ registerSuite({
 		'Option click with no options'() {
 			// mostly for code coverage; this shouldn't be possible
 			const select = new Select();
-			let clicked = false;
-			let changed = false;
+			const onClick = sinon.spy();
+			const onChange = sinon.spy();
 			select.__setProperties__({
-				onChange: () => changed = true,
-				onClick: () => clicked = true
+				onChange,
+				onClick
 			});
 
 			(<any> select)._onOptionClick(event(), undefined);
 
-			assert.isTrue(clicked, 'properties.onClick called');
-			assert.isFalse(changed, 'onChange shouldn\'t fire with no options');
+			assert.isTrue(onClick.called, 'properties.onClick called');
+			assert.isFalse(onChange.called, 'onChange shouldn\'t fire with no options');
 		},
 
 		'Custom option factory'() {
@@ -322,17 +323,17 @@ registerSuite({
 		},
 		'Open/close on trigger click'() {
 			const select = new Select();
-			let clicked = false;
+			const onClick = sinon.spy();
 
 			select.__setProperties__({
-				onClick: () => clicked = true
+				onClick
 			});
 
 			(<any> select)._onTriggerClick(event());
 			let vnode = <VNode> select.__render__();
 
 			assert.isTrue(vnode.children![0].properties!.classes![css.open], 'Open dropdown on first click');
-			assert.isTrue(clicked, 'properties.onClick called');
+			assert.isTrue(onClick.called, 'properties.onClick called');
 
 			(<any> select)._onTriggerClick(event());
 			vnode = <VNode> select.__render__();
@@ -341,11 +342,11 @@ registerSuite({
 		},
 		'Close on trigger blur'() {
 			const select = new Select();
-			let blurred = false;
+			const onBlur = sinon.spy();
 			(<any> select)._open = true;
 
 			select.__setProperties__({
-				onBlur: () => blurred = true
+				onBlur
 			});
 			let vnode = <VNode> select.__render__();
 
@@ -355,13 +356,12 @@ registerSuite({
 			vnode = <VNode> select.__render__();
 
 			assert.isFalse(vnode.children![0].properties!.classes![css.open], 'Dropdown closed on blur');
-			assert.isTrue(blurred, 'properties.onBlur called');
+			assert.isTrue(onBlur.called, 'properties.onBlur called');
 
 			(<any> select)._open = true;
-			blurred = false;
 			(<any> select)._onOptionMouseDown();
 			(<any> select)._onTriggerBlur();
-			assert.isFalse(blurred, 'Dropdown not closed on option click');
+			assert.isFalse(onBlur.calledTwice, 'Dropdown not closed on option click');
 		},
 		'Open/close with keyboard'() {
 			const select = new Select();
@@ -376,17 +376,17 @@ registerSuite({
 		'Navigate options with keyboard'() {
 			const select = new Select();
 			let selectedOption;
-			let keydown = false;
+			const onKeyDown = sinon.spy();
 			select.__setProperties__({
 				options: testOptions,
 				onChange: (option: OptionData) => selectedOption = option.value,
-				onKeyDown: () => keydown = true
+				onKeyDown
 			});
 			(<any> select)._open = true;
 
 			(<any> select)._onListboxKeyDown(event(keys.enter));
 			assert.strictEqual(selectedOption, 'one', 'First option is focused by default');
-			assert.isTrue(keydown, 'properties.onKeyDown called');
+			assert.isTrue(onKeyDown.called, 'properties.onKeyDown called');
 
 			(<any> select)._onListboxKeyDown(event(keys.down));
 			(<any> select)._onListboxKeyDown(event(keys.space));

--- a/src/slidepane/tests/unit/SlidePane.ts
+++ b/src/slidepane/tests/unit/SlidePane.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 
 import has from '@dojo/has/has';
 import harness, { Harness } from '@dojo/test-extras/harness';
@@ -102,18 +103,16 @@ registerSuite({
 	},
 
 	onOpen() {
-		let called = false;
+		const onOpen = sinon.spy();
 
 		widget.setProperties({
 			open: true,
-			onOpen() {
-				called = true;
-			}
+			onOpen
 		});
 
 		widget.getRender();
 
-		assert.isTrue(called, 'onOpen should be called');
+		assert.isTrue(onOpen.called, 'onOpen should be called');
 	},
 
 	'change property to close'() {
@@ -178,13 +177,11 @@ registerSuite({
 	},
 
 	'click underlay to close'() {
-		let called = false;
+		const onRequestClose = sinon.spy();
 
 		widget.setProperties({
 			open: true,
-			onRequestClose() {
-				called = true;
-			}
+			onRequestClose
 		});
 
 		widget.sendEvent('mousedown', {
@@ -201,7 +198,7 @@ registerSuite({
 			selector: ':first-child' /* this should be the underlay */
 		});
 
-		assert.isTrue(called, 'onRequestClose should have been called');
+		assert.isTrue(onRequestClose.called, 'onRequestClose should have been called');
 	},
 
 	'tap underlay to close'(this: any) {
@@ -209,13 +206,11 @@ registerSuite({
 			this.skip('Environment not support touch events');
 		}
 
-		let called = false;
+		const onRequestClose = sinon.spy();
 
 		widget.setProperties({
 			open: true,
-			onRequestClose() {
-				called = true;
-			}
+			onRequestClose
 		});
 
 		widget.sendEvent('touchstart', {
@@ -233,17 +228,15 @@ registerSuite({
 			selector: ':first-child' /* this should be the underlay */
 		});
 
-		assert.isTrue(called, 'onRequestClose should be called on underlay tap');
+		assert.isTrue(onRequestClose.called, 'onRequestClose should be called on underlay tap');
 	},
 
 	'drag to close'() {
-		let called = false;
+		const onRequestClose = sinon.spy();
 
 		widget.setProperties({
 			open: true,
-			onRequestClose() {
-				called = true;
-			}
+			onRequestClose
 		});
 
 		widget.sendEvent('mousedown', {
@@ -264,7 +257,7 @@ registerSuite({
 			}
 		});
 
-		assert.isTrue(called, 'onRequestClose should be called if dragged far enough');
+		assert.isTrue(onRequestClose.called, 'onRequestClose should be called if dragged far enough');
 	},
 
 	'swipe to close'(this: any) {
@@ -272,13 +265,11 @@ registerSuite({
 			this.skip('Environment not support touch events');
 		}
 
-		let called = false;
+		const onRequestClose = sinon.spy();
 
 		widget.setProperties({
 			open: true,
-			onRequestClose() {
-				called = true;
-			}
+			onRequestClose
 		});
 
 		widget.sendEvent('touchmove', {
@@ -305,7 +296,7 @@ registerSuite({
 			}
 		});
 
-		assert.isTrue(called, 'onRequestClose should be called if swiped far enough');
+		assert.isTrue(onRequestClose.called, 'onRequestClose should be called if swiped far enough');
 	},
 
 	'swipe to close right'(this: any) {
@@ -313,16 +304,13 @@ registerSuite({
 			this.skip('Environment not support touch events');
 		}
 
-		let called = false;
+		const onRequestClose = sinon.spy();
 
 		widget.setProperties({
 			align: Align.right,
 			open: true,
 			width: 256,
-
-			onRequestClose() {
-				called = true;
-			}
+			onRequestClose
 		});
 
 		widget.sendEvent('touchstart', {
@@ -343,18 +331,15 @@ registerSuite({
 			}
 		});
 
-		assert.isTrue(called, 'onRequestClose should be called if swiped far enough to close right');
+		assert.isTrue(onRequestClose.called, 'onRequestClose should be called if swiped far enough to close right');
 	},
 
 	'not dragged far enough to close'() {
-		let called = false;
+		const onRequestClose = sinon.spy();
 
 		widget.setProperties({
 			open: true,
-
-			onRequestClose() {
-				called = true;
-			}
+			onRequestClose
 		});
 
 		widget.sendEvent('mousedown', {
@@ -375,7 +360,7 @@ registerSuite({
 			}
 		});
 
-		assert.isFalse(called, 'onRequestClose should not be called if not swiped far enough to close');
+		assert.isFalse(onRequestClose.called, 'onRequestClose should not be called if not swiped far enough to close');
 	},
 
 	'pane cannot be moved past screen edge'() {

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import { v } from '@dojo/widget-core/d';
 import { VNode } from '@dojo/interfaces/vdom';
 import Slider from '../../Slider';
@@ -136,62 +137,62 @@ registerSuite({
 	},
 
 	events() {
-		let blurred = false,
-				changed = false,
-				clicked = false,
-				focused = false,
-				input = false,
-				keydown = false,
-				keypress = false,
-				keyup = false,
-				mousedown = false,
-				mouseup = false,
-				touchstart = false,
-				touchend = false,
-				touchcancel = false;
+		const onBlur = sinon.spy();
+		const onChange = sinon.spy();
+		const onClick = sinon.spy();
+		const onFocus = sinon.spy();
+		const onInput = sinon.spy();
+		const onKeyDown = sinon.spy();
+		const onKeyPress = sinon.spy();
+		const onKeyUp = sinon.spy();
+		const onMouseDown = sinon.spy();
+		const onMouseUp = sinon.spy();
+		const onTouchStart = sinon.spy();
+		const onTouchEnd = sinon.spy();
+		const onTouchCancel = sinon.spy();
 
 		const slider = new Slider();
 		slider.__setProperties__({
-			onBlur: () => { blurred = true; },
-			onChange: () => { changed = true; },
-			onClick: () => { clicked = true; },
-			onFocus: () => { focused = true; },
-			onInput: () => { input = true; },
-			onKeyDown: () => { keydown = true; },
-			onKeyPress: () => { keypress = true; },
-			onKeyUp: () => { keyup = true; },
-			onMouseDown: () => { mousedown = true; },
-			onMouseUp: () => { mouseup = true; },
-			onTouchStart: () => { touchstart = true; },
-			onTouchEnd: () => { touchend = true; },
-			onTouchCancel: () => { touchcancel = true; }
+			onBlur,
+			onChange,
+			onClick,
+			onInput,
+			onFocus,
+			onKeyDown,
+			onKeyPress,
+			onKeyUp,
+			onMouseDown,
+			onMouseUp,
+			onTouchStart,
+			onTouchEnd,
+			onTouchCancel
 		});
 
 		(<any> slider)._onBlur(<FocusEvent> {});
-		assert.isTrue(blurred);
+		assert.isTrue(onBlur.called);
 		(<any> slider)._onChange(<Event> {});
-		assert.isTrue(changed);
+		assert.isTrue(onChange.called);
 		(<any> slider)._onClick(<MouseEvent> {});
-		assert.isTrue(clicked);
+		assert.isTrue(onClick.called);
 		(<any> slider)._onFocus(<FocusEvent> {});
-		assert.isTrue(focused);
+		assert.isTrue(onFocus.called);
 		(<any> slider)._onInput(<Event> {});
-		assert.isTrue(input);
+		assert.isTrue(onInput.called);
 		(<any> slider)._onKeyDown(<KeyboardEvent> {});
-		assert.isTrue(keydown);
+		assert.isTrue(onKeyDown.called);
 		(<any> slider)._onKeyPress(<KeyboardEvent> {});
-		assert.isTrue(keypress);
+		assert.isTrue(onKeyPress.called);
 		(<any> slider)._onKeyUp(<KeyboardEvent> {});
-		assert.isTrue(keyup);
+		assert.isTrue(onKeyUp.called);
 		(<any> slider)._onMouseDown(<MouseEvent> {});
-		assert.isTrue(mousedown);
+		assert.isTrue(onMouseDown.called);
 		(<any> slider)._onMouseUp(<MouseEvent> {});
-		assert.isTrue(mouseup);
+		assert.isTrue(onMouseUp.called);
 		(<any> slider)._onTouchStart(<TouchEvent> {});
-		assert.isTrue(touchstart);
+		assert.isTrue(onTouchStart.called);
 		(<any> slider)._onTouchEnd(<TouchEvent> {});
-		assert.isTrue(touchend);
+		assert.isTrue(onTouchEnd.called);
 		(<any> slider)._onTouchCancel(<TouchEvent> {});
-		assert.isTrue(touchcancel);
+		assert.isTrue(onTouchCancel.called);
 	}
 });

--- a/src/splitpane/tests/unit/SplitPane.ts
+++ b/src/splitpane/tests/unit/SplitPane.ts
@@ -1,5 +1,6 @@
 import * as assert from 'intern/chai!assert';
 import * as registerSuite from 'intern!object';
+import * as sinon from 'sinon';
 
 import { v } from '@dojo/widget-core/d';
 import harness, { Harness } from '@dojo/test-extras/harness';
@@ -160,10 +161,10 @@ registerSuite({
 	},
 
 	'Mouse move should call onResize for row'() {
-		let called = false;
+		const onResize = sinon.spy();
 
 		widget.setProperties({
-			onResize: () => called = true
+			onResize
 		});
 
 		widget.sendEvent('mousedown', {
@@ -182,14 +183,14 @@ registerSuite({
 			selector: ':nth-child(2)' /* this should be the divider */
 		});
 
-		assert.isTrue(called);
+		assert.isTrue(onResize.called);
 	},
 
 	'Mouse move should call onResize for column'() {
-		let called = false;
+		const onResize = sinon.spy();
 
 		widget.setProperties({
-			onResize: () => called = true,
+			onResize,
 			direction: Direction.column
 		});
 
@@ -209,7 +210,7 @@ registerSuite({
 			selector: ':nth-child(2)' /* this should be the divider */
 		});
 
-		assert.isTrue(called);
+		assert.isTrue(onResize.called);
 	},
 
 	'Touch move should call onResize for row'(this: any) {
@@ -217,10 +218,10 @@ registerSuite({
 			this.skip('Environment not support touch events');
 		}
 
-		let called = false;
+		const onResize = sinon.spy();
 
 		widget.setProperties({
-			onResize: () => called = true,
+			onResize,
 			direction: Direction.row,
 			size: 100
 		});
@@ -247,7 +248,7 @@ registerSuite({
 			selector: ':nth-child(2)' /* this should be the divider */
 		});
 
-		assert.isTrue(called);
+		assert.isTrue(onResize.called);
 	},
 
 	'Touch move should call onResize for column'(this: any) {
@@ -255,10 +256,10 @@ registerSuite({
 			this.skip('Environment not support touch events');
 		}
 
-		let called = 0;
+		const onResize = sinon.spy();
 
 		widget.setProperties({
-			onResize: () => called++,
+			onResize,
 			direction: Direction.column
 		});
 
@@ -293,6 +294,6 @@ registerSuite({
 			selector: ':nth-child(2)' /* this should be the divider */
 		});
 
-		assert.strictEqual(called, 2);
+		assert.isTrue(onResize.calledTwice);
 	}
 });

--- a/src/tabpane/tests/unit/TabButton.ts
+++ b/src/tabpane/tests/unit/TabButton.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import { VNode } from '@dojo/interfaces/vdom';
 import TabButton from '../../TabButton';
 import * as css from '../../styles/tabPane.m.css';
@@ -43,139 +44,138 @@ registerSuite({
 
 	'Closing tab should trigger property'() {
 		const tabButton = new TabButton();
-		let called = false;
-		tabButton.__setProperties__(props({ onCloseClick: () => called = true }));
+		const onCloseClick = sinon.spy();
+		tabButton.__setProperties__(props({ onCloseClick }));
 		(<any> tabButton)._onCloseClick({ stopPropagation() { } });
-		assert.isTrue(called);
+		assert.isTrue(onCloseClick.called);
 	},
 
 	'Selecting tab should trigger property'() {
 		const tabButton = new TabButton();
-		let called = 0;
+		const onClick = sinon.spy();
 		tabButton.__setProperties__(props({
-			onClick: () => called++,
+			onClick,
 			disabled: true
 		}));
 		(<any> tabButton)._onClick();
 		tabButton.__setProperties__(props({
-			onClick: () => called++,
+			onClick,
 			disabled: false
 		}));
 		(<any> tabButton)._onClick();
-		assert.strictEqual(called, 1);
+		assert.isTrue(onClick.calledOnce);
 	},
 
 	'Key down should be ignored for disabled tab'() {
 		const tabButton = new TabButton();
-		let called = false;
+		const onLeftArrowPress = sinon.spy();
 		tabButton.__setProperties__(props({
 			disabled: true,
-			onLeftArrowPress: () => called = true
+			onLeftArrowPress
 		}));
 		(<any> tabButton)._onKeyDown({ which: 37 });
-		assert.isFalse(called);
+		assert.isFalse(onLeftArrowPress.called);
 	},
 
 	'Escape should close tab'() {
 		const tabButton = new TabButton();
-		let called = false;
+		const onCloseClick = sinon.spy();
 		tabButton.__setProperties__(props({
 			closeable: true,
-			onCloseClick: () => called = true
+			onCloseClick
 		}));
 		<VNode> tabButton.__render__();
 		(<any> tabButton)._onKeyDown({ which: 27 });
-		assert.isTrue(called);
+		assert.isTrue(onCloseClick.called);
 	},
 
 	'Left arrow should trigger property'() {
 		const tabButton = new TabButton();
-		let called = false;
+		const onLeftArrowPress = sinon.spy();
 		tabButton.__setProperties__(props({
-			onLeftArrowPress: () => called = true
+			onLeftArrowPress
 		}));
 		(<any> tabButton)._onKeyDown({ which: 37 });
-		assert.isTrue(called);
+		assert.isTrue(onLeftArrowPress.called);
 	},
 
 	'Up arrow should trigger property'() {
 		const tabButton = new TabButton();
-		let called = false;
+		const onUpArrowPress = sinon.spy();
 		tabButton.__setProperties__(props({
-			onUpArrowPress: () => called = true
+			onUpArrowPress
 		}));
 		(<any> tabButton)._onKeyDown({ which: 38 });
-		assert.isTrue(called);
+		assert.isTrue(onUpArrowPress.called);
 	},
 
 	'Right arrow should trigger property'() {
 		const tabButton = new TabButton();
-		let called = false;
+		const onRightArrowPress = sinon.spy();
 		tabButton.__setProperties__(props({
-			onRightArrowPress: () => called = true
+			onRightArrowPress
 		}));
 		(<any> tabButton)._onKeyDown({ which: 39 });
-		assert.isTrue(called);
+		assert.isTrue(onRightArrowPress.called);
 	},
 
 	'Down arrow should trigger property'() {
 		const tabButton = new TabButton();
-		let called = false;
+		const onDownArrowPress = sinon.spy();
 		tabButton.__setProperties__(props({
-			onDownArrowPress: () => called = true
+			onDownArrowPress
 		}));
 		(<any> tabButton)._onKeyDown({ which: 40 });
-		assert.isTrue(called);
+		assert.isTrue(onDownArrowPress.called);
 	},
 
 	'Home should trigger property'() {
 		const tabButton = new TabButton();
-		let called = false;
+		const onHomePress = sinon.spy();
 		tabButton.__setProperties__(props({
-			onHomePress: () => called = true
+			onHomePress
 		}));
 		(<any> tabButton)._onKeyDown({ which: 36 });
-		assert.isTrue(called);
+		assert.isTrue(onHomePress.called);
 	},
 
 	'End should trigger property'() {
 		const tabButton = new TabButton();
-		let called = false;
+		const onEndPress = sinon.spy();
 		tabButton.__setProperties__(props({
-			onEndPress: () => called = true
+			onEndPress
 		}));
 		(<any> tabButton)._onKeyDown({ which: 35 });
-		assert.isTrue(called);
+		assert.isTrue(onEndPress.called);
 	},
 
 	'Focus is restored after render'() {
 		const tabButton = new TabButton();
-		let focused = 0;
-		let focusCallback = false;
+		const focus = sinon.spy();
+		const onFocusCalled = sinon.spy();
 		tabButton.__setProperties__(props({ callFocus: true }));
 		(<any> tabButton).onElementCreated({
-			focus: () => focused++
+			focus
 		}, 'tab-button');
 		tabButton.__setProperties__(props({
 			callFocus: true,
-			onFocusCalled: () => { focusCallback = true; }
+			onFocusCalled
 		}));
 		(<any> tabButton).onElementUpdated({
-			focus: () => focused++
+			focus
 		}, 'tab-button');
-		assert.strictEqual(focused, 2);
-		assert.isTrue(focusCallback);
+		assert.isTrue(focus.calledTwice);
+		assert.isTrue(onFocusCalled.calledOnce);
 
-		focusCallback = false;
 		tabButton.__setProperties__(props({
 			callFocus: false,
-			onFocusCalled: () => { focusCallback = true; }
+			onFocusCalled
 		}));
 
 		(<any> tabButton).onElementUpdated({
-			focus: () => focused++
+			focus
 		}, 'tab-button');
-		assert.strictEqual(focused, 2, 'Focus isn\'t called when properties.callFocus is false');
-		assert.isFalse(focusCallback);
+		assert.isTrue(focus.calledTwice, 'Focus isn\'t called when properties.callFocus is false');
+		assert.isFalse(onFocusCalled.calledTwice);
 	}
 });

--- a/src/tabpane/tests/unit/TabPane.ts
+++ b/src/tabpane/tests/unit/TabPane.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import { VNode } from '@dojo/interfaces/vdom';
 import TabPane, { Align } from '../../TabPane';
 import * as css from '../../styles/tabPane.m.css';
@@ -50,20 +51,17 @@ registerSuite({
 
 	'Clicking tab should change activeIndex'() {
 		const tabPane = new TabPane();
-		let called = 0;
+		const onRequestTabChange = sinon.spy();
 		tabPane.__setChildren__([
 			w(Tab, { label: 'foo', key: 'foo' }),
 			w(Tab, { label: 'bar', key: 'bar' })
 		]);
 		tabPane.__setProperties__(props({
-			onRequestTabChange: (index: number) => {
-				called++;
-				tabPane.__setProperties__(props({ activeIndex: index }));
-			}
+			onRequestTabChange
 		}));
 		(<any> tabPane).selectIndex(0);
 		(<any> tabPane).selectIndex(1);
-		assert.strictEqual(called, 1);
+		assert.isTrue(onRequestTabChange.calledOnce);
 	},
 
 	'Closing a tab should change tabs'() {

--- a/src/textarea/tests/unit/Textarea.ts
+++ b/src/textarea/tests/unit/Textarea.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import { VNode } from '@dojo/interfaces/vdom';
 import Textarea from '../../Textarea';
 import * as css from '../../styles/textarea.m.css';
@@ -110,62 +111,62 @@ registerSuite({
 	},
 
 	events() {
-		let blurred = false,
-				changed = false,
-				clicked = false,
-				focused = false,
-				input = false,
-				keydown = false,
-				keypress = false,
-				keyup = false,
-				mousedown = false,
-				mouseup = false,
-				touchstart = false,
-				touchend = false,
-				touchcancel = false;
+		const onBlur = sinon.spy();
+		const onChange = sinon.spy();
+		const onClick = sinon.spy();
+		const onFocus = sinon.spy();
+		const onInput = sinon.spy();
+		const onKeyDown = sinon.spy();
+		const onKeyPress = sinon.spy();
+		const onKeyUp = sinon.spy();
+		const onMouseDown = sinon.spy();
+		const onMouseUp = sinon.spy();
+		const onTouchStart = sinon.spy();
+		const onTouchEnd = sinon.spy();
+		const onTouchCancel = sinon.spy();
 
 		const textarea = new Textarea();
 		textarea.__setProperties__({
-			onBlur: () => { blurred = true; },
-			onChange: () => { changed = true; },
-			onClick: () => { clicked = true; },
-			onFocus: () => { focused = true; },
-			onInput: () => { input = true; },
-			onKeyDown: () => { keydown = true; },
-			onKeyPress: () => { keypress = true; },
-			onKeyUp: () => { keyup = true; },
-			onMouseDown: () => { mousedown = true; },
-			onMouseUp: () => { mouseup = true; },
-			onTouchStart: () => { touchstart = true; },
-			onTouchEnd: () => { touchend = true; },
-			onTouchCancel: () => { touchcancel = true; }
+			onBlur,
+			onChange,
+			onClick,
+			onInput,
+			onFocus,
+			onKeyDown,
+			onKeyPress,
+			onKeyUp,
+			onMouseDown,
+			onMouseUp,
+			onTouchStart,
+			onTouchEnd,
+			onTouchCancel
 		});
 
 		(<any> textarea)._onBlur(<FocusEvent> {});
-		assert.isTrue(blurred);
+		assert.isTrue(onBlur.called);
 		(<any> textarea)._onChange(<Event> {});
-		assert.isTrue(changed);
+		assert.isTrue(onChange.called);
 		(<any> textarea)._onClick(<MouseEvent> {});
-		assert.isTrue(clicked);
+		assert.isTrue(onClick.called);
 		(<any> textarea)._onFocus(<FocusEvent> {});
-		assert.isTrue(focused);
+		assert.isTrue(onFocus.called);
 		(<any> textarea)._onInput(<Event> {});
-		assert.isTrue(input);
+		assert.isTrue(onInput.called);
 		(<any> textarea)._onKeyDown(<KeyboardEvent> {});
-		assert.isTrue(keydown);
+		assert.isTrue(onKeyDown.called);
 		(<any> textarea)._onKeyPress(<KeyboardEvent> {});
-		assert.isTrue(keypress);
+		assert.isTrue(onKeyPress.called);
 		(<any> textarea)._onKeyUp(<KeyboardEvent> {});
-		assert.isTrue(keyup);
+		assert.isTrue(onKeyUp.called);
 		(<any> textarea)._onMouseDown(<MouseEvent> {});
-		assert.isTrue(mousedown);
+		assert.isTrue(onMouseDown.called);
 		(<any> textarea)._onMouseUp(<MouseEvent> {});
-		assert.isTrue(mouseup);
+		assert.isTrue(onMouseUp.called);
 		(<any> textarea)._onTouchStart(<TouchEvent> {});
-		assert.isTrue(touchstart);
+		assert.isTrue(onTouchStart.called);
 		(<any> textarea)._onTouchEnd(<TouchEvent> {});
-		assert.isTrue(touchend);
+		assert.isTrue(onTouchEnd.called);
 		(<any> textarea)._onTouchCancel(<TouchEvent> {});
-		assert.isTrue(touchcancel);
+		assert.isTrue(onTouchCancel.called);
 	}
 });

--- a/src/textinput/tests/unit/TextInput.ts
+++ b/src/textinput/tests/unit/TextInput.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import { VNode } from '@dojo/interfaces/vdom';
 import TextInput from '../../TextInput';
 import * as css from '../../styles/textinput.m.css';
@@ -101,62 +102,62 @@ registerSuite({
 	},
 
 	events() {
-		let blurred = false,
-				changed = false,
-				clicked = false,
-				focused = false,
-				input = false,
-				keydown = false,
-				keypress = false,
-				keyup = false,
-				mousedown = false,
-				mouseup = false,
-				touchstart = false,
-				touchend = false,
-				touchcancel = false;
+		const onBlur = sinon.spy();
+		const onChange = sinon.spy();
+		const onClick = sinon.spy();
+		const onFocus = sinon.spy();
+		const onInput = sinon.spy();
+		const onKeyDown = sinon.spy();
+		const onKeyPress = sinon.spy();
+		const onKeyUp = sinon.spy();
+		const onMouseDown = sinon.spy();
+		const onMouseUp = sinon.spy();
+		const onTouchStart = sinon.spy();
+		const onTouchEnd = sinon.spy();
+		const onTouchCancel = sinon.spy();
 
-		const textinput = new TextInput();
-		textinput.__setProperties__({
-			onBlur: () => { blurred = true; },
-			onChange: () => { changed = true; },
-			onClick: () => { clicked = true; },
-			onFocus: () => { focused = true; },
-			onInput: () => { input = true; },
-			onKeyDown: () => { keydown = true; },
-			onKeyPress: () => { keypress = true; },
-			onKeyUp: () => { keyup = true; },
-			onMouseDown: () => { mousedown = true; },
-			onMouseUp: () => { mouseup = true; },
-			onTouchStart: () => { touchstart = true; },
-			onTouchEnd: () => { touchend = true; },
-			onTouchCancel: () => { touchcancel = true; }
+		const textInput = new TextInput();
+		textInput.__setProperties__({
+			onBlur,
+			onChange,
+			onClick,
+			onInput,
+			onFocus,
+			onKeyDown,
+			onKeyPress,
+			onKeyUp,
+			onMouseDown,
+			onMouseUp,
+			onTouchStart,
+			onTouchEnd,
+			onTouchCancel
 		});
 
-		(<any> textinput)._onBlur(<FocusEvent> {});
-		assert.isTrue(blurred);
-		(<any> textinput)._onChange(<Event> {});
-		assert.isTrue(changed);
-		(<any> textinput)._onClick(<MouseEvent> {});
-		assert.isTrue(clicked);
-		(<any> textinput)._onFocus(<FocusEvent> {});
-		assert.isTrue(focused);
-		(<any> textinput)._onInput(<Event> {});
-		assert.isTrue(input);
-		(<any> textinput)._onKeyDown(<KeyboardEvent> {});
-		assert.isTrue(keydown);
-		(<any> textinput)._onKeyPress(<KeyboardEvent> {});
-		assert.isTrue(keypress);
-		(<any> textinput)._onKeyUp(<KeyboardEvent> {});
-		assert.isTrue(keyup);
-		(<any> textinput)._onMouseDown(<MouseEvent> {});
-		assert.isTrue(mousedown);
-		(<any> textinput)._onMouseUp(<MouseEvent> {});
-		assert.isTrue(mouseup);
-		(<any> textinput)._onTouchStart(<TouchEvent> {});
-		assert.isTrue(touchstart);
-		(<any> textinput)._onTouchEnd(<TouchEvent> {});
-		assert.isTrue(touchend);
-		(<any> textinput)._onTouchCancel(<TouchEvent> {});
-		assert.isTrue(touchcancel);
+		(<any> textInput)._onBlur(<FocusEvent> {});
+		assert.isTrue(onBlur.called);
+		(<any> textInput)._onChange(<Event> {});
+		assert.isTrue(onChange.called);
+		(<any> textInput)._onClick(<MouseEvent> {});
+		assert.isTrue(onClick.called);
+		(<any> textInput)._onFocus(<FocusEvent> {});
+		assert.isTrue(onFocus.called);
+		(<any> textInput)._onInput(<Event> {});
+		assert.isTrue(onInput.called);
+		(<any> textInput)._onKeyDown(<KeyboardEvent> {});
+		assert.isTrue(onKeyDown.called);
+		(<any> textInput)._onKeyPress(<KeyboardEvent> {});
+		assert.isTrue(onKeyPress.called);
+		(<any> textInput)._onKeyUp(<KeyboardEvent> {});
+		assert.isTrue(onKeyUp.called);
+		(<any> textInput)._onMouseDown(<MouseEvent> {});
+		assert.isTrue(onMouseDown.called);
+		(<any> textInput)._onMouseUp(<MouseEvent> {});
+		assert.isTrue(onMouseUp.called);
+		(<any> textInput)._onTouchStart(<TouchEvent> {});
+		assert.isTrue(onTouchStart.called);
+		(<any> textInput)._onTouchEnd(<TouchEvent> {});
+		assert.isTrue(onTouchEnd.called);
+		(<any> textInput)._onTouchCancel(<TouchEvent> {});
+		assert.isTrue(onTouchCancel.called);
 	}
 });

--- a/src/titlepane/tests/unit/TitlePane.ts
+++ b/src/titlepane/tests/unit/TitlePane.ts
@@ -1,5 +1,6 @@
 import * as registerSuite from 'intern!object';
 import * as assert from 'intern/chai!assert';
+import * as sinon from 'sinon';
 import harness, { Harness } from '@dojo/test-extras/harness';
 import { compareProperty } from '@dojo/test-extras/support/d';
 import { v } from '@dojo/widget-core/d';
@@ -99,46 +100,41 @@ registerSuite({
 	},
 
 	'click title to close'() {
-		let called = false;
+		const onRequestClose = sinon.spy();
+
 		titlePane.setProperties({
 			closeable: true,
-			onRequestClose() {
-				called = true;
-			},
+			onRequestClose,
 			title: 'test'
 		});
 
 		titlePane.sendEvent('click', {
 			selector: `.${css.title}`
 		});
-		assert.isTrue(called, 'onRequestClose should be called on title click');
+		assert.isTrue(onRequestClose.called, 'onRequestClose should be called on title click');
 	},
 
 	'click title to open'() {
-		let called = false;
+		const onRequestOpen = sinon.spy();
 		titlePane.setProperties({
 			closeable: true,
 			open: false,
-			onRequestOpen() {
-				called = true;
-			},
+			onRequestOpen,
 			title: 'test'
 		});
 
 		titlePane.sendEvent('click', {
 			selector: `.${css.title}`
 		});
-		assert.isTrue(called, 'onRequestOpen should be called on title click');
+		assert.isTrue(onRequestOpen.called, 'onRequestOpen should be called on title click');
 	},
 
 	'can not open pane on click'() {
-		let called = 0;
+		const onRequestClose = sinon.spy();
 		titlePane.setProperties({
 			closeable: false,
 			open: true,
-			onRequestClose() {
-				called++;
-			},
+			onRequestClose,
 			title: 'test'
 		});
 		titlePane.getRender();
@@ -148,9 +144,7 @@ registerSuite({
 
 		titlePane.setProperties({
 			open: true,
-			onRequestClose() {
-				called++;
-			},
+			onRequestClose,
 			title: 'test'
 		});
 		titlePane.getRender();
@@ -158,17 +152,15 @@ registerSuite({
 			selector: `.${css.title}`
 		});
 
-		assert.strictEqual(called, 1, 'onRequestClose should only becalled once');
+		assert.isTrue(onRequestClose.calledOnce, 'onRequestClose should only becalled once');
 	},
 
 	'can not open pane on keyup'() {
-		let called = 0;
+		const onRequestClose = sinon.spy();
 		titlePane.setProperties({
 			closeable: false,
 			open: true,
-			onRequestClose() {
-				called++;
-			},
+			onRequestClose,
 			title: 'test'
 		});
 		titlePane.getRender();
@@ -179,9 +171,7 @@ registerSuite({
 
 		titlePane.setProperties({
 			open: true,
-			onRequestClose() {
-				called++;
-			},
+			onRequestClose,
 			title: 'test'
 		});
 		titlePane.getRender();
@@ -190,17 +180,15 @@ registerSuite({
 			selector: `.${css.title}`
 		});
 
-		assert.strictEqual(called, 1, 'onRequestClose should only becalled once');
+		assert.isTrue(onRequestClose.calledOnce, 'onRequestClose should only becalled once');
 	},
 
 	'open on keyup'() {
-		let openCount = 0;
+		const onRequestOpen = sinon.spy();
 		const props = {
 			closeable: true,
 			open: false,
-			onRequestOpen() {
-				openCount++;
-			},
+			onRequestOpen,
 			title: 'test'
 		};
 
@@ -209,24 +197,22 @@ registerSuite({
 			eventInit: { keyCode: Keys.Enter },
 			selector: `.${css.title}`
 		});
-		assert.strictEqual(openCount, 1, 'onRequestOpen should be called on title enter keyup');
+		assert.isTrue(onRequestOpen.calledOnce, 'onRequestOpen should be called on title enter keyup');
 
 		titlePane.setProperties(props);
 		titlePane.sendEvent('keyup', {
 			eventInit: { keyCode: Keys.Space },
 			selector: `.${css.title}`
 		});
-		assert.strictEqual(openCount, 2, 'onRequestOpen should be called on title space keyup');
+		assert.isTrue(onRequestOpen.calledTwice, 'onRequestOpen should be called on title space keyup');
 	},
 
 	'close on keyup'() {
-		let closeCount = 0;
+		const onRequestClose = sinon.spy();
 		const props = {
 			closeable: true,
 			open: true,
-			onRequestClose() {
-				closeCount++;
-			},
+			onRequestClose,
 			title: 'test'
 		};
 
@@ -235,27 +221,24 @@ registerSuite({
 			eventInit: { keyCode: Keys.Enter },
 			selector: `.${css.title}`
 		});
-		assert.strictEqual(closeCount, 1, 'onRequestClose should be called on title enter keyup');
+		assert.isTrue(onRequestClose.calledOnce, 'onRequestClose should be called on title enter keyup');
 
 		titlePane.setProperties(props);
 		titlePane.sendEvent('keyup', {
 			eventInit: { keyCode: Keys.Space },
 			selector: `.${css.title}`
 		});
-		assert.strictEqual(closeCount, 2, 'onRequestClose should be called on title space keyup');
+		assert.isTrue(onRequestClose.calledTwice, 'onRequestClose should be called on title space keyup');
 	},
 
 	'keyup: only respond to enter and space'() {
-		let called = false;
+		const onRequestClose = sinon.spy();
+		const onRequestOpen = sinon.spy();
 		titlePane.setProperties({
 			closeable: true,
 			open: false,
-			onRequestClose() {
-				called = true;
-			},
-			onRequestOpen() {
-				called = true;
-			},
+			onRequestClose,
+			onRequestOpen,
 			title: 'test'
 		});
 
@@ -265,7 +248,8 @@ registerSuite({
 					eventInit: { keyCode: i },
 					selector: `.${css.title}`
 				});
-				assert.isFalse(called, `keyCode {i} should be ignored`);
+				assert.isFalse(onRequestClose.called, `keyCode {i} should be ignored`);
+				assert.isFalse(onRequestOpen.called, `keyCode {i} should be ignored`);
 			}
 		}
 	}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

This PR updates all component unit tests to use sinon for mocking property callbacks instead of manually setting and asserting a variable.

Resolves #234
