### PR TITLE
add `grunt dist` to travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,6 +24,7 @@ script:
 - grunt intern:browserstack --combined
 - grunt remapIstanbul:ci
 - grunt uploadCoverage
+- grunt dist
 - grunt doc
 notifications:
   slack:


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds `grunt dist` to the `travis.yml`
