### PR TITLE
Theme: SplitPane

### DIFF
--- a/src/splitpane/styles/splitPane.m.css
+++ b/src/splitpane/styles/splitPane.m.css
@@ -1,13 +1,13 @@
 @import '../../common/styles/variables.css';
 
 .rootFixed {
-	width: 100%;
-	height: 100%;
-	position: relative;
-	display: flex;
-	align-items: stretch;
 	align-content: stretch;
+	align-items: stretch;
+	display: flex;
+	height: 100%;
 	overflow: hidden;
+	position: relative;
+	width: 100%;
 }
 
 .root { }
@@ -19,10 +19,10 @@
 .column { }
 
 .dividerFixed {
+	background-clip: padding-box;
 	background: var(--component-color);
 	cursor: pointer;
 	flex: 0 0 auto;
-	background-clip: padding-box;
 }
 
 .divider { }
@@ -35,28 +35,14 @@
 
 .rowFixed > .dividerFixed {
 	width: 1px;
-	border-left: 2.5px solid transparent;
-	border-right: 2.5px solid transparent;
 	cursor: ew-resize;
-}
-
-.rowFixed > .dividerFixed:hover {
-	border-left-color: var(--underlay-background);
-	border-right-color: var(--underlay-background);
 }
 
 .row { }
 
 .columnFixed > .dividerFixed {
 	height: 1px;
-	border-top: 2.5px solid transparent;
-	border-bottom: 2.5px solid transparent;
 	cursor: ns-resize;
-}
-
-.columnFixed > .dividerFixed:hover {
-	border-top-color: var(--underlay-background);
-	border-bottom-color: var(--underlay-background);
 }
 
 .trailingFixed {

--- a/src/themes/dojo/splitPane.m.css
+++ b/src/themes/dojo/splitPane.m.css
@@ -18,13 +18,13 @@
 }
 
 .row > .divider {
-	border-left: 2.5px solid transparent;
-	border-right: 2.5px solid transparent;
+	border-left: 2px solid transparent;
+	border-right: 2px solid transparent;
 }
 
 .column > .divider {
-	border-bottom: 2.5px solid transparent;
-	border-top: 2.5px solid transparent;
+	border-bottom: 2px solid transparent;
+	border-top: 2px solid transparent;
 }
 
 .row > .divider:hover {

--- a/src/themes/dojo/splitPane.m.css
+++ b/src/themes/dojo/splitPane.m.css
@@ -1,16 +1,28 @@
 @import './variables.css';
 
+.root {
+	box-sizing: border-box;
+	color: var(--color-text-primary);
+	font-size: var(--font-size-base);
+	line-height: var(--line-height-base);
+}
+
+.root * {
+	box-sizing: border-box;
+}
+
 .divider {
-	background-color: var(--dojo-blue);
-	transition: border var(--short-animation-duration) var(--short-animation-easing);
+	box-sizing: content-box;
+	background-color: var(--color-border);
+	transition: border var(--transition-duration) var(--transition-easing);
 }
 
 .row > .divider:hover {
-	border-left-color: var(--dojo-light-blue);
-	border-right-color: var(--dojo-light-blue);
+	border-left-color: var(--color-border-strong);
+	border-right-color: var(--color-border-strong);
 }
 
 .column > .divider:hover {
-	border-top-color: var(--dojo-light-blue);
-	border-bottom-color: var(--dojo-light-blue);
+	border-top-color: var(--color-border-strong);
+	border-bottom-color: var(--color-border-strong);
 }

--- a/src/themes/dojo/splitPane.m.css
+++ b/src/themes/dojo/splitPane.m.css
@@ -12,9 +12,19 @@
 }
 
 .divider {
-	box-sizing: content-box;
 	background-color: var(--color-border);
+	box-sizing: content-box;
 	transition: border var(--transition-duration) var(--transition-easing);
+}
+
+.row > .divider {
+	border-left: 2.5px solid transparent;
+	border-right: 2.5px solid transparent;
+}
+
+.column > .divider {
+	border-bottom: 2.5px solid transparent;
+	border-top: 2.5px solid transparent;
 }
 
 .row > .divider:hover {
@@ -23,6 +33,6 @@
 }
 
 .column > .divider:hover {
-	border-top-color: var(--color-border-strong);
 	border-bottom-color: var(--color-border-strong);
+	border-top-color: var(--color-border-strong);
 }

--- a/tscommand-bdde2fd3.tmp.txt
+++ b/tscommand-bdde2fd3.tmp.txt
@@ -1,0 +1,1 @@
+--project tsconfig.json

--- a/tscommand-bdde2fd3.tmp.txt
+++ b/tscommand-bdde2fd3.tmp.txt
@@ -1,1 +1,0 @@
---project tsconfig.json


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR adds an initial theme for the SplitPane component.

<img width="1026" alt="screen shot 2017-07-21 at 3 07 39 pm" src="https://user-images.githubusercontent.com/334586/28478437-5d0b33f0-6e26-11e7-9530-0e26cde88f7d.png">

