### PR TITLE
Add keys for tooltip nodes so that they can be uniquely identified

### DIFF
--- a/src/tooltip/Tooltip.ts
+++ b/src/tooltip/Tooltip.ts
@@ -53,12 +53,13 @@ export default class Tooltip extends ThemedBase<TooltipProperties> {
 
 	protected renderContent(): DNode {
 		return v('div', {
-			classes: [ this.theme(css.content), css.contentFixed ]
+			classes: [ this.theme(css.content), css.contentFixed ],
+			key: 'content'
 		}, [ this.properties.content ]);
 	}
 
 	protected renderTarget(): DNode {
-		return v('div', this.children);
+		return v('div', { key: 'target' }, this.children);
 	}
 
 	render(): DNode {

--- a/src/tooltip/tests/unit/Tooltip.ts
+++ b/src/tooltip/tests/unit/Tooltip.ts
@@ -22,7 +22,7 @@ registerSuite('Tooltip', {
 			widget.expectRender(v('div', {
 				classes: [ css.right, css.rootFixed, css.rightFixed ]
 			}, [
-				v('div', {}, []),
+				v('div', { key: 'target' }, []),
 				null
 			]));
 		},
@@ -36,10 +36,11 @@ registerSuite('Tooltip', {
 			widget.expectRender(v('div', {
 				classes: [ css.right, css.rootFixed, css.rightFixed ]
 			}, [
-				v('div', {}, []),
+				v('div', { key: 'target' }, []),
 				v('div', {
+					key: 'content',
 					classes: [ css.content, css.contentFixed ]
-				}, ['foobar' ])
+				}, [ 'foobar' ])
 			]));
 		},
 
@@ -52,7 +53,7 @@ registerSuite('Tooltip', {
 			widget.expectRender(v('div', {
 				classes: [ css.bottom, css.rootFixed, css.bottomFixed ]
 			}, [
-				v('div', {}, []),
+				v('div', { key: 'target' }, []),
 				null
 			]));
 		}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds keys to the nodes created by tooltip so that they are uniquely identifiable.

Resolves #380 
