### PR TITLE
Proposal: Update widget examples

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widgets",
-  "version": "0.2.1",
+  "version": "0.2.2-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/accordionpane/example/index.ts
+++ b/src/accordionpane/example/index.ts
@@ -1,35 +1,21 @@
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { Set } from '@dojo/shim/Set';
 import { w, v } from '@dojo/widget-core/d';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties, TypedTargetEvent } from '@dojo/widget-core/interfaces';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import { from } from '@dojo/shim/array';
 
 import AccordionPane from '../../accordionpane/AccordionPane';
 import TitlePane from '../../titlepane/TitlePane';
 
-import dojoTheme from '../../themes/dojo/theme';
-
-export class App extends WidgetBase<WidgetProperties> {
+export default class App extends WidgetBase<ThemedProperties> {
 	private _exclusiveKey: string | undefined;
 	private _openKeys = new Set<string>();
-	private _theme: {};
-
-	themeChange(event: TypedTargetEvent<HTMLInputElement>) {
-		this._theme = event.target.checked ? dojoTheme : {};
-		this.invalidate();
-	}
 
 	render() {
+		const { theme } = this.properties;
+
 		return v('div', { styles: { maxWidth: '350px' } }, [
 			v('h2', [ 'AccordionPane Examples' ]),
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
 			v('div', { id: 'pane' }, [
 				v('h3', [ 'Normal AccordionPane' ]),
 				w(AccordionPane, {
@@ -42,7 +28,7 @@ export class App extends WidgetBase<WidgetProperties> {
 						this.invalidate();
 					},
 					openKeys: from(this._openKeys),
-					theme: this._theme
+					theme
 				}, [
 					w(TitlePane, {
 						title: 'Pane 1',
@@ -66,7 +52,7 @@ export class App extends WidgetBase<WidgetProperties> {
 						this.invalidate();
 					},
 					openKeys: this._exclusiveKey ? [ this._exclusiveKey ] : [],
-					theme: this._theme
+					theme
 				}, [
 					w(TitlePane, {
 						title: 'Pane 1',
@@ -81,8 +67,3 @@ export class App extends WidgetBase<WidgetProperties> {
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/button/example/index.ts
+++ b/src/button/example/index.ts
@@ -1,19 +1,10 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties, TypedTargetEvent } from '@dojo/widget-core/interfaces';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import { w, v } from '@dojo/widget-core/d';
 import Button from '../../button/Button';
-import dojoTheme from '../../themes/dojo/theme';
 
-export class App extends WidgetBase<WidgetProperties> {
-	private _theme: {};
+export default class App extends WidgetBase<ThemedProperties> {
 	private _buttonPressed: boolean;
-
-	themeChange(event: TypedTargetEvent<HTMLInputElement>) {
-		const checked = event.target.checked;
-		this._theme = checked ? dojoTheme : {};
-		this.invalidate();
-	}
 
 	toggleButton() {
 		this._buttonPressed = !this._buttonPressed;
@@ -21,27 +12,22 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render() {
+		const { theme } = this.properties;
+
 		return v('div', [
 			v('h2', [ 'Button Examples' ]),
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
 			v('div', { id: 'example-1' }, [
 				v('p', [ 'Basic example:' ]),
 				w(Button, {
 					key: 'b1',
-					theme: this._theme
+					theme
 				}, [ 'Basic Button' ])
 			]),
 			v('div', { id: 'example-2' }, [
 				v('p', [ 'Disabled submit button:' ]),
 				w(Button, {
 					key: 'b2',
-					theme: this._theme,
+					theme,
 					disabled: true,
 					type: 'submit'
 				}, [ 'Submit' ])
@@ -50,7 +36,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				v('p', [ 'Popup button:' ]),
 				w(Button, {
 					key: 'b3',
-					theme: this._theme,
+					theme,
 					popup: { expanded: false, id: 'fakeId' }
 				}, [ 'Open' ])
 			]),
@@ -58,7 +44,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				v('p', [ 'Toggle Button' ]),
 				w(Button, {
 					key: 'b4',
-					theme: this._theme,
+					theme,
 					pressed: this._buttonPressed,
 					onClick: this.toggleButton
 				}, [ 'Button state' ])
@@ -66,8 +52,3 @@ export class App extends WidgetBase<WidgetProperties> {
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/calendar/example/index.ts
+++ b/src/calendar/example/index.ts
@@ -1,36 +1,21 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties } from '@dojo/widget-core/interfaces';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import { v, w } from '@dojo/widget-core/d';
 import Calendar from '../../calendar/Calendar';
-import Checkbox from '../../checkbox/Checkbox';
-import dojoTheme from '../../themes/dojo/theme';
 
-export class App extends WidgetBase<WidgetProperties> {
-	private _theme: {};
+export default class App extends WidgetBase<ThemedProperties> {
 	private _month: number;
 	private _year: number;
 	private _selectedDate: Date;
 
-	themeChange(event: Event) {
-		const checked = (<HTMLInputElement> event.target).checked;
-		this._theme = checked ? dojoTheme : {};
-		this.invalidate();
-	}
-
 	render() {
+		const { theme } = this.properties;
+
 		return v('div', {}, [
-			w(Checkbox, {
-				label: {
-					content: 'Use Dojo Theme',
-					before: false
-				},
-				onChange: this.themeChange
-			}),
 			w(Calendar, {
 				month: this._month,
 				selectedDate: this._selectedDate,
-				theme: this._theme,
+				theme,
 				year: this._year,
 				onMonthChange: (month: number) => {
 					this._month = month;
@@ -49,8 +34,3 @@ export class App extends WidgetBase<WidgetProperties> {
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/checkbox/example/index.ts
+++ b/src/checkbox/example/index.ts
@@ -1,12 +1,9 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties, TypedTargetEvent } from '@dojo/widget-core/interfaces';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import { v, w } from '@dojo/widget-core/d';
 import Checkbox, { Mode } from '../../checkbox/Checkbox';
-import dojoTheme from '../../themes/dojo/theme';
 
-export class App extends WidgetBase<WidgetProperties> {
-	private _theme: {};
+export default class App extends WidgetBase<ThemedProperties> {
 	private _checkboxStates: { [key: string]: boolean } = {
 		c1: true,
 		c2: false,
@@ -15,13 +12,7 @@ export class App extends WidgetBase<WidgetProperties> {
 		c5: true
 	};
 
-	themeChange(event: TypedTargetEvent<HTMLInputElement>) {
-		const checked = event.target.checked;
-		this._theme = checked ? dojoTheme : {};
-		this.invalidate();
-	}
-
-	onChange(event: TypedTargetEvent<HTMLInputElement>) {
+	onChange(event: any) {
 		const value = event.target.value;
 		const checked = event.target.checked;
 		this._checkboxStates[value] = checked;
@@ -29,6 +20,8 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render() {
+		const { theme } = this.properties;
+
 		const {
 			c1 = true,
 			c2 = false,
@@ -41,13 +34,6 @@ export class App extends WidgetBase<WidgetProperties> {
 			v('h2', {
 				innerHTML: 'Checkbox Examples'
 			}),
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
 			v('fieldset', [
 				v('legend', {}, ['Checkbox Example']),
 				v('div', { id: 'example-1' }, [
@@ -57,7 +43,7 @@ export class App extends WidgetBase<WidgetProperties> {
 						label: 'Sample checkbox that starts checked',
 						value: 'c1',
 						onChange: this.onChange,
-						theme: this._theme
+						theme
 					})
 				]),
 
@@ -69,7 +55,7 @@ export class App extends WidgetBase<WidgetProperties> {
 						disabled: true,
 						value: 'c2',
 						onChange: this.onChange,
-						theme: this._theme
+						theme
 					})
 				]),
 
@@ -81,7 +67,7 @@ export class App extends WidgetBase<WidgetProperties> {
 						required: true,
 						value: 'c3',
 						onChange: this.onChange,
-						theme: this._theme
+						theme
 					})
 				]),
 
@@ -93,7 +79,7 @@ export class App extends WidgetBase<WidgetProperties> {
 						mode: Mode.toggle,
 						value: 'c4',
 						onChange: this.onChange,
-						theme: this._theme
+						theme
 					})
 				]),
 
@@ -108,15 +94,10 @@ export class App extends WidgetBase<WidgetProperties> {
 						disabled: true,
 						value: 'c5',
 						onChange: this.onChange,
-						theme: this._theme
+						theme
 					})
 				])
 			])
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/combobox/example/index.ts
+++ b/src/combobox/example/index.ts
@@ -1,10 +1,8 @@
 import { DNode } from '@dojo/widget-core/interfaces';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { v, w } from '@dojo/widget-core/d';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties } from '@dojo/widget-core/interfaces';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import ComboBox from '../ComboBox';
-import dojoTheme from '../../themes/dojo/theme';
 
 const data = [
 	{ value: 'Maine' },
@@ -59,8 +57,7 @@ const data = [
 	{ value: 'West Virginia' }
 ];
 
-export class App extends WidgetBase<WidgetProperties> {
-	private _theme: {};
+export default class App extends WidgetBase<ThemedProperties> {
 	private _results: any[];
 	private _value1 = '';
 	private _value2 = '';
@@ -68,12 +65,6 @@ export class App extends WidgetBase<WidgetProperties> {
 	private _value8 = '';
 	private _value9 = '';
 	private _invalid: boolean;
-
-	themeChange(event: Event) {
-		const checked = (<HTMLInputElement> event.target).checked;
-		this._theme = checked ? dojoTheme : {};
-		this.invalidate();
-	}
 
 	onChange(value: string, key?: string) {
 		if (!key) {
@@ -96,6 +87,7 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render(): DNode {
+		const { theme } = this.properties;
 		const {
 			onChange,
 			onRequestResults
@@ -105,13 +97,6 @@ export class App extends WidgetBase<WidgetProperties> {
 			styles: { maxWidth: '256px' }
 		}, [
 			v('h1', ['ComboBox Examples']),
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
 			v('h3', ['Clearable']),
 			w(ComboBox, {
 				key: '2',
@@ -124,7 +109,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				inputProperties: {
 					placeholder: 'Enter a value'
 				},
-				theme: this._theme
+				theme
 			}),
 			v('h3', ['Open on focus']),
 			w(ComboBox, {
@@ -138,7 +123,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				inputProperties: {
 					placeholder: 'Enter a value'
 				},
-				theme: this._theme
+				theme
 			}),
 			v('h3', ['Disabled menu items']),
 			w(ComboBox, {
@@ -152,7 +137,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				inputProperties: {
 					placeholder: 'Enter a value'
 				},
-				theme: this._theme
+				theme
 			}),
 			v('h3', ['Disabled']),
 			w(ComboBox, {
@@ -161,7 +146,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				inputProperties: {
 					placeholder: 'Enter a value'
 				},
-				theme: this._theme
+				theme
 			}),
 			v('h3', ['Read Only']),
 			w(ComboBox, {
@@ -170,7 +155,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				inputProperties: {
 					placeholder: 'Enter a value'
 				},
-				theme: this._theme
+				theme
 			}),
 			v('h3', ['Label']),
 			w(ComboBox, {
@@ -181,7 +166,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				results: this._results,
 				value: this._value8,
 				label: 'Enter a value',
-				theme: this._theme
+				theme
 			}),
 			v('h3', ['Required and validated']),
 			w(ComboBox, {
@@ -200,13 +185,8 @@ export class App extends WidgetBase<WidgetProperties> {
 				inputProperties: {
 					placeholder: 'Enter a value'
 				},
-				theme: this._theme
+				theme
 			})
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/common/example/index.html
+++ b/src/common/example/index.html
@@ -38,25 +38,7 @@
 			}
 		}));
 
-		(function () {
-			var query = window.location.search.substring(1).split('&');
-			var module;
-
-			for (var i = 0; i < query.length; i++) {
-				var pair = query[i].split('=');
-				if (pair[0].toLowerCase() === 'module') {
-					module = pair[1].toLowerCase();
-					break;
-				}
-			}
-
-			require(['@dojo/shim/main'], function () {
-				require([ 'src/common/example/index' ], function () {});
-				if (module) {
-					require([ 'src/' + module + '/example/index' ], function () {});
-				}
-			});
-		})();
+		require([ 'src/common/example/index' ], function () {});
 	</script>
 </body>
 </html>

--- a/src/common/example/index.ts
+++ b/src/common/example/index.ts
@@ -1,8 +1,31 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties } from '@dojo/widget-core/interfaces';
 import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import Select from '../../select/Select';
 import { v, w } from '@dojo/widget-core/d';
+import { Registry } from '@dojo/widget-core/Registry';
+import dojoTheme from '../../themes/dojo/theme';
+
+import accordionpane from './../../accordionpane/example/index';
+import button from './../../button/example/index';
+import calendar from './../../calendar/example/index';
+import checkbox from './../../checkbox/example/index';
+import combobox from './../../combobox/example/index';
+import dialog from './../../dialog/example/index';
+import label from './../../label/example/index';
+import listbox from './../../listbox/example/index';
+import radio from './../../radio/example/index';
+import select from './../../select/example/index';
+import slidepane from './../../slidepane/example/index';
+import slider from './../../slider/example/index';
+import splitpane from './../../splitpane/example/index';
+import tabcontroller from './../../tabcontroller/example/index';
+import textarea from './../../textarea/example/index';
+import textinput from './../../textinput/example/index';
+import timepicker from './../../timepicker/example/index';
+import titlepane from './../../titlepane/example/index';
+import tooltip from './../../tooltip/example/index';
+
+const registry = new Registry();
 
 const modules = [
 	'accordionpane',
@@ -26,9 +49,38 @@ const modules = [
 	'tooltip'
 ];
 
-export class App extends WidgetBase<WidgetProperties> {
+registry.define('accordionpane', accordionpane);
+registry.define('button', button);
+registry.define('calendar', calendar);
+registry.define('checkbox', checkbox);
+registry.define('combobox', combobox);
+registry.define('dialog', dialog);
+registry.define('label', label);
+registry.define('listbox', listbox);
+registry.define('radio', radio);
+registry.define('select', select);
+registry.define('slidepane', slidepane);
+registry.define('slider', slider);
+registry.define('splitpane', splitpane);
+registry.define('tabcontroller', tabcontroller);
+registry.define('textarea', textarea);
+registry.define('textinput', textinput);
+registry.define('timepicker', timepicker);
+registry.define('titlepane', titlepane);
+registry.define('tooltip', tooltip);
+
+export class App extends WidgetBase {
+	private _module: string;
+	private _theme = {};
+
 	onModuleChange(module: any) {
-		window.location.search = `?module=${module}`;
+		this._module = module;
+		this.invalidate();
+	}
+
+	themeChange(event: any) {
+		this._theme = event.target.checked ? dojoTheme : {};
+		this.invalidate();
 	}
 
 	render() {
@@ -42,12 +94,24 @@ export class App extends WidgetBase<WidgetProperties> {
 				options: modules,
 				getOptionValue: (module: any) => module,
 				getOptionLabel: (module: any) => module
-			})
+			}),
+			v('label', [
+				'Use Dojo Theme ',
+				v('input', {
+					styles: {
+						'margin-top': '20px'
+					},
+					type: 'checkbox',
+					onchange: this.themeChange
+				})
+			]),
+			this._module ? w<any>(this._module, { theme: this._theme }) : null
 		]);
 	}
 }
 
 const Projector = ProjectorMixin(App);
 const projector = new Projector();
+projector.setProperties({ registry });
 
 projector.append();

--- a/src/dialog/example/index.ts
+++ b/src/dialog/example/index.ts
@@ -1,23 +1,14 @@
 import { DNode } from '@dojo/widget-core/interfaces';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties } from '@dojo/widget-core/interfaces';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import { v, w } from '@dojo/widget-core/d';
 import Dialog from '../../dialog/Dialog';
-import dojoTheme from '../../themes/dojo/theme';
 
-export class App extends WidgetBase<WidgetProperties> {
-	private _theme: {};
+export default class App extends WidgetBase<ThemedProperties> {
 	private _modal = false;
 	private _underlay = false;
 	private _closeable = true;
 	private _open = false;
-
-	themeChange(event: Event) {
-		const checked = (<HTMLInputElement> event.target).checked;
-		this._theme = checked ? dojoTheme : {};
-		this.invalidate();
-	}
 
 	openDialog() {
 		this._open = true;
@@ -40,6 +31,8 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render(): DNode {
+		const { theme } = this.properties;
+
 		return v('div', [
 			v('button', {
 				id: 'button',
@@ -57,20 +50,11 @@ export class App extends WidgetBase<WidgetProperties> {
 					this._open = false;
 					this.invalidate();
 				},
-				theme: this._theme
+				theme
 			}, [
 				`Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 				Quisque id purus ipsum. Aenean ac purus purus.
 				Nam sollicitudin varius augue, sed lacinia felis tempor in.`
-			]),
-			v('div', { classes: 'option' }, [
-				v('label', [
-					'Use Dojo Theme ',
-					v('input', {
-						type: 'checkbox',
-						onchange: this.themeChange
-					})
-				])
 			]),
 			v('div', { classes: 'option' }, [
 				v('input', {
@@ -109,8 +93,3 @@ export class App extends WidgetBase<WidgetProperties> {
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/label/example/index.ts
+++ b/src/label/example/index.ts
@@ -1,10 +1,9 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { WidgetProperties } from '@dojo/widget-core/interfaces';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { v, w } from '@dojo/widget-core/d';
 import Label from '../../label/Label';
 
-export class App extends WidgetBase<WidgetProperties> {
+export default class App extends WidgetBase<WidgetProperties> {
 	render() {
 		return v('div', [
 			v('h1', {}, ['Label Examples']),
@@ -37,8 +36,3 @@ export class App extends WidgetBase<WidgetProperties> {
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/listbox/example/index.ts
+++ b/src/listbox/example/index.ts
@@ -1,9 +1,7 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties } from '@dojo/widget-core/interfaces';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import { v, w } from '@dojo/widget-core/d';
 import Listbox from '../Listbox';
-import dojoTheme from '../../themes/dojo/theme';
 
 interface CustomOption {
 	disabled?: boolean;
@@ -12,17 +10,10 @@ interface CustomOption {
 	value: string;
 }
 
-export class App extends WidgetBase<WidgetProperties> {
+export default class App extends WidgetBase<ThemedProperties> {
 	private _listbox1Index = 0;
 	private _listbox1Value: string;
 	private _listbox2Index = 0;
-	private _theme: {};
-
-	themeChange(event: Event) {
-		const checked = (<HTMLInputElement> event.target).checked;
-		this._theme = checked ? dojoTheme : {};
-		this.invalidate();
-	}
 
 	_options: CustomOption[] = [
 		{ value: 'Maine' },
@@ -97,14 +88,9 @@ export class App extends WidgetBase<WidgetProperties> {
 	];
 
 	render() {
+		const { theme } = this.properties;
+
 		return v('div', [
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
 			v('br'),
 			v('label', { for: 'listbox1' }, [ 'Single-select listbox example' ]),
 			w(Listbox, {
@@ -112,7 +98,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				activeIndex: this._listbox1Index,
 				id: 'listbox1',
 				optionData: this._options,
-				theme: this._theme,
+				theme,
 				getOptionLabel: (option: CustomOption) => option.value,
 				getOptionDisabled: (option: CustomOption) => !!option.disabled,
 				getOptionSelected: (option: CustomOption) => option.value === this._listbox1Value,
@@ -133,7 +119,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				activeIndex: this._listbox2Index,
 				id: 'listbox2',
 				optionData: this._moreOptions,
-				theme: this._theme,
+				theme,
 				getOptionLabel: (option: CustomOption) => option.label,
 				getOptionDisabled: (option: CustomOption) => !!option.disabled,
 				getOptionSelected: (option: CustomOption) => !!option.selected,
@@ -150,8 +136,3 @@ export class App extends WidgetBase<WidgetProperties> {
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/radio/example/index.ts
+++ b/src/radio/example/index.ts
@@ -1,19 +1,11 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties, TypedTargetEvent } from '@dojo/widget-core/interfaces';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
+import { TypedTargetEvent } from '@dojo/widget-core/interfaces';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import { v, w } from '@dojo/widget-core/d';
 import Radio from '../../radio/Radio';
-import dojoTheme from '../../themes/dojo/theme';
 
-export class App extends WidgetBase<WidgetProperties> {
-	private _theme: {};
+export default class App extends WidgetBase<ThemedProperties> {
 	private _inputValue: string;
-
-	themeChange(event: TypedTargetEvent<HTMLInputElement>) {
-		const checked = event.target.checked;
-		this._theme = checked ? dojoTheme : {};
-		this.invalidate();
-	}
 
 	onChange(event: TypedTargetEvent<HTMLInputElement>) {
 		const value = event.target.value;
@@ -22,6 +14,7 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render() {
+		const { theme } = this.properties;
 		const {
 			_inputValue = 'first'
 		} = this;
@@ -30,13 +23,6 @@ export class App extends WidgetBase<WidgetProperties> {
 			v('h2', {
 				innerHTML: 'Radio Examples'
 			}),
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
 			v('fieldset', { id: 'example-1' }, [
 				v('legend', {}, ['Set of radio buttons with first option selected']),
 				w(Radio, {
@@ -46,7 +32,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					label: 'First option',
 					name: 'sample-radios',
 					onChange: this.onChange,
-					theme: this._theme
+					theme
 				}),
 				w(Radio, {
 					key: 'r2',
@@ -55,7 +41,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					label: 'Second option',
 					name: 'sample-radios',
 					onChange: this.onChange,
-					theme: this._theme
+					theme
 				}),
 				w(Radio, {
 					key: 'r3',
@@ -64,7 +50,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					label: 'Third option',
 					name: 'sample-radios',
 					onChange: this.onChange,
-					theme: this._theme
+					theme
 				})
 			]),
 			v('fieldset', { id: 'example-2' }, [
@@ -75,7 +61,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					disabled: true,
 					label: 'First option',
 					name: 'sample-radios-disabled',
-					theme: this._theme
+					theme
 				}),
 				w(Radio, {
 					key: 'r5',
@@ -83,14 +69,9 @@ export class App extends WidgetBase<WidgetProperties> {
 					disabled: true,
 					label: 'Second option',
 					name: 'sample-radios-disabled',
-					theme: this._theme
+					theme
 				})
 			])
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/select/example/index.ts
+++ b/src/select/example/index.ts
@@ -1,21 +1,12 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties } from '@dojo/widget-core/interfaces';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import { v, w } from '@dojo/widget-core/d';
 import Select, { SelectProperties } from '../Select';
-import dojoTheme from '../../themes/dojo/theme';
 
-export class App extends WidgetBase<WidgetProperties> {
-	private _theme: {};
+export default class App extends WidgetBase<ThemedProperties> {
 	private _value1: string;
 	private _value2: string;
 	private _value3: string;
-
-	themeChange(event: Event) {
-		const checked = (<HTMLInputElement> event.target).checked;
-		this._theme = checked ? dojoTheme : {};
-		this.invalidate();
-	}
 
 	_selectOptions = [
 		{
@@ -67,15 +58,9 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render() {
+		const { theme } = this.properties;
 
 		return v('div', [
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
 			v('br'),
 			w(Select, {
 				key: 'select1',
@@ -85,7 +70,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				options: this._selectOptions,
 				useNativeElement: true,
 				value: this._value1,
-				theme: this._theme,
+				theme,
 				onChange: (option: any) => {
 					this._value1 = option.value;
 					this.invalidate();
@@ -101,7 +86,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				label: 'Custom select box',
 				options: this._moreSelectOptions,
 				value: this._value2,
-				theme: this._theme,
+				theme,
 				onChange: (option: any) => {
 					this._value2 = option.value;
 					this.invalidate();
@@ -115,7 +100,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				options: this._evenMoreSelectOptions,
 				placeholder: 'Choose a cat',
 				value: this._value3,
-				theme: this._theme,
+				theme,
 				onChange: (option: any) => {
 					this._value3 = option;
 					this.invalidate();
@@ -124,8 +109,3 @@ export class App extends WidgetBase<WidgetProperties> {
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/slidepane/example/index.ts
+++ b/src/slidepane/example/index.ts
@@ -1,22 +1,13 @@
 import { DNode } from '@dojo/widget-core/interfaces';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { v, w } from '@dojo/widget-core/d';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties } from '@dojo/widget-core/interfaces';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import SlidePane, { Align } from '../../slidepane/SlidePane';
-import dojoTheme from '../../themes/dojo/theme';
 
-export class App extends WidgetBase<WidgetProperties> {
-	private _theme: {};
+export default class App extends WidgetBase<ThemedProperties> {
 	private _open = false;
 	private _underlay = false;
 	private _align: Align = Align.left;
-
-	themeChange(event: Event) {
-		const checked = (<HTMLInputElement> event.target).checked;
-		this._theme = checked ? dojoTheme : {};
-		this.invalidate();
-	}
 
 	openSlidePane() {
 		this._open = true;
@@ -34,6 +25,8 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render(): DNode {
+		const { theme } = this.properties;
+
 		return v('div', [
 			w(SlidePane, {
 				title: 'SlidePane',
@@ -45,7 +38,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					this._open = false;
 					this.invalidate();
 				},
-				theme: this._theme
+				theme
 			}, [
 				`Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 				Quisque id purus ipsum. Aenean ac purus purus.
@@ -56,15 +49,6 @@ export class App extends WidgetBase<WidgetProperties> {
 				innerHTML: 'open slidepane',
 				onclick: this.openSlidePane
 			}),
-			v('div', { classes: 'option' }, [
-				v('label', [
-					'Use Dojo Theme ',
-					v('input', {
-						type: 'checkbox',
-						onchange: this.themeChange
-					})
-				])
-			]),
 			v('div', { classes: 'option' }, [
 				v('input', {
 					type: 'checkbox',
@@ -90,8 +74,3 @@ export class App extends WidgetBase<WidgetProperties> {
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/slider/example/index.ts
+++ b/src/slider/example/index.ts
@@ -1,21 +1,13 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties, TypedTargetEvent } from '@dojo/widget-core/interfaces';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
+import { TypedTargetEvent } from '@dojo/widget-core/interfaces';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import { v, w } from '@dojo/widget-core/d';
 import Slider from '../../slider/Slider';
-import dojoTheme from '../../themes/dojo/theme';
 
-export class App extends WidgetBase<WidgetProperties> {
-	private _theme: {};
+export default class App extends WidgetBase<ThemedProperties> {
 	private _tribbleValue: number;
 	private _verticalValue: number;
 	private _verticalInvalid: boolean;
-
-	themeChange(event: TypedTargetEvent<HTMLInputElement>) {
-		const checked = event.target.checked;
-		this._theme = checked ? dojoTheme : {};
-		this.invalidate();
-	}
 
 	onTribbleInput(event: TypedTargetEvent<HTMLInputElement>) {
 		const value = event.target.value;
@@ -31,6 +23,7 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render() {
+		const { theme } = this.properties;
 		const {
 			_tribbleValue: tribbleValue = 50,
 			_verticalValue: verticalValue = 0,
@@ -38,13 +31,6 @@ export class App extends WidgetBase<WidgetProperties> {
 		} = this;
 
 		return v('div', [
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
 			v('h1', {}, ['Slider with custom output']),
 			v('div', { id: 'example-s1'}, [
 				w(Slider, {
@@ -63,7 +49,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					value: tribbleValue,
 					onChange: this.onTribbleInput,
 					onInput: this.onTribbleInput,
-					theme: this._theme
+					theme
 				})
 			]),
 			v('h1', {}, ['Disabled slider']),
@@ -76,7 +62,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					step: 1,
 					value: 30,
 					disabled: true,
-					theme: this._theme
+					theme
 				})
 			]),
 			v('h1', {}, ['Vertical slider']),
@@ -95,14 +81,9 @@ export class App extends WidgetBase<WidgetProperties> {
 					outputIsTooltip: true,
 					onChange: this.onVerticalInput,
 					onInput: this.onVerticalInput,
-					theme: this._theme
+					theme
 				})
 			])
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/splitpane/example/index.ts
+++ b/src/splitpane/example/index.ts
@@ -1,14 +1,11 @@
 import { deepAssign } from '@dojo/core/lang';
 import { DNode } from '@dojo/widget-core/interfaces';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties } from '@dojo/widget-core/interfaces';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import { v, w } from '@dojo/widget-core/d';
 import SplitPane, { Direction } from '../../splitpane/SplitPane';
-import dojoTheme from '../../themes/dojo/theme';
 
-export class App extends WidgetBase<WidgetProperties> {
-	private _theme: {};
+export default class App extends WidgetBase<ThemedProperties> {
 	private state: any = {};
 
 	public setState(state: any) {
@@ -16,13 +13,9 @@ export class App extends WidgetBase<WidgetProperties> {
 		this.invalidate();
 	}
 
-	themeChange(event: Event) {
-		const checked = (<HTMLInputElement> event.target).checked;
-		this._theme = checked ? dojoTheme : {};
-		this.invalidate();
-	}
-
 	render(): DNode {
+		const { theme } = this.properties;
+
 		const containerStyles = {
 			width: '100%',
 			height: '500px',
@@ -36,13 +29,6 @@ export class App extends WidgetBase<WidgetProperties> {
 			}
 		}, [
 			v('h1', ['SplitPane Examples']),
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
 			v('h3', ['Row']),
 			v('div', {
 				id: 'example-row',
@@ -55,7 +41,7 @@ export class App extends WidgetBase<WidgetProperties> {
 						this.setState({ rowSize: size });
 					},
 					size: this.state.rowSize,
-					theme: this._theme
+					theme
 				})
 			]),
 			v('h3', ['Column']),
@@ -70,7 +56,7 @@ export class App extends WidgetBase<WidgetProperties> {
 						this.setState({ columnSize: size });
 					},
 					size: this.state.columnSize,
-					theme: this._theme
+					theme
 				})
 			]),
 			v('h3', ['Nested']),
@@ -85,14 +71,14 @@ export class App extends WidgetBase<WidgetProperties> {
 						this.setState({ nestedSizeA: size });
 					},
 					size: this.state.nestedSizeA,
-					theme: this._theme,
+					theme,
 					trailing: w(SplitPane, {
 						direction: Direction.column,
 						onResize: (size: number) => {
 							this.setState({ nestedSizeB: size });
 						},
 						size: this.state.nestedSizeB,
-						theme: this._theme
+						theme
 					})
 				})
 			]),
@@ -108,14 +94,14 @@ export class App extends WidgetBase<WidgetProperties> {
 						this.setState({ nestedSizeC: size });
 					},
 					size: this.state.nestedSizeC,
-					theme: this._theme,
+					theme,
 					trailing: w(SplitPane, {
 						direction: Direction.row,
 						onResize: (size: number) => {
 							this.setState({ nestedSizeD: size });
 						},
 						size: this.state.nestedSizeD,
-						theme: this._theme
+						theme
 					})
 				})
 			]),
@@ -131,14 +117,14 @@ export class App extends WidgetBase<WidgetProperties> {
 						this.setState({ nestedSizeE: size });
 					},
 					size: this.state.nestedSizeE,
-					theme: this._theme,
+					theme,
 					trailing: w(SplitPane, {
 						direction: Direction.column,
 						onResize: (size: number) => {
 							this.setState({ nestedSizeF: size });
 						},
 						size: this.state.nestedSizeF,
-						theme: this._theme
+						theme
 					})
 				})
 			]),
@@ -155,7 +141,7 @@ export class App extends WidgetBase<WidgetProperties> {
 						this.setState({ maxSize: size });
 					},
 					size: this.state.maxSize,
-					theme: this._theme
+					theme
 				})
 			]),
 			v('h3', ['Minimum size']),
@@ -171,14 +157,9 @@ export class App extends WidgetBase<WidgetProperties> {
 						this.setState({ minSize: size });
 					},
 					size: this.state.minSize,
-					theme: this._theme
+					theme
 				})
 			])
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/tabcontroller/example/index.ts
+++ b/src/tabcontroller/example/index.ts
@@ -1,14 +1,12 @@
 import { DNode } from '@dojo/widget-core/interfaces';
 import { includes } from '@dojo/shim/array';
 import { deepAssign } from '@dojo/core/lang';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { v, w } from '@dojo/widget-core/d';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties } from '@dojo/widget-core/interfaces';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import Tab from '../Tab';
 import TabController, { Align } from '../TabController';
 import Task from '@dojo/core/async/Task';
-import dojoTheme from '../../themes/dojo/theme';
 
 let refresh: Task<any>;
 
@@ -25,8 +23,7 @@ interface State {
 	activeIndex: number;
 }
 
-export class App extends WidgetBase<WidgetProperties> {
-	private _theme: {};
+export default class App extends WidgetBase<ThemedProperties> {
 	private _state: State = {
 		align: Align.top,
 		closedKeys: [],
@@ -36,12 +33,6 @@ export class App extends WidgetBase<WidgetProperties> {
 
 	private setState(state: Partial<State>) {
 		this._state = deepAssign(this._state, state);
-		this.invalidate();
-	}
-
-	themeChange(event: Event) {
-		const checked = (<HTMLInputElement> event.target).checked;
-		this._theme = checked ? dojoTheme : {};
 		this.invalidate();
 	}
 
@@ -64,6 +55,7 @@ export class App extends WidgetBase<WidgetProperties> {
 		this.setState({ align: align });
 	}
 	render(): DNode {
+		const { theme } = this.properties;
 		const {
 			activeIndex = 0,
 			align,
@@ -74,13 +66,6 @@ export class App extends WidgetBase<WidgetProperties> {
 		return v('div', {
 			classes: 'example'
 		}, [
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
 			v('select', {
 				styles: { marginBottom: '20px' },
 				onchange: this.onAlignChange
@@ -91,7 +76,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				v('option', { value: 'bottom' }, [ 'Bottom' ])
 			]),
 			w(TabController, {
-				theme: this._theme,
+				theme,
 				activeIndex: activeIndex,
 				alignButtons: align,
 				onRequestTabClose: (index: number, key: string) => {
@@ -114,14 +99,14 @@ export class App extends WidgetBase<WidgetProperties> {
 				}
 			}, [
 				w(Tab, {
-					theme: this._theme,
+					theme,
 					key: 'default',
 					label: 'Default'
 				}, [
 					'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer in ex pharetra, iaculis turpis eget, tincidunt lorem. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.'
 				]),
 				w(Tab, {
-					theme: this._theme,
+					theme,
 					disabled: true,
 					key: 'disabled',
 					label: 'Disabled'
@@ -129,14 +114,14 @@ export class App extends WidgetBase<WidgetProperties> {
 					'Sed nibh est, sollicitudin consectetur porta finibus, condimentum gravida purus. Phasellus varius fringilla erat, a dignissim nunc iaculis et. Curabitur eu neque erat. Integer id lacus nulla. Phasellus ut sem eget enim interdum interdum ac ac orci.'
 				]),
 				w(Tab, {
-					theme: this._theme,
+					theme,
 					key: 'async',
 					label: 'Async'
 				}, [
 					loading ? 'Loading...' : 'Curabitur id elit a tellus consequat maximus in non lorem. Donec sagittis porta aliquam. Nulla facilisi. Quisque sed mauris justo. Donec eu fringilla urna. Aenean vulputate ipsum imperdiet orci ornare tempor.'
 				]),
 				!includes(closedKeys, 'closeable') ? w(Tab, {
-					theme: this._theme,
+					theme,
 					closeable: true,
 					key: 'closeable',
 					label: 'Closeable'
@@ -144,7 +129,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					'Nullam congue, massa in egestas sagittis, diam neque rutrum tellus, nec egestas metus tellus vel odio. Vivamus tincidunt quam nisl, sit amet venenatis purus bibendum eget. Phasellus fringilla ex vitae odio hendrerit, non volutpat orci rhoncus.'
 				]) : null,
 				w(Tab, {
-					theme: this._theme,
+					theme,
 					key: 'foo',
 					label: 'Foobar'
 				}, [
@@ -154,8 +139,3 @@ export class App extends WidgetBase<WidgetProperties> {
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/textarea/example/index.ts
+++ b/src/textarea/example/index.ts
@@ -1,32 +1,19 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties, TypedTargetEvent } from '@dojo/widget-core/interfaces';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
+import { TypedTargetEvent } from '@dojo/widget-core/interfaces';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import { v, w } from '@dojo/widget-core/d';
 import Textarea from '../../textarea/Textarea';
-import dojoTheme from '../../themes/dojo/theme';
 
-export class App extends WidgetBase<WidgetProperties> {
-	private _theme: {};
+export default class App extends WidgetBase<ThemedProperties> {
 	private _value1: string;
 	private _value2: string;
 	private _invalid: boolean;
 
-	themeChange(event: TypedTargetEvent<HTMLInputElement>) {
-		const checked = event.target.checked;
-		this._theme = checked ? dojoTheme : {};
-		this.invalidate();
-	}
-
 	render() {
+		const { theme } = this.properties;
+
 		return v('div', [
 			v('h2', {}, ['Textarea Example']),
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
 			v('div', { id: 'example-t1'}, [
 				w(Textarea, {
 					key: 't1',
@@ -39,7 +26,7 @@ export class App extends WidgetBase<WidgetProperties> {
 						this._value1 = event.target.value;
 						this.invalidate();
 					},
-					theme: this._theme
+					theme
 				})
 			]),
 			v('h3', {}, ['Disabled Textarea']),
@@ -51,7 +38,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					label: 'Can\'t type here',
 					value: 'Initial value',
 					disabled: true,
-					theme: this._theme
+					theme
 				})
 			]),
 			v('h3', {}, ['Validated, Required Textarea']),
@@ -70,7 +57,7 @@ export class App extends WidgetBase<WidgetProperties> {
 						this._invalid = value.trim().length === 0;
 						this.invalidate();
 					},
-					theme: this._theme
+					theme
 				})
 			]),
 			v('h3', {}, ['Hidden Label Textarea']),
@@ -89,8 +76,3 @@ export class App extends WidgetBase<WidgetProperties> {
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/textinput/example/index.ts
+++ b/src/textinput/example/index.ts
@@ -1,36 +1,23 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties, TypedTargetEvent } from '@dojo/widget-core/interfaces';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
+import { TypedTargetEvent } from '@dojo/widget-core/interfaces';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import { v, w } from '@dojo/widget-core/d';
 import TextInput from '../../textinput/TextInput';
-import dojoTheme from '../../themes/dojo/theme';
 
-export class App extends WidgetBase<WidgetProperties> {
-	private _theme: {};
+export default class App extends WidgetBase<ThemedProperties> {
 	private _value1: string;
 	private _value2: string;
 	private _value3: string;
 	private _value4: string;
 	private _invalid: boolean;
 
-	themeChange(event: Event) {
-		const checked = (<HTMLInputElement> event.target).checked;
-		this._theme = checked ? dojoTheme : {};
-		this.invalidate();
-	}
-
 	render() {
+		const { theme } = this.properties;
+
 		return v('div', {
 			styles: { maxWidth: '256px' }
 		}, [
 			v('h2', {}, ['Text Input Examples']),
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
 			v('div', { id: 'example-text' }, [
 				v('h3', {}, ['String label']),
 				w(TextInput, {
@@ -43,7 +30,7 @@ export class App extends WidgetBase<WidgetProperties> {
 						this._value1 = event.target.value;
 						this.invalidate();
 					},
-					theme: this._theme
+					theme
 				})
 			]),
 			v('div', { id: 'example-email' }, [
@@ -61,7 +48,7 @@ export class App extends WidgetBase<WidgetProperties> {
 						this._value2 = event.target.value;
 						this.invalidate();
 					},
-					theme: this._theme
+					theme
 				})
 			]),
 			v('div', { id: 'example-hidden-label' }, [
@@ -80,7 +67,7 @@ export class App extends WidgetBase<WidgetProperties> {
 						this._value3 = event.target.value;
 						this.invalidate();
 					},
-					theme: this._theme
+					theme
 				})
 			]),
 			v('div', { id: 'example-disabled' }, [
@@ -92,7 +79,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					value: 'Initial value',
 					disabled: true,
 					readOnly: true,
-					theme: this._theme
+					theme
 				})
 			]),
 			v('div', { id: 'example-validated' }, [
@@ -109,14 +96,9 @@ export class App extends WidgetBase<WidgetProperties> {
 						this._invalid = value.toLowerCase() !== 'foo' && value.toLowerCase() !== 'bar';
 						this.invalidate();
 					},
-					theme: this._theme
+					theme
 				})
 			])
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/timepicker/example/index.ts
+++ b/src/timepicker/example/index.ts
@@ -1,12 +1,10 @@
 import { getDateFormatter } from '@dojo/i18n/date';
 import { DNode } from '@dojo/widget-core/interfaces';
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { theme, ThemedMixin, ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 import { v, w } from '@dojo/widget-core/d';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import setLocaleData from './setLocaleData';
 import TimePicker, { TimeUnits } from '../TimePicker';
-import dojoTheme from '../../themes/dojo/theme';
 import * as baseCss from '../../common/styles/base.m.css';
 
 setLocaleData();
@@ -15,8 +13,7 @@ const TODAY = new Date();
 const getEnglishTime = getDateFormatter({ time: 'short' });
 
 @theme(baseCss)
-export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
-	private _theme: {};
+export default class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 	private _options: TimeUnits[];
 	private _values: any = {};
 	private _invalid = false;
@@ -26,28 +23,16 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 		this.invalidate();
 	}
 
-	themeChange(event: Event) {
-		const checked = (<HTMLInputElement> event.target).checked;
-		this._theme = checked ? dojoTheme : {};
-		this.invalidate();
-	}
-
 	private _setValue(key: string, value: string) {
 		this._values[key] = value;
 		this.invalidate();
 	}
 
 	render(): DNode {
+		const { theme } = this.properties;
+
 		return v('div', [
 			v('h1', [ 'TimePicker Examples' ]),
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
-
 			v('p', {
 				id: 'description1',
 				classes: baseCss.visuallyHidden
@@ -83,7 +68,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 					},
 					options: this._options,
 					step: 1800,
-					theme: this._theme,
+					theme,
 					value: this._values['value1']
 				})
 			]),
@@ -103,7 +88,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 					onRequestOptions: this.onRequestOptions,
 					options: this._options,
 					step: 1800,
-					theme: this._theme,
+					theme,
 					value: this._values['value2']
 				})
 			]),
@@ -127,7 +112,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 					onRequestOptions: this.onRequestOptions,
 					options: this._options,
 					step: 3600,
-					theme: this._theme,
+					theme,
 					value: this._values['value3']
 				})
 			]),
@@ -141,7 +126,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 					},
 					key: '4',
 					disabled: true,
-					theme: this._theme
+					theme
 				})
 			]),
 
@@ -154,7 +139,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 					},
 					key: '5',
 					readOnly: true,
-					theme: this._theme
+					theme
 				})
 			]),
 
@@ -172,7 +157,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 					onRequestOptions: this.onRequestOptions,
 					options: this._options,
 					step: 1800,
-					theme: this._theme,
+					theme,
 					value: this._values['value6']
 				})
 			]),
@@ -198,7 +183,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 					onRequestOptions: this.onRequestOptions,
 					options: this._options,
 					step: 1800,
-					theme: this._theme,
+					theme,
 					value: this._values['value7']
 				})
 			]),
@@ -223,7 +208,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 					onRequestOptions: this.onRequestOptions,
 					start: '12:00:00',
 					step: 1,
-					theme: this._theme,
+					theme,
 					value: this._values['value8']
 				})
 			]),
@@ -251,7 +236,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 					onRequestOptions: this.onRequestOptions,
 					options: this._options,
 					step: 1800,
-					theme: this._theme,
+					theme,
 					value: this._values['value9']
 				})
 			]),
@@ -268,7 +253,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 						this._setValue('value10', value);
 					},
 					step: 1800,
-					theme: this._theme,
+					theme,
 					useNativeElement: true,
 					invalid: true,
 					label: 'foo',
@@ -278,8 +263,3 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/titlepane/example/index.ts
+++ b/src/titlepane/example/index.ts
@@ -1,23 +1,15 @@
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { v, w } from '@dojo/widget-core/d';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties, TypedTargetEvent } from '@dojo/widget-core/interfaces';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 
 import TitlePane from '../TitlePane';
-import dojoTheme from '../../themes/dojo/theme';
 
-export class App extends WidgetBase<WidgetProperties> {
-	private _theme: {};
+export default class App extends WidgetBase<ThemedProperties> {
 	private _t2Open = true;
 	private _t3Open = false;
 
-	themeChange(event: TypedTargetEvent<HTMLInputElement>) {
-		const checked = event.target.checked;
-		this._theme = checked ? dojoTheme : {};
-		this.invalidate();
-	}
-
 	render() {
+		const { theme } = this.properties;
 		const {
 			_t2Open,
 			_t3Open
@@ -30,19 +22,6 @@ export class App extends WidgetBase<WidgetProperties> {
 			}
 		}, [
 			v('div', {
-				classes: 'option',
-				style: 'margin-bottom: 20px;'
-			}, [
-				v('label', [
-					'Use Dojo Theme ',
-					v('input', {
-						type: 'checkbox',
-						onchange: this.themeChange
-					})
-				])
-			]),
-
-			v('div', {
 				id: 'titlePane1',
 				styles: { 'margin-bottom': '15px' }
 			}, [
@@ -50,7 +29,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					headingLevel: 1,
 					closeable: false,
 					key: 'titlePane1',
-					theme: this._theme,
+					theme,
 					title: 'TitlePanel Widget With closeable=false'
 				}, [
 					v('div', {
@@ -69,7 +48,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					headingLevel: 2,
 					key: 'titlePane2',
 					open: _t2Open,
-					theme: this._theme,
+					theme,
 					title: 'TitlePanel Widget (closeable)',
 					onRequestClose: () => {
 						this._t2Open = false;
@@ -100,7 +79,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				w(TitlePane, {
 					key: 'titlePane3',
 					open: _t3Open,
-					theme: this._theme,
+					theme,
 					title: 'TitlePanel Widget with open=false',
 					onRequestClose: () => {
 						this._t3Open = false;
@@ -121,8 +100,3 @@ export class App extends WidgetBase<WidgetProperties> {
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();

--- a/src/tooltip/example/index.ts
+++ b/src/tooltip/example/index.ts
@@ -1,23 +1,14 @@
-import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { Set } from '@dojo/shim/Set';
 import { w, v } from '@dojo/widget-core/d';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
-import { WidgetProperties, TypedTargetEvent } from '@dojo/widget-core/interfaces';
+import { ThemedProperties } from '@dojo/widget-core/mixins/Themed';
 
 import Button from '../../button/Button';
 import TextInput from '../../textinput/TextInput';
 import Tooltip, { Orientation } from '../Tooltip';
 
-import dojoTheme from '../../themes/dojo/theme';
-
-export class App extends WidgetBase<WidgetProperties> {
+export default class App extends WidgetBase<ThemedProperties> {
 	private _open = new Set<string>();
-	private _theme: {};
-
-	themeChange(event: TypedTargetEvent<HTMLInputElement>) {
-		this._theme = event.target.checked ? dojoTheme : {};
-		this.invalidate();
-	}
 
 	onShow(key: string) {
 		this._open.add(key);
@@ -30,25 +21,20 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render() {
+		const { theme } = this.properties;
+
 		return v('div', [
 			v('h2', [ 'Tooltip Examples' ]),
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
 			v('div', { id: 'example-1' }, [
 				w(Tooltip, {
 					key: 'foo',
 					content: 'This is a right-oriented tooltip that opens and closes based on child click.',
 					orientation: Orientation.right,
 					open: this._open.has('foo'),
-					theme: this._theme
+					theme
 				}, [
 					w(Button, {
-						theme: this._theme,
+						theme,
 						onClick: () => {
 							const exists = this._open.has('foo');
 							exists ? this.onHide('foo') : this.onShow('foo');
@@ -62,10 +48,10 @@ export class App extends WidgetBase<WidgetProperties> {
 					content: 'This is a right-oriented tooltip that opens and closes based on child focus.',
 					orientation: Orientation.right,
 					open: this._open.has('bar'),
-					theme: this._theme
+					theme
 				}, [
 					w(TextInput, {
-						theme: this._theme,
+						theme,
 						placeholder: 'Focus me',
 						onFocus: () => { this.onShow('bar'); },
 						onBlur: () => { this.onHide('bar'); }
@@ -75,8 +61,3 @@ export class App extends WidgetBase<WidgetProperties> {
 		]);
 	}
 }
-
-const Projector = ProjectorMixin(App);
-const projector = new Projector();
-
-projector.append();


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

 * Use a single projector in the index instead and switch widgets using the registry instead of changing the window location and pealing the hash for the module
 * Add the theme switch to the common example index.ts instead of in every example

