### PR TITLE
Radio and Checkbox interaction with no label

### DIFF
--- a/src/themes/dojo/checkbox.m.css
+++ b/src/themes/dojo/checkbox.m.css
@@ -12,6 +12,7 @@
 	display: block;
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);
+	min-height: var(--line-height-base);
 	padding: 0 0 0 calc(var(--grid-base) * 3);
 	position: relative;
 }
@@ -30,7 +31,6 @@
 	position: absolute;
 	top: 0;
 	width: 100%;
-	z-index: -1;
 }
 
 .inputWrapper {

--- a/src/themes/dojo/radio.m.css
+++ b/src/themes/dojo/radio.m.css
@@ -4,6 +4,7 @@
 
 .root {
 	display: block;
+	min-height: var(--line-height-base);
 	padding: 0 0 0 calc(var(--grid-base) * 3);
 	position: relative;
 }
@@ -23,7 +24,6 @@
 	position: absolute;
 	top: 0;
 	width: 100%;
-	z-index: -1;
 }
 
 .input:focus {


### PR DESCRIPTION
**Type:** bug
The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Themed radio and checkbox inputs should be visible and toggle-able without a label. I added a min-height to the root element and removed `z-index: -1` so the `<input>` element sits on top of the styled control.