### PR TITLE
Update CI for new release of grunt-dojo2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ install:
 - travis_retry npm install
 script:
 - grunt
-- grunt intern:browserstack
+- grunt intern:browserstack --test-reporter
 - grunt uploadCoverage
 - grunt doc
 deploy:

--- a/intern.json
+++ b/intern.json
@@ -32,18 +32,16 @@
 		]
 	},
 
-	"configs": {
-		"coverage": {
-			"coverage": [
-				"./_build/**/*.js",
-				"!./_build/**/tests/**/*",
-				"!./_build/**/styles/**/*",
-				"!./_build/**/themes/**/*",
-				"!./_build/**/example/**/*",
-				"!./_build/**/*Element.js"
-			]
-		},
+	"coverage": [
+		"./_build/**/*.js",
+		"!./_build/**/tests/**/*",
+		"!./_build/**/styles/**/*",
+		"!./_build/**/themes/**/*",
+		"!./_build/**/example/**/*",
+		"!./_build/**/*Element.js"
+	],
 
+	"configs": {
 		"remoteCapabilities": {
 			"capabilities": {
 				"project": "Dojo 2",
@@ -52,7 +50,7 @@
 		},
 
 		"browserstack": {
-			"extends": [ "coverage", "remoteCapabilities" ],
+			"extends": [ "remoteCapabilities" ],
 
 			"tunnel": "browserstack",
 			"capabilities+": {
@@ -72,7 +70,7 @@
 		},
 
 		"local": {
-			"extends": [ "coverage", "remoteCapabilities" ],
+			"extends": [ "remoteCapabilities" ],
 
 			"tunnel": "selenium",
 			"tunnelOptions": {
@@ -86,7 +84,7 @@
 		},
 
 		"saucelabs": {
-			"extends": [ "coverage", "remoteCapabilities" ],
+			"extends": [ "remoteCapabilities" ],
 
 			"tunnel": "saucelabs",
 			"tunnelOptions": {},

--- a/intern.json
+++ b/intern.json
@@ -1,4 +1,10 @@
 {
+	"capabilities": {
+		"project": "Dojo 2",
+		"name": "@dojo/widgets",
+		"browserstack.debug": false
+	},
+
 	"environments": [
 		{ "browserName": "node" }
 	],
@@ -42,20 +48,8 @@
 	],
 
 	"configs": {
-		"remoteCapabilities": {
-			"capabilities": {
-				"project": "Dojo 2",
-				"name": "@dojo/widgets"
-			}
-		},
-
 		"browserstack": {
-			"extends": [ "remoteCapabilities" ],
-
 			"tunnel": "browserstack",
-			"capabilities+": {
-				"browserstack.debug": false
-			},
 
 			"environments+": [
 				{ "browserName": "internet explorer", "version": "11" },
@@ -70,8 +64,6 @@
 		},
 
 		"local": {
-			"extends": [ "remoteCapabilities" ],
-
 			"tunnel": "selenium",
 			"tunnelOptions": {
 				"hostname": "localhost",
@@ -84,8 +76,6 @@
 		},
 
 		"saucelabs": {
-			"extends": [ "remoteCapabilities" ],
-
 			"tunnel": "saucelabs",
 			"tunnelOptions": {},
 


### PR DESCRIPTION
**Type:** enhancement

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

`grunt-dojo2` has been updated in [a PR](https://github.com/dojo/grunt-dojo2/pull/162) to use Intern 4 exclusively which includes a reporter similar to the one developed for Intern 3. This PR updates the CI scripts to use these features and return the grunt tasks back to feature parity with the tasks before the Intern 4 conversion. The `grunt-dojo2` PR **MUST LAND** and be released before this can land.