### PR TITLE
Fix destructured theme assignment blocking theme injector

### DIFF
--- a/src/calendar/Calendar.ts
+++ b/src/calendar/Calendar.ts
@@ -288,7 +288,7 @@ export default class Calendar<P extends CalendarProperties = CalendarProperties>
 	}
 
 	protected renderDateCell(date: number, index: number, selected: boolean, currentMonth: boolean, today: boolean): DNode {
-		const { theme = {} } = this.properties;
+		const { theme } = this.properties;
 
 		return w(CalendarCell, {
 			key: `date-${index}`,
@@ -310,7 +310,7 @@ export default class Calendar<P extends CalendarProperties = CalendarProperties>
 			labels = DEFAULT_LABELS,
 			monthNames = DEFAULT_MONTHS,
 			renderMonthLabel,
-			theme = {},
+			theme,
 			onMonthChange,
 			onYearChange
 		} = this.properties;

--- a/src/calendar/tests/unit/Calendar.ts
+++ b/src/calendar/tests/unit/Calendar.ts
@@ -30,6 +30,7 @@ const expectedDateCell = function(widget: Harness<Calendar>, date: number, activ
 		disabled: !active,
 		focusable: date === 1 && active,
 		selected: false,
+		theme: undefined,
 		today: active && new Date().toDateString() === new Date(`June ${date} 2017`).toDateString(),
 		onClick: widget.listener,
 		onFocusCalled: widget.listener,
@@ -47,6 +48,7 @@ const expected = function(widget: Harness<Calendar>, popupOpen = false) {
 			month: 5,
 			monthNames: DEFAULT_MONTHS,
 			renderMonthLabel: undefined,
+			theme: undefined,
 			year: 2017,
 			onPopupChange: widget.listener,
 			onRequestMonthChange: widget.listener,
@@ -164,7 +166,6 @@ registerSuite('Calendar', {
 	tests: {
 		'Render specific month with default props'() {
 			widget.setProperties({
-				theme: {},
 				month: testDate.getMonth(),
 				year: testDate.getFullYear()
 			});

--- a/src/tabcontroller/TabController.ts
+++ b/src/tabcontroller/TabController.ts
@@ -117,7 +117,7 @@ export default class TabController<P extends TabControllerProperties = TabContro
 				disabled,
 				key,
 				label,
-				theme = {}
+				theme
 			} = <TabProperties> tab.properties;
 
 			return w(TabButton, {

--- a/src/tabcontroller/tests/unit/TabController.ts
+++ b/src/tabcontroller/tests/unit/TabController.ts
@@ -71,7 +71,7 @@ const expectedTabButtons = function(empty = false): DNode {
 			onLeftArrowPress: widget.listener,
 			onRightArrowPress: widget.listener,
 			onUpArrowPress: widget.listener,
-			theme: {}
+			theme: undefined
 		}, [ null ]),
 		w(TabButton, {
 			callFocus: false,
@@ -91,7 +91,7 @@ const expectedTabButtons = function(empty = false): DNode {
 			onLeftArrowPress: widget.listener,
 			onRightArrowPress: widget.listener,
 			onUpArrowPress: widget.listener,
-			theme: {}
+			theme: undefined
 		}, [ 'foo' ])
 	]);
 };

--- a/src/themes/dojo/tabController.m.css
+++ b/src/themes/dojo/tabController.m.css
@@ -60,7 +60,6 @@
 	border: none;
 	cursor: pointer;
 	font-size: 0;
-	outline: none;
 	padding: 1px 3px;
 	position: absolute;
 	right: 5px;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #400, removes destructuring assignment for `theme` in both TabController and Calendar.
