### PR TITLE
Add z-index to SlidePane content

### DIFF
--- a/src/slidepane/styles/slidePane.m.css
+++ b/src/slidepane/styles/slidePane.m.css
@@ -19,6 +19,7 @@
 	position: fixed;
 	top: 0;
 	box-sizing: border-box;
+	z-index: 1;
 }
 
 .pane {

--- a/src/slidepane/styles/slidePane.m.css
+++ b/src/slidepane/styles/slidePane.m.css
@@ -8,6 +8,7 @@
 	left: 0;
 	width: 100%;
 	height: 100%;
+	z-index: 1;
 }
 
 .underlayVisible {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

The SlidePane's main content pane was fixed with no z-index. While #335 will consolidate all z-indexes across the component base, this fix at least allows SlidePane to render properly (for example, on the showcase page) until the global z-index pattern is sorted.

<img width="812" alt="screen shot 2017-10-30 at 4 21 44 pm" src="https://user-images.githubusercontent.com/334586/32193791-c1fa4352-bd8e-11e7-8391-e049527407da.png">

Resolves #329 
