### PR TITLE
Themeable custom elements

### DIFF
--- a/src/accordionpane/createAccordionPaneElement.ts
+++ b/src/accordionpane/createAccordionPaneElement.ts
@@ -9,9 +9,8 @@ export default function createAccordionPaneElement(): CustomElementDescriptor {
 		tagName: 'dojo-accordionpane',
 		widgetConstructor: AccordionPane,
 		properties: [
-			{
-				propertyName: 'openKeys'
-			}
+			{ propertyName: 'openKeys' },
+			{ propertyName: 'theme' }
 		],
 		events: [
 			{

--- a/src/calendar/createCalendarElement.ts
+++ b/src/calendar/createCalendarElement.ts
@@ -28,7 +28,8 @@ export default function createCalendarElement(): CustomElementDescriptor {
 			{ propertyName: 'monthNames' },
 			{ propertyName: 'weekdayNames' },
 			{ propertyName: 'renderMonthLabel' },
-			{ propertyName: 'renderWeekdayCell' }
+			{ propertyName: 'renderWeekdayCell' },
+			{ propertyName: 'theme' }
 		],
 		events: [
 			{

--- a/src/combobox/createComboBoxElement.ts
+++ b/src/combobox/createComboBoxElement.ts
@@ -45,27 +45,14 @@ export default function createComboBoxElement(): CustomElementDescriptor {
 			}
 		],
 		properties: [
-			{
-				propertyName: 'results'
-			},
-			{
-				propertyName: 'inputProperties'
-			},
-			{
-				propertyName: 'CustomResultItem'
-			},
-			{
-				propertyName: 'CustomResultMenu'
-			},
-			{
-				propertyName: 'getResultLabel'
-			},
-			{
-				propertyName: 'isResultDisabled'
-			},
-			{
-				propertyName: 'label'
-			}
+			{ propertyName: 'results' },
+			{ propertyName: 'inputProperties' },
+			{ propertyName: 'CustomResultItem' },
+			{ propertyName: 'CustomResultMenu' },
+			{ propertyName: 'getResultLabel' },
+			{ propertyName: 'isResultDisabled' },
+			{ propertyName: 'label' },
+			{ propertyName: 'theme' }
 		],
 		events: [
 			{

--- a/src/dialog/createDialogElement.ts
+++ b/src/dialog/createDialogElement.ts
@@ -44,6 +44,9 @@ export default function createDialogElement(): CustomElementDescriptor {
 				value: value => value === 'false' || value === '0' ? false : true
 			}
 		],
+		properties: [
+			{ propertyName: 'theme' }
+		],
 		events: [
 			{
 				propertyName: 'onOpen',

--- a/src/slidepane/createSlidePaneElement.ts
+++ b/src/slidepane/createSlidePaneElement.ts
@@ -25,6 +25,9 @@ export default function createSlidePaneElement(): CustomElementDescriptor {
 				value: value => Number(value)
 			}
 		],
+		properties: [
+			{ propertyName: 'theme' }
+		],
 		events: [
 			{
 				propertyName: 'onOpen',

--- a/src/splitpane/createSplitPaneElement.ts
+++ b/src/splitpane/createSplitPaneElement.ts
@@ -17,12 +17,9 @@ export default function createSplitPaneElement(): CustomElementDescriptor {
 			}
 		],
 		properties: [
-			{
-				propertyName: 'leading'
-			},
-			{
-				propertyName: 'trailing'
-			}
+			{ propertyName: 'leading' },
+			{ propertyName: 'trailing' },
+			{ propertyName: 'theme' }
 		],
 		events: [
 			{

--- a/src/tabcontroller/createTabControllerElement.ts
+++ b/src/tabcontroller/createTabControllerElement.ts
@@ -20,6 +20,9 @@ export default function createTabControllerElement(): CustomElementDescriptor {
 				value: value => Number(value)
 			}
 		],
+		properties: [
+			{ propertyName: 'theme' }
+		],
 		events: [
 			{
 				propertyName: 'onRequestTabChange',

--- a/src/tabcontroller/createTabElement.ts
+++ b/src/tabcontroller/createTabElement.ts
@@ -23,9 +23,8 @@ export default function createTabElement(): CustomElementDescriptor {
 			}
 		],
 		properties: [
-			{
-				propertyName: 'label'
-			}
+			{ propertyName: 'label' },
+			{ propertyName: 'theme' }
 		]
 	};
 };

--- a/src/titlepane/createTitlePaneElement.ts
+++ b/src/titlepane/createTitlePaneElement.ts
@@ -25,6 +25,9 @@ export default function createTitlePaneElement(): CustomElementDescriptor {
 				attributeName: 'title'
 			}
 		],
+		properties: [
+			{ propertyName: 'theme' }
+		],
 		events: [
 			{
 				propertyName: 'onRequestClose',

--- a/src/tooltip/createTooltipElement.ts
+++ b/src/tooltip/createTooltipElement.ts
@@ -18,9 +18,8 @@ export default function createTooltipElement(): CustomElementDescriptor {
 			}
 		],
 		properties: [
-			{
-				propertyName: 'content'
-			}
+			{ propertyName: 'content' },
+			{ propertyName: 'theme' }
 		]
 	};
 };


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

This PR exposes a `theme` property on each applicable custom element descriptor so they can be properly themed.

Resolves #382
