### PR TITLE
Add AccordionPane README and custom element descriptor

### DIFF
--- a/src/accordionpane/README.md
+++ b/src/accordionpane/README.md
@@ -1,0 +1,53 @@
+# @dojo/widgets/accordionpane/AccordionPane widget
+
+Dojo 2's `AccordionPane` component can be used to show multiple pieces of content inside collapsible panes within a common parent component. It provides responsive styling and a mechanism of control over multiple child `TitlePane` components.
+
+## Features
+
+- Optionally supports multiple panes open at once
+
+![Image of basic dialog](http://placekitten.com/450/300)
+
+### Accessibility Features
+
+An `AccordionPane` expects all children to be `TitlePane` components, and as such, supports standard keyboard navigation for toggling child content open or closed.
+
+**TitleBar Events**:
+
+- Space bar: toggles the pane content of a closeable child `TitlePane`
+
+## Themeing
+
+The following CSS classes are used to style the `AccordionPane` widget and should be provided by custom themes:
+
+- `root`: Applied to the top-level wrapper node
+
+## Example Usage
+
+*Basic Example*
+```typescript
+import AccordionPane from '@dojo/widgets/accordionpane/AccordionPane';
+import TitlePane from '@dojo/widgets/titlepane/TitlePane';
+import { w } from '@dojo/widget-core/d';
+
+w(AccordionPane, {
+	onRequestOpen: (key: string) => {
+		this._openKey = key;
+		this.invalidate();
+	},
+	onRequestClose: (key: string) => {
+		this._openKey = null;
+		this.invalidate();
+	},
+	openKeys: [ this._openKey ]
+}, [
+	w(TitlePane, {
+		title: 'Pane 1',
+		key: 'foo'
+	}, [ 'Foo' ]),
+	w(TitlePane, {
+		title: 'Pane 2',
+		key: 'bar'
+	}, [ 'Bar' ])
+])
+```

--- a/src/accordionpane/README.md
+++ b/src/accordionpane/README.md
@@ -6,8 +6,6 @@ Dojo 2's `AccordionPane` component can be used to show multiple pieces of conten
 
 - Optionally supports multiple panes open at once
 
-![Image of basic dialog](http://placekitten.com/450/300)
-
 ### Accessibility Features
 
 An `AccordionPane` expects all children to be `TitlePane` components, and as such, supports standard keyboard navigation for toggling child content open or closed.

--- a/src/accordionpane/createAccordionPaneElement.ts
+++ b/src/accordionpane/createAccordionPaneElement.ts
@@ -8,8 +8,20 @@ export default function createAccordionPaneElement(): CustomElementDescriptor {
 	return {
 		tagName: 'dojo-accordionpane',
 		widgetConstructor: AccordionPane,
-		attributes: [],
-		properties: [],
-		events: []
+		properties: [
+			{
+				propertyName: 'openKeys'
+			}
+		],
+		events: [
+			{
+				propertyName: 'onRequestClose',
+				eventName: 'requestClose'
+			},
+			{
+				propertyName: 'onRequestOpen',
+				eventName: 'requestOpen'
+			}
+		]
 	};
 };


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] ~~Unit or Functional tests are included in the PR~~

**Description:**

Adds a README for AccordionPane (mostly placeholder, like other components) and a proper custom element descriptor.

Resolves #364 
