### PR TITLE
Fix slider thumb position on non-zero mins

### DIFF
--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -127,13 +127,15 @@ export default class Slider extends SliderBase<SliderProperties> {
 			vertical ? css.vertical : null
 		];
 
+		const percentValue = (value - min) / (max - min) * 100;
+
 		// custom output node
 		const outputNode = output ? output(value) : value + '';
 
 		// output styles
 		let outputStyles: { left?: string; top?: string } = {};
 		if (outputIsTooltip) {
-			outputStyles = vertical ? { top: ((max - value) / max * 100) + '%' } : { left: (value / max * 100) + '%' };
+			outputStyles = vertical ? { top: `${100 - percentValue}%` } : { left: `${percentValue}%` };
 		}
 
 		const slider = v('div', {
@@ -177,11 +179,11 @@ export default class Slider extends SliderBase<SliderProperties> {
 			}, [
 				v('span', {
 					classes: this.classes(css.fill).fixed(css.fillFixed),
-					styles: { width: (value / max * 100) + '%' }
+					styles: { width: `${percentValue}%` }
 				}),
 				v('span', {
 					classes: this.classes(css.thumb).fixed(css.thumbFixed),
-					styles: { left: (value / max * 100) + '%' }
+					styles: { left: `${percentValue}%` }
 				})
 			]),
 			v('output', {

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -159,6 +159,17 @@ registerSuite({
 
 		assert.strictEqual(outputNode.properties!.styles!.top, '75%');
 		assert.isUndefined(outputNode.properties!.styles!.left);
+
+		slider.__setProperties__({
+			max: 90,
+			min: 10,
+			outputIsTooltip: true,
+			value: 50
+		});
+		vnode = <VNode> slider.__render__();
+		outputNode = vnode.children![0].children![2];
+
+		assert.strictEqual(outputNode.properties!.styles!.left, '50%');
 	},
 
 	events() {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

The slider widget was calculating thumb position incorrectly when the minimum value was not zero
