### PR TITLE
Slider: min / max value fix

### DIFF
--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -111,9 +111,12 @@ export default class Slider extends SliderBase<SliderProperties> {
 			vertical = false,
 			verticalHeight = '200px'
 		} = this.properties;
-		const {
+		let {
 			value = min
 		} = this.properties;
+
+		value = value > max ? max : value;
+		value = value < min ? min : value;
 
 		const stateClasses = [
 			disabled ? css.disabled : null,

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -219,5 +219,24 @@ registerSuite({
 		assert.isTrue(touchend);
 		(<any> slider)._onTouchCancel(<TouchEvent> {});
 		assert.isTrue(touchcancel);
+	},
+
+	'min and max should be respected'() {
+		const slider = new Slider();
+		slider.__setProperties__({
+			max: 40,
+			value: 100
+		});
+		let vnode = <VNode> slider.__render__();
+		let inputNode = vnode.children![0].children![0];
+		assert.strictEqual(inputNode.properties!.value, '40');
+
+		slider.__setProperties__({
+			min: 30,
+			value: 20
+		});
+		vnode = <VNode> slider.__render__();
+		inputNode = vnode.children![0].children![0];
+		assert.strictEqual(inputNode.properties!.value, '30');
 	}
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

This PR updates the Slider component so it never renders a value higher than its `max` or lower than its `min`.

Resolves #259 
