### PR TITLE
300 - Fix splitpane border

### DIFF
--- a/src/splitpane/styles/splitPane.m.css
+++ b/src/splitpane/styles/splitPane.m.css
@@ -20,12 +20,13 @@
 
 .dividerFixed {
 	background-clip: padding-box;
-	background: var(--component-color);
 	cursor: pointer;
 	flex: 0 0 auto;
 }
 
-.divider { }
+.divider {
+	background-color: var(--component-color);
+}
 
 .leadingFixed {
 	flex: 0 0 auto;


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

`background` on fixed class was being used over `background-color` in the theme. Moved the background to the themeable class instead.

Resolves #300 
