### PR TITLE
Simplify widget render

### DIFF
--- a/src/accordionpane/tests/functional/AccordionPane.ts
+++ b/src/accordionpane/tests/functional/AccordionPane.ts
@@ -20,7 +20,7 @@ registerSuite('AccordionPane', {
 				.then((size: { height: number }) => {
 					assert.isBelow(size.height, 50);
 				})
-				.findByCssSelector('[role="heading"]')
+				.findByCssSelector('button')
 					.click()
 				.end()
 				.sleep(DELAY)

--- a/src/button/Button.ts
+++ b/src/button/Button.ts
@@ -70,11 +70,11 @@ export default class Button extends ButtonBase<ButtonProperties> {
 	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
 	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
 
-	protected getContent() {
+	protected getContent(): DNode[] {
 		return this.children;
 	}
 
-	protected getModifierClasses() {
+	protected getModifierClasses(): (string | null)[] {
 		const {
 			disabled,
 			popup = false,
@@ -88,7 +88,7 @@ export default class Button extends ButtonBase<ButtonProperties> {
 		];
 	}
 
-	protected renderPopupIcon() {
+	protected renderPopupIcon(): DNode {
 		return v('i', { classes: this.classes(css.addon, iconCss.icon, iconCss.downIcon),
 			role: 'presentation', 'aria-hidden': 'true'
 		});

--- a/src/button/Button.ts
+++ b/src/button/Button.ts
@@ -70,6 +70,30 @@ export default class Button extends ButtonBase<ButtonProperties> {
 	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
 	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
 
+	protected getContent() {
+		return this.children;
+	}
+
+	protected getModifierClasses() {
+		const {
+			disabled,
+			popup = false,
+			pressed
+		} = this.properties;
+
+		return [
+			disabled ? css.disabled : null,
+			popup ? css.popup : null,
+			pressed ? css.pressed : null
+		];
+	}
+
+	protected renderPopupIcon() {
+		return v('i', { classes: this.classes(css.addon, iconCss.icon, iconCss.downIcon),
+			role: 'presentation', 'aria-hidden': 'true'
+		});
+	}
+
 	render(): DNode {
 		let {
 			describedBy,
@@ -87,12 +111,7 @@ export default class Button extends ButtonBase<ButtonProperties> {
 		}
 
 		return v('button', {
-			classes: this.classes(
-				css.root,
-				disabled ? css.disabled : null,
-				popup ? css.popup : null,
-				pressed ? css.pressed : null
-			),
+			classes: this.classes(css.root, ...this.getModifierClasses()),
 			disabled,
 			id,
 			name,
@@ -115,10 +134,8 @@ export default class Button extends ButtonBase<ButtonProperties> {
 			'aria-pressed': typeof pressed === 'boolean' ? pressed.toString() : null,
 			'aria-describedby': describedBy
 		}, [
-			...this.children,
-			popup ? v('i', { classes: this.classes(css.addon, iconCss.icon, iconCss.downIcon),
-				role: 'presentation', 'aria-hidden': 'true'
-			}) : null
+			...this.getContent(),
+			popup ? this.renderPopupIcon() : null
 		]);
 	}
 }

--- a/src/button/tests/functional/Button.ts
+++ b/src/button/tests/functional/Button.ts
@@ -10,6 +10,8 @@ function getPage(remote: Remote) {
 		.setFindTimeout(5000);
 }
 
+const DELAY = 750;
+
 registerSuite('Button', {
 	'button should be visible'() {
 		return getPage(this.remote)
@@ -49,6 +51,7 @@ registerSuite('Button', {
 					assert.isNull(pressed, 'Initial state should be null');
 				})
 				.click()
+				.sleep(DELAY)
 			.end()
 			.findByCssSelector(`#example-4 .${css.root}`)
 				.getAttribute('aria-pressed')

--- a/src/calendar/Calendar.ts
+++ b/src/calendar/Calendar.ts
@@ -305,7 +305,7 @@ export default class Calendar extends CalendarBase<CalendarProperties> {
 		});
 	}
 
-	protected renderDatePicker() {
+	protected renderDatePicker(): DNode {
 		const {
 			labels = DEFAULT_LABELS,
 			monthNames = DEFAULT_MONTHS,
@@ -340,7 +340,7 @@ export default class Calendar extends CalendarBase<CalendarProperties> {
 		});
 	}
 
-	protected renderPagingButtonContent(type: Paging) {
+	protected renderPagingButtonContent(type: Paging): DNode[] {
 		const { labels = DEFAULT_LABELS } = this.properties;
 		const iconClass = type === Paging.next ? iconCss.rightIcon : iconCss.leftIcon;
 		const labelText = type === Paging.next ? labels.nextMonth : labels.previousMonth;

--- a/src/calendar/Calendar.ts
+++ b/src/calendar/Calendar.ts
@@ -5,7 +5,7 @@ import { DNode } from '@dojo/widget-core/interfaces';
 import uuid from '@dojo/core/uuid';
 import { Keys } from '../common/util';
 import { CalendarMessages } from './DatePicker';
-import DatePicker from './DatePicker';
+import DatePicker, { Paging } from './DatePicker';
 import CalendarCell from './CalendarCell';
 import * as css from './styles/calendar.m.css';
 import * as baseCss from '../common/styles/base.m.css';
@@ -341,10 +341,10 @@ export default class Calendar extends CalendarBase<CalendarProperties> {
 		});
 	}
 
-	protected renderPagingButtonContent(type: 'next' | 'previous') {
+	protected renderPagingButtonContent(type: Paging) {
 		const { labels = DEFAULT_LABELS } = this.properties;
-		const iconClass = type === 'next' ? iconCss.rightIcon : iconCss.leftIcon;
-		const labelText = type === 'next' ? labels.nextMonth : labels.previousMonth;
+		const iconClass = type === Paging.next ? iconCss.rightIcon : iconCss.leftIcon;
+		const labelText = type === Paging.next ? labels.nextMonth : labels.previousMonth;
 
 		return [
 			v('i', { classes: this.classes(iconCss.icon, iconClass),
@@ -400,12 +400,12 @@ export default class Calendar extends CalendarBase<CalendarProperties> {
 					classes: this.classes(css.previous),
 					tabIndex: this._popupOpen ? -1 : 0,
 					onclick: this._onMonthPageDown
-				}, this.renderPagingButtonContent('previous')),
+				}, this.renderPagingButtonContent(Paging.previous)),
 				v('button', {
 					classes: this.classes(css.next),
 					tabIndex: this._popupOpen ? -1 : 0,
 					onclick: this._onMonthPageUp
-				}, this.renderPagingButtonContent('next'))
+				}, this.renderPagingButtonContent(Paging.next))
 			])
 		]);
 	}

--- a/src/calendar/Calendar.ts
+++ b/src/calendar/Calendar.ts
@@ -278,7 +278,7 @@ export default class Calendar extends CalendarBase<CalendarProperties> {
 
 				const isToday = isCurrentMonth && dateString === todayString;
 
-				days.push(this.renderDateCell(date, isSelectedDay, isCurrentMonth, isToday));
+				days.push(this.renderDateCell(date, week * 7 + i, isSelectedDay, isCurrentMonth, isToday));
 			}
 
 			weeks.push(v('tr', days));
@@ -287,12 +287,11 @@ export default class Calendar extends CalendarBase<CalendarProperties> {
 		return weeks;
 	}
 
-	protected renderDateCell(date: number, selected: boolean, currentMonth: boolean, today: boolean): DNode {
-		const key = currentMonth ? `date-${date}` : `date-${date}-dimmed`;
+	protected renderDateCell(date: number, index: number, selected: boolean, currentMonth: boolean, today: boolean): DNode {
 		const { theme = {} } = this.properties;
 
 		return w(CalendarCell, {
-			key,
+			key: `date-${index}`,
 			callFocus: this._callDateFocus && currentMonth && date === this._focusedDay,
 			date,
 			disabled: !currentMonth,

--- a/src/calendar/CalendarCell.ts
+++ b/src/calendar/CalendarCell.ts
@@ -65,28 +65,33 @@ export default class CalendarCell extends CalendarCellBase<CalendarCellPropertie
 		return v('span', [ `${date}` ]);
 	}
 
-	protected render(): DNode {
+	protected getModifierClasses() {
 		const {
-			date,
 			disabled = false,
-			focusable = false,
 			selected = false,
 			today = false
 		} = this.properties;
 
-		const dateCellClasses = [
-			css.date,
+		return [
 			disabled ? css.inactiveDate : null,
 			selected ? css.selectedDate : null,
 			today ? css.todayDate : null
 		];
+	}
+
+	protected render(): DNode {
+		const {
+			date,
+			focusable = false,
+			selected = false
+		} = this.properties;
 
 		return v('td', {
 			key: 'root',
 			role: 'gridcell',
 			'aria-selected': `${selected}`,
 			tabIndex: focusable ? 0 : -1,
-			classes: this.classes(...dateCellClasses),
+			classes: this.classes(css.date, ...this.getModifierClasses()),
 			onclick: this._onClick,
 			onkeydown: this._onKeyDown
 		}, [ this.formatDate(date) ]);

--- a/src/calendar/CalendarCell.ts
+++ b/src/calendar/CalendarCell.ts
@@ -65,7 +65,7 @@ export default class CalendarCell extends CalendarCellBase<CalendarCellPropertie
 		return v('span', [ `${date}` ]);
 	}
 
-	protected getModifierClasses() {
+	protected getModifierClasses(): (string | null)[] {
 		const {
 			disabled = false,
 			selected = false,

--- a/src/calendar/DatePicker.ts
+++ b/src/calendar/DatePicker.ts
@@ -233,12 +233,12 @@ export default class DatePicker extends DatePickerBase<DatePickerProperties> {
 		}, [ content ]);
 	}
 
-	protected renderMonthLabel(month: number, year: number) {
+	protected renderMonthLabel(month: number, year: number): DNode {
 		const { monthNames, renderMonthLabel } = this.properties;
 		return renderMonthLabel ? renderMonthLabel(month, year) : `${monthNames[month].long} ${year}`;
 	}
 
-	protected renderMonthRadios() {
+	protected renderMonthRadios(): DNode[] {
 		const { month } = this.properties;
 
 		return this.properties.monthNames.map((monthName, i) => v('label', {
@@ -262,7 +262,7 @@ export default class DatePicker extends DatePickerBase<DatePickerProperties> {
 		]));
 	}
 
-	protected renderPagingButtonContent(type: Paging) {
+	protected renderPagingButtonContent(type: Paging): DNode[] {
 		const { labels } = this.properties;
 		const iconClass = type === Paging.next ? iconCss.rightIcon : iconCss.leftIcon;
 		const labelText = type === Paging.next ? labels.nextMonth : labels.previousMonth;
@@ -275,7 +275,7 @@ export default class DatePicker extends DatePickerBase<DatePickerProperties> {
 		];
 	}
 
-	protected renderYearRadios() {
+	protected renderYearRadios(): DNode[] {
 		const { year } = this.properties;
 		const radios = [];
 

--- a/src/calendar/DatePicker.ts
+++ b/src/calendar/DatePicker.ts
@@ -9,6 +9,22 @@ import * as baseCss from '../common/styles/base.m.css';
 import * as iconCss from '../common/styles/icons.m.css';
 
 /**
+ * Enum for next/previous buttons
+ */
+export const enum Paging {
+	next = 'next',
+	previous = 'previous'
+};
+
+/**
+ * Enum for month or year controls
+ */
+export const enum Controls {
+	month = 'month',
+	year = 'year'
+};
+
+/**
  * @type CalendarMessages
  *
  * Accessible text for Month Picker controls. Messages can be localized by passing a CalendarMessages object into the Calendar widget's labels property
@@ -191,16 +207,16 @@ export default class DatePicker extends DatePickerBase<DatePickerProperties> {
 		onPopupChange && onPopupChange(this._getPopupState());
 	}
 
-	protected renderControlsTrigger(type: 'month' | 'year'): DNode {
+	protected renderControlsTrigger(type: Controls): DNode {
 		const {
 			month,
 			monthNames,
 			year
 		} = this.properties;
 
-		const content = type === 'month' ? monthNames[month].long : `${year}`;
-		const open = type === 'month' ? this._monthPopupOpen : this._yearPopupOpen;
-		const onclick = type === 'month' ? this._onMonthButtonClick : this._onYearButtonClick;
+		const content = type === Controls.month ? monthNames[month].long : `${year}`;
+		const open = type === Controls.month ? this._monthPopupOpen : this._yearPopupOpen;
+		const onclick = type === Controls.month ? this._onMonthButtonClick : this._onYearButtonClick;
 
 		return v('button', {
 			key: `${type}-button`,
@@ -246,10 +262,10 @@ export default class DatePicker extends DatePickerBase<DatePickerProperties> {
 		]));
 	}
 
-	protected renderPagingButtonContent(type: 'next' | 'previous') {
+	protected renderPagingButtonContent(type: Paging) {
 		const { labels } = this.properties;
-		const iconClass = type === 'next' ? iconCss.rightIcon : iconCss.leftIcon;
-		const labelText = type === 'next' ? labels.nextMonth : labels.previousMonth;
+		const iconClass = type === Paging.next ? iconCss.rightIcon : iconCss.leftIcon;
+		const labelText = type === Paging.next ? labels.nextMonth : labels.previousMonth;
 
 		return [
 			v('i', { classes: this.classes(iconCss.icon, iconClass),
@@ -312,10 +328,10 @@ export default class DatePicker extends DatePickerBase<DatePickerProperties> {
 				}, [ this.renderMonthLabel(month, year) ]),
 
 				// month trigger
-				this.renderControlsTrigger('month'),
+				this.renderControlsTrigger(Controls.month),
 
 				// year trigger
-				this.renderControlsTrigger('year')
+				this.renderControlsTrigger(Controls.year)
 			]),
 
 			// month grid
@@ -359,12 +375,12 @@ export default class DatePicker extends DatePickerBase<DatePickerProperties> {
 						classes: this.classes(css.previous),
 						tabIndex: this._yearPopupOpen ? 0 : -1,
 						onclick: this._onYearPageDown
-					}, this.renderPagingButtonContent('previous')),
+					}, this.renderPagingButtonContent(Paging.previous)),
 					v('button', {
 						classes: this.classes(css.next),
 						tabIndex: this._yearPopupOpen ? 0 : -1,
 						onclick: this._onYearPageUp
-					}, this.renderPagingButtonContent('next'))
+					}, this.renderPagingButtonContent(Paging.next))
 				])
 			])
 		]);

--- a/src/calendar/createCalendarElement.ts
+++ b/src/calendar/createCalendarElement.ts
@@ -24,7 +24,6 @@ export default function createCalendarElement(): CustomElementDescriptor {
 			}
 		],
 		properties: [
-			{ propertyName: 'CustomDateCell' },
 			{ propertyName: 'labels' },
 			{ propertyName: 'monthNames' },
 			{ propertyName: 'weekdayNames' },

--- a/src/calendar/tests/unit/Calendar.ts
+++ b/src/calendar/tests/unit/Calendar.ts
@@ -20,9 +20,11 @@ const compareId = compareProperty((value: any) => {
 	return typeof value === 'string';
 });
 
+let dateIndex = -1;
 const expectedDateCell = function(widget: any, date: number, active: boolean) {
+	dateIndex++;
 	return w(CalendarCell, {
-		key: `date-${date}${active ? '' : '-dimmed'}`,
+		key: `date-${dateIndex}`,
 		callFocus: false,
 		date,
 		disabled: !active,
@@ -36,6 +38,7 @@ const expectedDateCell = function(widget: any, date: number, active: boolean) {
 };
 
 const expected = function(widget: any, popupOpen = false) {
+	dateIndex = -1;
 	return v('div', { classes: widget.classes(css.root) }, [
 		w(DatePicker, {
 			key: 'date-picker',
@@ -174,7 +177,7 @@ registerSuite('Calendar', {
 			});
 
 			const expectedVdom = expected(widget);
-			assignProperties(findKey(expectedVdom, 'date-3')!, {
+			assignProperties(findKey(expectedVdom, 'date-6')!, {
 				selected: true
 			});
 
@@ -198,7 +201,7 @@ registerSuite('Calendar', {
 			for (let i = 0; i < 7; i++) {
 				replaceChild(expectedVdom, `1,0,0,${i},0`, 'Bar');
 			}
-			assignProperties(findKey(expectedVdom, 'date-1')!, {
+			assignProperties(findKey(expectedVdom, 'date-4')!, {
 				selected: true
 			});
 			assignChildProperties(expectedVdom, '0', {
@@ -227,7 +230,7 @@ registerSuite('Calendar', {
 
 			widget.callListener('onClick', {
 				args: [1, false],
-				key: 'date-1'
+				key: 'date-4'
 			});
 
 			assert.strictEqual(selectedDate.getDate(), 1, 'Clicking cell selects correct date');
@@ -251,7 +254,7 @@ registerSuite('Calendar', {
 
 			widget.callListener('onClick', {
 				args: [1, true],
-				key: 'date-1-dimmed'
+				key: 'date-34'
 			});
 			assert.strictEqual(currentMonth, 6, 'Month changes to July');
 			assert.strictEqual(selectedDate.getMonth(), 6, 'selected date in July');
@@ -259,7 +262,7 @@ registerSuite('Calendar', {
 
 			widget.callListener('onClick', {
 				args: [30, true],
-				key: 'date-30-dimmed'
+				key: 'date-2'
 			});
 			assert.strictEqual(currentMonth, 4, 'Month changes to May');
 			assert.strictEqual(selectedDate.getMonth(), 4, 'selected date in May');
@@ -282,18 +285,18 @@ registerSuite('Calendar', {
 					which: Keys.Right,
 					preventDefault: () => {}
 				}],
-				key: 'date-1'
+				key: 'date-4'
 			});
 			// not a good way to test this, but this would be called with the arrow key
 			widget.callListener('onFocusCalled', {
-				key: 'date-1'
+				key: 'date-4'
 			});
 			widget.callListener('onKeyDown', {
 				args: [{
 					which: Keys.Enter,
 					preventDefault: () => {}
 				}],
-				key: 'date-2'
+				key: 'date-5'
 			});
 			assert.strictEqual(selectedDate.getDate(), 2, 'Right arrow + enter selects second day');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
@@ -304,14 +307,14 @@ registerSuite('Calendar', {
 					which: Keys.Down,
 					preventDefault: () => {}
 				}],
-				key: 'date-2'
+				key: 'date-5'
 			});
 			widget.callListener('onKeyDown', {
 				args: [{
 					which: Keys.Enter,
 					preventDefault: () => {}
 				}],
-				key: 'date-9'
+				key: 'date-12'
 			});
 			assert.strictEqual(selectedDate.getDate(), 9, 'Down arrow + enter selects one week down');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
@@ -322,14 +325,14 @@ registerSuite('Calendar', {
 					which: Keys.Left,
 					preventDefault: () => {}
 				}],
-				key: 'date-9'
+				key: 'date-12'
 			});
 			widget.callListener('onKeyDown', {
 				args: [{
 					which: Keys.Space,
 					preventDefault: () => {}
 				}],
-				key: 'date-8'
+				key: 'date-11'
 			});
 			assert.strictEqual(selectedDate.getDate(), 8, 'Left arrow + space selects previous day');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
@@ -340,14 +343,14 @@ registerSuite('Calendar', {
 					which: Keys.Up,
 					preventDefault: () => {}
 				}],
-				key: 'date-8'
+				key: 'date-11'
 			});
 			widget.callListener('onKeyDown', {
 				args: [{
 					which: Keys.Space,
 					preventDefault: () => {}
 				}],
-				key: 'date-1'
+				key: 'date-4'
 			});
 			assert.strictEqual(selectedDate.getDate(), 1, 'Left arrow + space selects previous day');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
@@ -358,14 +361,14 @@ registerSuite('Calendar', {
 					which: Keys.PageDown,
 					preventDefault: () => {}
 				}],
-				key: 'date-1'
+				key: 'date-4'
 			});
 			widget.callListener('onKeyDown', {
 				args: [{
 					which: Keys.Space,
 					preventDefault: () => {}
 				}],
-				key: 'date-30'
+				key: 'date-33'
 			});
 			assert.strictEqual(selectedDate.getDate(), 30, 'Page Down + space selects last day');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
@@ -376,14 +379,14 @@ registerSuite('Calendar', {
 					which: Keys.PageUp,
 					preventDefault: () => {}
 				}],
-				key: 'date-30'
+				key: 'date-33'
 			});
 			widget.callListener('onKeyDown', {
 				args: [{
 					which: Keys.Space,
 					preventDefault: () => {}
 				}],
-				key: 'date-1'
+				key: 'date-4'
 			});
 			assert.strictEqual(selectedDate.getDate(), 1, 'Page Up + space selects first day');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
@@ -404,7 +407,7 @@ registerSuite('Calendar', {
 					which: Keys.Left,
 					preventDefault: () => {}
 				}],
-				key: 'date-1'
+				key: 'date-4'
 			});
 			assert.strictEqual(currentMonth, testDate.getMonth() - 1, 'Going left from the first day goes to previous month');
 
@@ -413,14 +416,14 @@ registerSuite('Calendar', {
 					which: Keys.PageDown,
 					preventDefault: () => {}
 				}],
-				key: 'date-1'
+				key: 'date-4'
 			});
 			widget.callListener('onKeyDown', {
 				args: [{
 					which: Keys.Right,
 					preventDefault: () => {}
 				}],
-				key: 'date-1'
+				key: 'date-4'
 			});
 			assert.strictEqual(currentMonth, testDate.getMonth() + 1, 'Going right from the last day goes to next month');
 		},
@@ -444,7 +447,7 @@ registerSuite('Calendar', {
 					which: Keys.Up,
 					preventDefault: () => {}
 				}],
-				key: 'date-1'
+				key: 'date-0'
 			});
 			assert.strictEqual(currentMonth, 11, 'Previous month wraps from January to December');
 			assert.strictEqual(currentYear, 2016, 'Year decrements when month wraps');
@@ -465,7 +468,7 @@ registerSuite('Calendar', {
 					which: Keys.Down,
 					preventDefault: () => {}
 				}],
-				key: 'date-30'
+				key: 'date-35'
 			});
 			assert.strictEqual(currentMonth, 0, 'Next month wraps from December to January');
 			assert.strictEqual(currentYear, 2018, 'Year increments when month wraps');

--- a/src/calendar/tests/unit/Calendar.ts
+++ b/src/calendar/tests/unit/Calendar.ts
@@ -20,11 +20,9 @@ const compareId = compareProperty((value: any) => {
 	return typeof value === 'string';
 });
 
-let dateIndex = -1;
 const expectedDateCell = function(widget: any, date: number, active: boolean) {
-	dateIndex++;
 	return w(CalendarCell, {
-		key: `date-${dateIndex}`,
+		key: `date-${date}${active ? '' : '-dimmed'}`,
 		callFocus: false,
 		date,
 		disabled: !active,
@@ -38,7 +36,6 @@ const expectedDateCell = function(widget: any, date: number, active: boolean) {
 };
 
 const expected = function(widget: any, popupOpen = false) {
-	dateIndex = -1;
 	return v('div', { classes: widget.classes(css.root) }, [
 		w(DatePicker, {
 			key: 'date-picker',
@@ -177,7 +174,7 @@ registerSuite('Calendar', {
 			});
 
 			const expectedVdom = expected(widget);
-			assignProperties(findKey(expectedVdom, 'date-6')!, {
+			assignProperties(findKey(expectedVdom, 'date-3')!, {
 				selected: true
 			});
 
@@ -186,7 +183,6 @@ registerSuite('Calendar', {
 
 		'Renders with custom properties'() {
 			widget.setProperties({
-				CustomDateCell: CalendarCell,
 				labels: DEFAULT_LABELS,
 				month: testDate.getMonth(),
 				monthNames: DEFAULT_MONTHS,
@@ -202,7 +198,7 @@ registerSuite('Calendar', {
 			for (let i = 0; i < 7; i++) {
 				replaceChild(expectedVdom, `1,0,0,${i},0`, 'Bar');
 			}
-			assignProperties(findKey(expectedVdom, 'date-4')!, {
+			assignProperties(findKey(expectedVdom, 'date-1')!, {
 				selected: true
 			});
 			assignChildProperties(expectedVdom, '0', {
@@ -211,7 +207,6 @@ registerSuite('Calendar', {
 
 			widget.expectRender(expectedVdom);
 
-			class CustomCalendarCell extends CalendarCell {}
 			widget.setProperties({
 				month: testDate.getMonth(),
 				year: testDate.getFullYear()
@@ -232,7 +227,7 @@ registerSuite('Calendar', {
 
 			widget.callListener('onClick', {
 				args: [1, false],
-				key: 'date-4'
+				key: 'date-1'
 			});
 
 			assert.strictEqual(selectedDate.getDate(), 1, 'Clicking cell selects correct date');
@@ -256,7 +251,7 @@ registerSuite('Calendar', {
 
 			widget.callListener('onClick', {
 				args: [1, true],
-				key: 'date-34'
+				key: 'date-1-dimmed'
 			});
 			assert.strictEqual(currentMonth, 6, 'Month changes to July');
 			assert.strictEqual(selectedDate.getMonth(), 6, 'selected date in July');
@@ -264,7 +259,7 @@ registerSuite('Calendar', {
 
 			widget.callListener('onClick', {
 				args: [30, true],
-				key: 'date-2'
+				key: 'date-30-dimmed'
 			});
 			assert.strictEqual(currentMonth, 4, 'Month changes to May');
 			assert.strictEqual(selectedDate.getMonth(), 4, 'selected date in May');
@@ -287,18 +282,18 @@ registerSuite('Calendar', {
 					which: Keys.Right,
 					preventDefault: () => {}
 				}],
-				key: 'date-4'
+				key: 'date-1'
 			});
 			// not a good way to test this, but this would be called with the arrow key
 			widget.callListener('onFocusCalled', {
-				key: 'date-4'
+				key: 'date-1'
 			});
 			widget.callListener('onKeyDown', {
 				args: [{
 					which: Keys.Enter,
 					preventDefault: () => {}
 				}],
-				key: 'date-5'
+				key: 'date-2'
 			});
 			assert.strictEqual(selectedDate.getDate(), 2, 'Right arrow + enter selects second day');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
@@ -309,14 +304,14 @@ registerSuite('Calendar', {
 					which: Keys.Down,
 					preventDefault: () => {}
 				}],
-				key: 'date-5'
+				key: 'date-2'
 			});
 			widget.callListener('onKeyDown', {
 				args: [{
 					which: Keys.Enter,
 					preventDefault: () => {}
 				}],
-				key: 'date-12'
+				key: 'date-9'
 			});
 			assert.strictEqual(selectedDate.getDate(), 9, 'Down arrow + enter selects one week down');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
@@ -327,14 +322,14 @@ registerSuite('Calendar', {
 					which: Keys.Left,
 					preventDefault: () => {}
 				}],
-				key: 'date-12'
+				key: 'date-9'
 			});
 			widget.callListener('onKeyDown', {
 				args: [{
 					which: Keys.Space,
 					preventDefault: () => {}
 				}],
-				key: 'date-11'
+				key: 'date-8'
 			});
 			assert.strictEqual(selectedDate.getDate(), 8, 'Left arrow + space selects previous day');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
@@ -345,14 +340,14 @@ registerSuite('Calendar', {
 					which: Keys.Up,
 					preventDefault: () => {}
 				}],
-				key: 'date-11'
+				key: 'date-8'
 			});
 			widget.callListener('onKeyDown', {
 				args: [{
 					which: Keys.Space,
 					preventDefault: () => {}
 				}],
-				key: 'date-4'
+				key: 'date-1'
 			});
 			assert.strictEqual(selectedDate.getDate(), 1, 'Left arrow + space selects previous day');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
@@ -363,14 +358,14 @@ registerSuite('Calendar', {
 					which: Keys.PageDown,
 					preventDefault: () => {}
 				}],
-				key: 'date-4'
+				key: 'date-1'
 			});
 			widget.callListener('onKeyDown', {
 				args: [{
 					which: Keys.Space,
 					preventDefault: () => {}
 				}],
-				key: 'date-33'
+				key: 'date-30'
 			});
 			assert.strictEqual(selectedDate.getDate(), 30, 'Page Down + space selects last day');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
@@ -381,14 +376,14 @@ registerSuite('Calendar', {
 					which: Keys.PageUp,
 					preventDefault: () => {}
 				}],
-				key: 'date-33'
+				key: 'date-30'
 			});
 			widget.callListener('onKeyDown', {
 				args: [{
 					which: Keys.Space,
 					preventDefault: () => {}
 				}],
-				key: 'date-4'
+				key: 'date-1'
 			});
 			assert.strictEqual(selectedDate.getDate(), 1, 'Page Up + space selects first day');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
@@ -409,7 +404,7 @@ registerSuite('Calendar', {
 					which: Keys.Left,
 					preventDefault: () => {}
 				}],
-				key: 'date-4'
+				key: 'date-1'
 			});
 			assert.strictEqual(currentMonth, testDate.getMonth() - 1, 'Going left from the first day goes to previous month');
 
@@ -418,14 +413,14 @@ registerSuite('Calendar', {
 					which: Keys.PageDown,
 					preventDefault: () => {}
 				}],
-				key: 'date-4'
+				key: 'date-1'
 			});
 			widget.callListener('onKeyDown', {
 				args: [{
 					which: Keys.Right,
 					preventDefault: () => {}
 				}],
-				key: 'date-4'
+				key: 'date-1'
 			});
 			assert.strictEqual(currentMonth, testDate.getMonth() + 1, 'Going right from the last day goes to next month');
 		},
@@ -449,7 +444,7 @@ registerSuite('Calendar', {
 					which: Keys.Up,
 					preventDefault: () => {}
 				}],
-				key: 'date-0'
+				key: 'date-1'
 			});
 			assert.strictEqual(currentMonth, 11, 'Previous month wraps from January to December');
 			assert.strictEqual(currentYear, 2016, 'Year decrements when month wraps');
@@ -470,7 +465,7 @@ registerSuite('Calendar', {
 					which: Keys.Down,
 					preventDefault: () => {}
 				}],
-				key: 'date-35'
+				key: 'date-30'
 			});
 			assert.strictEqual(currentMonth, 0, 'Next month wraps from December to January');
 			assert.strictEqual(currentYear, 2018, 'Year increments when month wraps');

--- a/src/checkbox/Checkbox.ts
+++ b/src/checkbox/Checkbox.ts
@@ -87,7 +87,7 @@ export default class Checkbox extends CheckboxBase<CheckboxProperties> {
 	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
 	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
 
-	protected getModifierClasses() {
+	protected getModifierClasses(): (string | null)[] {
 		const {
 			checked = false,
 			disabled,

--- a/src/checkbox/Checkbox.ts
+++ b/src/checkbox/Checkbox.ts
@@ -87,6 +87,28 @@ export default class Checkbox extends CheckboxBase<CheckboxProperties> {
 	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
 	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
 
+	protected getModifierClasses() {
+		const {
+			checked = false,
+			disabled,
+			invalid,
+			mode,
+			readOnly,
+			required
+		} = this.properties;
+
+		return [
+			mode === Mode.toggle ? css.toggle : null,
+			checked ? css.checked : null,
+			disabled ? css.disabled : null,
+			this._focused ? css.focused : null,
+			invalid ? css.invalid : null,
+			invalid === false ? css.valid : null,
+			readOnly ? css.readonly : null,
+			required ? css.required : null
+		];
+	}
+
 	protected renderToggle(): DNode[] {
 		const {
 			checked,
@@ -117,23 +139,11 @@ export default class Checkbox extends CheckboxBase<CheckboxProperties> {
 			disabled,
 			invalid,
 			label,
-			mode,
 			name,
 			readOnly,
 			required,
 			value
 		} = this.properties;
-
-		const stateClasses = [
-			mode === Mode.toggle ? css.toggle : null,
-			checked ? css.checked : null,
-			disabled ? css.disabled : null,
-			this._focused ? css.focused : null,
-			invalid ? css.invalid : null,
-			invalid === false ? css.valid : null,
-			readOnly ? css.readonly : null,
-			required ? css.required : null
-		];
 
 		const children = [
 			v('div', { classes: this.classes(css.inputWrapper) }, [
@@ -167,14 +177,14 @@ export default class Checkbox extends CheckboxBase<CheckboxProperties> {
 
 		if (label) {
 			checkboxWidget = w(Label, {
-				extraClasses: { root: parseLabelClasses(this.classes(css.root, ...stateClasses).get()) },
+				extraClasses: { root: parseLabelClasses(this.classes(css.root, ...this.getModifierClasses()).get()) },
 				label,
 				theme: this.properties.theme
 			}, children);
 		}
 		else {
 			checkboxWidget = v('div', {
-				classes: this.classes(css.root, ...stateClasses)
+				classes: this.classes(css.root, ...this.getModifierClasses())
 			}, children);
 		}
 

--- a/src/dialog/Dialog.ts
+++ b/src/dialog/Dialog.ts
@@ -83,6 +83,35 @@ export default class Dialog extends DialogBase<DialogProperties> {
 		}));
 	}
 
+	protected getContent() {
+		return v('div', {
+			classes: this.classes(css.content),
+			key: 'content'
+		}, this.children);
+	}
+
+	protected renderCloseIcon() {
+		return v('i', { classes: this.classes(iconCss.icon, iconCss.closeIcon),
+			role: 'presentation', 'aria-hidden': 'true'
+		});
+	}
+
+	protected renderTitle() {
+		const { title = '' } = this.properties;
+		return v('div', { id: this._titleId }, [ title ]);
+	}
+
+	protected renderUnderlay() {
+		const { underlay } = this.properties;
+		return v('div', {
+			classes: this.classes(underlay ? css.underlayVisible : null).fixed(css.underlay),
+			enterAnimation: animations.fadeIn,
+			exitAnimation: animations.fadeOut,
+			key: 'underlay',
+			onclick: this._onUnderlayClick
+		});
+	}
+
 	render(): DNode {
 		const {
 			closeable = true,
@@ -91,9 +120,7 @@ export default class Dialog extends DialogBase<DialogProperties> {
 			exitAnimation = animations.fadeOut,
 			onOpen,
 			open = false,
-			role = 'dialog',
-			title = '',
-			underlay
+			role = 'dialog'
 		} = this.properties;
 
 		open && !this._wasOpen && onOpen && onOpen();
@@ -103,13 +130,7 @@ export default class Dialog extends DialogBase<DialogProperties> {
 		return v('div', {
 			classes: this.classes(css.root)
 		}, open ? [
-			v('div', {
-				classes: this.classes(underlay ? css.underlayVisible : null).fixed(css.underlay),
-				enterAnimation: animations.fadeIn,
-				exitAnimation: animations.fadeOut,
-				key: 'underlay',
-				onclick: this._onUnderlayClick
-			}),
+			this.renderUnderlay(),
 			v('div', {
 				'aria-labelledby': this._titleId,
 				classes: this.classes(css.main),
@@ -122,21 +143,16 @@ export default class Dialog extends DialogBase<DialogProperties> {
 					classes: this.classes(css.title),
 					key: 'title'
 				}, [
-					v('div', { id: this._titleId }, [ title ]),
+					this.renderTitle(),
 					closeable ? v('button', {
 						classes: this.classes(css.close),
 						onclick: this._onCloseClick
 					}, [
 						closeText,
-						v('i', { classes: this.classes(iconCss.icon, iconCss.closeIcon),
-							role: 'presentation', 'aria-hidden': 'true'
-						})
+						this.renderCloseIcon()
 					]) : null
 				]),
-				v('div', {
-					classes: this.classes(css.content),
-					key: 'content'
-				}, this.children)
+				this.getContent()
 			])
 		] : []);
 	}

--- a/src/dialog/Dialog.ts
+++ b/src/dialog/Dialog.ts
@@ -83,25 +83,25 @@ export default class Dialog extends DialogBase<DialogProperties> {
 		}));
 	}
 
-	protected getContent() {
+	protected getContent(): DNode {
 		return v('div', {
 			classes: this.classes(css.content),
 			key: 'content'
 		}, this.children);
 	}
 
-	protected renderCloseIcon() {
+	protected renderCloseIcon(): DNode {
 		return v('i', { classes: this.classes(iconCss.icon, iconCss.closeIcon),
 			role: 'presentation', 'aria-hidden': 'true'
 		});
 	}
 
-	protected renderTitle() {
+	protected renderTitle(): DNode {
 		const { title = '' } = this.properties;
 		return v('div', { id: this._titleId }, [ title ]);
 	}
 
-	protected renderUnderlay() {
+	protected renderUnderlay(): DNode {
 		const { underlay } = this.properties;
 		return v('div', {
 			classes: this.classes(underlay ? css.underlayVisible : null).fixed(css.underlay),

--- a/src/radio/Radio.ts
+++ b/src/radio/Radio.ts
@@ -74,6 +74,26 @@ export default class Radio extends RadioBase<RadioProperties> {
 	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
 	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
 
+	protected getModifierClasses() {
+		const {
+			checked = false,
+			disabled,
+			invalid,
+			readOnly,
+			required
+		} = this.properties;
+
+		return [
+			checked ? css.checked : null,
+			disabled ? css.disabled : null,
+			this._focused ? css.focused : null,
+			invalid ? css.invalid : null,
+			invalid === false ? css.valid : null,
+			readOnly ? css.readonly : null,
+			required ? css.required : null
+		];
+	}
+
 	render(): DNode {
 		const {
 			checked = false,
@@ -86,16 +106,6 @@ export default class Radio extends RadioBase<RadioProperties> {
 			required,
 			value
 		} = this.properties;
-
-		const stateClasses = [
-			checked ? css.checked : null,
-			disabled ? css.disabled : null,
-			this._focused ? css.focused : null,
-			invalid ? css.invalid : null,
-			invalid === false ? css.valid : null,
-			readOnly ? css.readonly : null,
-			required ? css.required : null
-		];
 
 		const radio = v('div', { classes: this.classes(css.inputWrapper) }, [
 			v('input', {
@@ -126,14 +136,14 @@ export default class Radio extends RadioBase<RadioProperties> {
 
 		if (label) {
 			radioWidget = w(Label, {
-				extraClasses: { root: parseLabelClasses(this.classes(css.root, ...stateClasses).get()) },
+				extraClasses: { root: parseLabelClasses(this.classes(css.root, ...this.getModifierClasses()).get()) },
 				label,
 				theme: this.properties.theme
 			}, [ radio ]);
 		}
 		else {
 			radioWidget = v('div', {
-				classes: this.classes(css.root, ...stateClasses)
+				classes: this.classes(css.root, ...this.getModifierClasses())
 			}, [ radio]);
 		}
 

--- a/src/radio/Radio.ts
+++ b/src/radio/Radio.ts
@@ -74,7 +74,7 @@ export default class Radio extends RadioBase<RadioProperties> {
 	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
 	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
 
-	protected getModifierClasses() {
+	protected getModifierClasses(): (string | null)[] {
 		const {
 			checked = false,
 			disabled,

--- a/src/slidepane/SlidePane.ts
+++ b/src/slidepane/SlidePane.ts
@@ -172,11 +172,11 @@ export default class SlidePane extends SlidePaneBase<SlidePaneProperties> {
 		}
 	}
 
-	protected getContent() {
+	protected getContent(): DNode {
 		return v('div', { classes: this.classes(css.content) }, this.children);
 	}
 
-	protected getStyles() {
+	protected getStyles(): { [key: string]: string | null } {
 		const {
 			align = Align.left,
 			open = false,
@@ -198,7 +198,7 @@ export default class SlidePane extends SlidePaneBase<SlidePaneProperties> {
 		};
 	}
 
-	protected getFixedModifierClasses() {
+	protected getFixedModifierClasses(): (string | null)[] {
 		const {
 			align = Align.left,
 			open = false
@@ -213,7 +213,7 @@ export default class SlidePane extends SlidePaneBase<SlidePaneProperties> {
 		];
 	}
 
-	protected getModifierClasses() {
+	protected getModifierClasses(): (string | null)[] {
 		const {
 			align = Align.left,
 			open = false
@@ -228,18 +228,18 @@ export default class SlidePane extends SlidePaneBase<SlidePaneProperties> {
 		];
 	}
 
-	protected renderCloseIcon() {
+	protected renderCloseIcon(): DNode {
 		return v('i', { classes: this.classes(iconCss.icon, iconCss.closeIcon),
 			role: 'presentation', 'aria-hidden': 'true'
 		});
 	}
 
-	protected renderTitle() {
+	protected renderTitle(): DNode {
 		const { title = '' } = this.properties;
 		return v('div', { id: this._titleId }, [ title ]);
 	}
 
-	protected renderUnderlay() {
+	protected renderUnderlay(): DNode {
 		const { underlay = false } = this.properties;
 		return v('div', {
 			classes: this.classes(underlay ? css.underlayVisible : null).fixed(css.underlay),

--- a/src/slidepane/SlidePane.ts
+++ b/src/slidepane/SlidePane.ts
@@ -172,51 +172,96 @@ export default class SlidePane extends SlidePaneBase<SlidePaneProperties> {
 		}
 	}
 
-	render(): DNode {
+	protected getContent() {
+		return v('div', { classes: this.classes(css.content) }, this.children);
+	}
+
+	protected getStyles() {
 		const {
 			align = Align.left,
-			closeText = 'close pane',
-			onOpen,
 			open = false,
-			title = '',
-			underlay = false,
 			width = DEFAULT_WIDTH
 		} = this.properties;
 
+		let translate = '';
+		const translateAxis = this.plane === Plane.x ? 'X' : 'Y';
+
+		// If pane is closing because of swipe
+		if (!open && this._wasOpen && this._transform) {
+			translate = align === Align.left || align === Align.top ? `-${this._transform}` : `${this._transform}`;
+		}
+
+		return {
+			transform: translate ? `translate${translateAxis}(${translate}%)` : '',
+			width: this.plane === Plane.x ? `${ width }px` : null,
+			height: this.plane === Plane.y ? `${ width }px` : null
+		};
+	}
+
+	protected getFixedModifierClasses() {
+		const {
+			align = Align.left,
+			open = false
+		} = this.properties;
 		const alignCss: {[key: string]: any} = css;
 
-		const contentClasses = [
-			css.pane,
-			alignCss[align],
-			open ? css.open : null,
-			this._slideIn || (open && !this._wasOpen) ? css.slideIn : null,
-			!open && this._wasOpen ? css.slideOut : null
-		];
-
-		const fixedContentClasses = [
-			css.paneFixed,
+		return [
 			open ? css.openFixed : null,
 			alignCss[`${align}Fixed`],
 			this._slideIn || (open && !this._wasOpen) ? css.slideInFixed : null,
 			!open && this._wasOpen ? css.slideOutFixed : null
 		];
+	}
 
-		const contentStyles: {[key: string]: any} = {
-			transform: '',
-			width: this.plane === Plane.x ? `${ width }px` : null,
-			height: this.plane === Plane.y ? `${ width }px` : null
-		};
+	protected getModifierClasses() {
+		const {
+			align = Align.left,
+			open = false
+		} = this.properties;
+		const alignCss: {[key: string]: any} = css;
 
-		if (!open && this._wasOpen && this._transform) {
-			// If pane is closing because of swipe
-			if (this.plane === Plane.x) {
-				contentStyles['transform'] = `translateX(${ align === Align.left ? '-' : '' }${ this._transform }%)`;
-			}
-			else {
-				contentStyles['transform'] = `translateY(${ align === Align.top ? '-' : '' }${ this._transform }%)`;
-			}
-		}
-		else if (this._slideIn && this._content) {
+		return [
+			alignCss[align],
+			open ? css.open : null,
+			this._slideIn || (open && !this._wasOpen) ? css.slideIn : null,
+			!open && this._wasOpen ? css.slideOut : null
+		];
+	}
+
+	protected renderCloseIcon() {
+		return v('i', { classes: this.classes(iconCss.icon, iconCss.closeIcon),
+			role: 'presentation', 'aria-hidden': 'true'
+		});
+	}
+
+	protected renderTitle() {
+		const { title = '' } = this.properties;
+		return v('div', { id: this._titleId }, [ title ]);
+	}
+
+	protected renderUnderlay() {
+		const { underlay = false } = this.properties;
+		return v('div', {
+			classes: this.classes(underlay ? css.underlayVisible : null).fixed(css.underlay),
+			enterAnimation: animations.fadeIn,
+			exitAnimation: animations.fadeOut,
+			key: 'underlay'
+		});
+	}
+
+	render(): DNode {
+		const {
+			closeText = 'close pane',
+			onOpen,
+			open = false,
+			title = ''
+		} = this.properties;
+
+		const contentStyles = this.getStyles();
+		const contentClasses = this.getModifierClasses();
+		const fixedContentClasses = this.getFixedModifierClasses();
+
+		if (this._slideIn && this._content) {
 			this._content.style.transform = '';
 		}
 
@@ -234,33 +279,26 @@ export default class SlidePane extends SlidePaneBase<SlidePaneProperties> {
 			ontouchmove: this._onSwipeMove,
 			ontouchstart: this._onSwipeStart
 		}, [
-			open ? v('div', {
-				classes: this.classes(underlay ? css.underlayVisible : null).fixed(css.underlay),
-				enterAnimation: animations.fadeIn,
-				exitAnimation: animations.fadeOut,
-				key: 'underlay'
-			}) : null,
+			open ? this.renderUnderlay() : null,
 			v('div', {
 				key: 'content',
-				classes: this.classes(...contentClasses).fixed(...fixedContentClasses),
+				classes: this.classes(css.pane, ...contentClasses).fixed(css.paneFixed, ...fixedContentClasses),
 				styles: contentStyles
 			}, [
 				title ? v('div', {
 					classes: this.classes(css.title),
 					key: 'title'
 				}, [
-					v('div', { id: this._titleId }, [ title ]),
+					this.renderTitle(),
 					v('button', {
 						classes: this.classes(css.close),
 						onclick: this._onCloseClick
 					}, [
 						closeText,
-						v('i', { classes: this.classes(iconCss.icon, iconCss.closeIcon),
-							role: 'presentation', 'aria-hidden': 'true'
-						})
+						this.renderCloseIcon()
 					])
 				]) : null,
-				v('div', { classes: this.classes(css.content) }, this.children)
+				this.getContent()
 			])
 		]);
 	}

--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -91,7 +91,7 @@ export default class Slider extends SliderBase<SliderProperties> {
 	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
 	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
 
-	protected getModifierClasses() {
+	protected getModifierClasses(): (string | null)[] {
 		const {
 			disabled,
 			invalid,
@@ -110,7 +110,7 @@ export default class Slider extends SliderBase<SliderProperties> {
 		];
 	}
 
-	protected renderControls(percentValue: number) {
+	protected renderControls(percentValue: number): DNode {
 		const {
 			vertical = false,
 			verticalHeight = '200px'
@@ -132,7 +132,7 @@ export default class Slider extends SliderBase<SliderProperties> {
 		]);
 	}
 
-	protected renderOutput(value: number, percentValue: number) {
+	protected renderOutput(value: number, percentValue: number): DNode {
 		const {
 			output,
 			outputIsTooltip = false,

--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -91,6 +91,69 @@ export default class Slider extends SliderBase<SliderProperties> {
 	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
 	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
 
+	protected getModifierClasses() {
+		const {
+			disabled,
+			invalid,
+			readOnly,
+			required,
+			vertical = false
+		} = this.properties;
+
+		return [
+			disabled ? css.disabled : null,
+			invalid ? css.invalid : null,
+			invalid === false ? css.valid : null,
+			readOnly ? css.readonly : null,
+			required ? css.required : null,
+			vertical ? css.vertical : null
+		];
+	}
+
+	protected renderControls(percentValue: number) {
+		const {
+			vertical = false,
+			verticalHeight = '200px'
+		} = this.properties;
+
+		return v('div', {
+			classes: this.classes(css.track).fixed(css.trackFixed),
+			'aria-hidden': 'true',
+			styles: vertical ? { width: verticalHeight } : {}
+		}, [
+			v('span', {
+				classes: this.classes(css.fill).fixed(css.fillFixed),
+				styles: { width: `${percentValue}%` }
+			}),
+			v('span', {
+				classes: this.classes(css.thumb).fixed(css.thumbFixed),
+				styles: { left: `${percentValue}%` }
+			})
+		]);
+	}
+
+	protected renderOutput(value: number, percentValue: number) {
+		const {
+			output,
+			outputIsTooltip = false,
+			vertical = false
+		} = this.properties;
+
+		const outputNode = output ? output(value) : `${value}`;
+
+		// output styles
+		let outputStyles: { left?: string; top?: string } = {};
+		if (outputIsTooltip) {
+			outputStyles = vertical ? { top: `${100 - percentValue}%` } : { left: `${percentValue}%` };
+		}
+
+		return v('output', {
+			classes: this.classes(css.output, outputIsTooltip ? css.outputTooltip : null),
+			for: `${this._inputId}`,
+			styles: outputStyles
+		}, [ outputNode ]);
+	}
+
 	render(): DNode {
 		const {
 			describedBy,
@@ -100,8 +163,6 @@ export default class Slider extends SliderBase<SliderProperties> {
 			max = 100,
 			min = 0,
 			name,
-			output,
-			outputIsTooltip = false,
 			readOnly,
 			required,
 			step = 1,
@@ -115,25 +176,7 @@ export default class Slider extends SliderBase<SliderProperties> {
 		value = value > max ? max : value;
 		value = value < min ? min : value;
 
-		const stateClasses = [
-			disabled ? css.disabled : null,
-			invalid ? css.invalid : null,
-			invalid === false ? css.valid : null,
-			readOnly ? css.readonly : null,
-			required ? css.required : null,
-			vertical ? css.vertical : null
-		];
-
 		const percentValue = (value - min) / (max - min) * 100;
-
-		// custom output node
-		const outputNode = output ? output(value) : `${value}`;
-
-		// output styles
-		let outputStyles: { left?: string; top?: string } = {};
-		if (outputIsTooltip) {
-			outputStyles = vertical ? { top: `${100 - percentValue}%` } : { left: `${percentValue}%` };
-		}
 
 		const slider = v('div', {
 			classes: this.classes(css.inputWrapper).fixed(css.inputWrapperFixed),
@@ -169,39 +212,22 @@ export default class Slider extends SliderBase<SliderProperties> {
 				ontouchend: this._onTouchEnd,
 				ontouchcancel: this._onTouchCancel
 			}),
-			v('div', {
-				classes: this.classes(css.track).fixed(css.trackFixed),
-				'aria-hidden': 'true',
-				styles: vertical ? { width: verticalHeight } : {}
-			}, [
-				v('span', {
-					classes: this.classes(css.fill).fixed(css.fillFixed),
-					styles: { width: `${percentValue}%` }
-				}),
-				v('span', {
-					classes: this.classes(css.thumb).fixed(css.thumbFixed),
-					styles: { left: `${percentValue}%` }
-				})
-			]),
-			v('output', {
-				classes: this.classes(css.output, outputIsTooltip ? css.outputTooltip : null),
-				for: `${this._inputId}`,
-				styles: outputStyles
-			}, [ outputNode ])
+			this.renderControls(percentValue),
+			this.renderOutput(value, percentValue)
 		]);
 
 		let sliderWidget;
 
 		if (label) {
 			sliderWidget = w(Label, {
-				extraClasses: { root: parseLabelClasses(this.classes(css.root, ...stateClasses).fixed(css.rootFixed)()) },
+				extraClasses: { root: parseLabelClasses(this.classes(css.root, ...this.getModifierClasses()).fixed(css.rootFixed)()) },
 				label,
 				theme: this.properties.theme
 			}, [ slider ]);
 		}
 		else {
 			sliderWidget = v('div', {
-				classes: this.classes(css.root, ...stateClasses).fixed(css.rootFixed)
+				classes: this.classes(css.root, ...this.getModifierClasses()).fixed(css.rootFixed)
 			}, [ slider ]);
 		}
 

--- a/src/splitpane/SplitPane.ts
+++ b/src/splitpane/SplitPane.ts
@@ -128,7 +128,7 @@ export default class SplitPane extends SplitPaneBase<SplitPaneProperties> {
 		this._lastSize = undefined;
 	}
 
-	protected getPaneContent(content: DNode) {
+	protected getPaneContent(content: DNode): DNode[] {
 		return [ content ];
 	}
 

--- a/src/splitpane/SplitPane.ts
+++ b/src/splitpane/SplitPane.ts
@@ -128,6 +128,21 @@ export default class SplitPane extends SplitPaneBase<SplitPaneProperties> {
 		this._lastSize = undefined;
 	}
 
+	protected getPaneContent(content: DNode) {
+		return [ content ];
+	}
+
+	protected getPaneStyles(): {[key: string]: string} {
+		const {
+			direction = Direction.row,
+			size = DEFAULT_SIZE
+		} = this.properties;
+		const styles: {[key: string]: string} = {};
+
+		styles[direction === Direction.row ? 'width' : 'height'] = `${size}px`;
+		return styles;
+	}
+
 	protected onElementCreated(element: HTMLElement, key: string) {
 		if (key === 'root') {
 			this._root = element;
@@ -141,12 +156,8 @@ export default class SplitPane extends SplitPaneBase<SplitPaneProperties> {
 		const {
 			direction = Direction.row,
 			leading = null,
-			size = DEFAULT_SIZE,
 			trailing = null
 		} = this.properties;
-
-		const styles: {[key: string]: string} = {};
-		styles[direction === Direction.row ? 'width' : 'height'] = `${size}px`;
 
 		return v('div', {
 			classes: this.classes(
@@ -165,8 +176,8 @@ export default class SplitPane extends SplitPaneBase<SplitPaneProperties> {
 					css.leadingFixed
 				),
 				key: 'leading',
-				styles
-			}, [ leading ]),
+				styles: this.getPaneStyles()
+			}, this.getPaneContent(leading)),
 			v('div', {
 				classes: this.classes(
 					css.divider
@@ -185,7 +196,7 @@ export default class SplitPane extends SplitPaneBase<SplitPaneProperties> {
 					css.trailingFixed
 				),
 				key: 'trailing'
-			}, [ trailing ])
+			}, this.getPaneContent(trailing))
 		]);
 	}
 }

--- a/src/tabcontroller/TabButton.ts
+++ b/src/tabcontroller/TabButton.ts
@@ -130,7 +130,7 @@ export default class TabButton extends TabButtonBase<TabButtonProperties> {
 		}
 	}
 
-	protected getContent() {
+	protected getContent(): DNode[] {
 		const { active, closeable } = this.properties;
 
 		return [
@@ -144,7 +144,7 @@ export default class TabButton extends TabButtonBase<TabButtonProperties> {
 		];
 	}
 
-	protected getModifierClasses() {
+	protected getModifierClasses(): (string | null)[] {
 		const { active, disabled } = this.properties;
 		return [
 			active ? css.activeTabButton : null,

--- a/src/tabcontroller/TabButton.ts
+++ b/src/tabcontroller/TabButton.ts
@@ -130,6 +130,28 @@ export default class TabButton extends TabButtonBase<TabButtonProperties> {
 		}
 	}
 
+	protected getContent() {
+		const { active, closeable } = this.properties;
+
+		return [
+			...this.children,
+			closeable ? v('button', {
+				tabIndex: active ? 0 : -1,
+				classes: this.classes(css.close),
+				innerHTML: 'close tab',
+				onclick: this._onCloseClick
+			}) : null
+		];
+	}
+
+	protected getModifierClasses() {
+		const { active, disabled } = this.properties;
+		return [
+			active ? css.activeTabButton : null,
+			disabled ? css.disabledTabButton : null
+		];
+	}
+
 	protected onElementCreated(element: HTMLElement, key: string) {
 		key === 'tab-button' && this._callFocus(element);
 	}
@@ -141,36 +163,22 @@ export default class TabButton extends TabButtonBase<TabButtonProperties> {
 	render(): DNode {
 		const {
 			active,
-			closeable,
 			controls,
 			disabled,
 			id
 		} = this.properties;
 
-		const children = closeable ? this.children.concat([
-			v('button', {
-				tabIndex: active ? 0 : -1,
-				classes: this.classes(css.close),
-				innerHTML: 'close tab',
-				onclick: this._onCloseClick
-			})
-		]) : this.children;
-
 		return v('div', {
 			'aria-controls': controls,
 			'aria-disabled': disabled ? 'true' : 'false',
 			'aria-selected': active ? 'true' : 'false',
-			classes: this.classes(
-				css.tabButton,
-				active ? css.activeTabButton : null,
-				disabled ? css.disabledTabButton : null
-			),
+			classes: this.classes(css.tabButton, ...this.getModifierClasses()),
 			id,
 			key: 'tab-button',
 			onclick: this._onClick,
 			onkeydown: this._onKeyDown,
 			role: 'tab',
 			tabIndex: active ? 0 : -1
-		}, children);
+		}, this.getContent());
 	}
 }

--- a/src/tabcontroller/TabController.ts
+++ b/src/tabcontroller/TabController.ts
@@ -71,57 +71,6 @@ export default class TabController extends TabControllerBase<TabControllerProper
 		}
 	}
 
-	private _renderTabButtons() {
-		return this._tabs.map((tab, i) => {
-			const {
-				closeable,
-				disabled,
-				key,
-				label,
-				theme = {}
-			} = <TabProperties> tab.properties;
-
-			return w(TabButton, {
-				callFocus: this._callTabFocus &&  i === this.properties.activeIndex,
-				active: i === this.properties.activeIndex,
-				closeable,
-				controls: `${ this._id }-tab-${i}`,
-				disabled,
-				id: `${ this._id }-tabbutton-${i}`,
-				index: i,
-				key: `${ key }-tabbutton`,
-				onClick: this.selectIndex,
-				onCloseClick: this.closeIndex,
-				onDownArrowPress: this._onDownArrowPress,
-				onEndPress: this.selectLastIndex,
-				onFocusCalled: () => { this._callTabFocus = false; },
-				onHomePress: this.selectFirstIndex,
-				onLeftArrowPress: this._onLeftArrowPress,
-				onRightArrowPress: this._onRightArrowPress,
-				onUpArrowPress: this._onUpArrowPress,
-				theme
-			}, [
-				label || null
-			]);
-		});
-	}
-
-	private _renderTabs() {
-		const { activeIndex } = this.properties;
-
-		return this._tabs
-			.filter((tab, i) => {
-				return i === activeIndex && tab.children.length;
-			})
-			.map((tab, i) => {
-				assign(tab.properties, {
-					id: `${ this._id }-tab-${i}`,
-					labelledBy: `${ this._id }-tabbutton-${i}`
-				});
-				return tab;
-			});
-	}
-
 	/**
 	 * Determines if the tab at `currentIndex` is enabled. If disabled,
 	 * returns the next valid index, or null if no enabled tabs exist.
@@ -155,6 +104,59 @@ export default class TabController extends TabControllerBase<TabControllerProper
 		this._callTabFocus = true;
 
 		onRequestTabClose && onRequestTabClose(index, key);
+	}
+
+	protected renderButtonContent(label?: DNode) {
+		return [ label || null ];
+	}
+
+	protected renderTabButtons() {
+		return this._tabs.map((tab, i) => {
+			const {
+				closeable,
+				disabled,
+				key,
+				label,
+				theme = {}
+			} = <TabProperties> tab.properties;
+
+			return w(TabButton, {
+				callFocus: this._callTabFocus &&  i === this.properties.activeIndex,
+				active: i === this.properties.activeIndex,
+				closeable,
+				controls: `${ this._id }-tab-${i}`,
+				disabled,
+				id: `${ this._id }-tabbutton-${i}`,
+				index: i,
+				key: `${ key }-tabbutton`,
+				onClick: this.selectIndex,
+				onCloseClick: this.closeIndex,
+				onDownArrowPress: this._onDownArrowPress,
+				onEndPress: this.selectLastIndex,
+				onFocusCalled: () => { this._callTabFocus = false; },
+				onHomePress: this.selectFirstIndex,
+				onLeftArrowPress: this._onLeftArrowPress,
+				onRightArrowPress: this._onRightArrowPress,
+				onUpArrowPress: this._onUpArrowPress,
+				theme
+			}, this.renderButtonContent(label));
+		});
+	}
+
+	protected renderTabs() {
+		const { activeIndex } = this.properties;
+
+		return this._tabs
+			.filter((tab, i) => {
+				return i === activeIndex && tab.children.length;
+			})
+			.map((tab, i) => {
+				assign(tab.properties, {
+					id: `${ this._id }-tab-${i}`,
+					labelledBy: `${ this._id }-tabbutton-${i}`
+				});
+				return tab;
+			});
 	}
 
 	protected selectFirstIndex() {
@@ -195,7 +197,7 @@ export default class TabController extends TabControllerBase<TabControllerProper
 	render(): DNode {
 		const { activeIndex } = this.properties;
 		const validIndex = this._validateIndex(activeIndex);
-		const tabs = this._renderTabs();
+		const tabs = this.renderTabs();
 
 		if (validIndex !== null && validIndex !== activeIndex) {
 			this.selectIndex(validIndex);
@@ -206,11 +208,11 @@ export default class TabController extends TabControllerBase<TabControllerProper
 			v('div', {
 				key: 'buttons',
 				classes: this.classes(css.tabButtons)
-			}, this._renderTabButtons()),
+			}, this.renderTabButtons()),
 			tabs.length ? v('div', {
 				key: 'tabs',
 				classes: this.classes(css.tabs)
-			}, this._renderTabs()) : null
+			}, tabs) : null
 		];
 
 		let alignClass;

--- a/src/tabcontroller/TabController.ts
+++ b/src/tabcontroller/TabController.ts
@@ -106,11 +106,11 @@ export default class TabController extends TabControllerBase<TabControllerProper
 		onRequestTabClose && onRequestTabClose(index, key);
 	}
 
-	protected renderButtonContent(label?: DNode) {
+	protected renderButtonContent(label?: DNode): DNode[] {
 		return [ label || null ];
 	}
 
-	protected renderTabButtons() {
+	protected renderTabButtons(): DNode[] {
 		return this._tabs.map((tab, i) => {
 			const {
 				closeable,
@@ -143,7 +143,7 @@ export default class TabController extends TabControllerBase<TabControllerProper
 		});
 	}
 
-	protected renderTabs() {
+	protected renderTabs(): DNode[] {
 		const { activeIndex } = this.properties;
 
 		return this._tabs

--- a/src/tabcontroller/tests/unit/TabButton.ts
+++ b/src/tabcontroller/tests/unit/TabButton.ts
@@ -30,14 +30,14 @@ const testChildren = [
 ];
 
 const expected = function(widget: any, closeable = false, children: any[] = []) {
-	if (closeable) {
-		children.push(v('button', {
+	children.push(
+		closeable ? v('button', {
 			tabIndex: -1,
 			classes: widget.classes(css.close),
 			innerHTML: 'close tab',
 			onclick: widget.listener
-		}));
-	}
+		}) : null
+	);
 
 	return v('div', {
 		'aria-controls': 'foo',

--- a/src/textarea/Textarea.ts
+++ b/src/textarea/Textarea.ts
@@ -86,7 +86,7 @@ export default class Textarea extends TextareaBase<TextareaProperties> {
 	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
 	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
 
-	protected getModifierClasses() {
+	protected getModifierClasses(): (string | null)[] {
 		const {
 			disabled,
 			invalid,

--- a/src/textarea/Textarea.ts
+++ b/src/textarea/Textarea.ts
@@ -86,6 +86,22 @@ export default class Textarea extends TextareaBase<TextareaProperties> {
 	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
 	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
 
+	protected getModifierClasses() {
+		const {
+			disabled,
+			invalid,
+			readOnly,
+			required
+		} = this.properties;
+		return [
+			disabled ? css.disabled : null,
+			invalid ? css.invalid : null,
+			invalid === false ? css.valid : null,
+			readOnly ? css.readonly : null,
+			required ? css.required : null
+		];
+	}
+
 	render(): DNode {
 		const {
 			columns,
@@ -103,14 +119,6 @@ export default class Textarea extends TextareaBase<TextareaProperties> {
 			value,
 			wrapText
 		} = this.properties;
-
-		const stateClasses = [
-			disabled ? css.disabled : null,
-			invalid ? css.invalid : null,
-			invalid === false ? css.valid : null,
-			readOnly ? css.readonly : null,
-			required ? css.required : null
-		];
 
 		const textarea = v('div', { classes: this.classes(css.inputWrapper) }, [
 			v('textarea', {
@@ -149,14 +157,14 @@ export default class Textarea extends TextareaBase<TextareaProperties> {
 
 		if (label) {
 			textareaWidget = w(Label, {
-				extraClasses: { root: parseLabelClasses(this.classes(css.root, ...stateClasses)()) },
+				extraClasses: { root: parseLabelClasses(this.classes(css.root, ...this.getModifierClasses())()) },
 				label,
 				theme: this.properties.theme
 			}, [ textarea ]);
 		}
 		else {
 			textareaWidget = v('div', {
-				classes: this.classes(css.root, ...stateClasses)
+				classes: this.classes(css.root, ...this.getModifierClasses())
 			}, [ textarea ]);
 		}
 

--- a/src/textinput/TextInput.ts
+++ b/src/textinput/TextInput.ts
@@ -86,7 +86,7 @@ export default class TextInput extends TextInputBase<TextInputProperties> {
 	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
 	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
 
-	protected getModifierClasses() {
+	protected getModifierClasses(): (string | null)[] {
 		const {
 			disabled,
 			invalid,

--- a/src/textinput/TextInput.ts
+++ b/src/textinput/TextInput.ts
@@ -86,6 +86,22 @@ export default class TextInput extends TextInputBase<TextInputProperties> {
 	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
 	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
 
+	protected getModifierClasses() {
+		const {
+			disabled,
+			invalid,
+			readOnly,
+			required
+		} = this.properties;
+		return [
+			disabled ? css.disabled : null,
+			invalid ? css.invalid : null,
+			invalid === false ? css.valid : null,
+			readOnly ? css.readonly : null,
+			required ? css.required : null
+		];
+	}
+
 	render(): DNode {
 		const {
 			controls,
@@ -102,14 +118,6 @@ export default class TextInput extends TextInputBase<TextInputProperties> {
 			type = 'text',
 			value
 		} = this.properties;
-
-		const stateClasses = [
-			disabled ? css.disabled : null,
-			invalid ? css.invalid : null,
-			invalid === false ? css.valid : null,
-			readOnly ? css.readonly : null,
-			required ? css.required : null
-		];
 
 		const textinput = v('div', { classes: this.classes(css.inputWrapper) }, [
 			v('input', {
@@ -147,14 +155,14 @@ export default class TextInput extends TextInputBase<TextInputProperties> {
 
 		if (label) {
 			textinputWidget = w(Label, {
-				extraClasses: { root: parseLabelClasses(this.classes(css.root, ...stateClasses)()) },
+				extraClasses: { root: parseLabelClasses(this.classes(css.root, ...this.getModifierClasses())()) },
 				label,
 				theme: this.properties.theme
 			}, [ textinput ]);
 		}
 		else {
 			textinputWidget = v('div', {
-				classes: this.classes(css.root, ...stateClasses)
+				classes: this.classes(css.root, ...this.getModifierClasses())
 			}, [ textinput ]);
 		}
 

--- a/src/themes/dojo/titlePane.m.css
+++ b/src/themes/dojo/titlePane.m.css
@@ -16,8 +16,11 @@
 	background-color: var(--color-background);
 	border: var(--border-width) solid var(--color-border);
 	color: var(--color-text-faded);
+	cursor: pointer;
+	font-size: var(--font-size-base);
 	padding: var(--grid-base) var(--grid-base) var(--grid-base) calc(var(--grid-base) * 4);
 	position: relative;
+	width: 100%;
 	z-index: 1;
 }
 
@@ -47,7 +50,7 @@
 .arrow {
 	position: absolute;
 	left: 8px;
-	top: 12px;
+	top: 10px;
 }
 
 .open .arrow {

--- a/src/timepicker/TimePicker.ts
+++ b/src/timepicker/TimePicker.ts
@@ -10,6 +10,10 @@ import ComboBox from '../combobox/ComboBox';
 import Label, { LabelOptions, parseLabelClasses } from '../label/Label';
 import { TextInputProperties } from '../textinput/TextInput';
 
+interface FocusInputEvent extends FocusEvent {
+	target: HTMLInputElement;
+}
+
 /**
  * @type TimePickerProperties
  *
@@ -181,23 +185,23 @@ export class TimePicker extends TimePickerBase<TimePickerProperties> {
 		return getOptionLabel ? getOptionLabel(units) : this._formatUnits(units);
 	}
 
-	private _onNativeBlur(event: FocusEvent) {
-		this.properties.onBlur && this.properties.onBlur((<HTMLInputElement> event.target).value);
+	private _onNativeBlur(event: FocusInputEvent) {
+		this.properties.onBlur && this.properties.onBlur(event.target.value);
 	}
 
-	private _onNativeChange(event: FocusEvent) {
-		this.properties.onChange && this.properties.onChange((<HTMLInputElement> event.target).value);
+	private _onNativeChange(event: FocusInputEvent) {
+		this.properties.onChange && this.properties.onChange(event.target.value);
 	}
 
-	private _onNativeFocus(event: FocusEvent) {
-		this.properties.onFocus && this.properties.onFocus((<HTMLInputElement> event.target).value);
+	private _onNativeFocus(event: FocusInputEvent) {
+		this.properties.onFocus && this.properties.onFocus(event.target.value);
 	}
 
 	private _onRequestOptions(value: string) {
 		this.properties.onRequestOptions && this.properties.onRequestOptions(value, this.getOptions());
 	}
 
-	protected getModifierClasses() {
+	protected getModifierClasses(): (string | null)[] {
 		const {
 			disabled,
 			invalid,

--- a/src/titlepane/TitlePane.ts
+++ b/src/titlepane/TitlePane.ts
@@ -4,8 +4,6 @@ import { theme, ThemeableMixin, ThemeableProperties } from '@dojo/widget-core/mi
 import { v } from '@dojo/widget-core/d';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 
-import { Keys } from '../common/util';
-
 import * as css from './styles/titlePane.m.css';
 import * as iconCss from '../common/styles/icons.m.css';
 
@@ -55,14 +53,6 @@ export default class TitlePane extends TitlePaneBase<TitlePaneProperties> {
 		this._toggle();
 	}
 
-	private _onTitleKeyUp(event: KeyboardEvent) {
-		const {keyCode } = event;
-
-		if (keyCode === Keys.Enter || keyCode === Keys.Space) {
-			this._toggle();
-		}
-	}
-
 	private _toggle() {
 		const {
 			closeable = true,
@@ -92,12 +82,46 @@ export default class TitlePane extends TitlePaneBase<TitlePaneProperties> {
 		key === 'content' && this._afterRender(element);
 	}
 
+	protected getButtonContent() {
+		return this.properties.title;
+	}
+
+	protected getFixedModifierClasses() {
+		const { closeable = true } = this.properties;
+		return [
+			closeable ? css.closeableFixed : null
+		];
+	}
+
+	protected getModifierClasses() {
+		const { closeable = true } = this.properties;
+		return [
+			closeable ? css.closeable : null
+		];
+	}
+
+	protected getPaneContent() {
+		return this.children;
+	}
+
+	protected renderExpandIcon() {
+		const { open = true } = this.properties;
+		return v('i', {
+			classes: this.classes(
+				css.arrow,
+				iconCss.icon,
+				open ? iconCss.downIcon : iconCss.rightIcon
+			),
+			role: 'presentation',
+			'aria-hidden': 'true'
+		});
+	}
+
 	render(): DNode {
 		const {
 			closeable = true,
 			headingLevel,
-			open = true,
-			title
+			open = true
 		} = this.properties;
 
 		return v('div', {
@@ -108,36 +132,19 @@ export default class TitlePane extends TitlePaneBase<TitlePaneProperties> {
 		}, [
 			v('div', {
 				'aria-level': headingLevel ? String(headingLevel) : null,
-				classes: this.classes(
-					closeable ? css.closeable : null,
-					css.title
-				).fixed(
-					closeable ? css.closeableFixed : null,
-					css.titleFixed
-				),
-				onclick: this._onTitleClick,
-				onkeyup: this._onTitleKeyUp,
+				classes: this.classes(css.title, ...this.getModifierClasses()).fixed(css.titleFixed, ...this.getFixedModifierClasses()),
 				role: 'heading'
 			}, [
-				v('div', {
+				v('button', {
 					'aria-controls': this._contentId,
-					'aria-disabled': closeable ? null : 'true',
 					'aria-expanded': String(open),
+					disabled: !closeable,
 					classes: this.classes(css.titleButton),
 					id: this._titleId,
-					role: 'button',
-					tabIndex: closeable ? 0 : -1
+					onclick: this._onTitleClick
 				}, [
-					v('i', {
-						classes: this.classes(
-							css.arrow,
-							iconCss.icon,
-							open ? iconCss.downIcon : iconCss.rightIcon
-						),
-						role: 'presentation',
-						'aria-hidden': 'true'
-					}),
-					title
+					this.renderExpandIcon(),
+					this.getButtonContent()
 				])
 			]),
 			v('div', {
@@ -146,7 +153,7 @@ export default class TitlePane extends TitlePaneBase<TitlePaneProperties> {
 				classes: this.classes(css.content),
 				id: this._contentId,
 				key: 'content'
-			}, this.children)
+			}, this.getPaneContent())
 		]);
 	}
 }

--- a/src/titlepane/TitlePane.ts
+++ b/src/titlepane/TitlePane.ts
@@ -82,29 +82,29 @@ export default class TitlePane extends TitlePaneBase<TitlePaneProperties> {
 		key === 'content' && this._afterRender(element);
 	}
 
-	protected getButtonContent() {
+	protected getButtonContent(): DNode {
 		return this.properties.title;
 	}
 
-	protected getFixedModifierClasses() {
+	protected getFixedModifierClasses(): (string | null)[] {
 		const { closeable = true } = this.properties;
 		return [
 			closeable ? css.closeableFixed : null
 		];
 	}
 
-	protected getModifierClasses() {
+	protected getModifierClasses(): (string | null)[] {
 		const { closeable = true } = this.properties;
 		return [
 			closeable ? css.closeable : null
 		];
 	}
 
-	protected getPaneContent() {
+	protected getPaneContent(): DNode[] {
 		return this.children;
 	}
 
-	protected renderExpandIcon() {
+	protected renderExpandIcon(): DNode {
 		const { open = true } = this.properties;
 		return v('i', {
 			classes: this.classes(

--- a/src/titlepane/tests/functional/TitlePane.ts
+++ b/src/titlepane/tests/functional/TitlePane.ts
@@ -32,7 +32,7 @@ registerSuite('TitlePane', {
 					height = size.height;
 				})
 			.end()
-			.findByCssSelector('#titlePane2 > div > :first-child')
+			.findByCssSelector('#titlePane2 button')
 				.click()
 			.end()
 			.sleep(DELAY)

--- a/src/titlepane/tests/unit/TitlePane.ts
+++ b/src/titlepane/tests/unit/TitlePane.ts
@@ -7,7 +7,6 @@ import { v } from '@dojo/widget-core/d';
 import TitlePane, { TitlePaneProperties } from '../../TitlePane';
 import * as css from '../../styles/titlePane.m.css';
 import * as iconCss from '../../../common/styles/icons.m.css';
-import { Keys } from '../../../common/util';
 
 const isNonEmptyString = compareProperty((value: any) => {
 	return typeof value === 'string' && value.length > 0;
@@ -40,18 +39,15 @@ registerSuite('TitlePane', {
 				v('div', {
 					'aria-level': null,
 					classes: titlePane.classes(css.title, css.titleFixed, css.closeable, css.closeableFixed),
-					onclick: titlePane.listener,
-					onkeyup: titlePane.listener,
 					role: 'heading'
 				}, [
-					v('div', {
+					v('button', {
 						'aria-controls': isNonEmptyString,
-						'aria-disabled': null,
 						'aria-expanded': 'true',
 						classes: titlePane.classes(css.titleButton),
+						disabled: false,
 						id: <any> isNonEmptyString,
-						role: 'button',
-						tabIndex: 0
+						onclick: titlePane.listener
 					}, [
 						v('i', {
 							classes: titlePane.classes(
@@ -89,18 +85,15 @@ registerSuite('TitlePane', {
 				v('div', {
 					'aria-level': '5',
 					classes: titlePane.classes(css.title, css.titleFixed),
-					onclick: titlePane.listener,
-					onkeyup: titlePane.listener,
 					role: 'heading'
 				}, [
-					v('div', {
+					v('button', {
 						'aria-controls': isNonEmptyString,
-						'aria-disabled': 'true',
 						'aria-expanded': 'false',
 						classes: titlePane.classes(css.titleButton),
+						disabled: true,
 						id: <any> isNonEmptyString,
-						role: 'button',
-						tabIndex: -1
+						onclick: titlePane.listener
 					}, [
 						v('i', {
 							classes: titlePane.classes(
@@ -135,7 +128,7 @@ registerSuite('TitlePane', {
 			});
 
 			titlePane.sendEvent('click', {
-				selector: `.${css.title}`
+				selector: `.${css.titleButton}`
 			});
 			assert.isTrue(called, 'onRequestClose should be called on title click');
 		},
@@ -152,7 +145,7 @@ registerSuite('TitlePane', {
 			});
 
 			titlePane.sendEvent('click', {
-				selector: `.${css.title}`
+				selector: `.${css.titleButton}`
 			});
 			assert.isTrue(called, 'onRequestOpen should be called on title click');
 		},
@@ -169,7 +162,7 @@ registerSuite('TitlePane', {
 			});
 			titlePane.getRender();
 			titlePane.sendEvent('click', {
-				selector: `.${css.title}`
+				selector: `.${css.titleButton}`
 			});
 
 			titlePane.setProperties({
@@ -181,119 +174,10 @@ registerSuite('TitlePane', {
 			});
 			titlePane.getRender();
 			titlePane.sendEvent('click', {
-				selector: `.${css.title}`
+				selector: `.${css.titleButton}`
 			});
 
 			assert.strictEqual(called, 1, 'onRequestClose should only becalled once');
-		},
-
-		'can not open pane on keyup'() {
-			let called = 0;
-			titlePane.setProperties({
-				closeable: false,
-				open: true,
-				onRequestClose() {
-					called++;
-				},
-				title: 'test'
-			});
-			titlePane.getRender();
-			titlePane.sendEvent<TestEventInit>('keyup', {
-				eventInit: { keyCode: Keys.Enter },
-				selector: `.${css.title}`
-			});
-
-			titlePane.setProperties({
-				open: true,
-				onRequestClose() {
-					called++;
-				},
-				title: 'test'
-			});
-			titlePane.getRender();
-			titlePane.sendEvent<TestEventInit>('keyup', {
-				eventInit: { keyCode: Keys.Enter },
-				selector: `.${css.title}`
-			});
-
-			assert.strictEqual(called, 1, 'onRequestClose should only becalled once');
-		},
-
-		'open on keyup'() {
-			let openCount = 0;
-			const props = {
-				closeable: true,
-				open: false,
-				onRequestOpen() {
-					openCount++;
-				},
-				title: 'test'
-			};
-
-			titlePane.setProperties(props);
-			titlePane.sendEvent<TestEventInit>('keyup', {
-				eventInit: { keyCode: Keys.Enter },
-				selector: `.${css.title}`
-			});
-			assert.strictEqual(openCount, 1, 'onRequestOpen should be called on title enter keyup');
-
-			titlePane.setProperties(props);
-			titlePane.sendEvent<TestEventInit>('keyup', {
-				eventInit: { keyCode: Keys.Space },
-				selector: `.${css.title}`
-			});
-			assert.strictEqual(openCount, 2, 'onRequestOpen should be called on title space keyup');
-		},
-
-		'close on keyup'() {
-			let closeCount = 0;
-			const props = {
-				closeable: true,
-				open: true,
-				onRequestClose() {
-					closeCount++;
-				},
-				title: 'test'
-			};
-
-			titlePane.setProperties(props);
-			titlePane.sendEvent<TestEventInit>('keyup', {
-				eventInit: { keyCode: Keys.Enter },
-				selector: `.${css.title}`
-			});
-			assert.strictEqual(closeCount, 1, 'onRequestClose should be called on title enter keyup');
-
-			titlePane.setProperties(props);
-			titlePane.sendEvent<TestEventInit>('keyup', {
-				eventInit: { keyCode: Keys.Space },
-				selector: `.${css.title}`
-			});
-			assert.strictEqual(closeCount, 2, 'onRequestClose should be called on title space keyup');
-		},
-
-		'keyup: only respond to enter and space'() {
-			let called = false;
-			titlePane.setProperties({
-				closeable: true,
-				open: false,
-				onRequestClose() {
-					called = true;
-				},
-				onRequestOpen() {
-					called = true;
-				},
-				title: 'test'
-			});
-
-			for (let i = 8; i < 223; i++) {
-				if (i !== Keys.Enter && i !== Keys.Space) {
-					titlePane.sendEvent<TestEventInit>('keyup', {
-						eventInit: { keyCode: i },
-						selector: `.${css.title}`
-					});
-					assert.isFalse(called, `keyCode {i} should be ignored`);
-				}
-			}
 		}
 	}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Resolves #316 

Makes widgets more easily extensible by simplifying the render code, particularly addressing these points from the issue:
- break out large chunks of rendered dom
- state classes are returned in a function
- icons are broken out
- inline styles are calculated separately
