### PR TITLE
Update intern to intern3 in grunt config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,8 +20,8 @@ install:
 - travis_retry npm install
 script:
 - grunt
-- grunt intern:node --combined
-- grunt intern:browserstack --combined
+- grunt test:node --combined
+- grunt test:browserstack --combined
 - grunt remapIstanbul:ci
 - grunt uploadCoverage
 - grunt doc

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -64,7 +64,7 @@ module.exports = function (grunt) {
 				}
 			}
 		},
-		intern: {
+		intern3: {
 			options: {
 				runType: 'runner',
 				config: '<%= devDirectory %>/common/tests/intern',


### PR DESCRIPTION
**Type:** bug

`grunt-dojo2` now looks for `intern${version}` instead of `intern` in config options.
