### PR TITLE
Custom element fixes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widgets",
-  "version": "0.2.2",
+  "version": "0.2.3-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/accordionpane/createAccordionPaneElement.ts
+++ b/src/accordionpane/createAccordionPaneElement.ts
@@ -6,7 +6,7 @@ import AccordionPane from './AccordionPane';
  */
 export default function createAccordionPaneElement(): CustomElementDescriptor {
 	return {
-		tagName: 'dojo-accordionpane',
+		tagName: 'dojo-accordion-pane',
 		widgetConstructor: AccordionPane,
 		properties: [
 			{

--- a/src/titlepane/createTitlePaneElement.ts
+++ b/src/titlepane/createTitlePaneElement.ts
@@ -28,11 +28,11 @@ export default function createTitlePaneElement(): CustomElementDescriptor {
 		events: [
 			{
 				propertyName: 'onRequestClose',
-				eventName: 'requestClose'
+				eventName: 'close'
 			},
 			{
 				propertyName: 'onRequestOpen',
-				eventName: 'requestOpen'
+				eventName: 'open'
 			}
 		]
 	};


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR updates the tag name of the AccordionPane custom element and the `onRequestClose` event name of the TitlePane custom element.

Resolves #383, #384
