### PR TITLE
Registry support built into WidgetBase

### DIFF
--- a/src/combobox/ResultMenu.ts
+++ b/src/combobox/ResultMenu.ts
@@ -1,6 +1,5 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { ThemeableMixin, ThemeableProperties, theme } from '@dojo/widget-core/mixins/Themeable';
-import { RegistryMixin, RegistryMixinProperties } from '@dojo/widget-core/mixins/Registry';
 import { v, w } from '@dojo/widget-core/d';
 import { DNode, WNode } from '@dojo/widget-core/interfaces';
 import ResultItem from './ResultItem';
@@ -21,7 +20,7 @@ import * as css from './styles/comboBox.m.css';
  * @property results                List of result data objects
  * @property selectedIndex          Position of the selected result in the list of results
  */
-export interface ResultMenuProperties extends ThemeableProperties, RegistryMixinProperties {
+export interface ResultMenuProperties extends ThemeableProperties {
 	getResultLabel(result: any): string;
 	id?: string;
 	isResultDisabled?(result: any): boolean;
@@ -32,7 +31,7 @@ export interface ResultMenuProperties extends ThemeableProperties, RegistryMixin
 	selectedIndex: number | undefined;
 };
 
-export const ResultMenuBase = RegistryMixin(ThemeableMixin(WidgetBase));
+export const ResultMenuBase = ThemeableMixin(WidgetBase);
 
 @theme(css)
 export default class ResultMenu extends ResultMenuBase<ResultMenuProperties> {

--- a/src/label/Label.ts
+++ b/src/label/Label.ts
@@ -1,7 +1,6 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { DNode } from '@dojo/widget-core/interfaces';
 import { ThemeableMixin, ThemeableProperties, theme } from '@dojo/widget-core/mixins/Themeable';
-import { RegistryMixin } from '@dojo/widget-core/mixins/Registry';
 import { WidgetRegistry } from '@dojo/widget-core/WidgetRegistry';
 import { v } from '@dojo/widget-core/d';
 import { assign } from '@dojo/core/lang';
@@ -55,7 +54,7 @@ export function parseLabelClasses(classes: { [key: string]: boolean | undefined 
 	}, '').trim();
 }
 
-export const LabelBase = RegistryMixin(ThemeableMixin(WidgetBase));
+export const LabelBase = ThemeableMixin(WidgetBase);
 
 @theme(css)
 export default class Label extends LabelBase<LabelProperties>  {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Registry support is now built into [built into](https://github.com/dojo/widget-core/pull/636/files) `WidgetBase`.

**DO NOT MERGE**

Related To https://github.com/dojo/widget-core/issues/613
