### PR TITLE
Add Prettier with tslint plugin and precommit hook

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -3,7 +3,7 @@
 The following has been addressed in the PR:
 
 * [ ] There is a related issue
-* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
+* [ ] All code has been formatted with [`prettier`](https://prettier.io/) as per the [readme code style guidelines](./../#code-style)<Paste>
 * [ ] Unit or Functional tests are included in the PR
 
 <!--

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This is not yet production ready, so you should use at your own risk.
   - [Icons](#icons)
   - [Coding conventions](#coding-conventions)
 - [How Do I Contribute?](#how-do-i-contribute)
+    - [Code Style](#code-style)
     - [Installation](#installation)
     - [Testing](#testing)
 - [Licensing Information](#licensing-information)
@@ -152,7 +153,17 @@ Dojo 2 widgets provide standard extension points to allow you to customise their
 ## How do I contribute?
 
 We appreciate your interest!  Please see the [Dojo 2 Meta Repository](https://github.com/dojo/meta#readme) for the
-Contributing Guidelines and Style Guide.
+Contributing Guidelines.
+
+### Code Style
+
+This repository uses [`prettier`](https://prettier.io/) for code styling rules and formatting. A pre-commit hook is installed automatically and configured to run `prettier` against all staged files as per the configuration in the projects `package.json`.
+
+An additional npm script to run `prettier` (with write set to `true`) against all `src` and `test` project files is available by running:
+
+```bash
+npm run prettier
+```
 
 ### Installation
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
       "integrity": "sha512-sgqHsKraTjKDoLfWece/E/ip29CsV3z+vEDSIzuBSWtXDEau6/pDRhbhuSnxjBB1bvvB8Drn93xWkO+PqqQ0Dg==",
       "dev": true,
       "requires": {
-        "@types/yargs": "8.0.2"
+        "@types/yargs": "8.0.3"
       }
     },
     "@dojo/loader": {
@@ -39,7 +39,7 @@
       "requires": {
         "intersection-observer": "0.4.3",
         "pepjs": "0.4.3",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@dojo/test-extras": {
@@ -64,7 +64,7 @@
         "@dojo/shim": "0.2.3",
         "decompress": "4.2.0",
         "semver": "5.4.1",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@theintern/leadfoot": {
@@ -79,7 +79,7 @@
         "@dojo/shim": "0.2.3",
         "@types/jszip": "0.0.33",
         "jszip": "3.1.5",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "@types/babel-types": {
@@ -101,13 +101,13 @@
       "dev": true,
       "requires": {
         "@types/express": "4.0.39",
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/chai": {
-      "version": "4.0.8",
-      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.8.tgz",
-      "integrity": "sha512-m812CONwdZn/dMzkIJEY0yAs4apyTkTORgfB2UsMOxgkUbC205AHnm4T8I0I5gPg9MHrFc1dJ35iS75c0CJkjg==",
+      "version": "4.0.10",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.0.10.tgz",
+      "integrity": "sha512-Ejh1AXTY8lm+x91X/yar3G2z4x9RyKwdTVdyyu7Xj3dNB35fMNCnEWqTO9FgS3zjzlRNqk1MruYhgb8yhRN9rA==",
       "dev": true
     },
     "@types/charm": {
@@ -116,13 +116,19 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/diff": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/@types/diff/-/diff-3.2.2.tgz",
       "integrity": "sha512-q3zfJvaTroV5BjAAR+peTHEGAAhGrPX0z2EzCzpt2mwFA+qzUn2nigJLqSekXRtdULKmT8am7zjvTMZSapIgHw==",
+      "dev": true
+    },
+    "@types/events": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@types/events/-/events-1.1.0.tgz",
+      "integrity": "sha512-y3bR98mzYOo0pAZuiLari+cQyiKk3UXRuT45h1RjhfeCzqkjaVsfZJNaxdgtk7/3tzOm1ozLTqEqMP3VbI48jw==",
       "dev": true
     },
     "@types/express": {
@@ -142,7 +148,7 @@
       "integrity": "sha512-QLAHjdLwEICm3thVbXSKRoisjfgMVI4xJH/HU8F385BR2HI7PmM6ax4ELXf8Du6sLmSpySXMYaI+xc//oQ/IFw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/fs-extra": {
@@ -151,17 +157,18 @@
       "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/glob": {
-      "version": "5.0.33",
-      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.33.tgz",
-      "integrity": "sha512-BcD4yyWz+qmCggaYMSFF0Xn7GkO6tgwm3Fh9Gxk/kQmEU3Z7flQTnVlMyKBUNvXXNTCCyjqK4XT4/2hLd1gQ2A==",
+      "version": "5.0.34",
+      "resolved": "https://registry.npmjs.org/@types/glob/-/glob-5.0.34.tgz",
+      "integrity": "sha512-sUvpieq+HsWTLdkeOI8Mi8u22Ag3AoGuM3sv+XMP1bKtbaIAHpEA2f52K2mz6vK5PVhTa3bFyRZLZMqTxOo2Cw==",
       "dev": true,
       "requires": {
-        "@types/minimatch": "3.0.1",
-        "@types/node": "8.0.55"
+        "@types/events": "1.1.0",
+        "@types/minimatch": "3.0.2",
+        "@types/node": "8.5.1"
       }
     },
     "@types/grunt": {
@@ -170,7 +177,7 @@
       "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/handlebars": {
@@ -244,9 +251,9 @@
       }
     },
     "@types/jquery": {
-      "version": "3.2.16",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.2.16.tgz",
-      "integrity": "sha512-q2WC02YxQoX2nY1HRKlYGHpGP1saPmD7GN0pwCDlTz35a4eOtJG+aHRlXyjCuXokUukSrR2aXyBhSW3j+jPc0A==",
+      "version": "3.2.17",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.2.17.tgz",
+      "integrity": "sha512-lt8i2ZqymxxN1JnWSOTPU7Xc3ze32lhASkVdsMd6/SZnb/jtBsmFEoYCBSa0tzGDSyO7ZB+4r4aihj+KTlDs5w==",
       "dev": true
     },
     "@types/jsdom": {
@@ -255,8 +262,8 @@
       "integrity": "sha512-xaHlMIzlReyciMIWGJBnkEdHngCOEpik2ojt9tJFe7rD+QiObCIcmr9/tAqxn7l1jflQ3wEIkh7+gt4ls5n1Dw==",
       "dev": true,
       "requires": {
-        "@types/jquery": "3.2.16",
-        "@types/node": "8.0.55"
+        "@types/jquery": "3.2.17",
+        "@types/node": "8.5.1"
       }
     },
     "@types/jszip": {
@@ -266,9 +273,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.87",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.87.tgz",
-      "integrity": "sha512-AqRC+aEF4N0LuNHtcjKtvF9OTfqZI0iaBoe3dA6m/W+/YZJBZjBmW/QIZ8fBeXC6cnytSY9tBoFBqZ9uSCeVsw==",
+      "version": "4.14.91",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.91.tgz",
+      "integrity": "sha512-k+nc3moSlAaXacyvz4/c6D9lnUeI6AKsLvkXFuNzUEEqMw7sjDnLW2GqlJ4nyFgMX/p+QzvVG6zRoDo4lJIV5g==",
       "dev": true
     },
     "@types/marked": {
@@ -290,15 +297,15 @@
       "dev": true
     },
     "@types/minimatch": {
-      "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.1.tgz",
-      "integrity": "sha512-rUO/jz10KRSyA9SHoCWQ8WX9BICyj5jZYu1/ucKEJKb4KzLZCKMURdYbadP157Q6Zl1x0vHsrU+Z/O0XlhYQDw==",
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.2.tgz",
+      "integrity": "sha512-tctoxbfuMCxeI2CAsnwoZQfaBA+T7gPzDzDuiiFnyCSSyGYEB92cmRTh6E3tdR1hWsprbJ9IdbvX3PzLmJU/GA==",
       "dev": true
     },
     "@types/node": {
-      "version": "8.0.55",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.0.55.tgz",
-      "integrity": "sha512-K8w0FWNsIRcw615d/Et90wMRvLfg8XH1T77fC0xObbusE3+eXwnitdoF9j0CS9zBt8A57J/TKgRVe7RX9ZlT1g==",
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.5.1.tgz",
+      "integrity": "sha512-SrmAO+NhnsuG/6TychSl2VdxBZiw/d6V+8j+DFo8O3PwFi+QeYXWHhAw+b170aSc6zYab6/PjEWRZHIDN9mNUw==",
       "dev": true
     },
     "@types/platform": {
@@ -313,7 +320,7 @@
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/serve-static": {
@@ -338,7 +345,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/sinon": {
@@ -365,13 +372,13 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "8.0.55"
+        "@types/node": "8.5.1"
       }
     },
     "@types/yargs": {
-      "version": "8.0.2",
-      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.2.tgz",
-      "integrity": "sha512-Upj9YsBZRgjEVPvsaeGru48d2JiyzBNZkmkebHyoaQ+UM9wqj/rp5mkilRjSq/Ga45yfd/zwrNuML9f2gGfVpw==",
+      "version": "8.0.3",
+      "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-8.0.3.tgz",
+      "integrity": "sha512-YdxO7zGQf2qJeMgR0fNO8QTlj88L2zCP5GOddovoTyetgLiNDOUXcWzhWKb4EdZZlOjLQUA0JM8lW7VcKQL+9w==",
       "dev": true
     },
     "abab": {
@@ -430,9 +437,9 @@
       }
     },
     "ajv": {
-      "version": "5.5.1",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.1.tgz",
-      "integrity": "sha1-s4u4h22ehr7plJVqBOch6IskjrI=",
+      "version": "5.5.2",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
+      "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
       "dev": true,
       "requires": {
         "co": "4.6.0",
@@ -479,6 +486,15 @@
       "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
       "dev": true
     },
+    "ansi-gray": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-gray/-/ansi-gray-0.1.1.tgz",
+      "integrity": "sha1-KWLPVOyXksSFEKPetSRDaGHvclE=",
+      "dev": true,
+      "requires": {
+        "ansi-wrap": "0.1.0"
+      }
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -489,6 +505,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "ansi-wrap": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-wrap/-/ansi-wrap-0.1.0.tgz",
+      "integrity": "sha1-qCJQ3bABXponyoLoLqYDu/pF768=",
       "dev": true
     },
     "any-observable": {
@@ -664,7 +686,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000783",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -725,14 +747,14 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.1",
-        "regenerator-runtime": "0.11.0"
+        "core-js": "2.5.3",
+        "regenerator-runtime": "0.11.1"
       },
       "dependencies": {
         "core-js": {
-          "version": "2.5.1",
-          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.1.tgz",
-          "integrity": "sha1-rmh03GaTd4m4B1T/VCjfZoGcpQs=",
+          "version": "2.5.3",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.3.tgz",
+          "integrity": "sha1-isw4NFgk8W2DZbfJtCWRaOjtYD4=",
           "dev": true
         }
       }
@@ -993,7 +1015,7 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000783",
         "electron-to-chromium": "1.3.28"
       }
     },
@@ -1057,15 +1079,15 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000778",
+        "caniuse-db": "1.0.30000783",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000778",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000778.tgz",
-      "integrity": "sha1-Fnxg6VQqKqYFN8RG+ziB2FOjByo=",
+      "version": "1.0.30000783",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000783.tgz",
+      "integrity": "sha1-FrMNRyZqT1FcxprgMWtnDJYDzb4=",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1507,6 +1529,12 @@
       "requires": {
         "color-name": "1.1.3"
       }
+    },
+    "color-support": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-support/-/color-support-1.1.3.tgz",
+      "integrity": "sha512-qiBjkpbMLO/HL68y+lh4q0/O1MZFj2RX6X/KmMa3+gJD3z+WwI1ZzDHysvqHGS3mP6mznPckpXmw1nI9cJjyRg==",
+      "dev": true
     },
     "colormin": {
       "version": "1.1.2",
@@ -2502,12 +2530,13 @@
       "dev": true
     },
     "fancy-log": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.0.tgz",
-      "integrity": "sha1-Rb4X0Cu5kX1gzP/UmVyZnmyMmUg=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/fancy-log/-/fancy-log-1.3.2.tgz",
+      "integrity": "sha1-9BEl49hPLn2JpD0G2VjI94vha+E=",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
+        "ansi-gray": "0.1.1",
+        "color-support": "1.1.3",
         "time-stamp": "1.1.0"
       }
     },
@@ -3115,7 +3144,7 @@
         "grunt-ts": "5.5.1",
         "grunt-tslint": "4.0.1",
         "grunt-typings": "0.1.5",
-        "intern": "4.1.3",
+        "intern": "4.1.4",
         "istanbul-lib-coverage": "1.1.1",
         "istanbul-lib-report": "1.1.2",
         "istanbul-reports": "1.1.3",
@@ -3335,7 +3364,7 @@
         "beeper": "1.1.1",
         "chalk": "1.1.3",
         "dateformat": "1.0.12",
-        "fancy-log": "1.3.0",
+        "fancy-log": "1.3.2",
         "gulplog": "1.0.0",
         "has-gulplog": "0.1.0",
         "lodash._reescape": "3.0.0",
@@ -3429,7 +3458,7 @@
       "integrity": "sha1-ukAsJmGU8VlW7xXg/PJCmT9qff0=",
       "dev": true,
       "requires": {
-        "ajv": "5.5.1",
+        "ajv": "5.5.2",
         "har-schema": "2.0.0"
       }
     },
@@ -3674,9 +3703,9 @@
       "dev": true
     },
     "intern": {
-      "version": "4.1.3",
-      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.3.tgz",
-      "integrity": "sha512-IWaqzIwc+KQcoyiG+INvvv9L0fPKmgDSj+LySSWgnPc0VnYT1vgEmmxpwSlMPHDtfMMqq28/5/tsQVRx4EM2bQ==",
+      "version": "4.1.4",
+      "resolved": "https://registry.npmjs.org/intern/-/intern-4.1.4.tgz",
+      "integrity": "sha512-QL5+pVjpjNVtp5mB2QwTgf3fuG3l+lA3UzhHTxjhahWt0Z84LfdFfHFXN6UeB72IYQq7LDhjStO6I51rsTjb6Q==",
       "dev": true,
       "requires": {
         "@dojo/core": "0.3.0",
@@ -3686,7 +3715,7 @@
         "@theintern/digdug": "2.0.4",
         "@theintern/leadfoot": "2.0.3",
         "@types/benchmark": "1.0.31",
-        "@types/chai": "4.0.8",
+        "@types/chai": "4.0.10",
         "@types/charm": "1.0.1",
         "@types/diff": "3.2.2",
         "@types/express": "4.0.39",
@@ -3697,7 +3726,7 @@
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.0",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.87",
+        "@types/lodash": "4.14.91",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -3727,7 +3756,7 @@
         "shell-quote": "1.6.1",
         "source-map": "0.5.7",
         "statuses": "1.3.1",
-        "tslib": "1.8.0",
+        "tslib": "1.8.1",
         "ws": "2.3.1"
       },
       "dependencies": {
@@ -7372,9 +7401,9 @@
       "dev": true
     },
     "regenerator-runtime": {
-      "version": "0.11.0",
-      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.0.tgz",
-      "integrity": "sha512-/aA0kLeRb5N9K0d4fw7ooEbI+xDe+DKD499EQqygGqeS8N3xto15p09uY2xj7ixP81sNPXvRLnAQIqdVStgb1A==",
+      "version": "0.11.1",
+      "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
       "dev": true
     },
     "regex-cache": {
@@ -8486,9 +8515,9 @@
       }
     },
     "tslib": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.0.tgz",
-      "integrity": "sha512-ymKWWZJST0/CkgduC2qkzjMOWr4bouhuURNXCn/inEX0L57BnRG6FhX76o7FOnsjHazCjfU2LKeSrlS2sIKQJg==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
       "dev": true
     },
     "tslint": {
@@ -8505,7 +8534,7 @@
         "optimist": "0.6.1",
         "resolve": "1.5.0",
         "semver": "5.4.1",
-        "tslib": "1.8.0",
+        "tslib": "1.8.1",
         "tsutils": "1.9.1"
       },
       "dependencies": {
@@ -8547,7 +8576,7 @@
       "dev": true,
       "requires": {
         "eslint-plugin-prettier": "2.4.0",
-        "tslib": "1.8.0"
+        "tslib": "1.8.1"
       }
     },
     "tsutils": {
@@ -9783,7 +9812,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.87",
+        "@types/lodash": "4.14.91",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",

--- a/package-lock.json
+++ b/package-lock.json
@@ -473,6 +473,12 @@
         "string-width": "2.1.1"
       }
     },
+    "ansi-escapes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-1.4.0.tgz",
+      "integrity": "sha1-06ioOzGapneTZisT52HHkRQiMG4=",
+      "dev": true
+    },
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -483,6 +489,12 @@
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
       "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
+    },
+    "any-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/any-observable/-/any-observable-0.2.0.tgz",
+      "integrity": "sha1-xnhwBYADV5AJCD9UrAq6+1wz0kI=",
       "dev": true
     },
     "any-promise": {
@@ -500,6 +512,12 @@
         "micromatch": "2.3.11",
         "normalize-path": "2.1.1"
       }
+    },
+    "app-root-path": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/app-root-path/-/app-root-path-2.0.1.tgz",
+      "integrity": "sha1-zWLc+OT9WkF+/GZNLlsQZTxlG0Y=",
+      "dev": true
     },
     "append-transform": {
       "version": "0.4.0",
@@ -1132,6 +1150,12 @@
         "readdirp": "1.4.0"
       }
     },
+    "ci-info": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-1.1.2.tgz",
+      "integrity": "sha512-uTGIPNx/nSpBdsF6xnseRXLLtfr9VLqkz8ZqHXr3Y7b6SftyRxBGjwMtJj1OhNbmlc1wZzLNAlAcvyIiE8a6ZA==",
+      "dev": true
+    },
     "clap": {
       "version": "1.2.3",
       "resolved": "https://registry.npmjs.org/clap/-/clap-1.2.3.tgz",
@@ -1146,6 +1170,53 @@
       "resolved": "https://registry.npmjs.org/cli-boxes/-/cli-boxes-1.0.0.tgz",
       "integrity": "sha1-T6kXw+WclKAEzWH47lCdplFocUM=",
       "dev": true
+    },
+    "cli-cursor": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-1.0.2.tgz",
+      "integrity": "sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "1.0.1"
+      }
+    },
+    "cli-spinners": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/cli-spinners/-/cli-spinners-0.1.2.tgz",
+      "integrity": "sha1-u3ZNiOGF+54eaiofGXcjGPYF4xw=",
+      "dev": true
+    },
+    "cli-truncate": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/cli-truncate/-/cli-truncate-0.2.1.tgz",
+      "integrity": "sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=",
+      "dev": true,
+      "requires": {
+        "slice-ansi": "0.0.4",
+        "string-width": "1.0.2"
+      },
+      "dependencies": {
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "1.0.1"
+          }
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "dev": true,
+          "requires": {
+            "code-point-at": "1.1.0",
+            "is-fullwidth-code-point": "1.0.0",
+            "strip-ansi": "3.0.1"
+          }
+        }
+      }
     },
     "cliui": {
       "version": "2.1.0",
@@ -1588,6 +1659,45 @@
       "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
       "dev": true
     },
+    "cosmiconfig": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-3.1.0.tgz",
+      "integrity": "sha512-zedsBhLSbPBms+kE7AH4vHg6JsKDz6epSv2/+5XHs8ILHlgDciSJfSWf8sX9aQ52Jb7KI7VswUTsLpR/G0cr2Q==",
+      "dev": true,
+      "requires": {
+        "is-directory": "0.3.1",
+        "js-yaml": "3.10.0",
+        "parse-json": "3.0.0",
+        "require-from-string": "2.0.1"
+      },
+      "dependencies": {
+        "esprima": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.0.tgz",
+          "integrity": "sha512-oftTcaMu/EGrEIu904mWteKIv8vMuOgGYo7EhVJJN00R/EED9DCua/xxHRdYnKtcECzVg7xOWhflvJMnqcFZjw==",
+          "dev": true
+        },
+        "js-yaml": {
+          "version": "3.10.0",
+          "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
+          "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
+          "dev": true,
+          "requires": {
+            "argparse": "1.0.9",
+            "esprima": "4.0.0"
+          }
+        },
+        "parse-json": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-3.0.0.tgz",
+          "integrity": "sha1-+m9HsY4jgm6tMvJj50TQ4ehH+xM=",
+          "dev": true,
+          "requires": {
+            "error-ex": "1.3.1"
+          }
+        }
+      }
+    },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
@@ -1862,6 +1972,12 @@
         "assert-plus": "1.0.0"
       }
     },
+    "date-fns": {
+      "version": "1.29.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-1.29.0.tgz",
+      "integrity": "sha512-lbTXWZ6M20cWH8N9S6afb0SBm6tMk+uUg6z3MqHPKE9atmsY3kJkTm8vKe93izJ2B2+q5MV990sM2CHgtAZaOw==",
+      "dev": true
+    },
     "dateformat": {
       "version": "1.0.12",
       "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-1.0.12.tgz",
@@ -1965,6 +2081,12 @@
           "dev": true
         }
       }
+    },
+    "dedent": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/dedent/-/dedent-0.7.0.tgz",
+      "integrity": "sha1-JJXduvbrh0q7Dhvp3yLS5aVEMmw=",
+      "dev": true
     },
     "deep-eql": {
       "version": "3.0.1",
@@ -2133,6 +2255,12 @@
       "integrity": "sha1-jdTmRYCGZE6fnwoc8y4qH53/2e4=",
       "dev": true
     },
+    "elegant-spinner": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/elegant-spinner/-/elegant-spinner-1.0.1.tgz",
+      "integrity": "sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=",
+      "dev": true
+    },
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
@@ -2194,6 +2322,16 @@
         "source-map": "0.5.7"
       }
     },
+    "eslint-plugin-prettier": {
+      "version": "2.4.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-prettier/-/eslint-plugin-prettier-2.4.0.tgz",
+      "integrity": "sha512-P0EohHM1MwL36GX5l1TOEYyt/5d7hcxrX3CqCjibTN3dH7VCAy2kjsC/WB6dUHnpB4mFkZq1Ndfh2DYQ2QMEGQ==",
+      "dev": true,
+      "requires": {
+        "fast-diff": "1.1.2",
+        "jest-docblock": "21.2.0"
+      }
+    },
     "esprima": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-3.1.3.tgz",
@@ -2242,6 +2380,12 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/exit/-/exit-0.1.2.tgz",
       "integrity": "sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=",
+      "dev": true
+    },
+    "exit-hook": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-1.1.1.tgz",
+      "integrity": "sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=",
       "dev": true
     },
     "expand-brackets": {
@@ -2373,6 +2517,12 @@
       "integrity": "sha1-liVqO8l1WV6zbYLpkp0GDYk0Of8=",
       "dev": true
     },
+    "fast-diff": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/fast-diff/-/fast-diff-1.1.2.tgz",
+      "integrity": "sha512-KaJUt+M9t1qaIteSvjc6P3RbMdXsNhK61GRftR6SNxqmhthcd9MGIi4T+o0jD8LUSpSnSKXE20nLtJ3fOHxQig==",
+      "dev": true
+    },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
@@ -2407,6 +2557,16 @@
       "dev": true,
       "requires": {
         "pend": "1.2.0"
+      }
+    },
+    "figures": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-1.7.0.tgz",
+      "integrity": "sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "1.0.5",
+        "object-assign": "4.1.1"
       }
     },
     "file-sync-cmp": {
@@ -2477,6 +2637,12 @@
           "dev": true
         }
       }
+    },
+    "find-parent-dir": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/find-parent-dir/-/find-parent-dir-0.3.0.tgz",
+      "integrity": "sha1-M8RLQpqysvBkYpnF+fcY83b/jVQ=",
+      "dev": true
     },
     "find-up": {
       "version": "1.1.2",
@@ -2637,6 +2803,12 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
       "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
+      "dev": true
+    },
+    "get-own-enumerable-property-symbols": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/get-own-enumerable-property-symbols/-/get-own-enumerable-property-symbols-2.0.1.tgz",
+      "integrity": "sha512-TtY/sbOemiMKPRUDDanGCSgBYe7Mf0vbRsWnBZ+9yghpZ1MvcpSpuZFjHdEeY/LZjZy0vdLjS77L6HosisFiug==",
       "dev": true
     },
     "get-stdin": {
@@ -2962,6 +3134,12 @@
         "umd-wrapper": "0.1.0"
       },
       "dependencies": {
+        "diff": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
+          "integrity": "sha512-QpVuMTEoJMF7cKzi6bvWhRulU1fZqZnvyVQgNhPaxxuTYwyjn/j1v9falseQ/uXWwPnO56RBfwtg4h/EQXmucA==",
+          "dev": true
+        },
         "glob": {
           "version": "7.1.2",
           "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
@@ -2974,6 +3152,29 @@
             "minimatch": "3.0.4",
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
+          }
+        },
+        "grunt-tslint": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
+          "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+          "dev": true
+        },
+        "tslint": {
+          "version": "4.5.1",
+          "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
+          "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+          "dev": true,
+          "requires": {
+            "babel-code-frame": "6.26.0",
+            "colors": "1.1.2",
+            "diff": "3.4.0",
+            "findup-sync": "0.3.0",
+            "glob": "7.1.2",
+            "optimist": "0.6.1",
+            "resolve": "1.1.7",
+            "tsutils": "1.9.1",
+            "update-notifier": "2.3.0"
           }
         }
       }
@@ -3109,9 +3310,9 @@
       }
     },
     "grunt-tslint": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-4.0.1.tgz",
-      "integrity": "sha1-dcRuAluereAUYrvrSfb9TBl4O1o=",
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-tslint/-/grunt-tslint-5.0.1.tgz",
+      "integrity": "sha1-dDK9G9VuijolAACI1cYf3MNC8MI=",
       "dev": true
     },
     "grunt-typings": {
@@ -3372,6 +3573,31 @@
         "agent-base": "2.1.1",
         "debug": "2.2.0",
         "extend": "3.0.1"
+      }
+    },
+    "husky": {
+      "version": "0.14.3",
+      "resolved": "https://registry.npmjs.org/husky/-/husky-0.14.3.tgz",
+      "integrity": "sha512-e21wivqHpstpoiWA/Yi8eFti8E+sQDSS53cpJsPptPs295QTOQR0ZwnHo2TXy1XOpZFD9rPOd3NpmqTK6uMLJA==",
+      "dev": true,
+      "requires": {
+        "is-ci": "1.0.10",
+        "normalize-path": "1.0.0",
+        "strip-indent": "2.0.0"
+      },
+      "dependencies": {
+        "normalize-path": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-1.0.0.tgz",
+          "integrity": "sha1-MtDkcvkf80VwHBWoMRAY07CpA3k=",
+          "dev": true
+        },
+        "strip-indent": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-2.0.0.tgz",
+          "integrity": "sha1-XvjbKV0B5u1sv3qrlpmNeCJSe2g=",
+          "dev": true
+        }
       }
     },
     "iconv-lite": {
@@ -3695,6 +3921,21 @@
         "builtin-modules": "1.1.1"
       }
     },
+    "is-ci": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.0.10.tgz",
+      "integrity": "sha1-9zkzayYyNlBhqdSCcM1WrjNpMY4=",
+      "dev": true,
+      "requires": {
+        "ci-info": "1.1.2"
+      }
+    },
+    "is-directory": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/is-directory/-/is-directory-0.3.1.tgz",
+      "integrity": "sha1-YTObbyR1/Hcv2cnYP1yFddwVSuE=",
+      "dev": true
+    },
     "is-dotfile": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/is-dotfile/-/is-dotfile-1.0.3.tgz",
@@ -3780,6 +4021,15 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
+    "is-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/is-observable/-/is-observable-0.2.0.tgz",
+      "integrity": "sha1-s2ExHYPG5dcmyr9eJQsCNxBvWuI=",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "0.2.4"
+      }
+    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -3807,10 +4057,22 @@
       "integrity": "sha1-IHurkWOEmcB7Kt8kCkGochADRXU=",
       "dev": true
     },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
     "is-redirect": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-redirect/-/is-redirect-1.0.0.tgz",
       "integrity": "sha1-HQPd7VO9jbDzDCbk+V02/HyH3CQ=",
+      "dev": true
+    },
+    "is-regexp": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-regexp/-/is-regexp-1.0.0.tgz",
+      "integrity": "sha1-/S2INUXEa6xaYz57mgnof6LLUGk=",
       "dev": true
     },
     "is-relative": {
@@ -4105,6 +4367,67 @@
         "handlebars": "4.0.11"
       }
     },
+    "jest-docblock": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-docblock/-/jest-docblock-21.2.0.tgz",
+      "integrity": "sha512-5IZ7sY9dBAYSV+YjQ0Ovb540Ku7AO9Z5o2Cg789xj167iQuZ2cG+z0f3Uct6WeYLbU6aQiM2pCs7sZ+4dotydw==",
+      "dev": true
+    },
+    "jest-get-type": {
+      "version": "21.2.0",
+      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-21.2.0.tgz",
+      "integrity": "sha512-y2fFw3C+D0yjNSDp7ab1kcd6NUYfy3waPTlD8yWkAtiocJdBRQqNoRqVfMNxgj+IjT0V5cBIHJO0z9vuSSZ43Q==",
+      "dev": true
+    },
+    "jest-validate": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/jest-validate/-/jest-validate-21.2.1.tgz",
+      "integrity": "sha512-k4HLI1rZQjlU+EC682RlQ6oZvLrE5SCh3brseQc24vbZTxzT/k/3urar5QMCVgjadmSO7lECeGdc6YxnM3yEGg==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0",
+        "jest-get-type": "21.2.0",
+        "leven": "2.1.0",
+        "pretty-format": "21.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "js-base64": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.0.tgz",
@@ -4303,6 +4626,12 @@
         "invert-kv": "1.0.0"
       }
     },
+    "leven": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+      "integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+      "dev": true
+    },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
@@ -4322,11 +4651,241 @@
         "immediate": "3.0.6"
       }
     },
+    "lint-staged": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-6.0.0.tgz",
+      "integrity": "sha512-ZUftK94S4vedpQG1LlA2tc2AuQXXBwc+1lB+j8SEfG5+p2dqu3Ug8iYQ8jdap+uLkhDw4OaJXqE+CZ/L+vfv+Q==",
+      "dev": true,
+      "requires": {
+        "app-root-path": "2.0.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
+        "cosmiconfig": "3.1.0",
+        "debug": "3.1.0",
+        "dedent": "0.7.0",
+        "execa": "0.8.0",
+        "find-parent-dir": "0.3.0",
+        "is-glob": "4.0.0",
+        "jest-validate": "21.2.1",
+        "listr": "0.13.0",
+        "lodash": "4.17.4",
+        "log-symbols": "2.1.0",
+        "minimatch": "3.0.4",
+        "npm-which": "3.0.1",
+        "p-map": "1.2.0",
+        "path-is-inside": "1.0.2",
+        "pify": "3.0.0",
+        "staged-git-files": "0.0.4",
+        "stringify-object": "3.2.1"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "dev": true,
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "execa": {
+          "version": "0.8.0",
+          "resolved": "https://registry.npmjs.org/execa/-/execa-0.8.0.tgz",
+          "integrity": "sha1-2NdrvBtVIX7RkP1t1J08d07PyNo=",
+          "dev": true,
+          "requires": {
+            "cross-spawn": "5.1.0",
+            "get-stream": "3.0.0",
+            "is-stream": "1.1.0",
+            "npm-run-path": "2.0.2",
+            "p-finally": "1.0.0",
+            "signal-exit": "3.0.2",
+            "strip-eof": "1.0.0"
+          }
+        },
+        "get-stream": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-extglob": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+          "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+          "dev": true
+        },
+        "is-glob": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.0.tgz",
+          "integrity": "sha1-lSHHaEXMJhCoUgPd8ICpWML/q8A=",
+          "dev": true,
+          "requires": {
+            "is-extglob": "2.1.1"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+          "dev": true
+        },
+        "npm-run-path": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
+          "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
+          "dev": true,
+          "requires": {
+            "path-key": "2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+          "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+          "dev": true
+        },
+        "pify": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
     "listify": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/listify/-/listify-1.0.0.tgz",
       "integrity": "sha1-A8p7otFQ1CZ3c/dOV1WNEFPSvuM=",
       "dev": true
+    },
+    "listr": {
+      "version": "0.13.0",
+      "resolved": "https://registry.npmjs.org/listr/-/listr-0.13.0.tgz",
+      "integrity": "sha1-ILsLowuuZg7oTMBQPfS+PVYjiH0=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "figures": "1.7.0",
+        "indent-string": "2.1.0",
+        "is-observable": "0.2.0",
+        "is-promise": "2.1.0",
+        "is-stream": "1.1.0",
+        "listr-silent-renderer": "1.1.1",
+        "listr-update-renderer": "0.4.0",
+        "listr-verbose-renderer": "0.4.1",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "ora": "0.2.3",
+        "p-map": "1.2.0",
+        "rxjs": "5.5.5",
+        "stream-to-observable": "0.2.0",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-silent-renderer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/listr-silent-renderer/-/listr-silent-renderer-1.1.1.tgz",
+      "integrity": "sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=",
+      "dev": true
+    },
+    "listr-update-renderer": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/listr-update-renderer/-/listr-update-renderer-0.4.0.tgz",
+      "integrity": "sha1-NE2YDaLKLosUW6MFkI8yrj9MyKc=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-truncate": "0.2.1",
+        "elegant-spinner": "1.0.1",
+        "figures": "1.7.0",
+        "indent-string": "3.2.0",
+        "log-symbols": "1.0.2",
+        "log-update": "1.0.2",
+        "strip-ansi": "3.0.1"
+      },
+      "dependencies": {
+        "indent-string": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-3.2.0.tgz",
+          "integrity": "sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "1.0.2",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-1.0.2.tgz",
+          "integrity": "sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=",
+          "dev": true,
+          "requires": {
+            "chalk": "1.1.3"
+          }
+        }
+      }
+    },
+    "listr-verbose-renderer": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/listr-verbose-renderer/-/listr-verbose-renderer-0.4.1.tgz",
+      "integrity": "sha1-ggb0z21S3cWCfl/RSYng6WWTOjU=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "date-fns": "1.29.0",
+        "figures": "1.7.0"
+      }
     },
     "livereload-js": {
       "version": "2.2.2",
@@ -4523,6 +5082,62 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=",
       "dev": true
+    },
+    "log-symbols": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.1.0.tgz",
+      "integrity": "sha512-zLeLrzMA1A2vRF1e/0Mo+LNINzi6jzBylHj5WqvQ/WK/5WCZt8si9SyN4p9llr/HRYvVR1AoXHRHl4WTHyQAzQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "2.3.0"
+      },
+      "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        }
+      }
+    },
+    "log-update": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/log-update/-/log-update-1.0.2.tgz",
+      "integrity": "sha1-GZKfZMQJPS0ucHWh2tivWcKWuNE=",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "1.4.0",
+        "cli-cursor": "1.0.2"
+      }
     },
     "lolex": {
       "version": "1.3.2",
@@ -4858,6 +5473,15 @@
         "sort-keys": "1.1.2"
       }
     },
+    "npm-path": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/npm-path/-/npm-path-2.0.3.tgz",
+      "integrity": "sha1-Fc/04ciaONp39W9gVbJPl137K74=",
+      "dev": true,
+      "requires": {
+        "which": "1.2.14"
+      }
+    },
     "npm-run-path": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-1.0.0.tgz",
@@ -4865,6 +5489,25 @@
       "dev": true,
       "requires": {
         "path-key": "1.0.0"
+      }
+    },
+    "npm-which": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/npm-which/-/npm-which-3.0.1.tgz",
+      "integrity": "sha1-kiXybsOihcIJyuZ8OxGmtKtxQKo=",
+      "dev": true,
+      "requires": {
+        "commander": "2.12.2",
+        "npm-path": "2.0.3",
+        "which": "1.2.14"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        }
       }
     },
     "num2fraction": {
@@ -4948,6 +5591,12 @@
       "integrity": "sha1-pT7D/xccNEYBbdUhDRobVEv32HQ=",
       "dev": true
     },
+    "onetime": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
+      "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=",
+      "dev": true
+    },
     "optimist": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/optimist/-/optimist-0.6.1.tgz",
@@ -4984,6 +5633,18 @@
         "prelude-ls": "1.1.2",
         "type-check": "0.3.2",
         "wordwrap": "1.0.0"
+      }
+    },
+    "ora": {
+      "version": "0.2.3",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-0.2.3.tgz",
+      "integrity": "sha1-N1J9Igrc1Tw5tzVx11QVbV22V6Q=",
+      "dev": true,
+      "requires": {
+        "chalk": "1.1.3",
+        "cli-cursor": "1.0.2",
+        "cli-spinners": "0.1.2",
+        "object-assign": "4.1.1"
       }
     },
     "os-homedir": {
@@ -5077,6 +5738,12 @@
       "requires": {
         "p-limit": "1.1.0"
       }
+    },
+    "p-map": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "dev": true
     },
     "package-json": {
       "version": "4.0.1",
@@ -6373,6 +7040,39 @@
       "integrity": "sha1-gV7R9uvGWSb4ZbMQwHE7yzMVzks=",
       "dev": true
     },
+    "prettier": {
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.9.2.tgz",
+      "integrity": "sha512-piXx9N2WT8hWb7PBbX1glAuJVIkEyUV9F5fMXFINpZ0x3otVOFKKeGmeuiclFJlP/UrgTckyV606VjH2rNK4bw==",
+      "dev": true
+    },
+    "pretty-format": {
+      "version": "21.2.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-21.2.1.tgz",
+      "integrity": "sha512-ZdWPGYAnYfcVP8yKA3zFjCn8s4/17TeYH28MXuC8vTp0o21eXjbFGcOAXZEaDaOFJjc3h2qa7HQNHNshhvoh2A==",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "3.0.0",
+        "ansi-styles": "3.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+          "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        }
+      }
+    },
     "process-nextick-args": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-1.0.7.tgz",
@@ -6842,6 +7542,12 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
+    "require-from-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.1.tgz",
+      "integrity": "sha1-xUUjPp19pmFunVmt+zn8n1iGdv8=",
+      "dev": true
+    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -6867,6 +7573,16 @@
       "dev": true,
       "requires": {
         "resolve-from": "2.0.0"
+      }
+    },
+    "restore-cursor": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-1.0.1.tgz",
+      "integrity": "sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=",
+      "dev": true,
+      "requires": {
+        "exit-hook": "1.1.1",
+        "onetime": "1.1.0"
       }
     },
     "resumer": {
@@ -6905,6 +7621,23 @@
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
       "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
       "dev": true
+    },
+    "rxjs": {
+      "version": "5.5.5",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-5.5.5.tgz",
+      "integrity": "sha512-D/MfQnPMBk8P8gfwGxvCkuaWBcG58W7dUMT//URPoYzIbDEKT0GezdirkK5whMgKFBATfCoTpxO8bJQGJ04W5A==",
+      "dev": true,
+      "requires": {
+        "symbol-observable": "1.0.1"
+      },
+      "dependencies": {
+        "symbol-observable": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-1.0.1.tgz",
+          "integrity": "sha1-g0D8RwLDEi310iKI+IKD9RPT/dQ=",
+          "dev": true
+        }
+      }
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -7102,6 +7835,12 @@
         "util": "0.10.3"
       }
     },
+    "slice-ansi": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-0.0.4.tgz",
+      "integrity": "sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=",
+      "dev": true
+    },
     "slide": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/slide/-/slide-1.1.6.tgz",
@@ -7199,6 +7938,12 @@
         "tweetnacl": "0.14.5"
       }
     },
+    "staged-git-files": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/staged-git-files/-/staged-git-files-0.0.4.tgz",
+      "integrity": "sha1-15fhtVHKemOd7AI33G60u5vhfTU=",
+      "dev": true
+    },
     "statuses": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
@@ -7218,6 +7963,15 @@
       "dev": true,
       "requires": {
         "duplexer": "0.1.1"
+      }
+    },
+    "stream-to-observable": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/stream-to-observable/-/stream-to-observable-0.2.0.tgz",
+      "integrity": "sha1-WdbqOT2HwsDdrBCqDVYbxrpvDhA=",
+      "dev": true,
+      "requires": {
+        "any-observable": "0.2.0"
       }
     },
     "strict-uri-encode": {
@@ -7270,6 +8024,17 @@
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
       "dev": true
+    },
+    "stringify-object": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/stringify-object/-/stringify-object-3.2.1.tgz",
+      "integrity": "sha512-jPcQYw/52HUPP8uOE4kkjxl5bB9LfHkKCTptIk3qw7ozP5XMIMlHMLjt00GGSwW6DJAf/njY5EU6Vpwl4LlBKQ==",
+      "dev": true,
+      "requires": {
+        "get-own-enumerable-property-symbols": "2.0.1",
+        "is-obj": "1.0.1",
+        "is-regexp": "1.0.0"
+      }
     },
     "stringstream": {
       "version": "0.0.5",
@@ -7363,6 +8128,12 @@
           }
         }
       }
+    },
+    "symbol-observable": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-0.2.4.tgz",
+      "integrity": "sha1-lag9smGG1q9+ehjb2XYKL4bQj0A=",
+      "dev": true
     },
     "symbol-tree": {
       "version": "3.2.2",
@@ -7721,9 +8492,9 @@
       "dev": true
     },
     "tslint": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-4.5.1.tgz",
-      "integrity": "sha1-BTVocb7yOkNJBnNABvwYgza6gks=",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
+      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
@@ -7732,9 +8503,10 @@
         "findup-sync": "0.3.0",
         "glob": "7.1.2",
         "optimist": "0.6.1",
-        "resolve": "1.1.7",
-        "tsutils": "1.9.1",
-        "update-notifier": "2.3.0"
+        "resolve": "1.5.0",
+        "semver": "5.4.1",
+        "tslib": "1.8.0",
+        "tsutils": "1.9.1"
       },
       "dependencies": {
         "diff": {
@@ -7756,7 +8528,26 @@
             "once": "1.4.0",
             "path-is-absolute": "1.0.1"
           }
+        },
+        "resolve": {
+          "version": "1.5.0",
+          "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
+          "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
+          "dev": true,
+          "requires": {
+            "path-parse": "1.0.5"
+          }
         }
+      }
+    },
+    "tslint-plugin-prettier": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/tslint-plugin-prettier/-/tslint-plugin-prettier-1.3.0.tgz",
+      "integrity": "sha512-6UqeeV6EABp0RdQkW6eC1vwnAXcKMGJgPeJ5soXiKdSm2vv7c3dp+835CM8pjgx9l4uSa7tICm1Kli+SMsADDg==",
+      "dev": true,
+      "requires": {
+        "eslint-plugin-prettier": "2.4.0",
+        "tslib": "1.8.0"
       }
     },
     "tsutils": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8521,23 +8521,50 @@
       "dev": true
     },
     "tslint": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.2.0.tgz",
-      "integrity": "sha1-FqKt3yDLdIOF9UTpoO2rCGvDQRQ=",
+      "version": "5.8.0",
+      "resolved": "https://registry.npmjs.org/tslint/-/tslint-5.8.0.tgz",
+      "integrity": "sha1-H0mtWy53x2w69N3K5VKuTjYS6xM=",
       "dev": true,
       "requires": {
         "babel-code-frame": "6.26.0",
-        "colors": "1.1.2",
+        "builtin-modules": "1.1.1",
+        "chalk": "2.3.0",
+        "commander": "2.12.2",
         "diff": "3.4.0",
-        "findup-sync": "0.3.0",
         "glob": "7.1.2",
-        "optimist": "0.6.1",
+        "minimatch": "3.0.4",
         "resolve": "1.5.0",
         "semver": "5.4.1",
         "tslib": "1.8.1",
-        "tsutils": "1.9.1"
+        "tsutils": "2.13.1"
       },
       "dependencies": {
+        "ansi-styles": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
+          "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
+          "dev": true,
+          "requires": {
+            "color-convert": "1.9.1"
+          }
+        },
+        "chalk": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+          "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "3.2.0",
+            "escape-string-regexp": "1.0.5",
+            "supports-color": "4.5.0"
+          }
+        },
+        "commander": {
+          "version": "2.12.2",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-2.12.2.tgz",
+          "integrity": "sha512-BFnaq5ZOGcDN7FlrtBT4xxkgIToalIIxwjxLWVJ8bGTpe1LroqMiqQXdA7ygc7CRvaYS+9zfPGFnJqFSayx+AA==",
+          "dev": true
+        },
         "diff": {
           "version": "3.4.0",
           "resolved": "https://registry.npmjs.org/diff/-/diff-3.4.0.tgz",
@@ -8558,6 +8585,12 @@
             "path-is-absolute": "1.0.1"
           }
         },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
         "resolve": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
@@ -8565,6 +8598,24 @@
           "dev": true,
           "requires": {
             "path-parse": "1.0.5"
+          }
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "2.0.0"
+          }
+        },
+        "tsutils": {
+          "version": "2.13.1",
+          "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.13.1.tgz",
+          "integrity": "sha512-XMOEvc2TiYesVSOJMI7OYPnBMSgcvERuGW5Li/J+2A0TuH607BPQnOLQ82oSPZCssB8c9+QGi6qhTBa/f1xQRA==",
+          "dev": true,
+          "requires": {
+            "tslib": "1.8.1"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "prettier": "1.9.2",
     "sinon": "^1.17.6",
     "ts-node": "^3.3.0",
-    "tslint": "5.2.0",
+    "tslint": "5.8.0",
     "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
   },

--- a/package.json
+++ b/package.json
@@ -18,6 +18,8 @@
   },
   "scripts": {
     "prepublish": "grunt peerDepInstall",
+    "precommit": "lint-staged",
+    "prettier": "prettier --write 'src/**/*.ts' 'tests/**/*.ts'",
     "test": "grunt test"
   },
   "peerDependencies": {
@@ -37,10 +39,30 @@
     "@types/sinon": "^1.16.31",
     "grunt": "^1.0.1",
     "grunt-dojo2": "latest",
+    "grunt-tslint": "5.0.1",
+    "husky": "0.14.3",
     "intern": "~4.1.0",
+    "lint-staged": "6.0.0",
     "load-grunt-tasks": "^3.5.2",
+    "prettier": "1.9.2",
     "sinon": "^1.17.6",
     "ts-node": "^3.3.0",
+    "tslint": "5.2.0",
+    "tslint-plugin-prettier": "1.3.0",
     "typescript": "~2.6.1"
+  },
+  "lint-staged": {
+    "*.{ts,tsx}": [
+      "prettier --write",
+      "git add"
+    ]
+  },
+  "prettier": {
+    "singleQuote": true,
+    "tabWidth": 4,
+    "useTabs": true,
+    "parser": "typescript",
+    "printWidth": 120,
+    "arrowParens": "always"
   }
 }

--- a/src/accordionpane/AccordionPane.ts
+++ b/src/accordionpane/AccordionPane.ts
@@ -23,15 +23,24 @@ export interface AccordionPaneProperties extends ThemedProperties {
 	onRequestClose?(key: string): void;
 	onRequestOpen?(key: string): void;
 	openKeys?: string[];
-};
+}
 
 export const ThemedBase = ThemedMixin(WidgetBase);
 
 @theme(css)
-export default class AccordionPane<P extends AccordionPaneProperties = AccordionPaneProperties> extends ThemedBase<P, WNode<TitlePane>> {
-	private _assignCallback(child: WNode<TitlePane>, functionName: 'onRequestClose' | 'onRequestOpen', callback: (key: string) => void) {
+export default class AccordionPane<P extends AccordionPaneProperties = AccordionPaneProperties> extends ThemedBase<
+	P,
+	WNode<TitlePane>
+> {
+	private _assignCallback(
+		child: WNode<TitlePane>,
+		functionName: 'onRequestClose' | 'onRequestOpen',
+		callback: (key: string) => void
+	) {
 		const existingProperty = child.properties[functionName];
-		const property = () => { callback.call(this, `${ child.properties.key }`); };
+		const property = () => {
+			callback.call(this, `${child.properties.key}`);
+		};
 
 		return existingProperty ? after(existingProperty, property) : property;
 	}
@@ -47,12 +56,9 @@ export default class AccordionPane<P extends AccordionPaneProperties = Accordion
 	}
 
 	protected renderChildren(): DNode[] {
-		const {
-			openKeys = [],
-			theme
-		} = this.properties;
+		const { openKeys = [], theme } = this.properties;
 
-		return this.children.filter((child) => child).map(child => {
+		return this.children.filter((child) => child).map((child) => {
 			// null checks skipped since children are filtered prior to mapping
 			assign(child!.properties, {
 				onRequestClose: this._assignCallback(child!, 'onRequestClose', this.onRequestClose),

--- a/src/accordionpane/createAccordionPaneElement.ts
+++ b/src/accordionpane/createAccordionPaneElement.ts
@@ -8,10 +8,7 @@ export default function createAccordionPaneElement(): CustomElementDescriptor {
 	return {
 		tagName: 'dojo-accordion-pane',
 		widgetConstructor: AccordionPane,
-		properties: [
-			{ propertyName: 'openKeys' },
-			{ propertyName: 'theme' }
-		],
+		properties: [{ propertyName: 'openKeys' }, { propertyName: 'theme' }],
 		events: [
 			{
 				propertyName: 'onRequestClose',
@@ -23,4 +20,4 @@ export default function createAccordionPaneElement(): CustomElementDescriptor {
 			}
 		]
 	};
-};
+}

--- a/src/accordionpane/example/index.ts
+++ b/src/accordionpane/example/index.ts
@@ -23,7 +23,7 @@ export class App extends WidgetBase<WidgetProperties> {
 
 	render() {
 		return v('div', { styles: { maxWidth: '350px' } }, [
-			v('h2', [ 'AccordionPane Examples' ]),
+			v('h2', ['AccordionPane Examples']),
 			v('label', [
 				'Use Dojo Theme ',
 				v('input', {
@@ -32,52 +32,84 @@ export class App extends WidgetBase<WidgetProperties> {
 				})
 			]),
 			v('div', { id: 'pane' }, [
-				v('h3', [ 'Normal AccordionPane' ]),
-				w(AccordionPane, {
-					onRequestOpen: (key: string) => {
-						this._openKeys.add(key);
-						this.invalidate();
+				v('h3', ['Normal AccordionPane']),
+				w(
+					AccordionPane,
+					{
+						onRequestOpen: (key: string) => {
+							this._openKeys.add(key);
+							this.invalidate();
+						},
+						onRequestClose: (key: string) => {
+							this._openKeys.delete(key);
+							this.invalidate();
+						},
+						openKeys: from(this._openKeys),
+						theme: this._theme
 					},
-					onRequestClose: (key: string) => {
-						this._openKeys.delete(key);
-						this.invalidate();
-					},
-					openKeys: from(this._openKeys),
-					theme: this._theme
-				}, [
-					w(TitlePane, {
-						title: 'Pane 1',
-						key: 'foo'
-					}, [ 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sodales ante sed massa finibus, at euismod ex molestie. Donec sagittis ligula at lorem blandit imperdiet. Aenean sapien justo, blandit at aliquet a, tincidunt ac nulla. Donec quis dapibus est. Donec id massa eu nisl cursus ornare quis sit amet velit.' ]),
-					w(TitlePane, {
-						title: 'Pane 2',
-						key: 'bar'
-					}, [ 'Ut non lectus vitae eros hendrerit pellentesque. In rhoncus ut lectus id tempus. Cras eget mauris scelerisque, condimentum ante sed, vehicula tellus. Donec congue ligula felis, a porta felis aliquet nec. Nulla mi lorem, efficitur nec lectus vehicula, vehicula varius eros.' ])
-				])
+					[
+						w(
+							TitlePane,
+							{
+								title: 'Pane 1',
+								key: 'foo'
+							},
+							[
+								'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sodales ante sed massa finibus, at euismod ex molestie. Donec sagittis ligula at lorem blandit imperdiet. Aenean sapien justo, blandit at aliquet a, tincidunt ac nulla. Donec quis dapibus est. Donec id massa eu nisl cursus ornare quis sit amet velit.'
+							]
+						),
+						w(
+							TitlePane,
+							{
+								title: 'Pane 2',
+								key: 'bar'
+							},
+							[
+								'Ut non lectus vitae eros hendrerit pellentesque. In rhoncus ut lectus id tempus. Cras eget mauris scelerisque, condimentum ante sed, vehicula tellus. Donec congue ligula felis, a porta felis aliquet nec. Nulla mi lorem, efficitur nec lectus vehicula, vehicula varius eros.'
+							]
+						)
+					]
+				)
 			]),
 			v('div', { id: 'pane2' }, [
-				v('h3', [ 'Exclusive AccordionPane' ]),
-				w(AccordionPane, {
-					onRequestOpen: (key: string) => {
-						this._exclusiveKey = key;
-						this.invalidate();
+				v('h3', ['Exclusive AccordionPane']),
+				w(
+					AccordionPane,
+					{
+						onRequestOpen: (key: string) => {
+							this._exclusiveKey = key;
+							this.invalidate();
+						},
+						onRequestClose: (key: string) => {
+							this._exclusiveKey = undefined;
+							this.invalidate();
+						},
+						openKeys: this._exclusiveKey ? [this._exclusiveKey] : [],
+						theme: this._theme
 					},
-					onRequestClose: (key: string) => {
-						this._exclusiveKey = undefined;
-						this.invalidate();
-					},
-					openKeys: this._exclusiveKey ? [ this._exclusiveKey ] : [],
-					theme: this._theme
-				}, [
-					w(TitlePane, {
-						title: 'Pane 1',
-						key: 'baz'
-					}, [ 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sodales ante sed massa finibus, at euismod ex molestie. Donec sagittis ligula at lorem blandit imperdiet. Aenean sapien justo, blandit at aliquet a, tincidunt ac nulla. Donec quis dapibus est. Donec id massa eu nisl cursus ornare quis sit amet velit.' ]),
-					w(TitlePane, {
-						title: 'Pane 2',
-						key: 'bax'
-					}, [ 'Ut non lectus vitae eros hendrerit pellentesque. In rhoncus ut lectus id tempus. Cras eget mauris scelerisque, condimentum ante sed, vehicula tellus. Donec congue ligula felis, a porta felis aliquet nec. Nulla mi lorem, efficitur nec lectus vehicula, vehicula varius eros.' ])
-				])
+					[
+						w(
+							TitlePane,
+							{
+								title: 'Pane 1',
+								key: 'baz'
+							},
+							[
+								'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sodales ante sed massa finibus, at euismod ex molestie. Donec sagittis ligula at lorem blandit imperdiet. Aenean sapien justo, blandit at aliquet a, tincidunt ac nulla. Donec quis dapibus est. Donec id massa eu nisl cursus ornare quis sit amet velit.'
+							]
+						),
+						w(
+							TitlePane,
+							{
+								title: 'Pane 2',
+								key: 'bax'
+							},
+							[
+								'Ut non lectus vitae eros hendrerit pellentesque. In rhoncus ut lectus id tempus. Cras eget mauris scelerisque, condimentum ante sed, vehicula tellus. Donec congue ligula felis, a porta felis aliquet nec. Nulla mi lorem, efficitur nec lectus vehicula, vehicula varius eros.'
+							]
+						)
+					]
+				)
 			])
 		]);
 	}

--- a/src/accordionpane/tests/functional/AccordionPane.ts
+++ b/src/accordionpane/tests/functional/AccordionPane.ts
@@ -4,9 +4,7 @@ const { assert } = intern.getPlugin('chai');
 import { Remote } from 'intern/lib/executors/Node';
 
 function getPage(remote: Remote) {
-	return remote
-		.get('http://localhost:9000/_build/common/example/?module=accordionpane')
-		.setFindTimeout(5000);
+	return remote.get('http://localhost:9000/_build/common/example/?module=accordionpane').setFindTimeout(5000);
 }
 
 const DELAY = 750;
@@ -16,17 +14,17 @@ registerSuite('AccordionPane', {
 		return getPage(this.remote)
 			.sleep(DELAY)
 			.findByCssSelector('#pane > div > :first-child')
-				.getSize()
-				.then((size: { height: number }) => {
-					assert.isBelow(size.height, 50);
-				})
-				.findByCssSelector('button')
-					.click()
-				.end()
-				.sleep(DELAY)
-				.getSize()
-				.then((size: { height: number }) => {
-					assert.isAbove(size.height, 50);
-				});
+			.getSize()
+			.then((size: { height: number }) => {
+				assert.isBelow(size.height, 50);
+			})
+			.findByCssSelector('button')
+			.click()
+			.end()
+			.sleep(DELAY)
+			.getSize()
+			.then((size: { height: number }) => {
+				assert.isAbove(size.height, 50);
+			});
 	}
 });

--- a/src/accordionpane/tests/unit/AccordionPane.ts
+++ b/src/accordionpane/tests/unit/AccordionPane.ts
@@ -22,9 +22,15 @@ registerSuite('AccordionPane', {
 
 	tests: {
 		'default rendering'() {
-			pane.expectRender(v('div', {
-				classes: css.root
-			}, []));
+			pane.expectRender(
+				v(
+					'div',
+					{
+						classes: css.root
+					},
+					[]
+				)
+			);
 		},
 
 		'default rendering with children'() {
@@ -37,34 +43,40 @@ registerSuite('AccordionPane', {
 				w(TitlePane, { title: 'baz', key: 'baz' })
 			]);
 
-			pane.expectRender(v('div', {
-				classes: css.root
-			}, [
-				w(TitlePane, {
-					key: 'foo',
-					onRequestClose: pane.listener,
-					onRequestOpen: pane.listener,
-					open: false,
-					theme: undefined,
-					title: 'foo'
-				}),
-				w(TitlePane, {
-					key: 'bar',
-					onRequestClose: pane.listener,
-					onRequestOpen: pane.listener,
-					open: false,
-					theme: undefined,
-					title: 'bar'
-				}),
-				w(TitlePane, {
-					key: 'baz',
-					onRequestClose: pane.listener,
-					onRequestOpen: pane.listener,
-					open: false,
-					theme: undefined,
-					title: 'baz'
-				})
-			]));
+			pane.expectRender(
+				v(
+					'div',
+					{
+						classes: css.root
+					},
+					[
+						w(TitlePane, {
+							key: 'foo',
+							onRequestClose: pane.listener,
+							onRequestOpen: pane.listener,
+							open: false,
+							theme: undefined,
+							title: 'foo'
+						}),
+						w(TitlePane, {
+							key: 'bar',
+							onRequestClose: pane.listener,
+							onRequestOpen: pane.listener,
+							open: false,
+							theme: undefined,
+							title: 'bar'
+						}),
+						w(TitlePane, {
+							key: 'baz',
+							onRequestClose: pane.listener,
+							onRequestOpen: pane.listener,
+							open: false,
+							theme: undefined,
+							title: 'baz'
+						})
+					]
+				)
+			);
 		},
 
 		'onRequestOpen should be called'() {
@@ -72,9 +84,7 @@ registerSuite('AccordionPane', {
 
 			pane.setProperties({ onRequestOpen });
 
-			pane.setChildren([
-				w(TitlePane, { title: 'foo', key: 'foo' })
-			]);
+			pane.setChildren([w(TitlePane, { title: 'foo', key: 'foo' })]);
 
 			pane.callListener('onRequestOpen', { key: 'foo' });
 			assert.isTrue(onRequestOpen.calledWith('foo'));
@@ -85,9 +95,7 @@ registerSuite('AccordionPane', {
 
 			pane.setProperties({ onRequestClose });
 
-			pane.setChildren([
-				w(TitlePane, { title: 'foo', key: 'foo' })
-			]);
+			pane.setChildren([w(TitlePane, { title: 'foo', key: 'foo' })]);
 
 			pane.callListener('onRequestClose', { key: 'foo' });
 			assert.isTrue(onRequestClose.calledWith('foo'));

--- a/src/button/Button.ts
+++ b/src/button/Button.ts
@@ -21,11 +21,15 @@ export type ButtonType = 'submit' | 'reset' | 'button' | 'menu';
  * @property type           Button type can be "submit", "reset", "button", or "menu"
  * @property value          Defines a value for the button submitted with form data
  */
-export interface ButtonProperties extends ThemedProperties, InputEventProperties, PointerEventProperties, KeyEventProperties {
+export interface ButtonProperties
+	extends ThemedProperties,
+		InputEventProperties,
+		PointerEventProperties,
+		KeyEventProperties {
 	describedBy?: string;
 	disabled?: boolean;
 	id?: string;
-	popup?: { expanded?: boolean; id?: string; } | boolean;
+	popup?: { expanded?: boolean; id?: string } | boolean;
 	name?: string;
 	pressed?: boolean;
 	type?: ButtonType;
@@ -37,84 +41,92 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 @theme(css)
 @theme(iconCss)
 export default class Button<P extends ButtonProperties = ButtonProperties> extends ThemedBase<P> {
-	private _onBlur (event: FocusEvent) { this.properties.onBlur && this.properties.onBlur(event); }
-	private _onClick (event: MouseEvent) { this.properties.onClick && this.properties.onClick(event); }
-	private _onFocus (event: FocusEvent) { this.properties.onFocus && this.properties.onFocus(event); }
-	private _onKeyDown (event: KeyboardEvent) { this.properties.onKeyDown && this.properties.onKeyDown(event); }
-	private _onKeyPress (event: KeyboardEvent) { this.properties.onKeyPress && this.properties.onKeyPress(event); }
-	private _onKeyUp (event: KeyboardEvent) { this.properties.onKeyUp && this.properties.onKeyUp(event); }
-	private _onMouseDown (event: MouseEvent) { this.properties.onMouseDown && this.properties.onMouseDown(event); }
-	private _onMouseUp (event: MouseEvent) { this.properties.onMouseUp && this.properties.onMouseUp(event); }
-	private _onTouchStart (event: TouchEvent) { this.properties.onTouchStart && this.properties.onTouchStart(event); }
-	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
-	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
+	private _onBlur(event: FocusEvent) {
+		this.properties.onBlur && this.properties.onBlur(event);
+	}
+	private _onClick(event: MouseEvent) {
+		this.properties.onClick && this.properties.onClick(event);
+	}
+	private _onFocus(event: FocusEvent) {
+		this.properties.onFocus && this.properties.onFocus(event);
+	}
+	private _onKeyDown(event: KeyboardEvent) {
+		this.properties.onKeyDown && this.properties.onKeyDown(event);
+	}
+	private _onKeyPress(event: KeyboardEvent) {
+		this.properties.onKeyPress && this.properties.onKeyPress(event);
+	}
+	private _onKeyUp(event: KeyboardEvent) {
+		this.properties.onKeyUp && this.properties.onKeyUp(event);
+	}
+	private _onMouseDown(event: MouseEvent) {
+		this.properties.onMouseDown && this.properties.onMouseDown(event);
+	}
+	private _onMouseUp(event: MouseEvent) {
+		this.properties.onMouseUp && this.properties.onMouseUp(event);
+	}
+	private _onTouchStart(event: TouchEvent) {
+		this.properties.onTouchStart && this.properties.onTouchStart(event);
+	}
+	private _onTouchEnd(event: TouchEvent) {
+		this.properties.onTouchEnd && this.properties.onTouchEnd(event);
+	}
+	private _onTouchCancel(event: TouchEvent) {
+		this.properties.onTouchCancel && this.properties.onTouchCancel(event);
+	}
 
 	protected getContent(): DNode[] {
 		return this.children;
 	}
 
 	protected getModifierClasses(): (string | null)[] {
-		const {
-			disabled,
-			popup = false,
-			pressed
-		} = this.properties;
+		const { disabled, popup = false, pressed } = this.properties;
 
-		return [
-			disabled ? css.disabled : null,
-			popup ? css.popup : null,
-			pressed ? css.pressed : null
-		];
+		return [disabled ? css.disabled : null, popup ? css.popup : null, pressed ? css.pressed : null];
 	}
 
 	protected renderPopupIcon(): DNode {
-		return v('i', { classes: this.theme([ css.addon, iconCss.icon, iconCss.downIcon ]),
-			role: 'presentation', 'aria-hidden': 'true'
+		return v('i', {
+			classes: this.theme([css.addon, iconCss.icon, iconCss.downIcon]),
+			role: 'presentation',
+			'aria-hidden': 'true'
 		});
 	}
 
 	render(): DNode {
-		let {
-			describedBy,
-			disabled,
-			id,
-			popup = false,
-			name,
-			pressed,
-			type,
-			value
-		} = this.properties;
+		let { describedBy, disabled, id, popup = false, name, pressed, type, value } = this.properties;
 
 		if (popup === true) {
 			popup = { expanded: false, id: '' };
 		}
 
-		return v('button', {
-			classes: this.theme([ css.root, ...this.getModifierClasses() ]),
-			disabled,
-			id,
-			name,
-			type,
-			value,
-			onblur: this._onBlur,
-			onclick: this._onClick,
-			onfocus: this._onFocus,
-			onkeydown: this._onKeyDown,
-			onkeypress: this._onKeyPress,
-			onkeyup: this._onKeyUp,
-			onmousedown: this._onMouseDown,
-			onmouseup: this._onMouseUp,
-			ontouchstart: this._onTouchStart,
-			ontouchend: this._onTouchEnd,
-			ontouchcancel: this._onTouchCancel,
-			'aria-haspopup': popup ? 'true' : null,
-			'aria-controls': popup ? popup.id : null,
-			'aria-expanded': popup ? popup.expanded + '' : null,
-			'aria-pressed': typeof pressed === 'boolean' ? pressed.toString() : null,
-			'aria-describedby': describedBy
-		}, [
-			...this.getContent(),
-			popup ? this.renderPopupIcon() : null
-		]);
+		return v(
+			'button',
+			{
+				classes: this.theme([css.root, ...this.getModifierClasses()]),
+				disabled,
+				id,
+				name,
+				type,
+				value,
+				onblur: this._onBlur,
+				onclick: this._onClick,
+				onfocus: this._onFocus,
+				onkeydown: this._onKeyDown,
+				onkeypress: this._onKeyPress,
+				onkeyup: this._onKeyUp,
+				onmousedown: this._onMouseDown,
+				onmouseup: this._onMouseUp,
+				ontouchstart: this._onTouchStart,
+				ontouchend: this._onTouchEnd,
+				ontouchcancel: this._onTouchCancel,
+				'aria-haspopup': popup ? 'true' : null,
+				'aria-controls': popup ? popup.id : null,
+				'aria-expanded': popup ? popup.expanded + '' : null,
+				'aria-pressed': typeof pressed === 'boolean' ? pressed.toString() : null,
+				'aria-describedby': describedBy
+			},
+			[...this.getContent(), popup ? this.renderPopupIcon() : null]
+		);
 	}
 }

--- a/src/button/example/index.ts
+++ b/src/button/example/index.ts
@@ -22,7 +22,7 @@ export class App extends WidgetBase<WidgetProperties> {
 
 	render() {
 		return v('div', [
-			v('h2', [ 'Button Examples' ]),
+			v('h2', ['Button Examples']),
 			v('label', [
 				'Use Dojo Theme ',
 				v('input', {
@@ -31,37 +31,53 @@ export class App extends WidgetBase<WidgetProperties> {
 				})
 			]),
 			v('div', { id: 'example-1' }, [
-				v('p', [ 'Basic example:' ]),
-				w(Button, {
-					key: 'b1',
-					theme: this._theme
-				}, [ 'Basic Button' ])
+				v('p', ['Basic example:']),
+				w(
+					Button,
+					{
+						key: 'b1',
+						theme: this._theme
+					},
+					['Basic Button']
+				)
 			]),
 			v('div', { id: 'example-2' }, [
-				v('p', [ 'Disabled submit button:' ]),
-				w(Button, {
-					key: 'b2',
-					theme: this._theme,
-					disabled: true,
-					type: 'submit'
-				}, [ 'Submit' ])
+				v('p', ['Disabled submit button:']),
+				w(
+					Button,
+					{
+						key: 'b2',
+						theme: this._theme,
+						disabled: true,
+						type: 'submit'
+					},
+					['Submit']
+				)
 			]),
 			v('div', { id: 'example-3' }, [
-				v('p', [ 'Popup button:' ]),
-				w(Button, {
-					key: 'b3',
-					theme: this._theme,
-					popup: { expanded: false, id: 'fakeId' }
-				}, [ 'Open' ])
+				v('p', ['Popup button:']),
+				w(
+					Button,
+					{
+						key: 'b3',
+						theme: this._theme,
+						popup: { expanded: false, id: 'fakeId' }
+					},
+					['Open']
+				)
 			]),
 			v('div', { id: 'example-4' }, [
-				v('p', [ 'Toggle Button' ]),
-				w(Button, {
-					key: 'b4',
-					theme: this._theme,
-					pressed: this._buttonPressed,
-					onClick: this.toggleButton
-				}, [ 'Button state' ])
+				v('p', ['Toggle Button']),
+				w(
+					Button,
+					{
+						key: 'b4',
+						theme: this._theme,
+						pressed: this._buttonPressed,
+						onClick: this.toggleButton
+					},
+					['Button state']
+				)
 			])
 		]);
 	}

--- a/src/button/tests/functional/Button.ts
+++ b/src/button/tests/functional/Button.ts
@@ -5,9 +5,7 @@ import { Remote } from 'intern/lib/executors/Node';
 import * as css from '../../styles/button.m.css';
 
 function getPage(remote: Remote) {
-	return remote
-		.get('http://localhost:9000/_build/common/example/?module=button')
-		.setFindTimeout(5000);
+	return remote.get('http://localhost:9000/_build/common/example/?module=button').setFindTimeout(5000);
 }
 
 const DELAY = 750;
@@ -17,7 +15,7 @@ registerSuite('Button', {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-1 .${css.root}`)
 			.getSize()
-			.then(({ height, width }: { height: number; width: number; }) => {
+			.then(({ height, width }: { height: number; width: number }) => {
 				assert.isAbove(height, 0, 'The button height should be greater than zero.');
 				assert.isAbove(width, 0, 'The button width should be greater than zero.');
 			})
@@ -32,13 +30,12 @@ registerSuite('Button', {
 				assert.strictEqual(text, 'Basic Button');
 			})
 			.end();
-
 	},
 	'button should be disabled'() {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-2 .${css.root}`)
 			.isEnabled()
-			.then(enabled => {
+			.then((enabled) => {
 				assert.isTrue(!enabled, 'The button should be disabled.');
 			})
 			.end();
@@ -46,25 +43,25 @@ registerSuite('Button', {
 	'button should be toggle-able'() {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-4 .${css.root}`)
-				.getAttribute('aria-pressed')
-				.then((pressed: string) => {
-					assert.isNull(pressed, 'Initial state should be null');
-				})
-				.click()
-				.sleep(DELAY)
+			.getAttribute('aria-pressed')
+			.then((pressed: string) => {
+				assert.isNull(pressed, 'Initial state should be null');
+			})
+			.click()
+			.sleep(DELAY)
 			.end()
 			.findByCssSelector(`#example-4 .${css.root}`)
-				.getAttribute('aria-pressed')
-				.then((pressed: string) => {
-					assert.strictEqual(pressed, 'true');
-				})
-				.click()
+			.getAttribute('aria-pressed')
+			.then((pressed: string) => {
+				assert.strictEqual(pressed, 'true');
+			})
+			.click()
 			.end()
 			.findByCssSelector(`#example-4 .${css.root}`)
-				.getAttribute('aria-pressed')
-				.then((pressed: string) => {
-					assert.strictEqual(pressed, 'false');
-				})
+			.getAttribute('aria-pressed')
+			.then((pressed: string) => {
+				assert.strictEqual(pressed, 'false');
+			})
 			.end();
 	}
 });

--- a/src/button/tests/unit/Button.ts
+++ b/src/button/tests/unit/Button.ts
@@ -22,30 +22,36 @@ registerSuite('Button', {
 
 	tests: {
 		'no content'() {
-			widget.expectRender(v('button', {
-				'aria-controls': null,
-				'aria-describedby': undefined,
-				'aria-expanded': null,
-				'aria-haspopup': null,
-				'aria-pressed': null,
-				classes: [ css.root, null, null, null ],
-				disabled: undefined,
-				id: undefined,
-				name: undefined,
-				onblur: widget.listener,
-				onclick: widget.listener,
-				onfocus: widget.listener,
-				onkeydown: widget.listener,
-				onkeypress: widget.listener,
-				onkeyup: widget.listener,
-				onmousedown: widget.listener,
-				onmouseup: widget.listener,
-				ontouchstart: widget.listener,
-				ontouchend: widget.listener,
-				ontouchcancel: widget.listener,
-				type: undefined,
-				value: undefined
-			}, [ null ]));
+			widget.expectRender(
+				v(
+					'button',
+					{
+						'aria-controls': null,
+						'aria-describedby': undefined,
+						'aria-expanded': null,
+						'aria-haspopup': null,
+						'aria-pressed': null,
+						classes: [css.root, null, null, null],
+						disabled: undefined,
+						id: undefined,
+						name: undefined,
+						onblur: widget.listener,
+						onclick: widget.listener,
+						onfocus: widget.listener,
+						onkeydown: widget.listener,
+						onkeypress: widget.listener,
+						onkeyup: widget.listener,
+						onmousedown: widget.listener,
+						onmouseup: widget.listener,
+						ontouchstart: widget.listener,
+						ontouchend: widget.listener,
+						ontouchcancel: widget.listener,
+						type: undefined,
+						value: undefined
+					},
+					[null]
+				)
+			);
 		},
 
 		'properties and attributes'() {
@@ -65,37 +71,43 @@ registerSuite('Button', {
 			widget.setProperties(buttonProperties);
 			widget.setChildren(['foo']);
 
-			widget.expectRender(v('button', {
-				'aria-controls': (<any> buttonProperties.popup).id,
-				'aria-describedby': buttonProperties.describedBy,
-				'aria-expanded': String((<any> buttonProperties.popup).expanded),
-				'aria-haspopup': 'true',
-				'aria-pressed': String(buttonProperties.pressed),
-				classes: [ css.root, css.disabled, css.popup, css.pressed ],
-				disabled: buttonProperties.disabled,
-				name: buttonProperties.name,
-				id: buttonProperties.id,
-				onblur: widget.listener,
-				onclick: widget.listener,
-				onfocus: widget.listener,
-				onkeydown: widget.listener,
-				onkeypress: widget.listener,
-				onkeyup: widget.listener,
-				onmousedown: widget.listener,
-				onmouseup: widget.listener,
-				ontouchstart: widget.listener,
-				ontouchend: widget.listener,
-				ontouchcancel: widget.listener,
-				type: buttonProperties.type,
-				value: buttonProperties.value
-			}, [
-				'foo',
-				v('i', {
-					classes: [ css.addon, iconCss.icon, iconCss.downIcon ],
-					role: 'presentation',
-					'aria-hidden': 'true'
-				})
-			]));
+			widget.expectRender(
+				v(
+					'button',
+					{
+						'aria-controls': (<any>buttonProperties.popup).id,
+						'aria-describedby': buttonProperties.describedBy,
+						'aria-expanded': String((<any>buttonProperties.popup).expanded),
+						'aria-haspopup': 'true',
+						'aria-pressed': String(buttonProperties.pressed),
+						classes: [css.root, css.disabled, css.popup, css.pressed],
+						disabled: buttonProperties.disabled,
+						name: buttonProperties.name,
+						id: buttonProperties.id,
+						onblur: widget.listener,
+						onclick: widget.listener,
+						onfocus: widget.listener,
+						onkeydown: widget.listener,
+						onkeypress: widget.listener,
+						onkeyup: widget.listener,
+						onmousedown: widget.listener,
+						onmouseup: widget.listener,
+						ontouchstart: widget.listener,
+						ontouchend: widget.listener,
+						ontouchcancel: widget.listener,
+						type: buttonProperties.type,
+						value: buttonProperties.value
+					},
+					[
+						'foo',
+						v('i', {
+							classes: [css.addon, iconCss.icon, iconCss.downIcon],
+							role: 'presentation',
+							'aria-hidden': 'true'
+						})
+					]
+				)
+			);
 		},
 
 		'popup = true'() {
@@ -103,36 +115,42 @@ registerSuite('Button', {
 				popup: true
 			});
 
-			widget.expectRender(v('button', {
-				'aria-controls': '',
-				'aria-describedby': undefined,
-				'aria-expanded': 'false',
-				'aria-haspopup': 'true',
-				'aria-pressed': null,
-				classes: [ css.root, null, css.popup, null ],
-				disabled: undefined,
-				name: undefined,
-				id: undefined,
-				onblur: widget.listener,
-				onclick: widget.listener,
-				onfocus: widget.listener,
-				onkeydown: widget.listener,
-				onkeypress: widget.listener,
-				onkeyup: widget.listener,
-				onmousedown: widget.listener,
-				onmouseup: widget.listener,
-				ontouchstart: widget.listener,
-				ontouchend: widget.listener,
-				ontouchcancel: widget.listener,
-				type: undefined,
-				value: undefined
-			}, [
-				v('i', {
-					classes: [ css.addon, iconCss.icon, iconCss.downIcon ],
-					role: 'presentation',
-					'aria-hidden': 'true'
-				})
-			]));
+			widget.expectRender(
+				v(
+					'button',
+					{
+						'aria-controls': '',
+						'aria-describedby': undefined,
+						'aria-expanded': 'false',
+						'aria-haspopup': 'true',
+						'aria-pressed': null,
+						classes: [css.root, null, css.popup, null],
+						disabled: undefined,
+						name: undefined,
+						id: undefined,
+						onblur: widget.listener,
+						onclick: widget.listener,
+						onfocus: widget.listener,
+						onkeydown: widget.listener,
+						onkeypress: widget.listener,
+						onkeyup: widget.listener,
+						onmousedown: widget.listener,
+						onmouseup: widget.listener,
+						ontouchstart: widget.listener,
+						ontouchend: widget.listener,
+						ontouchcancel: widget.listener,
+						type: undefined,
+						value: undefined
+					},
+					[
+						v('i', {
+							classes: [css.addon, iconCss.icon, iconCss.downIcon],
+							role: 'presentation',
+							'aria-hidden': 'true'
+						})
+					]
+				)
+			);
 		},
 
 		events() {
@@ -146,14 +164,30 @@ registerSuite('Button', {
 			let mouseup = false;
 
 			widget.setProperties({
-				onBlur: () => { blurred = true; },
-				onClick: () => { clicked = true; },
-				onFocus: () => { focused = true; },
-				onKeyDown: () => { keydown = true; },
-				onKeyPress: () => { keypress = true; },
-				onKeyUp: () => { keyup = true; },
-				onMouseDown: () => { mousedown = true; },
-				onMouseUp: () => { mouseup = true; }
+				onBlur: () => {
+					blurred = true;
+				},
+				onClick: () => {
+					clicked = true;
+				},
+				onFocus: () => {
+					focused = true;
+				},
+				onKeyDown: () => {
+					keydown = true;
+				},
+				onKeyPress: () => {
+					keypress = true;
+				},
+				onKeyUp: () => {
+					keyup = true;
+				},
+				onMouseDown: () => {
+					mousedown = true;
+				},
+				onMouseUp: () => {
+					mouseup = true;
+				}
 			});
 
 			widget.sendEvent('blur');
@@ -184,9 +218,15 @@ registerSuite('Button', {
 			let touchcancel = false;
 
 			widget.setProperties({
-				onTouchStart: () => { touchstart = true; },
-				onTouchEnd: () => { touchend = true; },
-				onTouchCancel: () => { touchcancel = true; }
+				onTouchStart: () => {
+					touchstart = true;
+				},
+				onTouchEnd: () => {
+					touchend = true;
+				},
+				onTouchCancel: () => {
+					touchcancel = true;
+				}
 			});
 
 			widget.sendEvent('touchstart');

--- a/src/calendar/Calendar.ts
+++ b/src/calendar/Calendar.ts
@@ -31,40 +31,40 @@ import * as iconCss from '../common/styles/icons.m.css';
 export interface CalendarProperties extends ThemedProperties {
 	labels?: CalendarMessages;
 	month?: number;
-	monthNames?: { short: string; long: string; }[];
+	monthNames?: { short: string; long: string }[];
 	selectedDate?: Date;
-	weekdayNames?: { short: string; long: string; }[];
+	weekdayNames?: { short: string; long: string }[];
 	year?: number;
 	renderMonthLabel?(month: number, year: number): string;
-	renderWeekdayCell?(day: { short: string; long: string; }): DNode;
+	renderWeekdayCell?(day: { short: string; long: string }): DNode;
 	onMonthChange?(month: number): void;
 	onYearChange?(year: number): void;
 	onDateSelect?(date: Date): void;
 }
 
 export const DEFAULT_MONTHS = [
-	{short: 'Jan', long: 'January'},
-	{short: 'Feb', long: 'February'},
-	{short: 'Mar', long: 'March'},
-	{short: 'Apr', long: 'April'},
-	{short: 'May', long: 'May'},
-	{short: 'Jun', long: 'June'},
-	{short: 'Jul', long: 'July'},
-	{short: 'Aug', long: 'August'},
-	{short: 'Sep', long: 'September'},
-	{short: 'Oct', long: 'October'},
-	{short: 'Nov', long: 'November'},
-	{short: 'Dec', long: 'December'}
+	{ short: 'Jan', long: 'January' },
+	{ short: 'Feb', long: 'February' },
+	{ short: 'Mar', long: 'March' },
+	{ short: 'Apr', long: 'April' },
+	{ short: 'May', long: 'May' },
+	{ short: 'Jun', long: 'June' },
+	{ short: 'Jul', long: 'July' },
+	{ short: 'Aug', long: 'August' },
+	{ short: 'Sep', long: 'September' },
+	{ short: 'Oct', long: 'October' },
+	{ short: 'Nov', long: 'November' },
+	{ short: 'Dec', long: 'December' }
 ];
 
 export const DEFAULT_WEEKDAYS = [
-	{short: 'Sun', long: 'Sunday'},
-	{short: 'Mon', long: 'Monday'},
-	{short: 'Tue', long: 'Tuesday'},
-	{short: 'Wed', long: 'Wednesday'},
-	{short: 'Thu', long: 'Thursday'},
-	{short: 'Fri', long: 'Friday'},
-	{short: 'Sat', long: 'Saturday'}
+	{ short: 'Sun', long: 'Sunday' },
+	{ short: 'Mon', long: 'Monday' },
+	{ short: 'Tue', long: 'Tuesday' },
+	{ short: 'Wed', long: 'Wednesday' },
+	{ short: 'Thu', long: 'Thursday' },
+	{ short: 'Fri', long: 'Friday' },
+	{ short: 'Sat', long: 'Saturday' }
 ];
 
 export const DEFAULT_LABELS: CalendarMessages = {
@@ -91,11 +91,7 @@ export default class Calendar<P extends CalendarProperties = CalendarProperties>
 	}
 
 	private _getMonthYear() {
-		const {
-			month,
-			selectedDate = this._defaultDate,
-			year
-		} = this.properties;
+		const { month, selectedDate = this._defaultDate, year } = this.properties;
 		return {
 			month: typeof month === 'number' ? month : selectedDate.getMonth(),
 			year: typeof year === 'number' ? year : selectedDate.getFullYear()
@@ -103,18 +99,14 @@ export default class Calendar<P extends CalendarProperties = CalendarProperties>
 	}
 
 	private _goToDate(day: number) {
-		const {
-			month,
-			year
-		} = this._getMonthYear();
+		const { month, year } = this._getMonthYear();
 		const currentMonthLength = this._getMonthLength(month, year);
 		const previousMonthLength = this._getMonthLength(month - 1, year);
 
 		if (day < 1) {
 			this._onMonthDecrement();
 			day += previousMonthLength;
-		}
-		else if (day > currentMonthLength) {
+		} else if (day > currentMonthLength) {
 			this._onMonthIncrement();
 			day -= currentMonthLength;
 		}
@@ -131,8 +123,7 @@ export default class Calendar<P extends CalendarProperties = CalendarProperties>
 		if (disabled && date < 15) {
 			({ month, year } = this._onMonthIncrement());
 			this._callDateFocus = true;
-		}
-		else if (disabled && date >= 15) {
+		} else if (disabled && date >= 15) {
 			({ month, year } = this._onMonthDecrement());
 			this._callDateFocus = true;
 		}
@@ -180,14 +171,8 @@ export default class Calendar<P extends CalendarProperties = CalendarProperties>
 	}
 
 	private _onMonthDecrement() {
-		const {
-			month,
-			year
-		} = this._getMonthYear();
-		const {
-			onMonthChange,
-			onYearChange
-		} = this.properties;
+		const { month, year } = this._getMonthYear();
+		const { onMonthChange, onYearChange } = this.properties;
 
 		if (month === 0) {
 			onMonthChange && onMonthChange(11);
@@ -200,14 +185,8 @@ export default class Calendar<P extends CalendarProperties = CalendarProperties>
 	}
 
 	private _onMonthIncrement() {
-		const {
-			month,
-			year
-		} = this._getMonthYear();
-		const {
-			onMonthChange,
-			onYearChange
-		} = this.properties;
+		const { month, year } = this._getMonthYear();
+		const { onMonthChange, onYearChange } = this.properties;
 
 		if (month === 11) {
 			onMonthChange && onMonthChange(0);
@@ -228,10 +207,7 @@ export default class Calendar<P extends CalendarProperties = CalendarProperties>
 	}
 
 	private _renderDateGrid(selectedDate?: Date) {
-		const {
-			month,
-			year
-		} = this._getMonthYear();
+		const { month, year } = this._getMonthYear();
 
 		const currentMonthLength = this._getMonthLength(month, year);
 		const previousMonthLength = this._getMonthLength(month - 1, year);
@@ -256,13 +232,11 @@ export default class Calendar<P extends CalendarProperties = CalendarProperties>
 				if (date > dayIndex && date >= previousMonthLength) {
 					date = 1;
 					isCurrentMonth = true;
-				}
-				// if we've reached the end of the current month, reset to 1
-				else if (date <= dayIndex && date >= currentMonthLength) {
+				} else if (date <= dayIndex && date >= currentMonthLength) {
+					// if we've reached the end of the current month, reset to 1
 					date = 1;
 					isCurrentMonth = false;
-				}
-				else {
+				} else {
 					date++;
 				}
 				dayIndex++;
@@ -271,8 +245,7 @@ export default class Calendar<P extends CalendarProperties = CalendarProperties>
 				dateString = new Date(year, month, date).toDateString();
 				if (isCurrentMonth && selectedDate && dateString === selectedDate.toDateString()) {
 					isSelectedDay = true;
-				}
-				else {
+				} else {
 					isSelectedDay = false;
 				}
 
@@ -287,7 +260,13 @@ export default class Calendar<P extends CalendarProperties = CalendarProperties>
 		return weeks;
 	}
 
-	protected renderDateCell(date: number, index: number, selected: boolean, currentMonth: boolean, today: boolean): DNode {
+	protected renderDateCell(
+		date: number,
+		index: number,
+		selected: boolean,
+		currentMonth: boolean,
+		today: boolean
+	): DNode {
 		const { theme } = this.properties;
 
 		return w(CalendarCell, {
@@ -314,10 +293,7 @@ export default class Calendar<P extends CalendarProperties = CalendarProperties>
 			onMonthChange,
 			onYearChange
 		} = this.properties;
-		const {
-			month,
-			year
-		} = this._getMonthYear();
+		const { month, year } = this._getMonthYear();
 
 		return w(DatePicker, {
 			key: 'date-picker',
@@ -346,66 +322,80 @@ export default class Calendar<P extends CalendarProperties = CalendarProperties>
 		const labelText = type === Paging.next ? labels.nextMonth : labels.previousMonth;
 
 		return [
-			v('i', { classes: this.theme([ iconCss.icon, iconClass ]),
-				role: 'presentation', 'aria-hidden': 'true'
+			v('i', {
+				classes: this.theme([iconCss.icon, iconClass]),
+				role: 'presentation',
+				'aria-hidden': 'true'
 			}),
-			v('span', { classes: [ baseCss.visuallyHidden ] }, [ labelText ])
+			v('span', { classes: [baseCss.visuallyHidden] }, [labelText])
 		];
 	}
 
-	protected renderWeekdayCell(day: { short: string; long: string; }): DNode {
+	protected renderWeekdayCell(day: { short: string; long: string }): DNode {
 		const { renderWeekdayCell } = this.properties;
-		return renderWeekdayCell ? renderWeekdayCell(day) : v('abbr', { title: day.long }, [ day.short ]);
+		return renderWeekdayCell ? renderWeekdayCell(day) : v('abbr', { title: day.long }, [day.short]);
 	}
 
 	protected render(): DNode {
-		const {
-			selectedDate,
-			weekdayNames = DEFAULT_WEEKDAYS
-		} = this.properties;
+		const { selectedDate, weekdayNames = DEFAULT_WEEKDAYS } = this.properties;
 
 		// Calendar Weekday array
 		const weekdays = [];
 		for (const weekday in weekdayNames) {
-			weekdays.push(v('th', {
-				role: 'columnheader',
-				classes: this.theme(css.weekday)
-			}, [
-				this.renderWeekdayCell(weekdayNames[weekday])
-			]));
+			weekdays.push(
+				v(
+					'th',
+					{
+						role: 'columnheader',
+						classes: this.theme(css.weekday)
+					},
+					[this.renderWeekdayCell(weekdayNames[weekday])]
+				)
+			);
 		}
 
 		return v('div', { classes: this.theme(css.root) }, [
 			// header
 			this.renderDatePicker(),
 			// date table
-			v('table', {
-				cellspacing: '0',
-				cellpadding: '0',
-				role: 'grid',
-				'aria-labelledby': this._monthLabelId,
-				classes: [ this.theme(css.dateGrid), this._popupOpen ? baseCss.visuallyHidden : null ]
-			}, [
-				v('thead', [
-					v('tr', weekdays)
-				]),
-				v('tbody', this._renderDateGrid(selectedDate))
-			]),
+			v(
+				'table',
+				{
+					cellspacing: '0',
+					cellpadding: '0',
+					role: 'grid',
+					'aria-labelledby': this._monthLabelId,
+					classes: [this.theme(css.dateGrid), this._popupOpen ? baseCss.visuallyHidden : null]
+				},
+				[v('thead', [v('tr', weekdays)]), v('tbody', this._renderDateGrid(selectedDate))]
+			),
 			// controls
-			v('div', {
-				classes: [ this.theme(css.controls), this._popupOpen ? baseCss.visuallyHidden : null ]
-			}, [
-				v('button', {
-					classes: this.theme(css.previous),
-					tabIndex: this._popupOpen ? -1 : 0,
-					onclick: this._onMonthPageDown
-				}, this.renderPagingButtonContent(Paging.previous)),
-				v('button', {
-					classes: this.theme(css.next),
-					tabIndex: this._popupOpen ? -1 : 0,
-					onclick: this._onMonthPageUp
-				}, this.renderPagingButtonContent(Paging.next))
-			])
+			v(
+				'div',
+				{
+					classes: [this.theme(css.controls), this._popupOpen ? baseCss.visuallyHidden : null]
+				},
+				[
+					v(
+						'button',
+						{
+							classes: this.theme(css.previous),
+							tabIndex: this._popupOpen ? -1 : 0,
+							onclick: this._onMonthPageDown
+						},
+						this.renderPagingButtonContent(Paging.previous)
+					),
+					v(
+						'button',
+						{
+							classes: this.theme(css.next),
+							tabIndex: this._popupOpen ? -1 : 0,
+							onclick: this._onMonthPageUp
+						},
+						this.renderPagingButtonContent(Paging.next)
+					)
+				]
+			)
 		]);
 	}
 }

--- a/src/calendar/CalendarCell.ts
+++ b/src/calendar/CalendarCell.ts
@@ -29,12 +29,15 @@ export interface CalendarCellProperties extends ThemedProperties {
 	onClick?(date: number, disabled: boolean): void;
 	onFocusCalled?(): void;
 	onKeyDown?(event: KeyboardEvent): void;
-};
+}
 
 export const ThemedBase = ThemedMixin(WidgetBase);
 
 @theme(css)
-export default class CalendarCell<P extends CalendarCellProperties = CalendarCellProperties> extends ThemedBase<P, null> {
+export default class CalendarCell<P extends CalendarCellProperties = CalendarCellProperties> extends ThemedBase<
+	P,
+	null
+> {
 	protected onElementCreated(element: HTMLElement, key: string) {
 		this._callFocus(element);
 	}
@@ -62,38 +65,30 @@ export default class CalendarCell<P extends CalendarCellProperties = CalendarCel
 	}
 
 	protected formatDate(date: number): DNode {
-		return v('span', [ `${date}` ]);
+		return v('span', [`${date}`]);
 	}
 
 	protected getModifierClasses(): (string | null)[] {
-		const {
-			disabled = false,
-			selected = false,
-			today = false
-		} = this.properties;
+		const { disabled = false, selected = false, today = false } = this.properties;
 
-		return [
-			disabled ? css.inactiveDate : null,
-			selected ? css.selectedDate : null,
-			today ? css.todayDate : null
-		];
+		return [disabled ? css.inactiveDate : null, selected ? css.selectedDate : null, today ? css.todayDate : null];
 	}
 
 	protected render(): DNode {
-		const {
-			date,
-			focusable = false,
-			selected = false
-		} = this.properties;
+		const { date, focusable = false, selected = false } = this.properties;
 
-		return v('td', {
-			key: 'root',
-			role: 'gridcell',
-			'aria-selected': `${selected}`,
-			tabIndex: focusable ? 0 : -1,
-			classes: this.theme([ css.date, ...this.getModifierClasses() ]),
-			onclick: this._onClick,
-			onkeydown: this._onKeyDown
-		}, [ this.formatDate(date) ]);
+		return v(
+			'td',
+			{
+				key: 'root',
+				role: 'gridcell',
+				'aria-selected': `${selected}`,
+				tabIndex: focusable ? 0 : -1,
+				classes: this.theme([css.date, ...this.getModifierClasses()]),
+				onclick: this._onClick,
+				onkeydown: this._onKeyDown
+			},
+			[this.formatDate(date)]
+		);
 	}
 }

--- a/src/calendar/DatePicker.ts
+++ b/src/calendar/DatePicker.ts
@@ -61,7 +61,7 @@ export interface DatePickerProperties extends ThemedProperties {
 	labelId?: string;
 	labels: CalendarMessages;
 	month: number;
-	monthNames: { short: string; long: string; }[];
+	monthNames: { short: string; long: string }[];
 	year: number;
 	yearRange?: number;
 	renderMonthLabel?(month: number, year: number): string;
@@ -110,10 +110,9 @@ export default class DatePicker<P extends DatePickerProperties = DatePickerPrope
 		const { year, yearRange = 20 } = this.properties;
 		const offset = (year - BASE_YEAR) % yearRange - yearRange * this._yearPage;
 
-		if ( year >= BASE_YEAR) {
+		if (year >= BASE_YEAR) {
 			return { first: year - offset, last: year + yearRange - offset };
-		}
-		else {
+		} else {
 			return { first: year - (yearRange + offset), last: year - offset };
 		}
 	}
@@ -135,14 +134,14 @@ export default class DatePicker<P extends DatePickerProperties = DatePickerPrope
 		if (this._callMonthPopupFocus && key.indexOf(`${this._idBase}_month_radios`) > -1) {
 			const month = key.split('_')[3];
 			if (this._monthPopupOpen && month === `${this.properties.month}`) {
-				(<HTMLInputElement> element.children[0]).focus();
+				(<HTMLInputElement>element.children[0]).focus();
 				this._callMonthPopupFocus = false;
 			}
 		}
 		if (this._callYearPopupFocus && key.indexOf(`${this._idBase}_year_radios`) > -1) {
 			const year = key.split('_')[3];
 			if (this._yearPopupOpen && year === `${this.properties.year}`) {
-				(<HTMLInputElement> element.children[0]).focus();
+				(<HTMLInputElement>element.children[0]).focus();
 				this._callYearPopupFocus = false;
 			}
 		}
@@ -159,11 +158,7 @@ export default class DatePicker<P extends DatePickerProperties = DatePickerPrope
 
 	private _onPopupKeyDown(event: KeyboardEvent) {
 		// close popup on escape, or if a value is selected with enter/space
-		if (
-			event.which === Keys.Escape ||
-			event.which === Keys.Enter ||
-			event.which === Keys.Space
-		) {
+		if (event.which === Keys.Escape || event.which === Keys.Enter || event.which === Keys.Space) {
 			this._closeMonthPopup();
 			this._closeYearPopup();
 		}
@@ -208,29 +203,29 @@ export default class DatePicker<P extends DatePickerProperties = DatePickerPrope
 	}
 
 	protected renderControlsTrigger(type: Controls): DNode {
-		const {
-			month,
-			monthNames,
-			year
-		} = this.properties;
+		const { month, monthNames, year } = this.properties;
 
 		const content = type === Controls.month ? monthNames[month].long : `${year}`;
 		const open = type === Controls.month ? this._monthPopupOpen : this._yearPopupOpen;
 		const onclick = type === Controls.month ? this._onMonthButtonClick : this._onYearButtonClick;
 
-		return v('button', {
-			key: `${type}-button`,
-			'aria-controls': `${this._idBase}_${type}_dialog`,
-			'aria-expanded': `${open}`,
-			'aria-haspopup': 'true',
-			id: `${this._idBase}_${type}_button`,
-			classes: this.theme([
-				(css as any)[`${type}Trigger`],
-				open ? (css as any)[`${type}TriggerActive`] : null
-			]),
-			role: 'menuitem',
-			onclick
-		}, [ content ]);
+		return v(
+			'button',
+			{
+				key: `${type}-button`,
+				'aria-controls': `${this._idBase}_${type}_dialog`,
+				'aria-expanded': `${open}`,
+				'aria-haspopup': 'true',
+				id: `${this._idBase}_${type}_button`,
+				classes: this.theme([
+					(css as any)[`${type}Trigger`],
+					open ? (css as any)[`${type}TriggerActive`] : null
+				]),
+				role: 'menuitem',
+				onclick
+			},
+			[content]
+		);
 	}
 
 	protected renderMonthLabel(month: number, year: number): DNode {
@@ -241,25 +236,35 @@ export default class DatePicker<P extends DatePickerProperties = DatePickerPrope
 	protected renderMonthRadios(): DNode[] {
 		const { month } = this.properties;
 
-		return this.properties.monthNames.map((monthName, i) => v('label', {
-			key: `${this._idBase}_month_radios_${i}`,
-			classes: this.theme([ css.monthRadio, i === month ? css.monthRadioChecked : null ])
-		}, [
-			v('input', {
-				checked: i === month,
-				classes: this.theme(css.monthRadioInput),
-				name: `${this._idBase}_month_radios`,
-				tabIndex: this._monthPopupOpen ? 0 : -1,
-				type: 'radio',
-				value: `${i}`,
-				onchange: this._onMonthRadioChange,
-				onmouseup: this._closeMonthPopup
-			}),
-			v('abbr', {
-				classes: this.theme(css.monthRadioLabel),
-				title: monthName.long
-			}, [ monthName.short ])
-		]));
+		return this.properties.monthNames.map((monthName, i) =>
+			v(
+				'label',
+				{
+					key: `${this._idBase}_month_radios_${i}`,
+					classes: this.theme([css.monthRadio, i === month ? css.monthRadioChecked : null])
+				},
+				[
+					v('input', {
+						checked: i === month,
+						classes: this.theme(css.monthRadioInput),
+						name: `${this._idBase}_month_radios`,
+						tabIndex: this._monthPopupOpen ? 0 : -1,
+						type: 'radio',
+						value: `${i}`,
+						onchange: this._onMonthRadioChange,
+						onmouseup: this._closeMonthPopup
+					}),
+					v(
+						'abbr',
+						{
+							classes: this.theme(css.monthRadioLabel),
+							title: monthName.long
+						},
+						[monthName.short]
+					)
+				]
+			)
+		);
 	}
 
 	protected renderPagingButtonContent(type: Paging): DNode[] {
@@ -268,10 +273,12 @@ export default class DatePicker<P extends DatePickerProperties = DatePickerPrope
 		const labelText = type === Paging.next ? labels.nextMonth : labels.previousMonth;
 
 		return [
-			v('i', { classes: this.theme([ iconCss.icon, iconClass ]),
-				role: 'presentation', 'aria-hidden': 'true'
+			v('i', {
+				classes: this.theme([iconCss.icon, iconClass]),
+				role: 'presentation',
+				'aria-hidden': 'true'
 			}),
-			v('span', { classes: baseCss.visuallyHidden }, [ labelText ])
+			v('span', { classes: baseCss.visuallyHidden }, [labelText])
 		];
 	}
 
@@ -281,108 +288,153 @@ export default class DatePicker<P extends DatePickerProperties = DatePickerPrope
 
 		const yearLimits = this._getYearRange();
 		for (let i = yearLimits.first; i < yearLimits.last; i++) {
-			radios.push(v('label', {
-				key: `${this._idBase}_year_radios_${i}`,
-				classes: this.theme([ css.yearRadio, i === year ? css.yearRadioChecked : null ])
-			}, [
-				v('input', {
-					checked: i === year,
-					classes: this.theme(css.yearRadioInput),
-					name: `${this._idBase}_year_radios`,
-					tabIndex: this._yearPopupOpen ? 0 : -1,
-					type: 'radio',
-					value: `${i}`,
-					onchange: this._onYearRadioChange,
-					onmouseup: this._closeYearPopup
-				}),
-				v('abbr', {
-					classes: this.theme(css.yearRadioLabel)
-				}, [ `${ i }` ])
-			]));
+			radios.push(
+				v(
+					'label',
+					{
+						key: `${this._idBase}_year_radios_${i}`,
+						classes: this.theme([css.yearRadio, i === year ? css.yearRadioChecked : null])
+					},
+					[
+						v('input', {
+							checked: i === year,
+							classes: this.theme(css.yearRadioInput),
+							name: `${this._idBase}_year_radios`,
+							tabIndex: this._yearPopupOpen ? 0 : -1,
+							type: 'radio',
+							value: `${i}`,
+							onchange: this._onYearRadioChange,
+							onmouseup: this._closeYearPopup
+						}),
+						v(
+							'abbr',
+							{
+								classes: this.theme(css.yearRadioLabel)
+							},
+							[`${i}`]
+						)
+					]
+				)
+			);
 		}
 
 		return radios;
 	}
 
 	protected render(): DNode {
-		const {
-			labelId = `${this._idBase}_label`,
-			labels,
-			month,
-			year
-		} = this.properties;
+		const { labelId = `${this._idBase}_label`, labels, month, year } = this.properties;
 
-		return v('div', {
-			classes: this.theme(css.datePicker)
-		}, [
-			v('div', {
-				classes: this.theme(css.topMatter),
-				role: 'menubar'
-			}, [
-				// hidden label
-				v('label', {
-					id: labelId,
-					classes: [ baseCss.visuallyHidden ],
-					'aria-live': 'polite',
-					'aria-atomic': 'false'
-				}, [ this.renderMonthLabel(month, year) ]),
+		return v(
+			'div',
+			{
+				classes: this.theme(css.datePicker)
+			},
+			[
+				v(
+					'div',
+					{
+						classes: this.theme(css.topMatter),
+						role: 'menubar'
+					},
+					[
+						// hidden label
+						v(
+							'label',
+							{
+								id: labelId,
+								classes: [baseCss.visuallyHidden],
+								'aria-live': 'polite',
+								'aria-atomic': 'false'
+							},
+							[this.renderMonthLabel(month, year)]
+						),
 
-				// month trigger
-				this.renderControlsTrigger(Controls.month),
+						// month trigger
+						this.renderControlsTrigger(Controls.month),
 
-				// year trigger
-				this.renderControlsTrigger(Controls.year)
-			]),
+						// year trigger
+						this.renderControlsTrigger(Controls.year)
+					]
+				),
 
-			// month grid
-			v('div', {
-				key: 'month-grid',
-				'aria-hidden': `${!this._monthPopupOpen}`,
-				'aria-labelledby': `${this._idBase}_month_button`,
-				classes: [ this.theme(css.monthGrid), !this._monthPopupOpen ? baseCss.visuallyHidden : null ],
-				id: `${this._idBase}_month_dialog`,
-				role: 'dialog'
-			}, [
-				v('fieldset', {
-					classes: this.theme(css.monthFields),
-					onkeydown: this._onPopupKeyDown
-				}, [
-					v('legend', { classes: baseCss.visuallyHidden }, [ labels.chooseMonth ]),
-					...this.renderMonthRadios()
-				])
-			]),
+				// month grid
+				v(
+					'div',
+					{
+						key: 'month-grid',
+						'aria-hidden': `${!this._monthPopupOpen}`,
+						'aria-labelledby': `${this._idBase}_month_button`,
+						classes: [this.theme(css.monthGrid), !this._monthPopupOpen ? baseCss.visuallyHidden : null],
+						id: `${this._idBase}_month_dialog`,
+						role: 'dialog'
+					},
+					[
+						v(
+							'fieldset',
+							{
+								classes: this.theme(css.monthFields),
+								onkeydown: this._onPopupKeyDown
+							},
+							[
+								v('legend', { classes: baseCss.visuallyHidden }, [labels.chooseMonth]),
+								...this.renderMonthRadios()
+							]
+						)
+					]
+				),
 
-			// year grid
-			v('div', {
-				key: 'year-grid',
-				'aria-hidden': `${!this._yearPopupOpen}`,
-				'aria-labelledby': `${this._idBase}_year_button`,
-				classes: [ this.theme(css.yearGrid), !this._yearPopupOpen ? baseCss.visuallyHidden : null ],
-				id: `${this._idBase}_year_dialog`,
-				role: 'dialog'
-			}, [
-				v('fieldset', {
-					classes: this.theme(css.yearFields),
-					onkeydown: this._onPopupKeyDown
-				}, [
-					v('legend', { classes: [ baseCss.visuallyHidden ] }, [ labels.chooseYear ]),
-					...this.renderYearRadios()
-				]),
-				v('div', {
-					classes: this.theme(css.controls)
-				}, [
-					v('button', {
-						classes: this.theme(css.previous),
-						tabIndex: this._yearPopupOpen ? 0 : -1,
-						onclick: this._onYearPageDown
-					}, this.renderPagingButtonContent(Paging.previous)),
-					v('button', {
-						classes: this.theme(css.next),
-						tabIndex: this._yearPopupOpen ? 0 : -1,
-						onclick: this._onYearPageUp
-					}, this.renderPagingButtonContent(Paging.next))
-				])
-			])
-		]);
+				// year grid
+				v(
+					'div',
+					{
+						key: 'year-grid',
+						'aria-hidden': `${!this._yearPopupOpen}`,
+						'aria-labelledby': `${this._idBase}_year_button`,
+						classes: [this.theme(css.yearGrid), !this._yearPopupOpen ? baseCss.visuallyHidden : null],
+						id: `${this._idBase}_year_dialog`,
+						role: 'dialog'
+					},
+					[
+						v(
+							'fieldset',
+							{
+								classes: this.theme(css.yearFields),
+								onkeydown: this._onPopupKeyDown
+							},
+							[
+								v('legend', { classes: [baseCss.visuallyHidden] }, [labels.chooseYear]),
+								...this.renderYearRadios()
+							]
+						),
+						v(
+							'div',
+							{
+								classes: this.theme(css.controls)
+							},
+							[
+								v(
+									'button',
+									{
+										classes: this.theme(css.previous),
+										tabIndex: this._yearPopupOpen ? 0 : -1,
+										onclick: this._onYearPageDown
+									},
+									this.renderPagingButtonContent(Paging.previous)
+								),
+								v(
+									'button',
+									{
+										classes: this.theme(css.next),
+										tabIndex: this._yearPopupOpen ? 0 : -1,
+										onclick: this._onYearPageUp
+									},
+									this.renderPagingButtonContent(Paging.next)
+								)
+							]
+						)
+					]
+				)
+			]
+		);
 	}
 }

--- a/src/calendar/createCalendarElement.ts
+++ b/src/calendar/createCalendarElement.ts
@@ -11,16 +11,16 @@ export default function createCalendarElement(): CustomElementDescriptor {
 		attributes: [
 			{
 				attributeName: 'month',
-				value: value => value ? parseInt(value, 10) : undefined
+				value: (value) => (value ? parseInt(value, 10) : undefined)
 			},
 			{
 				attributeName: 'selecteddate',
 				propertyName: 'selectedDate',
-				value: value => value ? new Date(value) : undefined
+				value: (value) => (value ? new Date(value) : undefined)
 			},
 			{
 				attributeName: 'year',
-				value: value => value ? parseInt(value, 10) : undefined
+				value: (value) => (value ? parseInt(value, 10) : undefined)
 			}
 		],
 		properties: [
@@ -46,4 +46,4 @@ export default function createCalendarElement(): CustomElementDescriptor {
 			}
 		]
 	};
-};
+}

--- a/src/calendar/example/index.ts
+++ b/src/calendar/example/index.ts
@@ -42,7 +42,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					this.invalidate();
 				}
 			}),
-			this._selectedDate ? v('p', [ `Selected Date: ${this._selectedDate.toDateString()}` ]) : null
+			this._selectedDate ? v('p', [`Selected Date: ${this._selectedDate.toDateString()}`]) : null
 		]);
 	}
 }

--- a/src/calendar/tests/functional/Calendar.ts
+++ b/src/calendar/tests/functional/Calendar.ts
@@ -15,9 +15,9 @@ function openMonthPicker(remote: Remote) {
 		.get('http://localhost:9000/_build/common/example/?module=calendar')
 		.setFindTimeout(5000)
 		.findByCssSelector(`.${css.monthTrigger}`)
-			.click()
-			.sleep(DELAY)
-			.end();
+		.click()
+		.sleep(DELAY)
+		.end();
 }
 
 function openYearPicker(remote: Remote) {
@@ -25,9 +25,9 @@ function openYearPicker(remote: Remote) {
 		.get('http://localhost:9000/_build/common/example/?module=calendar')
 		.setFindTimeout(5000)
 		.findByCssSelector(`.${css.yearTrigger}`)
-			.click()
-			.sleep(DELAY)
-			.end();
+		.click()
+		.sleep(DELAY)
+		.end();
 }
 
 function clickDate(remote: Remote) {
@@ -35,59 +35,59 @@ function clickDate(remote: Remote) {
 		.get('http://localhost:9000/_build/common/example/?module=calendar')
 		.setFindTimeout(5000)
 		.findByCssSelector(`tbody > tr:first-child > td:nth-child(${firstDay + 1})`)
-			.click()
-			.sleep(DELAY)
-			.end();
+		.click()
+		.sleep(DELAY)
+		.end();
 }
 
 registerSuite('Calendar', {
 	'Open month picker'() {
 		return openMonthPicker(this.remote)
 			.findByCssSelector(`.${css.monthGrid}`)
-				.getAttribute('aria-hidden')
-				.then((hidden: string) => {
-					assert.strictEqual(hidden, 'false', 'The month dialog should open on first click');
-				})
-				.end()
+			.getAttribute('aria-hidden')
+			.then((hidden: string) => {
+				assert.strictEqual(hidden, 'false', 'The month dialog should open on first click');
+			})
+			.end()
 			.getActiveElement()
-				.getAttribute('value')
-				.then((value: string) => {
-					assert.strictEqual(value, `${today.getMonth()}`, 'focus moved to current month radio inside popup');
-				});
+			.getAttribute('value')
+			.then((value: string) => {
+				assert.strictEqual(value, `${today.getMonth()}`, 'focus moved to current month radio inside popup');
+			});
 	},
 
 	'Close month picker'() {
 		return openMonthPicker(this.remote)
 			.findByCssSelector(`.${css.monthTrigger}`)
-				.click()
-				.sleep(DELAY)
-				.end()
+			.click()
+			.sleep(DELAY)
+			.end()
 			.findByCssSelector(`.${css.monthGrid}`)
-				.getAttribute('aria-hidden')
-				.then((hidden: string) => {
-					assert.strictEqual(hidden, 'true', 'The month dialog should close on second click');
-				})
-				.end()
+			.getAttribute('aria-hidden')
+			.then((hidden: string) => {
+				assert.strictEqual(hidden, 'true', 'The month dialog should close on second click');
+			})
+			.end()
 			.getActiveElement()
-				.getAttribute('class')
-				.then((className: string) => {
-					assert.include(className, css.monthTrigger, 'focus moved to button');
-				});
+			.getAttribute('class')
+			.then((className: string) => {
+				assert.include(className, css.monthTrigger, 'focus moved to button');
+			});
 	},
 
 	'Open year picker'() {
 		return openYearPicker(this.remote)
 			.findByCssSelector(`.${css.yearGrid}`)
-				.getAttribute('aria-hidden')
-				.then((hidden: string) => {
-					assert.strictEqual(hidden, 'false', 'The month dialog should open on first click');
-				})
-				.end()
+			.getAttribute('aria-hidden')
+			.then((hidden: string) => {
+				assert.strictEqual(hidden, 'false', 'The month dialog should open on first click');
+			})
+			.end()
 			.getActiveElement()
-				.getAttribute('value')
-				.then((value: string) => {
-					assert.strictEqual(value, `${today.getFullYear()}`, 'focus moved to current year radio inside popup');
-				});
+			.getAttribute('value')
+			.then((value: string) => {
+				assert.strictEqual(value, `${today.getFullYear()}`, 'focus moved to current year radio inside popup');
+			});
 	},
 
 	'Clicking month radio selects month and closes popup'() {
@@ -98,36 +98,37 @@ registerSuite('Calendar', {
 
 		return openMonthPicker(this.remote)
 			.findByCssSelector('input[type=radio]')
-				.click()
-				.sleep(DELAY)
-				.end()
+			.click()
+			.sleep(DELAY)
+			.end()
 			.findByCssSelector(`.${css.monthTrigger}`)
-				.getVisibleText()
-				.then(label => {
-					assert.include(label, 'January', 'Clicking first month radio changes label text to January');
-				})
-				.end()
+			.getVisibleText()
+			.then((label) => {
+				assert.include(label, 'January', 'Clicking first month radio changes label text to January');
+			})
+			.end()
 			.findByCssSelector(`.${css.monthGrid}`)
-				.getAttribute('aria-hidden')
-				.then((hidden: string) => {
-					assert.strictEqual(hidden, 'true', 'Clicking month radio closes popup');
-				});
+			.getAttribute('aria-hidden')
+			.then((hidden: string) => {
+				assert.strictEqual(hidden, 'true', 'Clicking month radio closes popup');
+			});
 	},
 
 	'Correct dates are disabled'() {
-		const disabledDateSelector = firstDay === 0 ? 'tbody tr:last-child td:last-child' : `tbody tr:first-child td:nth-child(${firstDay})`;
+		const disabledDateSelector =
+			firstDay === 0 ? 'tbody tr:last-child td:last-child' : `tbody tr:first-child td:nth-child(${firstDay})`;
 		return clickDate(this.remote)
 			.findByCssSelector(`tbody tr:first-child td:nth-child(${firstDay + 1})`)
-				.getVisibleText()
-				.then(text => {
-					assert.strictEqual(text, '1', 'Month starts on correct day');
-				})
-				.end()
+			.getVisibleText()
+			.then((text) => {
+				assert.strictEqual(text, '1', 'Month starts on correct day');
+			})
+			.end()
 			.findByCssSelector(disabledDateSelector)
-				.getAttribute('class')
-				.then((className: string) => {
-					assert.include(className, css.inactiveDate, 'Disabled date has correct css class');
-				});
+			.getAttribute('class')
+			.then((className: string) => {
+				assert.include(className, css.inactiveDate, 'Disabled date has correct css class');
+			});
 	},
 
 	'Arrow keys move date focus'() {
@@ -141,88 +142,88 @@ registerSuite('Calendar', {
 
 		return clickDate(this.remote)
 			.findByCssSelector(`tbody tr:first-child td:nth-child(${firstDay + 1})`)
-				.pressKeys(keys.ARROW_RIGHT)
-				.end()
+			.pressKeys(keys.ARROW_RIGHT)
+			.end()
 			.sleep(DELAY)
 			.getActiveElement()
-				.getVisibleText()
-				.then(text => {
-					assert.strictEqual(text, '2', 'Right arrow moves active element to second day');
-				})
-				.end()
+			.getVisibleText()
+			.then((text) => {
+				assert.strictEqual(text, '2', 'Right arrow moves active element to second day');
+			})
+			.end()
 			.findByCssSelector(`tbody tr:first-child td:nth-child(${firstDay + 1})`)
-				.pressKeys(keys.ARROW_DOWN)
-				.end()
+			.pressKeys(keys.ARROW_DOWN)
+			.end()
 			.sleep(DELAY)
 			.getActiveElement()
-				.getVisibleText()
-				.then(text => {
-					assert.strictEqual(text, '9', 'Down arrow moves active element to next week');
-				})
-				.end()
+			.getVisibleText()
+			.then((text) => {
+				assert.strictEqual(text, '9', 'Down arrow moves active element to next week');
+			})
+			.end()
 			.findByCssSelector(`tbody tr:first-child td:nth-child(${firstDay + 1})`)
-				.pressKeys(keys.ARROW_LEFT)
-				.end()
+			.pressKeys(keys.ARROW_LEFT)
+			.end()
 			.sleep(DELAY)
 			.getActiveElement()
-				.getVisibleText()
-				.then(text => {
-					assert.strictEqual(text, '8', 'Left arrow moves active element to previous day');
-				})
-				.end()
+			.getVisibleText()
+			.then((text) => {
+				assert.strictEqual(text, '8', 'Left arrow moves active element to previous day');
+			})
+			.end()
 			.findByCssSelector(`tbody tr:first-child td:nth-child(${firstDay + 1})`)
-				.pressKeys(keys.ARROW_UP)
-				.end()
+			.pressKeys(keys.ARROW_UP)
+			.end()
 			.sleep(DELAY)
 			.getActiveElement()
-				.getVisibleText()
-				.then(text => {
-					assert.strictEqual(text, '1', 'Up arrow moves active element to previous week');
-				})
-				.end()
+			.getVisibleText()
+			.then((text) => {
+				assert.strictEqual(text, '1', 'Up arrow moves active element to previous week');
+			})
+			.end()
 			.findByCssSelector(`tbody tr:first-child td:nth-child(${firstDay + 1})`)
-				.pressKeys(keys.PAGE_DOWN)
-				.end()
+			.pressKeys(keys.PAGE_DOWN)
+			.end()
 			.sleep(DELAY)
 			.getActiveElement()
-				.getVisibleText()
-				.then(text => {
-					const today = new Date();
-					const monthLengh = new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate();
-					assert.strictEqual(text, `${monthLengh}`, 'Page down moves to last day');
-				})
-				.end()
+			.getVisibleText()
+			.then((text) => {
+				const today = new Date();
+				const monthLengh = new Date(today.getFullYear(), today.getMonth() + 1, 0).getDate();
+				assert.strictEqual(text, `${monthLengh}`, 'Page down moves to last day');
+			})
+			.end()
 			.findByCssSelector(`tbody tr:first-child td:nth-child(${firstDay + 1})`)
-				.pressKeys(keys.PAGE_UP)
-				.end()
+			.pressKeys(keys.PAGE_UP)
+			.end()
 			.sleep(DELAY)
 			.getActiveElement()
-				.getVisibleText()
-				.then(text => {
-					assert.strictEqual(text, '1', 'Page up moves to first day');
-				})
-				.end();
+			.getVisibleText()
+			.then((text) => {
+				assert.strictEqual(text, '1', 'Page up moves to first day');
+			})
+			.end();
 	},
 
 	'Clicking disabled date moves focus'() {
 		let clickedDate = '';
 		return clickDate(this.remote)
 			.findByCssSelector(`.${css.inactiveDate}`)
-				.getVisibleText()
-				.then(text => {
-					clickedDate = text;
-				})
-				.click()
-				.end()
+			.getVisibleText()
+			.then((text) => {
+				clickedDate = text;
+			})
+			.click()
+			.end()
 			.sleep(DELAY)
 			.getActiveElement()
-				.getVisibleText()
-				.then(text => {
-					assert.strictEqual(text, clickedDate, 'Clicked date has focus');
-				})
-				.getAttribute('class')
-				.then((className: string) => {
-					assert.include(className, css.selectedDate, 'Clicked date has selected class');
-				});
+			.getVisibleText()
+			.then((text) => {
+				assert.strictEqual(text, clickedDate, 'Clicked date has focus');
+			})
+			.getAttribute('class')
+			.then((className: string) => {
+				assert.include(className, css.selectedDate, 'Clicked date has selected class');
+			});
 	}
 });

--- a/src/calendar/tests/unit/Calendar.ts
+++ b/src/calendar/tests/unit/Calendar.ts
@@ -2,7 +2,13 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import harness, { Harness } from '@dojo/test-extras/harness';
-import { compareProperty, assignProperties, assignChildProperties, replaceChild, findKey } from '@dojo/test-extras/support/d';
+import {
+	compareProperty,
+	assignProperties,
+	assignChildProperties,
+	replaceChild,
+	findKey
+} from '@dojo/test-extras/support/d';
 import { v, w } from '@dojo/widget-core/d';
 import { Keys } from '../../../common/util';
 
@@ -43,7 +49,7 @@ const expected = function(widget: Harness<Calendar>, popupOpen = false) {
 	return v('div', { classes: css.root }, [
 		w(DatePicker, {
 			key: 'date-picker',
-			labelId: <any> compareId,
+			labelId: <any>compareId,
 			labels: DEFAULT_LABELS,
 			month: 5,
 			monthNames: DEFAULT_MONTHS,
@@ -54,103 +60,129 @@ const expected = function(widget: Harness<Calendar>, popupOpen = false) {
 			onRequestMonthChange: widget.listener,
 			onRequestYearChange: widget.listener
 		}),
-		v('table', {
-			cellspacing: '0',
-			cellpadding: '0',
-			role: 'grid',
-			'aria-labelledby': compareId, // this._monthLabelId,
-			classes: [ css.dateGrid, popupOpen ? baseCss.visuallyHidden : null ]
-		}, [
-			v('thead', [
-				v('tr', DEFAULT_WEEKDAYS.map((weekday: { short: string; long: string; }) => v('th', {
-						role: 'columnheader',
-						classes: css.weekday
-					}, [
-						v('abbr', { title: weekday.long }, [ weekday.short ])
+		v(
+			'table',
+			{
+				cellspacing: '0',
+				cellpadding: '0',
+				role: 'grid',
+				'aria-labelledby': compareId, // this._monthLabelId,
+				classes: [css.dateGrid, popupOpen ? baseCss.visuallyHidden : null]
+			},
+			[
+				v('thead', [
+					v(
+						'tr',
+						DEFAULT_WEEKDAYS.map((weekday: { short: string; long: string }) =>
+							v(
+								'th',
+								{
+									role: 'columnheader',
+									classes: css.weekday
+								},
+								[v('abbr', { title: weekday.long }, [weekday.short])]
+							)
+						)
+					)
+				]),
+				v('tbody', [
+					v('tr', [
+						expectedDateCell(widget, 28, false),
+						expectedDateCell(widget, 29, false),
+						expectedDateCell(widget, 30, false),
+						expectedDateCell(widget, 31, false),
+						expectedDateCell(widget, 1, true),
+						expectedDateCell(widget, 2, true),
+						expectedDateCell(widget, 3, true)
+					]),
+					v('tr', [
+						expectedDateCell(widget, 4, true),
+						expectedDateCell(widget, 5, true),
+						expectedDateCell(widget, 6, true),
+						expectedDateCell(widget, 7, true),
+						expectedDateCell(widget, 8, true),
+						expectedDateCell(widget, 9, true),
+						expectedDateCell(widget, 10, true)
+					]),
+					v('tr', [
+						expectedDateCell(widget, 11, true),
+						expectedDateCell(widget, 12, true),
+						expectedDateCell(widget, 13, true),
+						expectedDateCell(widget, 14, true),
+						expectedDateCell(widget, 15, true),
+						expectedDateCell(widget, 16, true),
+						expectedDateCell(widget, 17, true)
+					]),
+					v('tr', [
+						expectedDateCell(widget, 18, true),
+						expectedDateCell(widget, 19, true),
+						expectedDateCell(widget, 20, true),
+						expectedDateCell(widget, 21, true),
+						expectedDateCell(widget, 22, true),
+						expectedDateCell(widget, 23, true),
+						expectedDateCell(widget, 24, true)
+					]),
+					v('tr', [
+						expectedDateCell(widget, 25, true),
+						expectedDateCell(widget, 26, true),
+						expectedDateCell(widget, 27, true),
+						expectedDateCell(widget, 28, true),
+						expectedDateCell(widget, 29, true),
+						expectedDateCell(widget, 30, true),
+						expectedDateCell(widget, 1, false)
+					]),
+					v('tr', [
+						expectedDateCell(widget, 2, false),
+						expectedDateCell(widget, 3, false),
+						expectedDateCell(widget, 4, false),
+						expectedDateCell(widget, 5, false),
+						expectedDateCell(widget, 6, false),
+						expectedDateCell(widget, 7, false),
+						expectedDateCell(widget, 8, false)
 					])
-				))
-			]),
-			v('tbody', [
-				v('tr', [
-					expectedDateCell(widget, 28, false),
-					expectedDateCell(widget, 29, false),
-					expectedDateCell(widget, 30, false),
-					expectedDateCell(widget, 31, false),
-					expectedDateCell(widget, 1, true),
-					expectedDateCell(widget, 2, true),
-					expectedDateCell(widget, 3, true)
-				]),
-				v('tr', [
-					expectedDateCell(widget, 4, true),
-					expectedDateCell(widget, 5, true),
-					expectedDateCell(widget, 6, true),
-					expectedDateCell(widget, 7, true),
-					expectedDateCell(widget, 8, true),
-					expectedDateCell(widget, 9, true),
-					expectedDateCell(widget, 10, true)
-				]),
-				v('tr', [
-					expectedDateCell(widget, 11, true),
-					expectedDateCell(widget, 12, true),
-					expectedDateCell(widget, 13, true),
-					expectedDateCell(widget, 14, true),
-					expectedDateCell(widget, 15, true),
-					expectedDateCell(widget, 16, true),
-					expectedDateCell(widget, 17, true)
-				]),
-				v('tr', [
-					expectedDateCell(widget, 18, true),
-					expectedDateCell(widget, 19, true),
-					expectedDateCell(widget, 20, true),
-					expectedDateCell(widget, 21, true),
-					expectedDateCell(widget, 22, true),
-					expectedDateCell(widget, 23, true),
-					expectedDateCell(widget, 24, true)
-				]),
-				v('tr', [
-					expectedDateCell(widget, 25, true),
-					expectedDateCell(widget, 26, true),
-					expectedDateCell(widget, 27, true),
-					expectedDateCell(widget, 28, true),
-					expectedDateCell(widget, 29, true),
-					expectedDateCell(widget, 30, true),
-					expectedDateCell(widget, 1, false)
-				]),
-				v('tr', [
-					expectedDateCell(widget, 2, false),
-					expectedDateCell(widget, 3, false),
-					expectedDateCell(widget, 4, false),
-					expectedDateCell(widget, 5, false),
-					expectedDateCell(widget, 6, false),
-					expectedDateCell(widget, 7, false),
-					expectedDateCell(widget, 8, false)
 				])
-			])
-		]),
-		v('div', {
-			classes: [ css.controls, popupOpen ? baseCss.visuallyHidden : null ]
-		}, [
-			v('button', {
-				classes: css.previous,
-				tabIndex: popupOpen ? -1 : 0,
-				onclick: widget.listener
-			}, [
-				v('i', { classes: [ iconCss.icon, iconCss.leftIcon ],
-					role: 'presentation', 'aria-hidden': 'true'
-				}),
-				v('span', { classes: [ baseCss.visuallyHidden ] }, [ 'Previous Month' ])
-			]),
-			v('button', {
-				classes: css.next,
-				tabIndex: popupOpen ? -1 : 0,
-				onclick: widget.listener
-			}, [
-				v('i', { classes: [ iconCss.icon, iconCss.rightIcon ],
-					role: 'presentation', 'aria-hidden': 'true'
-				}),
-				v('span', { classes: [ baseCss.visuallyHidden ] }, [ 'Next Month' ])
-			])
-		])
+			]
+		),
+		v(
+			'div',
+			{
+				classes: [css.controls, popupOpen ? baseCss.visuallyHidden : null]
+			},
+			[
+				v(
+					'button',
+					{
+						classes: css.previous,
+						tabIndex: popupOpen ? -1 : 0,
+						onclick: widget.listener
+					},
+					[
+						v('i', {
+							classes: [iconCss.icon, iconCss.leftIcon],
+							role: 'presentation',
+							'aria-hidden': 'true'
+						}),
+						v('span', { classes: [baseCss.visuallyHidden] }, ['Previous Month'])
+					]
+				),
+				v(
+					'button',
+					{
+						classes: css.next,
+						tabIndex: popupOpen ? -1 : 0,
+						onclick: widget.listener
+					},
+					[
+						v('i', {
+							classes: [iconCss.icon, iconCss.rightIcon],
+							role: 'presentation',
+							'aria-hidden': 'true'
+						}),
+						v('span', { classes: [baseCss.visuallyHidden] }, ['Next Month'])
+					]
+				)
+			]
+		)
 	]);
 };
 
@@ -194,7 +226,7 @@ registerSuite('Calendar', {
 				weekdayNames: DEFAULT_WEEKDAYS,
 				year: testDate.getFullYear(),
 				renderMonthLabel: (month: number, year: number) => 'Foo',
-				renderWeekdayCell: (day: { short: string; long: string; }) => 'Bar'
+				renderWeekdayCell: (day: { short: string; long: string }) => 'Bar'
 			});
 
 			let expectedVdom = expected(widget);
@@ -282,10 +314,12 @@ registerSuite('Calendar', {
 
 			// right arrow, then select
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.Right,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.Right,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-4'
 			});
 			// not a good way to test this, but this would be called with the arrow key
@@ -293,10 +327,12 @@ registerSuite('Calendar', {
 				key: 'date-4'
 			});
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.Enter,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.Enter,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-5'
 			});
 			assert.strictEqual(selectedDate.getDate(), 2, 'Right arrow + enter selects second day');
@@ -304,17 +340,21 @@ registerSuite('Calendar', {
 
 			// down arrow
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.Down,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.Down,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-5'
 			});
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.Enter,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.Enter,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-12'
 			});
 			assert.strictEqual(selectedDate.getDate(), 9, 'Down arrow + enter selects one week down');
@@ -322,17 +362,21 @@ registerSuite('Calendar', {
 
 			// left arrow
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.Left,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.Left,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-12'
 			});
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.Space,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.Space,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-11'
 			});
 			assert.strictEqual(selectedDate.getDate(), 8, 'Left arrow + space selects previous day');
@@ -340,17 +384,21 @@ registerSuite('Calendar', {
 
 			// up arrow
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.Up,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.Up,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-11'
 			});
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.Space,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.Space,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-4'
 			});
 			assert.strictEqual(selectedDate.getDate(), 1, 'Left arrow + space selects previous day');
@@ -358,17 +406,21 @@ registerSuite('Calendar', {
 
 			// page down
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.PageDown,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.PageDown,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-4'
 			});
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.Space,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.Space,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-33'
 			});
 			assert.strictEqual(selectedDate.getDate(), 30, 'Page Down + space selects last day');
@@ -376,17 +428,21 @@ registerSuite('Calendar', {
 
 			// page up
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.PageUp,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.PageUp,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-33'
 			});
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.Space,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.Space,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-4'
 			});
 			assert.strictEqual(selectedDate.getDate(), 1, 'Page Up + space selects first day');
@@ -404,29 +460,43 @@ registerSuite('Calendar', {
 			});
 
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.Left,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.Left,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-4'
 			});
-			assert.strictEqual(currentMonth, testDate.getMonth() - 1, 'Going left from the first day goes to previous month');
+			assert.strictEqual(
+				currentMonth,
+				testDate.getMonth() - 1,
+				'Going left from the first day goes to previous month'
+			);
 
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.PageDown,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.PageDown,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-4'
 			});
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.Right,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.Right,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-4'
 			});
-			assert.strictEqual(currentMonth, testDate.getMonth() + 1, 'Going right from the last day goes to next month');
+			assert.strictEqual(
+				currentMonth,
+				testDate.getMonth() + 1,
+				'Going right from the last day goes to next month'
+			);
 		},
 
 		'Month changes wrap and change year'() {
@@ -444,10 +514,12 @@ registerSuite('Calendar', {
 			});
 
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.Up,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.Up,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-0'
 			});
 			assert.strictEqual(currentMonth, 11, 'Previous month wraps from January to December');
@@ -465,10 +537,12 @@ registerSuite('Calendar', {
 			});
 
 			widget.callListener('onKeyDown', {
-				args: [{
-					which: Keys.Down,
-					preventDefault: () => {}
-				}],
+				args: [
+					{
+						which: Keys.Down,
+						preventDefault: () => {}
+					}
+				],
 				key: 'date-35'
 			});
 			assert.strictEqual(currentMonth, 0, 'Next month wraps from December to January');

--- a/src/calendar/tests/unit/CalendarCell.ts
+++ b/src/calendar/tests/unit/CalendarCell.ts
@@ -24,17 +24,21 @@ registerSuite('CalendarCell', {
 				date: 1
 			});
 
-			widget.expectRender(v('td', {
-				key: 'root',
-				role: 'gridcell',
-				'aria-selected': 'false',
-				tabIndex: -1,
-				classes: [ css.date, null, null, null ],
-				onclick: widget.listener,
-				onkeydown: widget.listener
-			}, [
-				v('span', {}, [ '1' ])
-			]));
+			widget.expectRender(
+				v(
+					'td',
+					{
+						key: 'root',
+						role: 'gridcell',
+						'aria-selected': 'false',
+						tabIndex: -1,
+						classes: [css.date, null, null, null],
+						onclick: widget.listener,
+						onkeydown: widget.listener
+					},
+					[v('span', {}, ['1'])]
+				)
+			);
 		},
 
 		'Calendar cell with custom properties'() {
@@ -46,21 +50,26 @@ registerSuite('CalendarCell', {
 				today: true
 			});
 
-			widget.expectRender(v('td', {
-				key: 'root',
-				role: 'gridcell',
-				'aria-selected': 'true',
-				tabIndex: 0,
-				classes: [ css.date, css.inactiveDate, css.selectedDate, css.todayDate ],
-				onclick: widget.listener,
-				onkeydown: widget.listener
-			}, [
-				v('span', {}, [ '2' ])
-			]));
+			widget.expectRender(
+				v(
+					'td',
+					{
+						key: 'root',
+						role: 'gridcell',
+						'aria-selected': 'true',
+						tabIndex: 0,
+						classes: [css.date, css.inactiveDate, css.selectedDate, css.todayDate],
+						onclick: widget.listener,
+						onkeydown: widget.listener
+					},
+					[v('span', {}, ['2'])]
+				)
+			);
 		},
 
 		'Click handler called with correct arguments'() {
-			let clickedDate = 0, clickedDisabled = false;
+			let clickedDate = 0,
+				clickedDisabled = false;
 			widget.setProperties({
 				date: 1,
 				disabled: true,

--- a/src/calendar/tests/unit/DatePicker.ts
+++ b/src/calendar/tests/unit/DatePicker.ts
@@ -27,164 +27,246 @@ const compareId = compareProperty((value: any) => {
 });
 
 const monthRadios = function(widget: Harness<DatePicker>, open?: boolean) {
-	return DEFAULT_MONTHS.map((monthName, i) => v('label', {
-		key: <any> compareId,
-		classes: [ css.monthRadio, i === 5 ? css.monthRadioChecked : null ]
-	}, [
-		v('input', {
-			checked: i === 5,
-			classes: css.monthRadioInput,
-			name: <any> compareId,
-			tabIndex: open ? 0 : -1,
-			type: 'radio',
-			value: `${i}`,
-			onchange: widget.listener,
-			onmouseup: widget.listener
-		}),
-		v('abbr', {
-			classes: css.monthRadioLabel,
-			title: monthName.long
-		}, [ monthName.short ])
-	]));
+	return DEFAULT_MONTHS.map((monthName, i) =>
+		v(
+			'label',
+			{
+				key: <any>compareId,
+				classes: [css.monthRadio, i === 5 ? css.monthRadioChecked : null]
+			},
+			[
+				v('input', {
+					checked: i === 5,
+					classes: css.monthRadioInput,
+					name: <any>compareId,
+					tabIndex: open ? 0 : -1,
+					type: 'radio',
+					value: `${i}`,
+					onchange: widget.listener,
+					onmouseup: widget.listener
+				}),
+				v(
+					'abbr',
+					{
+						classes: css.monthRadioLabel,
+						title: monthName.long
+					},
+					[monthName.short]
+				)
+			]
+		)
+	);
 };
 
 const yearRadios = function(widget: Harness<DatePicker>, open?: boolean, yearStart = 2000, yearEnd = 2020) {
 	const radios = [];
 	for (let i = yearStart; i < yearEnd; i++) {
-		radios.push(v('label', {
-			key: <any> compareId,
-			classes: [ css.yearRadio, i === 2017 ? css.yearRadioChecked : null ]
-		}, [
-			v('input', {
-				checked: i === 2017,
-				classes: css.yearRadioInput,
-				name: <any> compareId,
-				tabIndex: open ? 0 : -1,
-				type: 'radio',
-				value: `${ i }`,
-				onchange: widget.listener,
-				onmouseup: widget.listener
-			}),
-			v('abbr', {
-				classes: css.yearRadioLabel
-			}, [ `${ i }` ])
-		]));
+		radios.push(
+			v(
+				'label',
+				{
+					key: <any>compareId,
+					classes: [css.yearRadio, i === 2017 ? css.yearRadioChecked : null]
+				},
+				[
+					v('input', {
+						checked: i === 2017,
+						classes: css.yearRadioInput,
+						name: <any>compareId,
+						tabIndex: open ? 0 : -1,
+						type: 'radio',
+						value: `${i}`,
+						onchange: widget.listener,
+						onmouseup: widget.listener
+					}),
+					v(
+						'abbr',
+						{
+							classes: css.yearRadioLabel
+						},
+						[`${i}`]
+					)
+				]
+			)
+		);
 	}
 	return radios;
 };
 
 const expectedMonthPopup = function(widget: Harness<DatePicker>, open: boolean) {
-	return v('div', {
-		key: 'month-grid',
-		'aria-hidden': `${!open}`,
-		'aria-labelledby': <any> compareId,
-		classes: [ css.monthGrid, !open ? baseCss.visuallyHidden : null ],
-		id: <any> compareId,
-		role: 'dialog'
-	}, [
-		v('fieldset', {
-			classes: css.monthFields,
-			onkeydown: widget.listener
-		}, [
-			v('legend', {
-				classes: baseCss.visuallyHidden
-			}, [ DEFAULT_LABELS.chooseMonth ]),
-			...monthRadios(widget, open)
-		])
-	]);
+	return v(
+		'div',
+		{
+			key: 'month-grid',
+			'aria-hidden': `${!open}`,
+			'aria-labelledby': <any>compareId,
+			classes: [css.monthGrid, !open ? baseCss.visuallyHidden : null],
+			id: <any>compareId,
+			role: 'dialog'
+		},
+		[
+			v(
+				'fieldset',
+				{
+					classes: css.monthFields,
+					onkeydown: widget.listener
+				},
+				[
+					v(
+						'legend',
+						{
+							classes: baseCss.visuallyHidden
+						},
+						[DEFAULT_LABELS.chooseMonth]
+					),
+					...monthRadios(widget, open)
+				]
+			)
+		]
+	);
 };
 
 const expectedYearPopup = function(widget: Harness<DatePicker>, open: boolean, yearStart?: number, yearEnd?: number) {
-	return v('div', {
-		key: 'year-grid',
-		'aria-hidden': `${!open}`,
-		'aria-labelledby': <any> compareId,
-		classes: [ css.yearGrid, !open ? baseCss.visuallyHidden : null ],
-		id: <any> compareId,
-		role: 'dialog'
-	}, [
-		v('fieldset', {
-			classes: css.yearFields,
-			onkeydown: widget.listener
-		}, [
-			v('legend', { classes: [ baseCss.visuallyHidden ] }, [ DEFAULT_LABELS.chooseYear ]),
-			...yearRadios(widget, open, yearStart, yearEnd)
-		]),
-		v('div', {
-			classes: css.controls
-		}, [
-			v('button', {
-				classes: css.previous,
-				tabIndex: open ? 0 : -1,
-				onclick: widget.listener
-			}, [
-				v('i', { classes: [ iconCss.icon, iconCss.leftIcon ],
-					role: 'presentation', 'aria-hidden': 'true'
-				}),
-				v('span', { classes: baseCss.visuallyHidden }, [ DEFAULT_LABELS.previousMonth ])
-			]),
-			v('button', {
-				classes: css.next,
-				tabIndex: open ? 0 : -1,
-				onclick: widget.listener
-			}, [
-				v('i', { classes: [ iconCss.icon, iconCss.rightIcon ],
-					role: 'presentation', 'aria-hidden': 'true'
-				}),
-				v('span', { classes: baseCss.visuallyHidden }, [ DEFAULT_LABELS.nextMonth ])
-			])
-		])
-	]);
+	return v(
+		'div',
+		{
+			key: 'year-grid',
+			'aria-hidden': `${!open}`,
+			'aria-labelledby': <any>compareId,
+			classes: [css.yearGrid, !open ? baseCss.visuallyHidden : null],
+			id: <any>compareId,
+			role: 'dialog'
+		},
+		[
+			v(
+				'fieldset',
+				{
+					classes: css.yearFields,
+					onkeydown: widget.listener
+				},
+				[
+					v('legend', { classes: [baseCss.visuallyHidden] }, [DEFAULT_LABELS.chooseYear]),
+					...yearRadios(widget, open, yearStart, yearEnd)
+				]
+			),
+			v(
+				'div',
+				{
+					classes: css.controls
+				},
+				[
+					v(
+						'button',
+						{
+							classes: css.previous,
+							tabIndex: open ? 0 : -1,
+							onclick: widget.listener
+						},
+						[
+							v('i', {
+								classes: [iconCss.icon, iconCss.leftIcon],
+								role: 'presentation',
+								'aria-hidden': 'true'
+							}),
+							v('span', { classes: baseCss.visuallyHidden }, [DEFAULT_LABELS.previousMonth])
+						]
+					),
+					v(
+						'button',
+						{
+							classes: css.next,
+							tabIndex: open ? 0 : -1,
+							onclick: widget.listener
+						},
+						[
+							v('i', {
+								classes: [iconCss.icon, iconCss.rightIcon],
+								role: 'presentation',
+								'aria-hidden': 'true'
+							}),
+							v('span', { classes: baseCss.visuallyHidden }, [DEFAULT_LABELS.nextMonth])
+						]
+					)
+				]
+			)
+		]
+	);
 };
 
-const expected = function(widget: Harness<DatePicker>, monthOpen = false, yearOpen = false, yearStart?: number, yearEnd?: number) {
+const expected = function(
+	widget: Harness<DatePicker>,
+	monthOpen = false,
+	yearOpen = false,
+	yearStart?: number,
+	yearEnd?: number
+) {
 	// new
-	return v('div', {
-		classes: css.datePicker
-	}, [
-		v('div', {
-			classes: css.topMatter,
-			role: 'menubar'
-		}, [
-			// hidden label
-			v('label', {
-				id: customProps.labelId ? customProps.labelId : <any> compareId,
-				classes: [ baseCss.visuallyHidden ],
-				'aria-live': 'polite',
-				'aria-atomic': 'false'
-			}, [ 'June 2017' ]),
+	return v(
+		'div',
+		{
+			classes: css.datePicker
+		},
+		[
+			v(
+				'div',
+				{
+					classes: css.topMatter,
+					role: 'menubar'
+				},
+				[
+					// hidden label
+					v(
+						'label',
+						{
+							id: customProps.labelId ? customProps.labelId : <any>compareId,
+							classes: [baseCss.visuallyHidden],
+							'aria-live': 'polite',
+							'aria-atomic': 'false'
+						},
+						['June 2017']
+					),
 
-			// month trigger
-			v('button', {
-				key: 'month-button',
-				'aria-controls': <any> compareId,
-				'aria-expanded': `${monthOpen}`,
-				'aria-haspopup': 'true',
-				id: <any> compareId,
-				classes: [ css.monthTrigger, monthOpen ? css.monthTriggerActive : null ],
-				role: 'menuitem',
-				onclick: widget.listener
-			}, [ 'June' ]),
+					// month trigger
+					v(
+						'button',
+						{
+							key: 'month-button',
+							'aria-controls': <any>compareId,
+							'aria-expanded': `${monthOpen}`,
+							'aria-haspopup': 'true',
+							id: <any>compareId,
+							classes: [css.monthTrigger, monthOpen ? css.monthTriggerActive : null],
+							role: 'menuitem',
+							onclick: widget.listener
+						},
+						['June']
+					),
 
-			// year trigger
-			v('button', {
-				key: 'year-button',
-				'aria-controls': <any> compareId,
-				'aria-expanded': `${yearOpen}`,
-				'aria-haspopup': 'true',
-				id: <any> compareId,
-				classes: [ css.yearTrigger, yearOpen ? css.yearTriggerActive : null ],
-				role: 'menuitem',
-				onclick: widget.listener
-			}, [ '2017' ])
-		]),
+					// year trigger
+					v(
+						'button',
+						{
+							key: 'year-button',
+							'aria-controls': <any>compareId,
+							'aria-expanded': `${yearOpen}`,
+							'aria-haspopup': 'true',
+							id: <any>compareId,
+							classes: [css.yearTrigger, yearOpen ? css.yearTriggerActive : null],
+							role: 'menuitem',
+							onclick: widget.listener
+						},
+						['2017']
+					)
+				]
+			),
 
-		// month picker
-		expectedMonthPopup(widget, monthOpen),
+			// month picker
+			expectedMonthPopup(widget, monthOpen),
 
-		// year picker
-		expectedYearPopup(widget, yearOpen, yearStart, yearEnd)
-	]);
+			// year picker
+			expectedYearPopup(widget, yearOpen, yearStart, yearEnd)
+		]
+	);
 };
 
 interface TestEventInit extends EventInit {
@@ -216,7 +298,9 @@ registerSuite('Calendar DatePicker', {
 				yearRange: 25
 			};
 			widget.setProperties({
-				renderMonthLabel: () => { return 'bar'; },
+				renderMonthLabel: () => {
+					return 'bar';
+				},
 				...customProps,
 				...requiredProps
 			});
@@ -243,7 +327,7 @@ registerSuite('Calendar DatePicker', {
 			const yearGridVdom = findKey(expectedVdom, 'year-grid');
 			replaceChild(expectedVdom, '0,0,0', 'June 1997');
 			replaceChild(expectedVdom, '0,2,0', '1997');
-			assignChildProperties(yearGridVdom!, '0,18', { classes: [ css.yearRadio, css.yearRadioChecked ] });
+			assignChildProperties(yearGridVdom!, '0,18', { classes: [css.yearRadio, css.yearRadioChecked] });
 			assignChildProperties(yearGridVdom!, '0,18,0', { checked: true });
 			widget.expectRender(expectedVdom);
 		},
@@ -251,7 +335,9 @@ registerSuite('Calendar DatePicker', {
 		'Month popup opens and closes on button click'() {
 			let isOpen;
 			widget.setProperties({
-				onPopupChange: open => { isOpen = open; },
+				onPopupChange: (open) => {
+					isOpen = open;
+				},
 				...requiredProps
 			});
 
@@ -269,7 +355,9 @@ registerSuite('Calendar DatePicker', {
 		'Year popup opens and closes on button click'() {
 			let isOpen;
 			widget.setProperties({
-				onPopupChange: open => { isOpen = open; },
+				onPopupChange: (open) => {
+					isOpen = open;
+				},
 				...requiredProps
 			});
 
@@ -288,7 +376,9 @@ registerSuite('Calendar DatePicker', {
 			let isOpen;
 			let expectedVdom = expected(widget, false, false);
 			widget.setProperties({
-				onPopupChange: open => { isOpen = open; },
+				onPopupChange: (open) => {
+					isOpen = open;
+				},
 				...requiredProps
 			});
 			widget.expectRender(expectedVdom);
@@ -312,7 +402,9 @@ registerSuite('Calendar DatePicker', {
 			let isOpen;
 			let expectedVdom = expected(widget, false, false);
 			widget.setProperties({
-				onPopupChange: open => { isOpen = open; },
+				onPopupChange: (open) => {
+					isOpen = open;
+				},
 				...requiredProps
 			});
 			widget.expectRender(expectedVdom);
@@ -361,7 +453,7 @@ registerSuite('Calendar DatePicker', {
 			});
 			expectedVdom = expected(widget, true, false);
 			widget.expectRender(expectedVdom);
-			assert.isTrue(isOpen, 'Other keys don\'t close popup');
+			assert.isTrue(isOpen, "Other keys don't close popup");
 		},
 
 		'year popup closes with correct keys'() {
@@ -369,7 +461,9 @@ registerSuite('Calendar DatePicker', {
 			let expectedVdom = expected(widget, false, false);
 			expectedVdom = expected(widget, false, false);
 			widget.setProperties({
-				onPopupChange: open => { isOpen = open; },
+				onPopupChange: (open) => {
+					isOpen = open;
+				},
 				...requiredProps
 			});
 
@@ -416,7 +510,7 @@ registerSuite('Calendar DatePicker', {
 			});
 			expectedVdom = expected(widget, false, true);
 			widget.expectRender(expectedVdom);
-			assert.isTrue(isOpen, 'Other keys don\'t close popup');
+			assert.isTrue(isOpen, "Other keys don't close popup");
 		},
 
 		'Clicking buttons changes year page'() {
@@ -444,8 +538,12 @@ registerSuite('Calendar DatePicker', {
 			let isOpen = false;
 			widget.setProperties({
 				...requiredProps,
-				onPopupChange: (open: boolean) => { isOpen = open; },
-				onRequestMonthChange: (month: number) => { currentMonth = month; }
+				onPopupChange: (open: boolean) => {
+					isOpen = open;
+				},
+				onRequestMonthChange: (month: number) => {
+					currentMonth = month;
+				}
 			});
 
 			widget.sendEvent('click', { key: 'month-button' });
@@ -467,8 +565,12 @@ registerSuite('Calendar DatePicker', {
 			let isOpen = false;
 			widget.setProperties({
 				...requiredProps,
-				onPopupChange: (open: boolean) => { isOpen = open; },
-				onRequestYearChange: (year: number) => { currentYear = year; }
+				onPopupChange: (open: boolean) => {
+					isOpen = open;
+				},
+				onRequestYearChange: (year: number) => {
+					currentYear = year;
+				}
 			});
 
 			widget.sendEvent('click', { key: 'year-button' });

--- a/src/checkbox/Checkbox.ts
+++ b/src/checkbox/Checkbox.ts
@@ -2,7 +2,13 @@ import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { DNode } from '@dojo/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import Label from '../label/Label';
-import { LabeledProperties, InputProperties, InputEventProperties, KeyEventProperties, PointerEventProperties } from '../common/interfaces';
+import {
+	LabeledProperties,
+	InputProperties,
+	InputEventProperties,
+	KeyEventProperties,
+	PointerEventProperties
+} from '../common/interfaces';
 import { v, w } from '@dojo/widget-core/d';
 import uuid from '@dojo/core/uuid';
 import * as css from './styles/checkbox.m.css';
@@ -18,7 +24,13 @@ import * as css from './styles/checkbox.m.css';
  * @property onLabel        Label to show in the "on" positin of a toggle
  * @property value           The current value
  */
-export interface CheckboxProperties extends ThemedProperties, InputProperties, LabeledProperties, InputEventProperties, KeyEventProperties, PointerEventProperties {
+export interface CheckboxProperties
+	extends ThemedProperties,
+		InputProperties,
+		LabeledProperties,
+		InputEventProperties,
+		KeyEventProperties,
+		PointerEventProperties {
 	checked?: boolean;
 	mode?: Mode;
 	offLabel?: DNode;
@@ -32,42 +44,49 @@ export interface CheckboxProperties extends ThemedProperties, InputProperties, L
 export const enum Mode {
 	normal,
 	toggle
-};
+}
 
 export const ThemedBase = ThemedMixin(WidgetBase);
 
 @theme(css)
 export default class Checkbox<P extends CheckboxProperties = CheckboxProperties> extends ThemedBase<P, null> {
 	private _focused = false;
-	private _onBlur (event: FocusEvent) {
+	private _onBlur(event: FocusEvent) {
 		this._focused = false;
 		this.properties.onBlur && this.properties.onBlur(event);
 		this.invalidate();
 	}
-	private _onChange (event: Event) { this.properties.onChange && this.properties.onChange(event); }
-	private _onClick (event: MouseEvent) { this.properties.onClick && this.properties.onClick(event); }
-	private _onFocus (event: FocusEvent) {
+	private _onChange(event: Event) {
+		this.properties.onChange && this.properties.onChange(event);
+	}
+	private _onClick(event: MouseEvent) {
+		this.properties.onClick && this.properties.onClick(event);
+	}
+	private _onFocus(event: FocusEvent) {
 		this._focused = true;
 		this.properties.onFocus && this.properties.onFocus(event);
 		this.invalidate();
 	}
-	private _onMouseDown (event: MouseEvent) { this.properties.onMouseDown && this.properties.onMouseDown(event); }
-	private _onMouseUp (event: MouseEvent) { this.properties.onMouseUp && this.properties.onMouseUp(event); }
-	private _onTouchStart (event: TouchEvent) { this.properties.onTouchStart && this.properties.onTouchStart(event); }
-	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
-	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
+	private _onMouseDown(event: MouseEvent) {
+		this.properties.onMouseDown && this.properties.onMouseDown(event);
+	}
+	private _onMouseUp(event: MouseEvent) {
+		this.properties.onMouseUp && this.properties.onMouseUp(event);
+	}
+	private _onTouchStart(event: TouchEvent) {
+		this.properties.onTouchStart && this.properties.onTouchStart(event);
+	}
+	private _onTouchEnd(event: TouchEvent) {
+		this.properties.onTouchEnd && this.properties.onTouchEnd(event);
+	}
+	private _onTouchCancel(event: TouchEvent) {
+		this.properties.onTouchCancel && this.properties.onTouchCancel(event);
+	}
 
 	private _uuid = uuid();
 
 	protected getRootClasses(): (string | null)[] {
-		const {
-			checked = false,
-			disabled,
-			invalid,
-			mode,
-			readOnly,
-			required
-		} = this.properties;
+		const { checked = false, disabled, invalid, mode, readOnly, required } = this.properties;
 
 		return [
 			css.root,
@@ -83,29 +102,38 @@ export default class Checkbox<P extends CheckboxProperties = CheckboxProperties>
 	}
 
 	protected renderToggle(): DNode[] {
-		const {
-			checked,
-			mode,
-			onLabel,
-			offLabel
-		} = this.properties;
+		const { checked, mode, onLabel, offLabel } = this.properties;
 
-		return mode === Mode.toggle ? [
-			offLabel ? v('div', {
-				key: 'offLabel',
-				classes: this.theme(css.offLabel),
-				'aria-hidden': checked ? 'true' : null
-			}, [ offLabel ]) : null,
-			v('div', {
-				key: 'toggle',
-				classes: this.theme(css.toggleSwitch)
-			}),
-			onLabel ? v('div', {
-				key: 'onLabel',
-				classes: this.theme(css.onLabel),
-				'aria-hidden': checked ? null : 'true'
-			}, [ onLabel ]) : null
-		] : [];
+		return mode === Mode.toggle
+			? [
+					offLabel
+						? v(
+								'div',
+								{
+									key: 'offLabel',
+									classes: this.theme(css.offLabel),
+									'aria-hidden': checked ? 'true' : null
+								},
+								[offLabel]
+							)
+						: null,
+					v('div', {
+						key: 'toggle',
+						classes: this.theme(css.toggleSwitch)
+					}),
+					onLabel
+						? v(
+								'div',
+								{
+									key: 'onLabel',
+									classes: this.theme(css.onLabel),
+									'aria-hidden': checked ? null : 'true'
+								},
+								[onLabel]
+							)
+						: null
+				]
+			: [];
 	}
 
 	protected render(): DNode {
@@ -151,21 +179,31 @@ export default class Checkbox<P extends CheckboxProperties = CheckboxProperties>
 					ontouchcancel: this._onTouchCancel
 				})
 			]),
-			label ? w(Label, {
-				theme,
-				disabled,
-				invalid,
-				readOnly,
-				required,
-				hidden: labelHidden,
-				forId: this._uuid,
-				secondary: true
-			}, [ label ]) : null
+			label
+				? w(
+						Label,
+						{
+							theme,
+							disabled,
+							invalid,
+							readOnly,
+							required,
+							hidden: labelHidden,
+							forId: this._uuid,
+							secondary: true
+						},
+						[label]
+					)
+				: null
 		];
 
-		return v('div', {
-			key: 'root',
-			classes: this.theme(this.getRootClasses())
-		}, labelAfter ? children : children.reverse());
+		return v(
+			'div',
+			{
+				key: 'root',
+				classes: this.theme(this.getRootClasses())
+			},
+			labelAfter ? children : children.reverse()
+		);
 	}
 }

--- a/src/checkbox/example/index.ts
+++ b/src/checkbox/example/index.ts
@@ -29,13 +29,7 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render() {
-		const {
-			c1 = true,
-			c2 = false,
-			c3 = false,
-			c4 = false,
-			c5 = true
-		} = this._checkboxStates;
+		const { c1 = true, c2 = false, c3 = false, c4 = false, c5 = true } = this._checkboxStates;
 
 		return v('div', [
 			v('h2', {

--- a/src/checkbox/tests/functional/Checkbox.ts
+++ b/src/checkbox/tests/functional/Checkbox.ts
@@ -5,9 +5,7 @@ import { Remote } from 'intern/lib/executors/Node';
 import * as css from '../../styles/checkbox.m.css';
 
 function getPage(remote: Remote) {
-	return remote
-		.get('http://localhost:9000/_build/common/example/?module=checkbox')
-		.setFindTimeout(5000);
+	return remote.get('http://localhost:9000/_build/common/example/?module=checkbox').setFindTimeout(5000);
 }
 
 function nthCheckbox(n: number) {
@@ -29,17 +27,16 @@ registerSuite('Checkbox', {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-1 .${css.root}`)
 			.getVisibleText()
-			.then(text => {
+			.then((text) => {
 				assert.strictEqual(text, 'Sample checkbox that starts checked');
 			})
 			.end();
-
 	},
 	'checkbox should be disabled'() {
 		return getPage(this.remote)
 			.findByCssSelector(nthCheckbox(2))
 			.isEnabled()
-			.then(enabled => {
+			.then((enabled) => {
 				assert.isTrue(!enabled, 'The checkbox should be disabled.');
 			})
 			.end();
@@ -57,17 +54,17 @@ registerSuite('Checkbox', {
 		return getPage(this.remote)
 			.findByCssSelector(nthCheckbox(1))
 			.isSelected()
-			.then(checked => {
+			.then((checked) => {
 				assert.isTrue(checked, 'Initial state should be true');
 			})
 			.click()
 			.isSelected()
-			.then(checked => {
+			.then((checked) => {
 				assert.isFalse(checked);
 			})
 			.click()
 			.isSelected()
-			.then(checked => {
+			.then((checked) => {
 				assert.isTrue(checked);
 			})
 			.end();
@@ -76,36 +73,38 @@ registerSuite('Checkbox', {
 		return getPage(this.remote)
 			.findByCssSelector(nthCheckbox(4))
 			.isSelected()
-			.then(checked => {
+			.then((checked) => {
 				assert.isFalse(checked, 'Initial state should be false');
 			})
 			.click()
 			.isSelected()
-			.then(checked => {
+			.then((checked) => {
 				assert.isTrue(checked);
 			})
 			.click()
 			.isSelected()
-			.then(checked => {
+			.then((checked) => {
 				assert.isFalse(checked);
 			})
 			.end();
 	},
 
 	'disabled checkbox should not be toggle-able'() {
-		return getPage(this.remote)
-			.findByCssSelector(nthCheckbox(2))
-			.isSelected()
-			.then(checked => {
-				assert.isFalse(checked, 'Initial state should be false');
-			})
-			.click()
-		// the error callback is needed only in FireFox with Firefox Driver. See: https://github.com/dojo/meta/issues/182
-			.then(undefined, (err: Error) => {})
-			.isSelected()
-			.then(checked => {
-				assert.isFalse(checked);
-			})
-			.end();
+		return (
+			getPage(this.remote)
+				.findByCssSelector(nthCheckbox(2))
+				.isSelected()
+				.then((checked) => {
+					assert.isFalse(checked, 'Initial state should be false');
+				})
+				.click()
+				// the error callback is needed only in FireFox with Firefox Driver. See: https://github.com/dojo/meta/issues/182
+				.then(undefined, (err: Error) => {})
+				.isSelected()
+				.then((checked) => {
+					assert.isFalse(checked);
+				})
+				.end()
+		);
 	}
 });

--- a/src/checkbox/tests/unit/Checkbox.ts
+++ b/src/checkbox/tests/unit/Checkbox.ts
@@ -19,20 +19,28 @@ const compareId = compareProperty((value: any) => {
 const expectedToggle = function(widget: Harness<Checkbox>, labels = false) {
 	if (labels) {
 		return [
-			v('div', {
-				key: 'offLabel',
-				classes: css.offLabel,
-				'aria-hidden': null
-			}, [ 'off' ]),
+			v(
+				'div',
+				{
+					key: 'offLabel',
+					classes: css.offLabel,
+					'aria-hidden': null
+				},
+				['off']
+			),
 			v('div', {
 				key: 'toggle',
 				classes: css.toggleSwitch
 			}),
-			v('div', {
-				key: 'onLabel',
-				classes: css.onLabel,
-				'aria-hidden': 'true'
-			}, [ 'on' ])
+			v(
+				'div',
+				{
+					key: 'onLabel',
+					classes: css.onLabel,
+					'aria-hidden': 'true'
+				},
+				['on']
+			)
 		];
 	}
 
@@ -51,7 +59,7 @@ const expected = function(widget: Harness<Checkbox>, label = false, toggle = fal
 		v('div', { classes: css.inputWrapper }, [
 			...(toggle ? expectedToggle(widget, toggleLabels) : []),
 			v('input', {
-				id: <any> compareId,
+				id: <any>compareId,
 				classes: css.input,
 				checked: false,
 				'aria-describedby': undefined,
@@ -74,22 +82,32 @@ const expected = function(widget: Harness<Checkbox>, label = false, toggle = fal
 				ontouchcancel: widget.listener
 			})
 		]),
-		label ? w(Label, {
-			theme: undefined,
-			disabled: undefined,
-			hidden: undefined,
-			invalid: undefined,
-			readOnly: undefined,
-			required: undefined,
-			forId: <any> compareId,
-			secondary: true
-		}, [ 'foo' ]) : null
+		label
+			? w(
+					Label,
+					{
+						theme: undefined,
+						disabled: undefined,
+						hidden: undefined,
+						invalid: undefined,
+						readOnly: undefined,
+						required: undefined,
+						forId: <any>compareId,
+						secondary: true
+					},
+					['foo']
+				)
+			: null
 	];
 
-	return v('div', {
-		key: 'root',
-		classes: [ css.root, null, null, null, null, null, null, null, null ]
-	}, children);
+	return v(
+		'div',
+		{
+			key: 'root',
+			classes: [css.root, null, null, null, null, null, null, null, null]
+		},
+		children
+	);
 };
 
 let widget: Harness<Checkbox>;
@@ -124,13 +142,13 @@ registerSuite('Checkbox', {
 				value: 'baz'
 			});
 			assignProperties(expectedVdom, {
-				classes: [ css.root, null, css.checked, null, null, null, null, null, null ]
+				classes: [css.root, null, css.checked, null, null, null, null, null, null]
 			});
 
 			widget.expectRender(expectedVdom);
 		},
 
-		'label'() {
+		label() {
 			widget.setProperties({
 				label: 'foo'
 			});
@@ -155,7 +173,7 @@ registerSuite('Checkbox', {
 				required: true
 			});
 			assignProperties(expectedVdom, {
-				classes: [ css.root, null, null, css.disabled, null, css.invalid, null, css.readonly, css.required ]
+				classes: [css.root, null, null, css.disabled, null, css.invalid, null, css.readonly, css.required]
 			});
 
 			widget.expectRender(expectedVdom, 'Widget should be invalid, disabled, read-only, and required');
@@ -174,7 +192,7 @@ registerSuite('Checkbox', {
 				required: false
 			});
 			assignProperties(expectedVdom, {
-				classes: [ css.root, null, null, null, null, null, css.valid, null, null ]
+				classes: [css.root, null, null, null, null, null, css.valid, null, null]
 			});
 
 			widget.expectRender(expectedVdom, 'State classes should be false, css.valid should be true');
@@ -206,17 +224,7 @@ registerSuite('Checkbox', {
 			});
 
 			assignProperties(expectedVdom, {
-				classes: [
-					css.root,
-					null,
-					null,
-					css.disabled,
-					null,
-					css.invalid,
-					null,
-					css.readonly,
-					css.required
-				]
+				classes: [css.root, null, null, css.disabled, null, css.invalid, null, css.readonly, css.required]
 			});
 
 			widget.expectRender(expectedVdom);
@@ -229,7 +237,7 @@ registerSuite('Checkbox', {
 			widget.sendEvent('focus', { selector: 'input' });
 			expectedVdom = expected(widget);
 			assignProperties(expectedVdom, {
-				classes: [ css.root, null, null, null, css.focused, null, null, null, null ]
+				classes: [css.root, null, null, null, css.focused, null, null, null, null]
 			});
 			widget.expectRender(expectedVdom, 'Should have focused class after focus event');
 
@@ -244,7 +252,7 @@ registerSuite('Checkbox', {
 			});
 			let expectedVdom = expected(widget, false, true);
 			assignProperties(expectedVdom, {
-				classes: [ css.root, css.toggle, null, null, null, null, null, null, null ]
+				classes: [css.root, css.toggle, null, null, null, null, null, null, null]
 			});
 			widget.expectRender(expectedVdom, 'Toggle input without toggle labels');
 
@@ -255,7 +263,7 @@ registerSuite('Checkbox', {
 			});
 			expectedVdom = expected(widget, false, true, true);
 			assignProperties(expectedVdom, {
-				classes: [ css.root, css.toggle, null, null, null, null, null, null, null ]
+				classes: [css.root, css.toggle, null, null, null, null, null, null, null]
 			});
 			widget.expectRender(expectedVdom, 'Toggle input with toggle labels');
 
@@ -267,7 +275,7 @@ registerSuite('Checkbox', {
 			});
 			expectedVdom = expected(widget, false, true, true);
 			assignProperties(expectedVdom, {
-				classes: [ css.root, css.toggle, css.checked, null, null, null, null, null, null ]
+				classes: [css.root, css.toggle, css.checked, null, null, null, null, null, null]
 			});
 			assignChildProperties(expectedVdom, '0,3', {
 				checked: true

--- a/src/combobox/ComboBox.ts
+++ b/src/combobox/ComboBox.ts
@@ -99,10 +99,7 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 	}
 
 	private _onArrowClick() {
-		const {
-			disabled,
-			readOnly
-		} = this.properties;
+		const { disabled, readOnly } = this.properties;
 
 		if (!disabled && !readOnly) {
 			this._callInputFocus = true;
@@ -121,7 +118,7 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 	private _onInput(event: Event) {
 		const { key, onChange } = this.properties;
 
-		onChange && onChange((<HTMLInputElement> event.target).value, key);
+		onChange && onChange((<HTMLInputElement>event.target).value, key);
 		this._openMenu();
 	}
 
@@ -133,28 +130,19 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 			return;
 		}
 
-		onBlur && onBlur((<HTMLInputElement> event.target).value, key);
+		onBlur && onBlur((<HTMLInputElement>event.target).value, key);
 		this._closeMenu();
 	}
 
 	private _onInputFocus(event: FocusEvent) {
-		const {
-			key,
-			onFocus,
-			openOnFocus
-		} = this.properties;
+		const { key, onFocus, openOnFocus } = this.properties;
 
-		onFocus && onFocus((<HTMLInputElement> event.target).value, key);
+		onFocus && onFocus((<HTMLInputElement>event.target).value, key);
 		openOnFocus && this._openMenu();
 	}
 
 	private _onInputKeyDown(event: KeyboardEvent) {
-		const {
-			disabled,
-			isResultDisabled = () => false,
-			readOnly,
-			results = []
-		} = this.properties;
+		const { disabled, isResultDisabled = () => false, readOnly, results = [] } = this.properties;
 		this._menuHasVisualFocus = true;
 
 		switch (event.which) {
@@ -166,8 +154,7 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 				event.preventDefault();
 				if (!this._open && !disabled && !readOnly) {
 					this._openMenu();
-				}
-				else if (this._open) {
+				} else if (this._open) {
 					this._moveActiveIndex(Operation.increase);
 				}
 				break;
@@ -216,10 +203,7 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 	}
 
 	private _openMenu() {
-		const {
-			key,
-			onRequestResults
-		} = this.properties;
+		const { key, onRequestResults } = this.properties;
 
 		this._activeIndex = 0;
 		this._open = true;
@@ -228,11 +212,7 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 	}
 
 	private _selectIndex(index: number) {
-		const {
-			key,
-			onChange,
-			results = []
-		} = this.properties;
+		const { key, onChange, results = [] } = this.properties;
 
 		this._callInputFocus = true;
 		this._closeMenu();
@@ -264,15 +244,7 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 	}
 
 	protected renderInput(): DNode {
-		const {
-			disabled,
-			inputProperties = {},
-			invalid,
-			readOnly,
-			required,
-			value = '',
-			theme
-		} = this.properties;
+		const { disabled, inputProperties = {}, invalid, readOnly, required, value = '', theme } = this.properties;
 
 		return w(TextInput, {
 			...inputProperties,
@@ -292,47 +264,51 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 	}
 
 	protected renderClearButton(): DNode {
-		const {
-			disabled,
-			readOnly
-		} = this.properties;
+		const { disabled, readOnly } = this.properties;
 
-		return v('button', {
-			key: 'clear',
-			'aria-controls': this._getMenuId(),
-			classes: this.theme(css.clear),
-			disabled,
-			readOnly,
-			onclick: this._onClearClick
-		}, [
-			'clear combo box',
-			v('i', { classes: this.theme([ iconCss.icon, iconCss.closeIcon ]),
-				role: 'presentation', 'aria-hidden': 'true'
-			})
-		]);
+		return v(
+			'button',
+			{
+				key: 'clear',
+				'aria-controls': this._getMenuId(),
+				classes: this.theme(css.clear),
+				disabled,
+				readOnly,
+				onclick: this._onClearClick
+			},
+			[
+				'clear combo box',
+				v('i', {
+					classes: this.theme([iconCss.icon, iconCss.closeIcon]),
+					role: 'presentation',
+					'aria-hidden': 'true'
+				})
+			]
+		);
 	}
 
 	protected renderMenuButton(): DNode {
-		const {
-			disabled,
-			readOnly
-		} = this.properties;
+		const { disabled, readOnly } = this.properties;
 
-		return v('button', {
-			key: 'trigger',
-			classes: this.theme(css.trigger),
-			disabled,
-			readOnly,
-			tabIndex: -1,
-			onclick: this._onArrowClick
-		}, [
-			'open combo box',
-			v('i', {
-				'aria-hidden': 'true',
-				classes: this.theme([ iconCss.icon, iconCss.downIcon ]),
-				role: 'presentation'
-			})
-		]);
+		return v(
+			'button',
+			{
+				key: 'trigger',
+				classes: this.theme(css.trigger),
+				disabled,
+				readOnly,
+				tabIndex: -1,
+				onclick: this._onArrowClick
+			},
+			[
+				'open combo box',
+				v('i', {
+					'aria-hidden': 'true',
+					classes: this.theme([iconCss.icon, iconCss.downIcon]),
+					role: 'presentation'
+				})
+			]
+		);
 	}
 
 	protected renderMenu(results: any[]): DNode {
@@ -342,32 +318,36 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 			return null;
 		}
 
-		return v('div', {
-			key: 'dropdown',
-			classes: this.theme(css.dropdown),
-			onmouseover: this._onResultHover,
-			onmousedown: this._onResultMouseDown
-		}, [
-			w(Listbox, {
-				key: 'listbox',
-				activeIndex: this._activeIndex,
-				id: this._getMenuId(),
-				visualFocus: this._menuHasVisualFocus,
-				optionData: results,
-				tabIndex: -1,
-				getOptionDisabled: isResultDisabled,
-				getOptionId: this._getResultId,
-				getOptionLabel: this._getResultLabel,
-				onActiveIndexChange: (index: number) => {
-					this._activeIndex = index;
-					this.invalidate();
-				},
-				onOptionSelect: (option: any, index: number) => {
-					this._selectIndex(index);
-				},
-				theme
-			})
-		]);
+		return v(
+			'div',
+			{
+				key: 'dropdown',
+				classes: this.theme(css.dropdown),
+				onmouseover: this._onResultHover,
+				onmousedown: this._onResultMouseDown
+			},
+			[
+				w(Listbox, {
+					key: 'listbox',
+					activeIndex: this._activeIndex,
+					id: this._getMenuId(),
+					visualFocus: this._menuHasVisualFocus,
+					optionData: results,
+					tabIndex: -1,
+					getOptionDisabled: isResultDisabled,
+					getOptionId: this._getResultId,
+					getOptionLabel: this._getResultLabel,
+					onActiveIndexChange: (index: number) => {
+						this._activeIndex = index;
+						this.invalidate();
+					},
+					onOptionSelect: (option: any, index: number) => {
+						this._selectIndex(index);
+					},
+					theme
+				})
+			]
+		);
 	}
 
 	render(): DNode {
@@ -390,40 +370,50 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 		this._wasOpen = this._open;
 
 		const controls = [
-			label ? w(Label, {
-				key: 'label',
-				theme,
-				disabled,
-				invalid,
-				readOnly,
-				required,
-				hidden: labelHidden,
-				forId: id
-			}, [ label ]) : null,
-			v('div', {
-				classes: this.theme(css.controls)
-			}, [
-				this.renderInput(),
-				clearable ? this.renderClearButton() : null,
-				this.renderMenuButton()
-			]),
+			label
+				? w(
+						Label,
+						{
+							key: 'label',
+							theme,
+							disabled,
+							invalid,
+							readOnly,
+							required,
+							hidden: labelHidden,
+							forId: id
+						},
+						[label]
+					)
+				: null,
+			v(
+				'div',
+				{
+					classes: this.theme(css.controls)
+				},
+				[this.renderInput(), clearable ? this.renderClearButton() : null, this.renderMenuButton()]
+			),
 			menu
 		];
 
-		return v('div', {
-			'aria-expanded': this._open ? 'true' : 'false',
-			'aria-haspopup': 'true',
-			'aria-readonly': readOnly ? 'true' : 'false',
-			'aria-required': required ? 'true' : 'false',
-			id,
-			classes: this.theme([
-				css.root,
-				this._open ? css.open : null,
-				invalid === true ? css.invalid : null,
-				invalid === false ? css.valid : null
-			]),
-			key: 'root',
-			role: 'combobox'
-		}, labelAfter ? controls.reverse() : controls);
+		return v(
+			'div',
+			{
+				'aria-expanded': this._open ? 'true' : 'false',
+				'aria-haspopup': 'true',
+				'aria-readonly': readOnly ? 'true' : 'false',
+				'aria-required': required ? 'true' : 'false',
+				id,
+				classes: this.theme([
+					css.root,
+					this._open ? css.open : null,
+					invalid === true ? css.invalid : null,
+					invalid === false ? css.valid : null
+				]),
+				key: 'root',
+				role: 'combobox'
+			},
+			labelAfter ? controls.reverse() : controls
+		);
 	}
 }

--- a/src/combobox/createComboBoxElement.ts
+++ b/src/combobox/createComboBoxElement.ts
@@ -12,33 +12,33 @@ export default function createComboBoxElement(): CustomElementDescriptor {
 			{
 				attributeName: 'autoblur',
 				propertyName: 'autoBlur',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'clearable',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'invalid',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'disabled',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'openonfocus',
 				propertyName: 'openOnFocus',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'readonly',
 				propertyName: 'readOnly',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'required',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'value'
@@ -77,4 +77,4 @@ export default function createComboBoxElement(): CustomElementDescriptor {
 			}
 		]
 	};
-};
+}

--- a/src/combobox/example/index.ts
+++ b/src/combobox/example/index.ts
@@ -86,123 +86,124 @@ export class App extends WidgetBase<WidgetProperties> {
 
 	onRequestResults(key: string) {
 		const value = (this as any)[`_value${key}`];
-		const results = data.filter(item => {
+		const results = data.filter((item) => {
 			const match = item.value.toLowerCase().match(new RegExp('^' + value.toLowerCase()));
 			return Boolean(match && match.length > 0);
 		});
 
-		this._results = results.sort((a, b) => a.value < b.value ? -1 : 1);
+		this._results = results.sort((a, b) => (a.value < b.value ? -1 : 1));
 		this.invalidate();
 	}
 
 	render(): DNode {
-		const {
-			onChange,
-			onRequestResults
-		} = this;
+		const { onChange, onRequestResults } = this;
 
-		return v('div', {
-			styles: { maxWidth: '256px' }
-		}, [
-			v('h1', ['ComboBox Examples']),
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
+		return v(
+			'div',
+			{
+				styles: { maxWidth: '256px' }
+			},
+			[
+				v('h1', ['ComboBox Examples']),
+				v('label', [
+					'Use Dojo Theme ',
+					v('input', {
+						type: 'checkbox',
+						onchange: this.themeChange
+					})
+				]),
+				v('h3', ['Clearable']),
+				w(ComboBox, {
+					key: '2',
+					clearable: true,
+					onChange,
+					getResultLabel: (result: any) => result.value,
+					onRequestResults,
+					results: this._results,
+					value: this._value2,
+					inputProperties: {
+						placeholder: 'Enter a value'
+					},
+					theme: this._theme
+				}),
+				v('h3', ['Open on focus']),
+				w(ComboBox, {
+					key: '1',
+					openOnFocus: true,
+					onChange,
+					getResultLabel: (result: any) => result.value,
+					onRequestResults,
+					results: this._results,
+					value: this._value1,
+					inputProperties: {
+						placeholder: 'Enter a value'
+					},
+					theme: this._theme
+				}),
+				v('h3', ['Disabled menu items']),
+				w(ComboBox, {
+					key: '5',
+					onChange,
+					getResultLabel: (result: any) => result.value,
+					onRequestResults,
+					results: this._results,
+					value: this._value5,
+					isResultDisabled: (result: any) => result.value.length > 9,
+					inputProperties: {
+						placeholder: 'Enter a value'
+					},
+					theme: this._theme
+				}),
+				v('h3', ['Disabled']),
+				w(ComboBox, {
+					key: '6',
+					disabled: true,
+					inputProperties: {
+						placeholder: 'Enter a value'
+					},
+					theme: this._theme
+				}),
+				v('h3', ['Read Only']),
+				w(ComboBox, {
+					key: '7',
+					readOnly: true,
+					inputProperties: {
+						placeholder: 'Enter a value'
+					},
+					theme: this._theme
+				}),
+				v('h3', ['Label']),
+				w(ComboBox, {
+					key: '8',
+					onChange,
+					getResultLabel: (result: any) => result.value,
+					onRequestResults,
+					results: this._results,
+					value: this._value8,
+					label: 'Enter a value',
+					theme: this._theme
+				}),
+				v('h3', ['Required and validated']),
+				w(ComboBox, {
+					key: '9',
+					required: true,
+					onChange: (value: string) => {
+						this._value9 = value;
+						this._invalid = value.trim().length === 0;
+						this.invalidate();
+					},
+					getResultLabel: (result: any) => result.value,
+					onRequestResults,
+					results: this._results,
+					value: this._value9,
+					invalid: this._invalid,
+					inputProperties: {
+						placeholder: 'Enter a value'
+					},
+					theme: this._theme
 				})
-			]),
-			v('h3', ['Clearable']),
-			w(ComboBox, {
-				key: '2',
-				clearable: true,
-				onChange,
-				getResultLabel: (result: any) => result.value,
-				onRequestResults,
-				results: this._results,
-				value: this._value2,
-				inputProperties: {
-					placeholder: 'Enter a value'
-				},
-				theme: this._theme
-			}),
-			v('h3', ['Open on focus']),
-			w(ComboBox, {
-				key: '1',
-				openOnFocus: true,
-				onChange,
-				getResultLabel: (result: any) => result.value,
-				onRequestResults,
-				results: this._results,
-				value: this._value1,
-				inputProperties: {
-					placeholder: 'Enter a value'
-				},
-				theme: this._theme
-			}),
-			v('h3', ['Disabled menu items']),
-			w(ComboBox, {
-				key: '5',
-				onChange,
-				getResultLabel: (result: any) => result.value,
-				onRequestResults,
-				results: this._results,
-				value: this._value5,
-				isResultDisabled: (result: any) => result.value.length > 9,
-				inputProperties: {
-					placeholder: 'Enter a value'
-				},
-				theme: this._theme
-			}),
-			v('h3', ['Disabled']),
-			w(ComboBox, {
-				key: '6',
-				disabled: true,
-				inputProperties: {
-					placeholder: 'Enter a value'
-				},
-				theme: this._theme
-			}),
-			v('h3', ['Read Only']),
-			w(ComboBox, {
-				key: '7',
-				readOnly: true,
-				inputProperties: {
-					placeholder: 'Enter a value'
-				},
-				theme: this._theme
-			}),
-			v('h3', ['Label']),
-			w(ComboBox, {
-				key: '8',
-				onChange,
-				getResultLabel: (result: any) => result.value,
-				onRequestResults,
-				results: this._results,
-				value: this._value8,
-				label: 'Enter a value',
-				theme: this._theme
-			}),
-			v('h3', ['Required and validated']),
-			w(ComboBox, {
-				key: '9',
-				required: true,
-				onChange: (value: string) => {
-					this._value9 = value;
-					this._invalid = value.trim().length === 0;
-					this.invalidate();
-				},
-				getResultLabel: (result: any) => result.value,
-				onRequestResults,
-				results: this._results,
-				value: this._value9,
-				invalid: this._invalid,
-				inputProperties: {
-					placeholder: 'Enter a value'
-				},
-				theme: this._theme
-			})
-		]);
+			]
+		);
 	}
 }
 

--- a/src/combobox/tests/functional/ComboBox.ts
+++ b/src/combobox/tests/functional/ComboBox.ts
@@ -14,17 +14,12 @@ function getPage(remote: Remote) {
 
 registerSuite('ComboBox', {
 	'the results menu should be visible'() {
-		let inputWidth: number;
-
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.trigger}`)
 			.click()
 			.end()
 			.findByCssSelector(`.${css.controls} input`)
 			.getSize()
-			.then(({ width }) => {
-				inputWidth = width;
-			})
 			.end()
 			.sleep(DELAY)
 			.findByCssSelector(`.${css.dropdown}`)

--- a/src/combobox/tests/functional/ComboBox.ts
+++ b/src/combobox/tests/functional/ComboBox.ts
@@ -9,9 +9,7 @@ import * as css from '../../styles/comboBox.m.css';
 const DELAY = 300;
 
 function getPage(remote: Remote) {
-	return remote
-		.get('http://localhost:9000/_build/common/example/?module=combobox')
-		.setFindTimeout(5000);
+	return remote.get('http://localhost:9000/_build/common/example/?module=combobox').setFindTimeout(5000);
 }
 
 registerSuite('ComboBox', {
@@ -20,20 +18,20 @@ registerSuite('ComboBox', {
 
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.trigger}`)
-				.click()
-				.end()
+			.click()
+			.end()
 			.findByCssSelector(`.${css.controls} input`)
-				.getSize()
-					.then(({ width }) => {
-						inputWidth = width;
-					})
-				.end()
+			.getSize()
+			.then(({ width }) => {
+				inputWidth = width;
+			})
+			.end()
 			.sleep(DELAY)
 			.findByCssSelector(`.${css.dropdown}`)
-				.getSize()
-				.then(({ height }) => {
-					assert.isAbove(height, 0);
-				});
+			.getSize()
+			.then(({ height }) => {
+				assert.isAbove(height, 0);
+			});
 	},
 
 	'the selected result menu should be visible'() {
@@ -51,33 +49,33 @@ registerSuite('ComboBox', {
 
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.trigger}`)
-				.click()
-				.end()
+			.click()
+			.end()
 			.sleep(DELAY)
 			.findByCssSelector(`.${css.controls} input`)
-				.type(keys.ARROW_UP)
-				.end()
+			.type(keys.ARROW_UP)
+			.end()
 			.sleep(DELAY)
 			.findByCssSelector(`.${css.dropdown}`)
-				.getPosition()
-				.then(({ y }: { y: number; }) => {
-					menuTop = y;
-				})
-				.getSize()
-				.then(({ height }: { height: number }) => {
-					menuBottom = menuTop + height;
-				})
-				.end()
+			.getPosition()
+			.then(({ y }: { y: number }) => {
+				menuTop = y;
+			})
+			.getSize()
+			.then(({ height }: { height: number }) => {
+				menuBottom = menuTop + height;
+			})
+			.end()
 			.findByCssSelector(`.${listboxCss.activeOption}`)
-				.getSize()
-				.then(({ height }: { height: number }) => {
-					itemHeight = height;
-				})
-				.getPosition()
-				.then(({ y }: { y: number; }) => {
-					assert.isAtLeast(y, menuTop);
-					assert.isAtMost(Math.floor(y), Math.ceil(menuBottom - itemHeight));
-				});
+			.getSize()
+			.then(({ height }: { height: number }) => {
+				itemHeight = height;
+			})
+			.getPosition()
+			.then(({ y }: { y: number }) => {
+				assert.isAtLeast(y, menuTop);
+				assert.isAtMost(Math.floor(y), Math.ceil(menuBottom - itemHeight));
+			});
 	},
 
 	'tab order'() {
@@ -92,26 +90,31 @@ registerSuite('ComboBox', {
 			this.skip('FirefoxDriver sends actual charcodes to the input.');
 		}
 
-		const initialTab = browserName === 'chrome' ?
-			() => this.remote.findByTagName('body').type(keys.TAB) :
-			() => this.remote.pressKeys(keys.TAB);
+		const initialTab =
+			browserName === 'chrome'
+				? () => this.remote.findByTagName('body').type(keys.TAB)
+				: () => this.remote.pressKeys(keys.TAB);
 
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.trigger}`)
-				.click()
-				.sleep(DELAY)
-				.then(initialTab)
+			.click()
+			.sleep(DELAY)
+			.then(initialTab)
 			.getActiveElement()
-				.getProperty('textContent')
-				.then((text: string) => {
-					assert.strictEqual(text, 'clear combo box', 'The "clear" button should receive focus.');
-				})
-				.type(keys.TAB)
+			.getProperty('textContent')
+			.then((text: string) => {
+				assert.strictEqual(text, 'clear combo box', 'The "clear" button should receive focus.');
+			})
+			.type(keys.TAB)
 			.getActiveElement()
-				.getTagName()
-				.then((tag: string) => {
-					assert.strictEqual(tag.toLowerCase(), 'input', 'The results menu and "open" button should not receive focus.');
-				});
+			.getTagName()
+			.then((tag: string) => {
+				assert.strictEqual(
+					tag.toLowerCase(),
+					'input',
+					'The results menu and "open" button should not receive focus.'
+				);
+			});
 	},
 
 	'the input should receive focus when the "clear" button is activated'() {
@@ -122,22 +125,30 @@ registerSuite('ComboBox', {
 
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.clear}`)
-				.click()
-				.sleep(30)
+			.click()
+			.sleep(30)
 			.getActiveElement()
-				.getTagName()
-				.then(tag => {
-					assert.strictEqual(tag.toLowerCase(), 'input', 'The input should receive focus when the "clear" button is clicked.');
-				})
-				.type(keys.TAB)
+			.getTagName()
+			.then((tag) => {
+				assert.strictEqual(
+					tag.toLowerCase(),
+					'input',
+					'The input should receive focus when the "clear" button is clicked.'
+				);
+			})
+			.type(keys.TAB)
 			.getActiveElement()
-				.type(keys.ENTER)
-				.sleep(30)
+			.type(keys.ENTER)
+			.sleep(30)
 			.getActiveElement()
-				.getTagName()
-				.then(tag => {
-					assert.strictEqual(tag.toLowerCase(), 'input', 'The input should receive focus when the "clear" button is activated with the ENTER key.');
-				});
+			.getTagName()
+			.then((tag) => {
+				assert.strictEqual(
+					tag.toLowerCase(),
+					'input',
+					'The input should receive focus when the "clear" button is activated with the ENTER key.'
+				);
+			});
 	},
 
 	'the input should receive focus when the "open" button is activated'() {
@@ -148,21 +159,29 @@ registerSuite('ComboBox', {
 
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.trigger}`)
-				.click()
-				.sleep(30)
+			.click()
+			.sleep(30)
 			.getActiveElement()
-				.getTagName()
-				.then(tag => {
-					assert.strictEqual(tag.toLowerCase(), 'input', 'The input should receive focus when the "open" button is clicked.');
-				})
-				.type(keys.TAB)
+			.getTagName()
+			.then((tag) => {
+				assert.strictEqual(
+					tag.toLowerCase(),
+					'input',
+					'The input should receive focus when the "open" button is clicked.'
+				);
+			})
+			.type(keys.TAB)
 			.getActiveElement()
-				.type(keys.ENTER)
-				.sleep(30)
+			.type(keys.ENTER)
+			.sleep(30)
 			.getActiveElement()
-				.getTagName()
-				.then(tag => {
-					assert.strictEqual(tag.toLowerCase(), 'input', 'The input should receive focus when the "open" button is activated with the ENTER key.');
-				});
+			.getTagName()
+			.then((tag) => {
+				assert.strictEqual(
+					tag.toLowerCase(),
+					'input',
+					'The input should receive focus when the "open" button is activated with the ENTER key.'
+				);
+			});
 	}
 });

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -47,59 +47,75 @@ const testProperties = {
 };
 
 const getExpectedControls = function(widget: Harness<ComboBox>, useTestProperties: boolean, label: boolean) {
-	const controlsVdom = v('div', {
-		classes: css.controls
-	}, [
-		w(TextInput, <any> {
-			key: 'textinput',
-			controls: <any> compareId,
-			disabled: undefined,
-			invalid: undefined,
-			readOnly: undefined,
-			required: undefined,
-			theme: useTestProperties ? {} : undefined,
-			value: useTestProperties ? 'one' : '',
-			onBlur: widget.listener,
-			onFocus: widget.listener,
-			onInput: widget.listener,
-			onKeyDown: widget.listener
-		}),
-		useTestProperties ? v('button', {
-			'aria-controls': <any> compareId,
-			key: 'clear',
-			classes: css.clear,
-			disabled: undefined,
-			readOnly: undefined,
-			onclick: widget.listener
-		}, [
-			'clear combo box',
-			v('i', { classes: [ iconCss.icon, iconCss.closeIcon ],
-				role: 'presentation', 'aria-hidden': 'true'
-			})
-		]) : null,
-		v('button', {
-			key: 'trigger',
-			classes: css.trigger,
-			disabled: undefined,
-			readOnly: undefined,
-			tabIndex: -1,
-			onclick: widget.listener
-		}, [
-			'open combo box',
-			v('i', {
-				'aria-hidden': 'true',
-				classes: [ iconCss.icon, iconCss.downIcon ],
-				role: 'presentation'
-			})
-		])
-	]);
+	const controlsVdom = v(
+		'div',
+		{
+			classes: css.controls
+		},
+		[
+			w(TextInput, <any>{
+				key: 'textinput',
+				controls: <any>compareId,
+				disabled: undefined,
+				invalid: undefined,
+				readOnly: undefined,
+				required: undefined,
+				theme: useTestProperties ? {} : undefined,
+				value: useTestProperties ? 'one' : '',
+				onBlur: widget.listener,
+				onFocus: widget.listener,
+				onInput: widget.listener,
+				onKeyDown: widget.listener
+			}),
+			useTestProperties
+				? v(
+						'button',
+						{
+							'aria-controls': <any>compareId,
+							key: 'clear',
+							classes: css.clear,
+							disabled: undefined,
+							readOnly: undefined,
+							onclick: widget.listener
+						},
+						[
+							'clear combo box',
+							v('i', {
+								classes: [iconCss.icon, iconCss.closeIcon],
+								role: 'presentation',
+								'aria-hidden': 'true'
+							})
+						]
+					)
+				: null,
+			v(
+				'button',
+				{
+					key: 'trigger',
+					classes: css.trigger,
+					disabled: undefined,
+					readOnly: undefined,
+					tabIndex: -1,
+					onclick: widget.listener
+				},
+				[
+					'open combo box',
+					v('i', {
+						'aria-hidden': 'true',
+						classes: [iconCss.icon, iconCss.downIcon],
+						role: 'presentation'
+					})
+				]
+			)
+		]
+	);
 
 	return controlsVdom;
 };
 
 function isOpen(widget: Harness<ComboBox>): boolean {
 	const vdom = widget.getRender();
-	return (<any> vdom)!.properties!['aria-expanded'] === 'true';
+	return (<any>vdom)!.properties!['aria-expanded'] === 'true';
 }
 
 const getExpectedMenu = function(widget: Harness<ComboBox>, useTestProperties: boolean, open: boolean) {
@@ -107,61 +123,70 @@ const getExpectedMenu = function(widget: Harness<ComboBox>, useTestProperties: b
 		return null;
 	}
 
-	return v('div', {
-		key: 'dropdown',
-		classes: css.dropdown,
-		onmouseover: widget.listener,
-		onmousedown: widget.listener
-	}, [
-		w(Listbox, {
-			activeIndex: 0,
-			id: <any> compareId,
-			key: 'listbox',
-			visualFocus: false,
-			optionData: testOptions,
-			tabIndex: -1,
-			getOptionDisabled: undefined,
-			getOptionId: widget.listener as any,
-			getOptionLabel: widget.listener as any,
-			onActiveIndexChange: widget.listener,
-			onOptionSelect: widget.listener,
-			theme: useTestProperties ? {} : undefined
-		})
-	]);
+	return v(
+		'div',
+		{
+			key: 'dropdown',
+			classes: css.dropdown,
+			onmouseover: widget.listener,
+			onmousedown: widget.listener
+		},
+		[
+			w(Listbox, {
+				activeIndex: 0,
+				id: <any>compareId,
+				key: 'listbox',
+				visualFocus: false,
+				optionData: testOptions,
+				tabIndex: -1,
+				getOptionDisabled: undefined,
+				getOptionId: widget.listener as any,
+				getOptionLabel: widget.listener as any,
+				onActiveIndexChange: widget.listener,
+				onOptionSelect: widget.listener,
+				theme: useTestProperties ? {} : undefined
+			})
+		]
+	);
 };
 
 const getExpectedVdom = function(widget: Harness<ComboBox>, useTestProperties = false, open = false, label = false) {
 	const menuVdom = getExpectedMenu(widget, useTestProperties, open);
 	const controlsVdom = getExpectedControls(widget, useTestProperties, label);
 
-	return v('div', {
-		'aria-expanded': open ? 'true' : 'false',
-		'aria-haspopup': 'true',
-		'aria-readonly': 'false',
-		'aria-required': 'false',
-		id: useTestProperties ? 'foo' : undefined,
-		classes: [
-			css.root,
-			open ? css.open : null,
-			null,
-			null
-		],
-		key: 'root',
-		role: 'combobox'
-	}, [
-		label ? w(Label, {
-			key: 'label',
-			theme: undefined,
-			disabled: undefined,
-			hidden: undefined,
-			invalid: undefined,
-			readOnly: undefined,
-			required: undefined,
-			forId: <any> compareId
-		}, [ 'foo' ]) : null,
-		controlsVdom,
-		menuVdom
-	]);
+	return v(
+		'div',
+		{
+			'aria-expanded': open ? 'true' : 'false',
+			'aria-haspopup': 'true',
+			'aria-readonly': 'false',
+			'aria-required': 'false',
+			id: useTestProperties ? 'foo' : undefined,
+			classes: [css.root, open ? css.open : null, null, null],
+			key: 'root',
+			role: 'combobox'
+		},
+		[
+			label
+				? w(
+						Label,
+						{
+							key: 'label',
+							theme: undefined,
+							disabled: undefined,
+							hidden: undefined,
+							invalid: undefined,
+							readOnly: undefined,
+							required: undefined,
+							forId: <any>compareId
+						},
+						['foo']
+					)
+				: null,
+			controlsVdom,
+			menuVdom
+		]
+	);
 };
 
 registerSuite('ComboBox', {
@@ -222,7 +247,7 @@ registerSuite('ComboBox', {
 			});
 
 			widget.callListener('onInput', {
-				args: [ { target: { value: 'foo' } } ],
+				args: [{ target: { value: 'foo' } }],
 				key: 'textinput'
 			});
 
@@ -246,7 +271,7 @@ registerSuite('ComboBox', {
 			assert.isTrue(isOpen(widget), 'widget is open after arrow click');
 
 			widget.callListener('onBlur', {
-				args: [ { target: { value: 'foo' } } ],
+				args: [{ target: { value: 'foo' } }],
 				key: 'textinput'
 			});
 			assert.isTrue(onBlur.calledWith('foo'), 'onBlur callback called with input value');
@@ -269,7 +294,7 @@ registerSuite('ComboBox', {
 
 			widget.sendEvent('mousedown', { key: 'dropdown' });
 			widget.callListener('onBlur', {
-				args: [ { target: { value: 'foo' } } ],
+				args: [{ target: { value: 'foo' } }],
 				key: 'textinput'
 			});
 
@@ -290,7 +315,7 @@ registerSuite('ComboBox', {
 			assert.isTrue(isOpen(widget), 'widget is open after arrow click');
 
 			widget.callListener('onOptionSelect', {
-				args: [ testOptions[1], 1 ],
+				args: [testOptions[1], 1],
 				index: '1,0'
 			});
 			assert.isTrue(onChange.calledWith('Two'), 'onChange callback called with label of second option');
@@ -307,7 +332,7 @@ registerSuite('ComboBox', {
 			});
 
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Down, preventDefault } ],
+				args: [{ which: Keys.Down, preventDefault }],
 				key: 'textinput'
 			});
 			assert.isTrue(isOpen(widget), 'widget is open after down key press');
@@ -315,7 +340,7 @@ registerSuite('ComboBox', {
 			assert.isTrue(preventDefault.calledOnce, 'down key press prevents default page scroll');
 
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Escape } ],
+				args: [{ which: Keys.Escape }],
 				key: 'textinput'
 			});
 			assert.isFalse(isOpen(widget), 'widget is closed after escape key press');
@@ -328,7 +353,7 @@ registerSuite('ComboBox', {
 			// open dropdown
 			widget.sendEvent('click', { selector: `.${css.trigger}` });
 			widget.callListener('onActiveIndexChange', {
-				args: [ 1 ],
+				args: [1],
 				key: 'listbox'
 			});
 
@@ -350,7 +375,7 @@ registerSuite('ComboBox', {
 			widget.sendEvent('click', { selector: `.${css.trigger}` });
 
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Down, preventDefault } ],
+				args: [{ which: Keys.Down, preventDefault }],
 				key: 'textinput'
 			});
 
@@ -360,12 +385,15 @@ registerSuite('ComboBox', {
 				activeIndex: 1,
 				visualFocus: true
 			});
-			widget.expectRender(expected, 'down arrow moves active index to second option and sets visualFocus to true');
+			widget.expectRender(
+				expected,
+				'down arrow moves active index to second option and sets visualFocus to true'
+			);
 
 			// shouldn't need this line with correct bind
 			widget.setProperties({ ...testProperties, label: undefined });
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Up, preventDefault } ],
+				args: [{ which: Keys.Up, preventDefault }],
 				key: 'textinput'
 			});
 			widget.setProperties(testProperties);
@@ -377,7 +405,7 @@ registerSuite('ComboBox', {
 			// shouldn't need this line with correct bind
 			widget.setProperties({ ...testProperties, label: undefined });
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Up, preventDefault } ],
+				args: [{ which: Keys.Up, preventDefault }],
 				key: 'textinput'
 			});
 			widget.setProperties(testProperties);
@@ -389,7 +417,7 @@ registerSuite('ComboBox', {
 			// shouldn't need this line with correct bind
 			widget.setProperties({ ...testProperties, label: undefined });
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Down, preventDefault } ],
+				args: [{ which: Keys.Down, preventDefault }],
 				key: 'textinput'
 			});
 			widget.setProperties(testProperties);
@@ -401,7 +429,7 @@ registerSuite('ComboBox', {
 			// shouldn't need this line with correct bind
 			widget.setProperties({ ...testProperties, label: undefined });
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.End, preventDefault } ],
+				args: [{ which: Keys.End, preventDefault }],
 				key: 'textinput'
 			});
 			widget.setProperties(testProperties);
@@ -413,7 +441,7 @@ registerSuite('ComboBox', {
 			// shouldn't need this line with correct bind
 			widget.setProperties({ ...testProperties, label: undefined });
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Home, preventDefault } ],
+				args: [{ which: Keys.Home, preventDefault }],
 				key: 'textinput'
 			});
 			widget.setProperties(testProperties);
@@ -435,26 +463,32 @@ registerSuite('ComboBox', {
 
 			widget.sendEvent('click', { selector: `.${css.trigger}` });
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Enter } ],
+				args: [{ which: Keys.Enter }],
 				key: 'textinput'
 			});
-			assert.isTrue(onChange.calledWith('One'), 'enter triggers onChange callback called with label of first option');
+			assert.isTrue(
+				onChange.calledWith('One'),
+				'enter triggers onChange callback called with label of first option'
+			);
 			assert.isFalse(isOpen(widget), 'widget is closed after selecting option');
 
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Enter } ],
+				args: [{ which: Keys.Enter }],
 				key: 'textinput'
 			});
-			assert.isFalse(onChange.calledTwice, 'enter doesn\'t trigger onChange when menu is closed');
+			assert.isFalse(onChange.calledTwice, "enter doesn't trigger onChange when menu is closed");
 
 			onChange.reset();
 
 			widget.sendEvent('click', { selector: `.${css.trigger}` });
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Space } ],
+				args: [{ which: Keys.Space }],
 				key: 'textinput'
 			});
-			assert.isTrue(onChange.calledWith('One'), 'space triggers onChange callback called with label of first option');
+			assert.isTrue(
+				onChange.calledWith('One'),
+				'space triggers onChange callback called with label of first option'
+			);
 			assert.isFalse(isOpen(widget), 'widget is closed after selecting option');
 		},
 
@@ -469,11 +503,11 @@ registerSuite('ComboBox', {
 
 			widget.sendEvent('click', { selector: `.${css.trigger}` });
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Up, preventDefault: sinon.stub() } ],
+				args: [{ which: Keys.Up, preventDefault: sinon.stub() }],
 				key: 'textinput'
 			});
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Enter } ],
+				args: [{ which: Keys.Enter }],
 				key: 'textinput'
 			});
 
@@ -493,11 +527,11 @@ registerSuite('ComboBox', {
 			widget.expectRender(expected, 'dropdown does not render with no results');
 
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Down, preventDefault: sinon.stub() } ],
+				args: [{ which: Keys.Down, preventDefault: sinon.stub() }],
 				key: 'textinput'
 			});
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Enter } ],
+				args: [{ which: Keys.Enter }],
 				key: 'textinput'
 			});
 
@@ -539,7 +573,7 @@ registerSuite('ComboBox', {
 			});
 
 			widget.callListener('onFocus', {
-				args: [ { target: { value: 'foo' } } ],
+				args: [{ target: { value: 'foo' } }],
 				key: 'textinput'
 			});
 
@@ -580,7 +614,7 @@ registerSuite('ComboBox', {
 			assignProperties(expected, {
 				'aria-readonly': 'true',
 				'aria-required': 'true',
-				classes: [ css.root, null, css.invalid, null ]
+				classes: [css.root, null, css.invalid, null]
 			});
 			widget.expectRender(expected, 'disabled, invalid, readOnly, and required render');
 
@@ -590,7 +624,7 @@ registerSuite('ComboBox', {
 				invalid: false
 			});
 			assignProperties(expected, {
-				classes: [ css.root, null, null, css.valid ]
+				classes: [css.root, null, null, css.valid]
 			});
 			widget.expectRender(expected, 'valid render');
 		},
@@ -610,7 +644,7 @@ registerSuite('ComboBox', {
 			assert.isFalse(isOpen(widget), 'widget stays closed on arrow click');
 
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Down, preventDefault: sinon.stub() } ],
+				args: [{ which: Keys.Down, preventDefault: sinon.stub() }],
 				key: 'textinput'
 			});
 			assert.isFalse(isOpen(widget), 'widget stays closed on key down');
@@ -634,7 +668,7 @@ registerSuite('ComboBox', {
 			assert.isFalse(isOpen(widget), 'widget stays closed on arrow click');
 
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Down, preventDefault: sinon.stub() } ],
+				args: [{ which: Keys.Down, preventDefault: sinon.stub() }],
 				key: 'textinput'
 			});
 			assert.isFalse(isOpen(widget), 'widget stays closed on key down');
@@ -651,11 +685,11 @@ registerSuite('ComboBox', {
 			widget.sendEvent('click', { selector: `.${css.trigger}` });
 
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Up, preventDefault: sinon.stub() } ],
+				args: [{ which: Keys.Up, preventDefault: sinon.stub() }],
 				key: 'textinput'
 			});
 			widget.callListener('onKeyDown', {
-				args: [ { which: Keys.Down, preventDefault: sinon.stub() } ],
+				args: [{ which: Keys.Down, preventDefault: sinon.stub() }],
 				key: 'textinput'
 			});
 			assignProperties(findKey(expected, 'listbox')!, {

--- a/src/common/tests/unit/util.ts
+++ b/src/common/tests/unit/util.ts
@@ -4,7 +4,6 @@ const { assert } = intern.getPlugin('chai');
 import { Keys } from '../../util';
 
 registerSuite('util', {
-
 	keys() {
 		assert.strictEqual(Keys.Down, 40);
 		assert.strictEqual(Keys.End, 35);

--- a/src/dialog/Dialog.ts
+++ b/src/dialog/Dialog.ts
@@ -43,7 +43,7 @@ export interface DialogProperties extends ThemedProperties {
 	role?: RoleType;
 	title?: string;
 	underlay?: boolean;
-};
+}
 
 export const ThemedBase = ThemedMixin(WidgetBase);
 
@@ -54,10 +54,7 @@ export default class Dialog<P extends DialogProperties = DialogProperties> exten
 	private _wasOpen: boolean;
 
 	private _onCloseClick() {
-		const {
-			closeable = true,
-			onRequestClose
-		} = this.properties;
+		const { closeable = true, onRequestClose } = this.properties;
 
 		closeable && onRequestClose && onRequestClose();
 	}
@@ -70,7 +67,7 @@ export default class Dialog<P extends DialogProperties = DialogProperties> exten
 		if (event.which === Keys.Escape) {
 			this._onCloseClick();
 		}
-	}
+	};
 
 	constructor() {
 		super();
@@ -82,27 +79,33 @@ export default class Dialog<P extends DialogProperties = DialogProperties> exten
 	}
 
 	protected getContent(): DNode {
-		return v('div', {
-			classes: this.theme(css.content),
-			key: 'content'
-		}, this.children);
+		return v(
+			'div',
+			{
+				classes: this.theme(css.content),
+				key: 'content'
+			},
+			this.children
+		);
 	}
 
 	protected renderCloseIcon(): DNode {
-		return v('i', { classes: this.theme([ iconCss.icon, iconCss.closeIcon ]),
-			role: 'presentation', 'aria-hidden': 'true'
+		return v('i', {
+			classes: this.theme([iconCss.icon, iconCss.closeIcon]),
+			role: 'presentation',
+			'aria-hidden': 'true'
 		});
 	}
 
 	protected renderTitle(): DNode {
 		const { title = '' } = this.properties;
-		return v('div', { id: this._titleId }, [ title ]);
+		return v('div', { id: this._titleId }, [title]);
 	}
 
 	protected renderUnderlay(): DNode {
 		const { underlay } = this.properties;
 		return v('div', {
-			classes: [ this.theme(underlay ? css.underlayVisible : null), css.underlay ],
+			classes: [this.theme(underlay ? css.underlayVisible : null), css.underlay],
 			enterAnimation: animations.fadeIn,
 			exitAnimation: animations.fadeOut,
 			key: 'underlay',
@@ -125,33 +128,50 @@ export default class Dialog<P extends DialogProperties = DialogProperties> exten
 
 		this._wasOpen = open;
 
-		return v('div', {
-			classes: this.theme(css.root)
-		}, open ? [
-			this.renderUnderlay(),
-			v('div', {
-				'aria-labelledby': this._titleId,
-				classes: this.theme(css.main),
-				enterAnimation,
-				exitAnimation,
-				key: 'main',
-				role
-			}, [
-				v('div', {
-					classes: this.theme(css.title),
-					key: 'title'
-				}, [
-					this.renderTitle(),
-					closeable ? v('button', {
-						classes: this.theme(css.close),
-						onclick: this._onCloseClick
-					}, [
-						closeText,
-						this.renderCloseIcon()
-					]) : null
-				]),
-				this.getContent()
-			])
-		] : []);
+		return v(
+			'div',
+			{
+				classes: this.theme(css.root)
+			},
+			open
+				? [
+						this.renderUnderlay(),
+						v(
+							'div',
+							{
+								'aria-labelledby': this._titleId,
+								classes: this.theme(css.main),
+								enterAnimation,
+								exitAnimation,
+								key: 'main',
+								role
+							},
+							[
+								v(
+									'div',
+									{
+										classes: this.theme(css.title),
+										key: 'title'
+									},
+									[
+										this.renderTitle(),
+										closeable
+											? v(
+													'button',
+													{
+														classes: this.theme(css.close),
+														onclick: this._onCloseClick
+													},
+													[closeText, this.renderCloseIcon()]
+												)
+											: null
+									]
+								),
+								this.getContent()
+							]
+						)
+					]
+				: []
+		);
 	}
 }

--- a/src/dialog/createDialogElement.ts
+++ b/src/dialog/createDialogElement.ts
@@ -11,7 +11,7 @@ export default function createDialogElement(): CustomElementDescriptor {
 		attributes: [
 			{
 				attributeName: 'closeable',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'closetext',
@@ -27,11 +27,11 @@ export default function createDialogElement(): CustomElementDescriptor {
 			},
 			{
 				attributeName: 'modal',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'open',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'role'
@@ -41,12 +41,10 @@ export default function createDialogElement(): CustomElementDescriptor {
 			},
 			{
 				attributeName: 'underlay',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			}
 		],
-		properties: [
-			{ propertyName: 'theme' }
-		],
+		properties: [{ propertyName: 'theme' }],
 		events: [
 			{
 				propertyName: 'onOpen',
@@ -58,4 +56,4 @@ export default function createDialogElement(): CustomElementDescriptor {
 			}
 		]
 	};
-};
+}

--- a/src/dialog/example/index.ts
+++ b/src/dialog/example/index.ts
@@ -46,23 +46,27 @@ export class App extends WidgetBase<WidgetProperties> {
 				innerHTML: 'open dialog',
 				onclick: this.openDialog
 			}),
-			w(Dialog, {
-				key: 'dialog',
-				title: 'Dialog',
-				open: this._open,
-				modal: this._modal,
-				underlay: this._underlay,
-				closeable: this._closeable,
-				onRequestClose: () => {
-					this._open = false;
-					this.invalidate();
+			w(
+				Dialog,
+				{
+					key: 'dialog',
+					title: 'Dialog',
+					open: this._open,
+					modal: this._modal,
+					underlay: this._underlay,
+					closeable: this._closeable,
+					onRequestClose: () => {
+						this._open = false;
+						this.invalidate();
+					},
+					theme: this._theme
 				},
-				theme: this._theme
-			}, [
-				`Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+				[
+					`Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 				Quisque id purus ipsum. Aenean ac purus purus.
 				Nam sollicitudin varius augue, sed lacinia felis tempor in.`
-			]),
+				]
+			),
 			v('div', { classes: 'option' }, [
 				v('label', [
 					'Use Dojo Theme ',

--- a/src/dialog/tests/functional/Dialog.ts
+++ b/src/dialog/tests/functional/Dialog.ts
@@ -14,35 +14,33 @@ interface Options {
 const DELAY = 400;
 
 function openDialog(remote: Remote, { closeable = true, modal, underlay }: Options = {}) {
-	let promise = remote
-		.get('http://localhost:9000/_build/common/example/?module=dialog')
-		.setFindTimeout(5000);
+	let promise = remote.get('http://localhost:9000/_build/common/example/?module=dialog').setFindTimeout(5000);
 
 	if (!closeable) {
 		promise = promise
 			.findById('closeable')
-				.click()
-				.end();
+			.click()
+			.end();
 	}
 
 	if (modal) {
 		promise = promise
 			.findById('modal')
-				.click()
-				.end();
+			.click()
+			.end();
 	}
 
 	if (underlay) {
 		promise = promise
 			.findById('underlay')
-				.click()
-				.end();
+			.click()
+			.end();
 	}
 
 	return promise
 		.findById('button')
-			.click()
-			.end()
+		.click()
+		.end()
 		.sleep(DELAY);
 }
 
@@ -72,22 +70,22 @@ registerSuite('Dialog', {
 
 		return openDialog(this.remote)
 			.getWindowSize()
-				.then(({ height, width }) => {
-					viewportSize = { height, width };
-				})
+			.then(({ height, width }) => {
+				viewportSize = { height, width };
+			})
 			.findByCssSelector(`.${css.main}`)
-				.getSize()
-					.then(({ height, width }) => {
-						dialogSize = { height, width };
-					})
-				.getPosition()
-					.then(({ x, y }) => {
-						const expectedX = (viewportSize.width - dialogSize.width) / 2;
-						const expectedY = (viewportSize.height - dialogSize.height) / 2;
+			.getSize()
+			.then(({ height, width }) => {
+				dialogSize = { height, width };
+			})
+			.getPosition()
+			.then(({ x, y }) => {
+				const expectedX = (viewportSize.width - dialogSize.width) / 2;
+				const expectedY = (viewportSize.height - dialogSize.height) / 2;
 
-						assert.closeTo(x, expectedX, expectedX * 0.2);
-						assert.closeTo(y, expectedY, expectedY * 0.2);
-					});
+				assert.closeTo(x, expectedX, expectedX * 0.2);
+				assert.closeTo(y, expectedY, expectedY * 0.2);
+			});
 	},
 
 	'The underlay should cover the entire visible screen'() {
@@ -95,56 +93,56 @@ registerSuite('Dialog', {
 
 		return openDialog(this.remote, { underlay: true })
 			.getWindowSize()
-				.then(({ height, width }) => {
-					viewportSize = { height, width };
-				})
+			.then(({ height, width }) => {
+				viewportSize = { height, width };
+			})
 			.sleep(DELAY)
 			.findByCssSelector(`.${css.underlay}`)
-				.getSize()
-				.then(({ height, width }) => {
-					assert.isAtLeast(height, viewportSize.height * 0.8);
-					assert.isAtLeast(width, viewportSize.width * 0.9);
-				});
+			.getSize()
+			.then(({ height, width }) => {
+				assert.isAtLeast(height, viewportSize.height * 0.8);
+				assert.isAtLeast(width, viewportSize.width * 0.9);
+			});
 	},
 
 	'Clicking the underlay should destroy the dialog'() {
 		return clickUnderlay(this.remote)
 			.findByCssSelector(`.${css.root}`)
-				.getProperty('children')
-				.then((children: HTMLElement[]) => {
-					assert.lengthOf(children, 0);
-				});
+			.getProperty('children')
+			.then((children: HTMLElement[]) => {
+				assert.lengthOf(children, 0);
+			});
 	},
 
 	'Clicking the underlay should not destroy the dialog when "modal" is true'() {
 		return clickUnderlay(this.remote, { underlay: true, modal: true })
 			.findByCssSelector(`.${css.root}`)
-				.getProperty('children')
-				.then((children: HTMLElement[]) => {
-					assert.lengthOf(children, 2);
-				});
+			.getProperty('children')
+			.then((children: HTMLElement[]) => {
+				assert.lengthOf(children, 2);
+			});
 	},
 
 	'The dialog should not be closeable when "closeable" is false'() {
 		return clickUnderlay(this.remote, { underlay: true, closeable: false })
 			.findByCssSelector(`.${css.root}`)
-				.getProperty('children')
-				.then((children: HTMLElement[]) => {
-					assert.lengthOf(children, 2, 'The dialog should not be destroyed when the underlay is clicked.');
-				});
+			.getProperty('children')
+			.then((children: HTMLElement[]) => {
+				assert.lengthOf(children, 2, 'The dialog should not be destroyed when the underlay is clicked.');
+			});
 	},
 
 	'The dialog should be hidden when the close button is clicked'() {
 		return openDialog(this.remote)
 			.findByCssSelector(`.${css.close}`)
-				.click()
-				.sleep(DELAY)
-				.end()
+			.click()
+			.sleep(DELAY)
+			.end()
 			.findByCssSelector(`.${css.root}`)
-				.getProperty('children')
-				.then((children: HTMLElement[]) => {
-					assert.lengthOf(children, 0);
-				});
+			.getProperty('children')
+			.then((children: HTMLElement[]) => {
+				assert.lengthOf(children, 0);
+			});
 	},
 
 	'The dialog should be hidden when the close button is activated with the enter key'() {
@@ -162,9 +160,9 @@ registerSuite('Dialog', {
 			.pressKeys(keys.ENTER)
 			.sleep(DELAY)
 			.findByCssSelector(`.${css.root}`)
-				.getProperty('children')
-				.then((children: HTMLElement[]) => {
-					assert.lengthOf(children, 0);
-				});
+			.getProperty('children')
+			.then((children: HTMLElement[]) => {
+				assert.lengthOf(children, 0);
+			});
 	}
 });

--- a/src/dialog/tests/unit/Dialog.ts
+++ b/src/dialog/tests/unit/Dialog.ts
@@ -18,55 +18,73 @@ const compareId = compareProperty((value: any) => {
 });
 
 const expectedCloseButton = function() {
-	return v('button', {
-		classes: css.close,
-		onclick: widget.listener
-	}, [
-		'close dialog',
-		v('i', {
-			classes: [ iconCss.icon, iconCss.closeIcon ],
-			role: 'presentation',
-			'aria-hidden': 'true'
-		})
-	]);
+	return v(
+		'button',
+		{
+			classes: css.close,
+			onclick: widget.listener
+		},
+		[
+			'close dialog',
+			v('i', {
+				classes: [iconCss.icon, iconCss.closeIcon],
+				role: 'presentation',
+				'aria-hidden': 'true'
+			})
+		]
+	);
 };
 
 const expected = function(widget: Harness<Dialog>, open = false, closeable = false, children: any[] = []) {
-	return v('div', { classes: css.root }, open ? [
-		v('div', {
-			classes: [ null, css.underlay ],
-			enterAnimation: animations.fadeIn,
-			exitAnimation: animations.fadeOut,
-			key: 'underlay',
-			onclick: widget.listener
-		}),
-		v('div', {
-			'aria-labelledby': compareId,
-			classes: css.main,
-			enterAnimation: animations.fadeIn,
-			exitAnimation: animations.fadeOut,
-			key: 'main',
-			role: 'dialog'
-		}, [
-			v('div', {
-				classes: css.title,
-				key: 'title'
-			}, [
-				v('div', { id: <any> compareId }, [ '' ]),
-				closeable ? expectedCloseButton() : null
-			]),
-			v('div', {
-				classes: css.content,
-				key: 'content'
-			}, children)
-		])
-	] : []);
+	return v(
+		'div',
+		{ classes: css.root },
+		open
+			? [
+					v('div', {
+						classes: [null, css.underlay],
+						enterAnimation: animations.fadeIn,
+						exitAnimation: animations.fadeOut,
+						key: 'underlay',
+						onclick: widget.listener
+					}),
+					v(
+						'div',
+						{
+							'aria-labelledby': compareId,
+							classes: css.main,
+							enterAnimation: animations.fadeIn,
+							exitAnimation: animations.fadeOut,
+							key: 'main',
+							role: 'dialog'
+						},
+						[
+							v(
+								'div',
+								{
+									classes: css.title,
+									key: 'title'
+								},
+								[v('div', { id: <any>compareId }, ['']), closeable ? expectedCloseButton() : null]
+							),
+							v(
+								'div',
+								{
+									classes: css.content,
+									key: 'content'
+								},
+								children
+							)
+						]
+					)
+				]
+			: []
+	);
 };
 
 let widget: Harness<Dialog>;
 
 registerSuite('Dialog', {
-
 	beforeEach() {
 		widget = harness(Dialog);
 	},
@@ -107,13 +125,13 @@ registerSuite('Dialog', {
 
 			let expectedVdom = expected(widget, true, true);
 			assignChildProperties(expectedVdom, '0', {
-				classes: [ css.underlayVisible, css.underlay ] // do this here so the class is present in future renders
+				classes: [css.underlayVisible, css.underlay] // do this here so the class is present in future renders
 			});
 			expectedVdom = expected(widget, true, true);
 			replaceChild(expectedVdom, '1,0,1,0', 'foo');
 			replaceChild(expectedVdom, '1,0,0,0', 'foo');
 			assignChildProperties(expectedVdom, '0', {
-				classes: [ css.underlayVisible, css.underlay ]
+				classes: [css.underlayVisible, css.underlay]
 			});
 			assignChildProperties(expectedVdom, '1', {
 				enterAnimation: 'fooAnimation',
@@ -125,10 +143,7 @@ registerSuite('Dialog', {
 		},
 
 		children() {
-			const testChildren = [
-				v('p', [ 'Lorem ipsum dolor sit amet' ]),
-				v('a', { href: '#foo' }, [ 'foo' ])
-			];
+			const testChildren = [v('p', ['Lorem ipsum dolor sit amet']), v('a', { href: '#foo' }, ['foo'])];
 
 			widget.setProperties({
 				open: true
@@ -195,7 +210,10 @@ registerSuite('Dialog', {
 			widget.sendEvent('click', {
 				selector: `.${css.underlay}`
 			});
-			assert.isFalse(onRequestClose.called, 'onRequestClose should not be called when the underlay is clicked and modal is true');
+			assert.isFalse(
+				onRequestClose.called,
+				'onRequestClose should not be called when the underlay is clicked and modal is true'
+			);
 
 			widget.setProperties({
 				open: true,
@@ -207,7 +225,10 @@ registerSuite('Dialog', {
 			widget.sendEvent('click', {
 				selector: `.${css.underlay}`
 			});
-			assert.isTrue(onRequestClose.called, 'onRequestClose is called when the underlay is clicked and modal is false');
+			assert.isTrue(
+				onRequestClose.called,
+				'onRequestClose is called when the underlay is clicked and modal is false'
+			);
 		},
 
 		escapeKey() {
@@ -220,7 +241,7 @@ registerSuite('Dialog', {
 			widget.getRender();
 
 			widget.sendEvent('keyup', {
-				eventInit: <KeyboardEventInit> {
+				eventInit: <KeyboardEventInit>{
 					which: Keys.Down
 				}
 			});
@@ -228,7 +249,7 @@ registerSuite('Dialog', {
 			assert.isTrue(onRequestClose.notCalled);
 
 			widget.sendEvent('keyup', {
-				eventInit: <KeyboardEventInit> {
+				eventInit: <KeyboardEventInit>{
 					which: Keys.Escape
 				}
 			});

--- a/src/enhancedtextinput/EnhancedTextInput.ts
+++ b/src/enhancedtextinput/EnhancedTextInput.ts
@@ -13,16 +13,17 @@ export interface EnhancedTextInputProperties extends TextInputProperties {
 @theme(css)
 export default class EnhancedTextInput extends TextInput<EnhancedTextInputProperties> {
 	protected renderAddon(addon: DNode, before = false): DNode {
-		return v('span', {
-			classes: this.theme([css.addon, before ? css.addonBefore : css.addonAfter])
-		}, [ addon ]);
+		return v(
+			'span',
+			{
+				classes: this.theme([css.addon, before ? css.addonBefore : css.addonAfter])
+			},
+			[addon]
+		);
 	}
 
 	protected renderInputWrapper(): DNode {
-		let {
-			addonAfter = [],
-			addonBefore = []
-		} = this.properties;
+		let { addonAfter = [], addonBefore = [] } = this.properties;
 
 		return v('div', { classes: this.theme(css.inputWrapper) }, [
 			...addonBefore.map((addon: DNode) => this.renderAddon(addon, true)),

--- a/src/enhancedtextinput/example/index.ts
+++ b/src/enhancedtextinput/example/index.ts
@@ -17,52 +17,60 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render() {
-		return v('div', {
-			styles: { maxWidth: '256px' }
-		}, [
-			v('h2', {}, ['Text Input Examples']),
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
-			v('div', { id: 'example-text' }, [
-				v('h3', {}, ['String label']),
-				w(EnhancedTextInput, {
-					key: 't1',
-					addonBefore: [ '@' ],
-					describedBy: 'twitter-desc',
-					label: 'Twitter Username',
-					type: 'text',
-					placeholder: 'username',
-					value: this._value1,
-					onChange: (event: Event) => {
-						this._value1 = (event.target as HTMLInputElement).value;
-						this.invalidate();
-					},
-					theme: this._theme
-				}),
-				v('span', {
-					id: 'twitter-desc'
-				}, [ 'Not including the "@" symbol' ]),
-				v('br'),
-				w(EnhancedTextInput, {
-					key: 't2',
-					addonBefore: [ '$' ],
-					addonAfter: [ '.00' ],
-					label: 'Price, rounded to the nearest dollar',
-					type: 'number',
-					value: this._value2,
-					onChange: (event: Event) => {
-						this._value2 = (event.target as HTMLInputElement).value;
-						this.invalidate();
-					},
-					theme: this._theme
-				})
-			])
-		]);
+		return v(
+			'div',
+			{
+				styles: { maxWidth: '256px' }
+			},
+			[
+				v('h2', {}, ['Text Input Examples']),
+				v('label', [
+					'Use Dojo Theme ',
+					v('input', {
+						type: 'checkbox',
+						onchange: this.themeChange
+					})
+				]),
+				v('div', { id: 'example-text' }, [
+					v('h3', {}, ['String label']),
+					w(EnhancedTextInput, {
+						key: 't1',
+						addonBefore: ['@'],
+						describedBy: 'twitter-desc',
+						label: 'Twitter Username',
+						type: 'text',
+						placeholder: 'username',
+						value: this._value1,
+						onChange: (event: Event) => {
+							this._value1 = (event.target as HTMLInputElement).value;
+							this.invalidate();
+						},
+						theme: this._theme
+					}),
+					v(
+						'span',
+						{
+							id: 'twitter-desc'
+						},
+						['Not including the "@" symbol']
+					),
+					v('br'),
+					w(EnhancedTextInput, {
+						key: 't2',
+						addonBefore: ['$'],
+						addonAfter: ['.00'],
+						label: 'Price, rounded to the nearest dollar',
+						type: 'number',
+						value: this._value2,
+						onChange: (event: Event) => {
+							this._value2 = (event.target as HTMLInputElement).value;
+							this.invalidate();
+						},
+						theme: this._theme
+					})
+				])
+			]
+		);
 	}
 }
 

--- a/src/enhancedtextinput/tests/unit/EnhancedTextInput.ts
+++ b/src/enhancedtextinput/tests/unit/EnhancedTextInput.ts
@@ -17,7 +17,12 @@ const compareId = compareProperty((value: any) => {
 	return typeof value === 'string';
 });
 
-const expected = function(label = false, addonBefore = false, addonAfter = false, classes: (string | null)[] = [ textInputCss.root, null, null, null, null, null ]) {
+const expected = function(
+	label = false,
+	addonBefore = false,
+	addonAfter = false,
+	classes: (string | null)[] = [textInputCss.root, null, null, null, null, null]
+) {
 	const children = [
 		v('input', {
 			'aria-controls': undefined,
@@ -25,7 +30,7 @@ const expected = function(label = false, addonBefore = false, addonAfter = false
 			'aria-invalid': null,
 			classes: css.input,
 			disabled: undefined,
-			id: <any> compareId,
+			id: <any>compareId,
 			key: 'input',
 			maxlength: null,
 			minlength: null,
@@ -52,37 +57,58 @@ const expected = function(label = false, addonBefore = false, addonAfter = false
 		})
 	];
 	if (addonBefore) {
-		children.unshift(v('span', {
-			classes: [css.addon, css.addonBefore]
-		}, [ 'foo' ]));
+		children.unshift(
+			v(
+				'span',
+				{
+					classes: [css.addon, css.addonBefore]
+				},
+				['foo']
+			)
+		);
 	}
 	if (addonAfter) {
-		children.push(v('span', {
-			classes: [css.addon, css.addonAfter]
-		}, [ 'bar' ]));
+		children.push(
+			v(
+				'span',
+				{
+					classes: [css.addon, css.addonAfter]
+				},
+				['bar']
+			)
+		);
 	}
 
-	return v('div', {
-		key: 'root',
-		classes
-	}, [
-		label ? w(Label, {
-			theme: undefined,
-			disabled: undefined,
-			hidden: false,
-			invalid: undefined,
-			readOnly: undefined,
-			required: undefined,
-			forId: <any> compareId
-		}, [ 'foo' ]) : null,
-		v('div', { classes: css.inputWrapper }, children)
-	]);
+	return v(
+		'div',
+		{
+			key: 'root',
+			classes
+		},
+		[
+			label
+				? w(
+						Label,
+						{
+							theme: undefined,
+							disabled: undefined,
+							hidden: false,
+							invalid: undefined,
+							readOnly: undefined,
+							required: undefined,
+							forId: <any>compareId
+						},
+						['foo']
+					)
+				: null,
+			v('div', { classes: css.inputWrapper }, children)
+		]
+	);
 };
 
 let widget: Harness<EnhancedTextInput>;
 
 registerSuite('EnhancedTextInput', {
-
 	beforeEach() {
 		widget = harness(EnhancedTextInput);
 	},
@@ -94,22 +120,22 @@ registerSuite('EnhancedTextInput', {
 	tests: {
 		'addon before'() {
 			widget.setProperties({
-				addonBefore: [ 'foo' ]
+				addonBefore: ['foo']
 			});
 			widget.expectRender(expected(false, true));
 		},
 
 		'addon after'() {
 			widget.setProperties({
-				addonAfter: [ 'bar' ]
+				addonAfter: ['bar']
 			});
 			widget.expectRender(expected(false, false, true));
 		},
 
 		'addons before and after'() {
 			widget.setProperties({
-				addonBefore: [ 'foo' ],
-				addonAfter: [ 'bar' ]
+				addonBefore: ['foo'],
+				addonAfter: ['bar']
 			});
 			widget.expectRender(expected(false, true, true));
 		},
@@ -133,7 +159,7 @@ registerSuite('EnhancedTextInput', {
 
 				const expectedVdom = expected();
 				assignProperties(expectedVdom, {
-					classes: [ textInputCss.root, null, null, null, null, null ]
+					classes: [textInputCss.root, null, null, null, null, null]
 				});
 				assignChildProperties(expectedVdom, '1,0', {
 					'aria-controls': 'foo',
@@ -149,7 +175,7 @@ registerSuite('EnhancedTextInput', {
 				widget.expectRender(expectedVdom);
 			},
 
-			'label'() {
+			label() {
 				widget.setProperties({
 					label: 'foo'
 				});
@@ -165,7 +191,14 @@ registerSuite('EnhancedTextInput', {
 					required: true
 				});
 
-				let expectedVdom = expected(false, false, false, [ textInputCss.root, textInputCss.disabled, textInputCss.invalid, null, textInputCss.readonly, textInputCss.required ]);
+				let expectedVdom = expected(false, false, false, [
+					textInputCss.root,
+					textInputCss.disabled,
+					textInputCss.invalid,
+					null,
+					textInputCss.readonly,
+					textInputCss.required
+				]);
 				assignChildProperties(expectedVdom, '1,0', {
 					disabled: true,
 					'aria-invalid': 'true',
@@ -190,7 +223,7 @@ registerSuite('EnhancedTextInput', {
 					required: false
 				});
 				assignProperties(expectedVdom, {
-					classes: [ textInputCss.root, null, null, textInputCss.valid, null, null ]
+					classes: [textInputCss.root, null, null, textInputCss.valid, null, null]
 				});
 
 				widget.expectRender(expectedVdom, 'State classes should be false, css.valid should be true');
@@ -205,7 +238,14 @@ registerSuite('EnhancedTextInput', {
 					required: true
 				});
 
-				const expectedVdom = expected(true, false, false, [ textInputCss.root, textInputCss.disabled, textInputCss.invalid, null, textInputCss.readonly, textInputCss.required ]);
+				const expectedVdom = expected(true, false, false, [
+					textInputCss.root,
+					textInputCss.disabled,
+					textInputCss.invalid,
+					null,
+					textInputCss.readonly,
+					textInputCss.required
+				]);
 				assignChildProperties(expectedVdom, '1,0', {
 					disabled: true,
 					'aria-invalid': 'true',

--- a/src/label/Label.ts
+++ b/src/label/Label.ts
@@ -31,16 +31,9 @@ export interface LabelProperties extends ThemedProperties {
 export const ThemedBase = ThemedMixin(WidgetBase);
 
 @theme(css)
-export default class Label<P extends LabelProperties = LabelProperties> extends ThemedBase<P>  {
-
+export default class Label<P extends LabelProperties = LabelProperties> extends ThemedBase<P> {
 	protected getRootClasses(): (string | null)[] {
-		const {
-			disabled,
-			invalid,
-			readOnly,
-			required,
-			secondary
-		} = this.properties;
+		const { disabled, invalid, readOnly, required, secondary } = this.properties;
 		return [
 			css.root,
 			disabled ? css.disabled : null,
@@ -55,12 +48,13 @@ export default class Label<P extends LabelProperties = LabelProperties> extends 
 	render(): DNode {
 		const { forId, hidden } = this.properties;
 
-		return v('label', {
-			classes: [
-				...this.theme(this.getRootClasses()),
-				hidden ? baseCss.visuallyHidden : null
-			],
-			for: forId
-		}, this.children);
+		return v(
+			'label',
+			{
+				classes: [...this.theme(this.getRootClasses()), hidden ? baseCss.visuallyHidden : null],
+				for: forId
+			},
+			this.children
+		);
 	}
 }

--- a/src/label/example/index.ts
+++ b/src/label/example/index.ts
@@ -9,16 +9,12 @@ export class App extends WidgetBase<WidgetProperties> {
 		return v('div', [
 			v('h1', {}, ['Label Examples']),
 			v('h3', {}, ['Label assigned as string without extra options']),
-			v('div', { id: 'example-1'}, [
-				w(Label, {}, [ 'Type Something' ])
-			]),
+			v('div', { id: 'example-1' }, [w(Label, {}, ['Type Something'])]),
 			v('h3', {}, ['Hidden label']),
-			v('div', { id: 'example-2'}, [
-				w(Label, { hidden: true }, [ 'Can\'t read me!' ])
-			]),
+			v('div', { id: 'example-2' }, [w(Label, { hidden: true }, ["Can't read me!"])]),
 			v('h3', {}, ['Label with Input']),
-			v('div', { id: 'example-3'}, [
-				w(Label, { forId: 'input-1' }, [ 'Type Something' ]),
+			v('div', { id: 'example-3' }, [
+				w(Label, { forId: 'input-1' }, ['Type Something']),
 				v('input', { id: 'input-1' })
 			])
 		]);

--- a/src/label/tests/functional/Label.ts
+++ b/src/label/tests/functional/Label.ts
@@ -5,9 +5,7 @@ import { Remote } from 'intern/lib/executors/Node';
 import * as css from '../../styles/label.m.css';
 
 function getPage(remote: Remote) {
-	return remote
-		.get('http://localhost:9000/_build/common/example/?module=label')
-		.setFindTimeout(5000);
+	return remote.get('http://localhost:9000/_build/common/example/?module=label').setFindTimeout(5000);
 }
 
 registerSuite('Label', {
@@ -15,7 +13,7 @@ registerSuite('Label', {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-1 .${css.root}`)
 			.getSize()
-			.then(({ height, width }: { height: number; width: number; }) => {
+			.then(({ height, width }: { height: number; width: number }) => {
 				assert.isAbove(height, 0, 'The label height should be greater than zero.');
 				assert.isAbove(width, 0, 'The label width should be greater than zero.');
 			})
@@ -24,37 +22,36 @@ registerSuite('Label', {
 	'Label text should be as defined'() {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-1 .${css.root}`)
-				.getVisibleText()
-				.then((text: string) => {
-					assert.strictEqual(text, 'Type Something');
-				})
+			.getVisibleText()
+			.then((text: string) => {
+				assert.strictEqual(text, 'Type Something');
+			})
 			.end();
-
 	},
 	'Input box should gain focus when clicking on the label'() {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-3 .${css.root}`)
-				.click()
+			.click()
 			.end()
 			.sleep(250)
 			.execute(`return document.activeElement === document.querySelector('#example-3 input');`)
-			.then(isEqual => {
+			.then((isEqual) => {
 				assert.isTrue(isEqual);
 			});
 	},
 	'Hidden label text should not be displayed'() {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-2 .${css.root}`)
-				.getVisibleText()
-				.then((text: string) => {
-					assert.strictEqual(text, 'Can\'t read me!');
-				})
+			.getVisibleText()
+			.then((text: string) => {
+				assert.strictEqual(text, "Can't read me!");
+			})
 
-				.getSize()
-				.then(({ height, width }: { height: number; width: number; }) => {
-					assert.isAtMost(height, 1, 'The label text height should be no more than 1px.');
-					assert.isAtMost(width, 1, 'The label text width should be no more than 1px.');
-				})
+			.getSize()
+			.then(({ height, width }: { height: number; width: number }) => {
+				assert.isAtMost(height, 1, 'The label text height should be no more than 1px.');
+				assert.isAtMost(width, 1, 'The label text width should be no more than 1px.');
+			})
 			.end();
 	}
 });

--- a/src/label/tests/unit/Label.ts
+++ b/src/label/tests/unit/Label.ts
@@ -10,7 +10,6 @@ import * as baseCss from '../../../common/styles/base.m.css';
 let widget: Harness<Label>;
 
 registerSuite('Label', {
-
 	beforeEach() {
 		widget = harness(Label);
 	},
@@ -21,22 +20,18 @@ registerSuite('Label', {
 
 	tests: {
 		simple() {
-			widget.setChildren([ 'baz' ]);
+			widget.setChildren(['baz']);
 
-			widget.expectRender(v('label', {
-				classes: [
-					css.root,
-					null,
-					null,
-					null,
-					null,
-					null,
-					null
-				],
-				for: undefined
-			}, [
-				'baz'
-			]));
+			widget.expectRender(
+				v(
+					'label',
+					{
+						classes: [css.root, null, null, null, null, null, null],
+						for: undefined
+					},
+					['baz']
+				)
+			);
 		},
 
 		hidden() {
@@ -44,21 +39,18 @@ registerSuite('Label', {
 				hidden: true
 			});
 
-			widget.setChildren([ 'baz' ]);
+			widget.setChildren(['baz']);
 
-			widget.expectRender(v('label', {
-				classes: [
-					css.root,
-					null,
-					null,
-					null,
-					null,
-					null,
-					baseCss.visuallyHidden ],
-				for: undefined
-			}, [
-				'baz'
-			]));
+			widget.expectRender(
+				v(
+					'label',
+					{
+						classes: [css.root, null, null, null, null, null, baseCss.visuallyHidden],
+						for: undefined
+					},
+					['baz']
+				)
+			);
 		}
 	}
 });

--- a/src/listbox/Listbox.ts
+++ b/src/listbox/Listbox.ts
@@ -140,18 +140,14 @@ export default class Listbox<P extends ListboxProperties = ListboxProperties> ex
 
 		if (optionOffset.top - scrollOffset < 0) {
 			this.animateScroll(optionOffset.top);
-		}
-
-		else if ((optionOffset.top + optionOffset.height) > (scrollOffset + menuHeight)) {
+		} else if (optionOffset.top + optionOffset.height > scrollOffset + menuHeight) {
 			this.animateScroll(optionOffset.top + optionOffset.height - menuHeight);
 		}
 	}
 
 	protected getModifierClasses() {
 		const { visualFocus } = this.properties;
-		return [
-			visualFocus ? css.focused : null
-		];
+		return [visualFocus ? css.focused : null];
 	}
 
 	protected getOptionClasses(active: boolean, disabled: boolean, selected: boolean) {
@@ -169,11 +165,7 @@ export default class Listbox<P extends ListboxProperties = ListboxProperties> ex
 	}
 
 	protected renderOption(option: any, index: number): DNode {
-		const {
-			activeIndex = 0,
-			getOptionSelected,
-			theme
-		} = this.properties;
+		const { activeIndex = 0, getOptionSelected, theme } = this.properties;
 
 		const disabled = this._getOptionDisabled(option, index);
 		const selected = getOptionSelected ? getOptionSelected(option, index) : false;
@@ -196,32 +188,28 @@ export default class Listbox<P extends ListboxProperties = ListboxProperties> ex
 	}
 
 	protected renderOptions(): DNode[] {
-		const {
-			optionData = []
-		} = this.properties;
+		const { optionData = [] } = this.properties;
 
 		return optionData.map(this._boundRenderOption);
 	}
 
 	protected render(): DNode {
-		const {
-			activeIndex = 0,
-			describedBy,
-			id,
-			multiselect = false,
-			tabIndex = 0
-		} = this.properties;
+		const { activeIndex = 0, describedBy, id, multiselect = false, tabIndex = 0 } = this.properties;
 
-		return v('div', {
-			'aria-activedescendant': this._getOptionId(activeIndex),
-			'aria-multiselectable': multiselect ? 'true' : null,
-			classes: this.theme([ css.root, ...this.getModifierClasses() ]),
-			describedBy,
-			id,
-			key: 'root',
-			role: 'listbox',
-			tabIndex,
-			onkeydown: this._onKeyDown
-		}, this.renderOptions());
+		return v(
+			'div',
+			{
+				'aria-activedescendant': this._getOptionId(activeIndex),
+				'aria-multiselectable': multiselect ? 'true' : null,
+				classes: this.theme([css.root, ...this.getModifierClasses()]),
+				describedBy,
+				id,
+				key: 'root',
+				role: 'listbox',
+				tabIndex,
+				onkeydown: this._onKeyDown
+			},
+			this.renderOptions()
+		);
 	}
 }

--- a/src/listbox/ListboxOption.ts
+++ b/src/listbox/ListboxOption.ts
@@ -20,28 +20,29 @@ export interface ListboxOptionProperties extends ThemedProperties {
 export const ThemedBase = ThemedMixin(WidgetBase);
 
 @theme(css)
-export default class ListboxOption<P extends ListboxOptionProperties = ListboxOptionProperties> extends ThemedBase<P, null> {
+export default class ListboxOption<P extends ListboxOptionProperties = ListboxOptionProperties> extends ThemedBase<
+	P,
+	null
+> {
 	private _onClick(event: MouseEvent) {
 		const { index, key, option, onClick } = this.properties;
 		onClick && onClick(option, index, key);
 	}
 
 	protected render(): DNode {
-		const {
-			classes = [],
-			disabled = false,
-			id,
-			label,
-			selected = false
-		} = this.properties;
+		const { classes = [], disabled = false, id, label, selected = false } = this.properties;
 
-		return v('div', {
-			'aria-disabled': disabled ? 'true' : null,
-			'aria-selected': disabled ? null : String(selected),
-			classes: this.theme(classes),
-			id,
-			role: 'option',
-			onclick: this._onClick
-		}, [ label ]);
+		return v(
+			'div',
+			{
+				'aria-disabled': disabled ? 'true' : null,
+				'aria-selected': disabled ? null : String(selected),
+				classes: this.theme(classes),
+				id,
+				role: 'option',
+				onclick: this._onClick
+			},
+			[label]
+		);
 	}
 }

--- a/src/listbox/example/index.ts
+++ b/src/listbox/example/index.ts
@@ -106,7 +106,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				})
 			]),
 			v('br'),
-			v('label', { for: 'listbox1' }, [ 'Single-select listbox example' ]),
+			v('label', { for: 'listbox1' }, ['Single-select listbox example']),
 			w(Listbox, {
 				key: 'listbox1',
 				activeIndex: this._listbox1Index,
@@ -122,12 +122,12 @@ export class App extends WidgetBase<WidgetProperties> {
 				},
 				onOptionSelect: (option: any, index: number) => {
 					this._listbox1Value = option.value;
-					this._options = [ ...this._options ];
+					this._options = [...this._options];
 					this.invalidate();
 				}
 			}),
 			v('br'),
-			v('label', { for: 'listbox2' }, [ 'Multi-select listbox example' ]),
+			v('label', { for: 'listbox2' }, ['Multi-select listbox example']),
 			w(Listbox, {
 				key: 'listbox2',
 				activeIndex: this._listbox2Index,
@@ -143,7 +143,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				},
 				onOptionSelect: (option: any, index: number) => {
 					this._moreOptions[index].selected = !this._moreOptions[index].selected;
-					this._moreOptions = [ ...this._moreOptions ];
+					this._moreOptions = [...this._moreOptions];
 					this.invalidate();
 				}
 			})

--- a/src/listbox/tests/functional/Listbox.ts
+++ b/src/listbox/tests/functional/Listbox.ts
@@ -8,9 +8,7 @@ import * as css from '../../styles/listbox.m.css';
 const DELAY = 300;
 
 function getPage(remote: Remote) {
-	return remote
-		.get('http://localhost:9000/_build/common/example/?module=listbox')
-		.setFindTimeout(5000);
+	return remote.get('http://localhost:9000/_build/common/example/?module=listbox').setFindTimeout(5000);
 }
 
 registerSuite('Listbox', {
@@ -23,23 +21,23 @@ registerSuite('Listbox', {
 		let selectedId = '';
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.root} > div:nth-child(2) > div`)
-				.getAttribute('id')
-				.then((id: string) => {
-					selectedId = id;
-				})
-				.click()
-				.sleep(DELAY)
-				.getAttribute('class')
-				.then((className: string) => {
-					assert.include(className, css.activeOption, 'clicked option has activeOption class');
-					assert.include(className, css.selectedOption, 'clicked option has selectedOption class');
-				})
-				.end()
+			.getAttribute('id')
+			.then((id: string) => {
+				selectedId = id;
+			})
+			.click()
+			.sleep(DELAY)
+			.getAttribute('class')
+			.then((className: string) => {
+				assert.include(className, css.activeOption, 'clicked option has activeOption class');
+				assert.include(className, css.selectedOption, 'clicked option has selectedOption class');
+			})
+			.end()
 			.findByCssSelector(`.${css.root}`)
-				.getAttribute('aria-activedescendant')
-				.then((id: string) => {
-					assert.strictEqual(id, selectedId, 'listbox aria-activedescendant is equal to clicked option id');
-				});
+			.getAttribute('aria-activedescendant')
+			.then((id: string) => {
+				assert.strictEqual(id, selectedId, 'listbox aria-activedescendant is equal to clicked option id');
+			});
 	},
 
 	'the selected option should be visible'() {
@@ -54,45 +52,45 @@ registerSuite('Listbox', {
 
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.root} > div:first-child > div`)
-				.click()
-				.end()
+			.click()
+			.end()
 			.sleep(DELAY)
 			.pressKeys(keys.ARROW_UP)
 			.sleep(DELAY)
 			.findByCssSelector(`.${css.root}`)
-				.getPosition()
-				.then(({ y }: { y: number; }) => {
-					menuTop = y;
-				})
-				.getSize()
-				.then(({ height }: { height: number }) => {
-					menuBottom = menuTop + height;
-				})
-				.end()
+			.getPosition()
+			.then(({ y }: { y: number }) => {
+				menuTop = y;
+			})
+			.getSize()
+			.then(({ height }: { height: number }) => {
+				menuBottom = menuTop + height;
+			})
+			.end()
 			.findByCssSelector(`.${css.activeOption}`)
-				.getSize()
-				.then(({ height }: { height: number }) => {
-					itemHeight = height;
-				})
-				.getPosition()
-				.then(({ y }: { y: number; }) => {
-					assert.isAtLeast(y, menuTop);
-					assert.isAtMost(Math.floor(y), Math.ceil(menuBottom - itemHeight), 'scrolled down');
-				})
-				.end()
+			.getSize()
+			.then(({ height }: { height: number }) => {
+				itemHeight = height;
+			})
+			.getPosition()
+			.then(({ y }: { y: number }) => {
+				assert.isAtLeast(y, menuTop);
+				assert.isAtMost(Math.floor(y), Math.ceil(menuBottom - itemHeight), 'scrolled down');
+			})
+			.end()
 			.pressKeys(keys.ARROW_DOWN)
 			.sleep(DELAY)
 			.findByCssSelector(`.${css.root}`)
-				.getPosition()
-				.then(({ y }: { y: number; }) => {
-					menuTop = y;
-				})
-				.end()
+			.getPosition()
+			.then(({ y }: { y: number }) => {
+				menuTop = y;
+			})
+			.end()
 			.findByCssSelector(`.${css.activeOption}`)
-				.getPosition()
-				.then(({ y }: { y: number; }) => {
-					assert.isAtLeast(y, menuTop, 'scroll back up');
-				});
+			.getPosition()
+			.then(({ y }: { y: number }) => {
+				assert.isAtLeast(y, menuTop, 'scroll back up');
+			});
 	},
 
 	'keys move and select active option'() {
@@ -104,20 +102,20 @@ registerSuite('Listbox', {
 
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.root} > div:nth-child(2) > div`)
-				.click()
-				.sleep(DELAY)
-				.end()
+			.click()
+			.sleep(DELAY)
+			.end()
 			.findByCssSelector(`.${css.root}`)
-				.type(keys.ARROW_DOWN)
-				.type(keys.ENTER)
-				.sleep(DELAY)
-				.end()
+			.type(keys.ARROW_DOWN)
+			.type(keys.ENTER)
+			.sleep(DELAY)
+			.end()
 			.findByCssSelector(`.${css.root} > div:nth-child(3) > div`)
-				.getAttribute('class')
-				.then((className: string) => {
-					assert.include(className, css.activeOption, 'down arrow moves active option');
-					assert.include(className, css.selectedOption, 'enter selects option');
-				});
+			.getAttribute('class')
+			.then((className: string) => {
+				assert.include(className, css.activeOption, 'down arrow moves active option');
+				assert.include(className, css.selectedOption, 'enter selects option');
+			});
 	},
 
 	'listbox is in tab order'() {
@@ -129,15 +127,15 @@ registerSuite('Listbox', {
 
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.root}`)
-				.click()
-				.sleep(DELAY)
-				.type(keys.TAB)
-				.sleep(DELAY)
-				.end()
+			.click()
+			.sleep(DELAY)
+			.type(keys.TAB)
+			.sleep(DELAY)
+			.end()
 			.getActiveElement()
-				.getAttribute('id')
-				.then((id: string) => {
-					assert.strictEqual(id, 'listbox2');
-				});
+			.getAttribute('id')
+			.then((id: string) => {
+				assert.strictEqual(id, 'listbox2');
+			});
 	}
 });

--- a/src/listbox/tests/unit/Listbox.ts
+++ b/src/listbox/tests/unit/Listbox.ts
@@ -46,7 +46,7 @@ const expectedOptions = function(widget: Harness<Listbox>, activeIndex = 0) {
 		v('div', { key: 'first' }, [
 			w(ListboxOption, {
 				active: activeIndex === 0,
-				classes: [ css.option, css.activeOption, null, null ],
+				classes: [css.option, css.activeOption, null, null],
 				disabled: false,
 				id: 'first',
 				index: 0,
@@ -58,12 +58,12 @@ const expectedOptions = function(widget: Harness<Listbox>, activeIndex = 0) {
 				theme: undefined
 			})
 		]),
-		v('div', { key: <any> compareId }, [
+		v('div', { key: <any>compareId }, [
 			w(ListboxOption, {
 				active: activeIndex === 1,
-				classes: [ css.option, null, null, null ],
+				classes: [css.option, null, null, null],
 				disabled: false,
-				id: <any> compareId,
+				id: <any>compareId,
 				index: 1,
 				key: 'option-1',
 				label: '[object Object]',
@@ -73,12 +73,12 @@ const expectedOptions = function(widget: Harness<Listbox>, activeIndex = 0) {
 				theme: undefined
 			})
 		]),
-		v('div', { key: <any> compareId }, [
+		v('div', { key: <any>compareId }, [
 			w(ListboxOption, {
 				active: activeIndex === 2,
-				classes: [ css.option, null, null, null ],
+				classes: [css.option, null, null, null],
 				disabled: false,
-				id: <any> compareId,
+				id: <any>compareId,
 				index: 2,
 				key: 'option-2',
 				label: '[object Object]',
@@ -92,17 +92,21 @@ const expectedOptions = function(widget: Harness<Listbox>, activeIndex = 0) {
 };
 
 const expectedVdom = function(widget: Harness<Listbox>, options: DNode[]) {
-	return v('div', {
-		'aria-activedescendant': compareId,
-		'aria-multiselectable': null,
-		classes: [ css.root, null ],
-		describedBy: undefined,
-		id: undefined,
-		key: 'root',
-		role: 'listbox',
-		tabIndex: 0,
-		onkeydown: widget.listener
-	}, options);
+	return v(
+		'div',
+		{
+			'aria-activedescendant': compareId,
+			'aria-multiselectable': null,
+			classes: [css.root, null],
+			describedBy: undefined,
+			id: undefined,
+			key: 'root',
+			role: 'listbox',
+			tabIndex: 0,
+			onkeydown: widget.listener
+		},
+		options
+	);
 };
 
 registerSuite('Listbox', {
@@ -123,10 +127,10 @@ registerSuite('Listbox', {
 			widget.setProperties({ optionData: testOptions });
 			const vdom = expectedVdom(widget, expectedOptions(widget));
 			assignChildProperties(vdom, '0', {
-				key: <any> compareId
+				key: <any>compareId
 			});
 			assignChildProperties(vdom, '0,0', {
-				id: <any> compareId
+				id: <any>compareId
 			});
 			widget.expectRender(vdom);
 		},
@@ -151,7 +155,7 @@ registerSuite('Listbox', {
 			assignProperties(vdom, {
 				'aria-activedescendant': 'first',
 				'aria-multiselectable': 'true',
-				classes: [ css.root, css.focused ],
+				classes: [css.root, css.focused],
 				describedBy: 'foo',
 				id: 'bar',
 				tabIndex: -1
@@ -161,13 +165,13 @@ registerSuite('Listbox', {
 				theme: {}
 			});
 			assignChildProperties(vdom, '1,0', {
-				classes: <any> [ css.option, null, null, css.selectedOption ],
+				classes: <any>[css.option, null, null, css.selectedOption],
 				label: 'Two',
 				selected: true,
 				theme: {}
 			});
 			assignChildProperties(vdom, '2,0', {
-				classes: <any> [ css.option, null, css.disabledOption, null ],
+				classes: <any>[css.option, null, css.disabledOption, null],
 				disabled: true,
 				label: 'Three',
 				theme: {}
@@ -280,8 +284,7 @@ registerSuite('Listbox', {
 							scroll: { top: 0 },
 							offset: { height: 200 }
 						};
-					}
-					else {
+					} else {
 						return {
 							offset: {
 								top: 300,
@@ -295,7 +298,7 @@ registerSuite('Listbox', {
 				public scroll(key: string | number, scrollValue: number) {
 					scrollStub(key, scrollValue);
 				}
-			};
+			}
 			class ScrollListbox extends Listbox {
 				meta(MetaType: any): any {
 					return new StubMeta();
@@ -317,8 +320,7 @@ registerSuite('Listbox', {
 							scroll: { top: 300 },
 							offset: { height: 200 }
 						};
-					}
-					else {
+					} else {
 						return {
 							offset: {
 								top: 100,
@@ -332,7 +334,7 @@ registerSuite('Listbox', {
 				public scroll(key: string | number, scrollValue: number) {
 					scrollStub(key, scrollValue);
 				}
-			};
+			}
 			class ScrollListbox extends Listbox {
 				meta(MetaType: any): any {
 					return new StubDimensions();
@@ -354,15 +356,19 @@ registerSuite('Listbox', {
 			class TestWidget extends ProjectorMixin(WidgetBase) {
 				render() {
 					this.meta(ScrollMeta).scroll('root', 100);
-					return v('div', {
-						key: 'root',
-						classes: 'root',
-						styles: { height: '200px', 'overflow-y': 'scroll' }
-					}, [
-						v('div', {
-							styles: { height: '400px' }
-						})
-					]);
+					return v(
+						'div',
+						{
+							key: 'root',
+							classes: 'root',
+							styles: { height: '200px', 'overflow-y': 'scroll' }
+						},
+						[
+							v('div', {
+								styles: { height: '400px' }
+							})
+						]
+					);
 				}
 			}
 

--- a/src/listbox/tests/unit/ListboxOption.ts
+++ b/src/listbox/tests/unit/ListboxOption.ts
@@ -28,20 +28,26 @@ registerSuite('ListboxOption', {
 				option: 'baz'
 			});
 
-			widget.expectRender(v('div', {
-				'aria-disabled': null,
-				'aria-selected': 'false',
-				classes: null,
-				id: 'bar',
-				role: 'option',
-				onclick: widget.listener
-			}, [ 'foo' ]));
+			widget.expectRender(
+				v(
+					'div',
+					{
+						'aria-disabled': null,
+						'aria-selected': 'false',
+						classes: null,
+						id: 'bar',
+						role: 'option',
+						onclick: widget.listener
+					},
+					['foo']
+				)
+			);
 		},
 
 		'custom properties'() {
 			widget.setProperties({
 				active: true,
-				classes: [ css.option ],
+				classes: [css.option],
 				disabled: true,
 				label: 'foo',
 				id: 'bar',
@@ -50,14 +56,20 @@ registerSuite('ListboxOption', {
 				selected: true
 			});
 
-			widget.expectRender(v('div', {
-				'aria-disabled': 'true',
-				'aria-selected': null,
-				classes: [ css.option ],
-				id: 'bar',
-				role: 'option',
-				onclick: widget.listener
-			}, [ 'foo' ]));
+			widget.expectRender(
+				v(
+					'div',
+					{
+						'aria-disabled': 'true',
+						'aria-selected': null,
+						classes: [css.option],
+						id: 'bar',
+						role: 'option',
+						onclick: widget.listener
+					},
+					['foo']
+				)
+			);
 		},
 
 		'option click'() {

--- a/src/progress/Progress.ts
+++ b/src/progress/Progress.ts
@@ -46,28 +46,26 @@ export default class Progress extends ProgressBase<ProgressProperties> {
 	}
 
 	render() {
-		const {
-			value,
-			showOutput = true,
-			max = 100,
-			min = 0,
-			id
-		} = this.properties;
+		const { value, showOutput = true, max = 100, min = 0, id } = this.properties;
 
-		const percent = Math.round(((value - min) / (max - min)) * 100);
+		const percent = Math.round((value - min) / (max - min) * 100);
 		const output = this._output(value, percent);
 
 		return v('div', { classes: this.theme(css.root) }, [
-			v('div', {
-				classes: this.theme(css.bar),
-				role: 'progressbar',
-				'aria-valuemin': `${min}`,
-				'aria-valuemax': `${max}`,
-				'aria-valuenow': `${value}`,
-				'aria-valuetext': output,
-				id
-			}, this.renderProgress(percent)),
-			showOutput ? v('span', { classes: this.theme(css.output) }, [ output ]) : null
+			v(
+				'div',
+				{
+					classes: this.theme(css.bar),
+					role: 'progressbar',
+					'aria-valuemin': `${min}`,
+					'aria-valuemax': `${max}`,
+					'aria-valuenow': `${value}`,
+					'aria-valuetext': output,
+					id
+				},
+				this.renderProgress(percent)
+			),
+			showOutput ? v('span', { classes: this.theme(css.output) }, [output]) : null
 		]);
 	}
 }

--- a/src/progress/createProgressElement.ts
+++ b/src/progress/createProgressElement.ts
@@ -11,26 +11,24 @@ export default function createProgressElement(): CustomElementDescriptor {
 		attributes: [
 			{
 				attributeName: 'value',
-				value: value => Number(value)
+				value: (value) => Number(value)
 			},
 			{
 				attributeName: 'max',
-				value: value => Number(value)
+				value: (value) => Number(value)
 			},
 			{
 				attributeName: 'min',
-				value: value => Number(value)
+				value: (value) => Number(value)
 			},
 			{
 				attributeName: 'id'
 			},
 			{
 				attributeName: 'showOutput',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			}
 		],
-		properties: [
-			{ propertyName: 'theme' }
-		]
+		properties: [{ propertyName: 'theme' }]
 	};
-};
+}

--- a/src/progress/example/index.ts
+++ b/src/progress/example/index.ts
@@ -30,19 +30,13 @@ export class App extends WidgetBase<WidgetProperties> {
 				})
 			]),
 			v('h3', {}, ['Progress with 50% value']),
-			v('div', { id: 'example-1'}, [
-				w(Progress, { value: 50, theme: this._theme })
-			]),
+			v('div', { id: 'example-1' }, [w(Progress, { value: 50, theme: this._theme })]),
 			v('h3', {}, ['Progress with an id']),
-			v('div', { id: 'example-2'}, [
-				w(Progress, { value: 80, id: 'progress-2', theme: this._theme })
-			]),
+			v('div', { id: 'example-2' }, [w(Progress, { value: 80, id: 'progress-2', theme: this._theme })]),
 			v('h3', {}, ['Progress with max']),
-			v('div', { id: 'example-3'}, [
-				w(Progress, { value: 0.3, max: 1, theme: this._theme })
-			]),
+			v('div', { id: 'example-3' }, [w(Progress, { value: 0.3, max: 1, theme: this._theme })]),
 			v('h3', {}, ['Progress with custom output']),
-			v('div', { id: 'example-4'}, [
+			v('div', { id: 'example-4' }, [
 				w(Progress, {
 					value: 250,
 					max: customOutputMax,
@@ -51,9 +45,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				})
 			]),
 			v('h3', {}, ['Progress with no output']),
-			v('div', { id: 'example-5'}, [
-				w(Progress, { value: 10, showOutput: false, theme: this._theme })
-			])
+			v('div', { id: 'example-5' }, [w(Progress, { value: 10, showOutput: false, theme: this._theme })])
 		]);
 	}
 }

--- a/src/progress/tests/unit/Progress.ts
+++ b/src/progress/tests/unit/Progress.ts
@@ -1,45 +1,40 @@
-const { beforeEach, afterEach, describe, it} = intern.getInterface('bdd');
+const { beforeEach, afterEach, describe, it } = intern.getInterface('bdd');
 import { v } from '@dojo/widget-core/d';
 import harness, { Harness } from '@dojo/test-extras/harness';
 import Progress from '../../Progress';
 import * as css from '../../styles/progress.m.css';
 
 const expectedVDom = function(args: any) {
-	const {
-		width,
-		output,
-		value,
-		showOutput = true,
-		max = 100,
-		min = 0,
-		id
-	} = args;
+	const { width, output, value, showOutput = true, max = 100, min = 0, id } = args;
 
 	return v('div', { classes: css.root }, [
-		v('div', {
-			classes: css.bar,
-			'aria-valuemax': `${max}`,
-			'aria-valuemin': `${min}`,
-			'aria-valuenow': `${value}`,
-			'aria-valuetext': `${output}`,
-			role: 'progressbar',
-			id
-		}, [
-			v('div', {
-				classes: css.progress,
-				styles: {
-					width: `${width}%`
-				}
-			})
-		]),
-		showOutput ? v('span', { classes: css.output }, [ output ]) : null
+		v(
+			'div',
+			{
+				classes: css.bar,
+				'aria-valuemax': `${max}`,
+				'aria-valuemin': `${min}`,
+				'aria-valuenow': `${value}`,
+				'aria-valuetext': `${output}`,
+				role: 'progressbar',
+				id
+			},
+			[
+				v('div', {
+					classes: css.progress,
+					styles: {
+						width: `${width}%`
+					}
+				})
+			]
+		),
+		showOutput ? v('span', { classes: css.output }, [output]) : null
 	]);
 };
 
 let widget: Harness<Progress>;
 
 describe('Progress', () => {
-
 	beforeEach(() => {
 		widget = harness(Progress);
 	});

--- a/src/radio/Radio.ts
+++ b/src/radio/Radio.ts
@@ -15,7 +15,12 @@ import * as css from './styles/radio.m.css';
  * @property checked          Checked/unchecked property of the radio
  * @property value           The current value
  */
-export interface RadioProperties extends ThemedProperties, LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties {
+export interface RadioProperties
+	extends ThemedProperties,
+		LabeledProperties,
+		InputProperties,
+		InputEventProperties,
+		PointerEventProperties {
 	checked?: boolean;
 	value?: string;
 }
@@ -27,32 +32,40 @@ export default class Radio<P extends RadioProperties = RadioProperties> extends 
 	private _focused = false;
 	private _uuid = uuid();
 
-	private _onBlur (event: FocusEvent) {
+	private _onBlur(event: FocusEvent) {
 		this._focused = false;
 		this.properties.onBlur && this.properties.onBlur(event);
 		this.invalidate();
 	}
-	private _onChange (event: Event) { this.properties.onChange && this.properties.onChange(event); }
-	private _onClick (event: MouseEvent) { this.properties.onClick && this.properties.onClick(event); }
-	private _onFocus (event: FocusEvent) {
+	private _onChange(event: Event) {
+		this.properties.onChange && this.properties.onChange(event);
+	}
+	private _onClick(event: MouseEvent) {
+		this.properties.onClick && this.properties.onClick(event);
+	}
+	private _onFocus(event: FocusEvent) {
 		this._focused = true;
 		this.properties.onFocus && this.properties.onFocus(event);
 		this.invalidate();
 	}
-	private _onMouseDown (event: MouseEvent) { this.properties.onMouseDown && this.properties.onMouseDown(event); }
-	private _onMouseUp (event: MouseEvent) { this.properties.onMouseUp && this.properties.onMouseUp(event); }
-	private _onTouchStart (event: TouchEvent) { this.properties.onTouchStart && this.properties.onTouchStart(event); }
-	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
-	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
+	private _onMouseDown(event: MouseEvent) {
+		this.properties.onMouseDown && this.properties.onMouseDown(event);
+	}
+	private _onMouseUp(event: MouseEvent) {
+		this.properties.onMouseUp && this.properties.onMouseUp(event);
+	}
+	private _onTouchStart(event: TouchEvent) {
+		this.properties.onTouchStart && this.properties.onTouchStart(event);
+	}
+	private _onTouchEnd(event: TouchEvent) {
+		this.properties.onTouchEnd && this.properties.onTouchEnd(event);
+	}
+	private _onTouchCancel(event: TouchEvent) {
+		this.properties.onTouchCancel && this.properties.onTouchCancel(event);
+	}
 
 	protected getRootClasses(): (string | null)[] {
-		const {
-			checked = false,
-			disabled,
-			invalid,
-			readOnly,
-			required
-		} = this.properties;
+		const { checked = false, disabled, invalid, readOnly, required } = this.properties;
 
 		return [
 			css.root,
@@ -108,21 +121,31 @@ export default class Radio<P extends RadioProperties = RadioProperties> extends 
 					ontouchcancel: this._onTouchCancel
 				})
 			]),
-			label ? w(Label, {
-				theme,
-				disabled,
-				invalid,
-				readOnly,
-				required,
-				hidden: labelHidden,
-				forId: this._uuid,
-				secondary: true
-			}, [ label ]) : null
+			label
+				? w(
+						Label,
+						{
+							theme,
+							disabled,
+							invalid,
+							readOnly,
+							required,
+							hidden: labelHidden,
+							forId: this._uuid,
+							secondary: true
+						},
+						[label]
+					)
+				: null
 		];
 
-		return v('div', {
-			key: 'root',
-			classes: this.theme(this.getRootClasses())
-		}, labelAfter ? children : children.reverse());
+		return v(
+			'div',
+			{
+				key: 'root',
+				classes: this.theme(this.getRootClasses())
+			},
+			labelAfter ? children : children.reverse()
+		);
 	}
 }

--- a/src/radio/example/index.ts
+++ b/src/radio/example/index.ts
@@ -22,9 +22,7 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render() {
-		const {
-			_inputValue = 'first'
-		} = this;
+		const { _inputValue = 'first' } = this;
 
 		return v('div', [
 			v('h2', {

--- a/src/radio/tests/functional/Radio.ts
+++ b/src/radio/tests/functional/Radio.ts
@@ -5,13 +5,10 @@ import { Remote } from 'intern/lib/executors/Node';
 import * as css from '../../styles/radio.m.css';
 
 function getPage(remote: Remote) {
-	return remote
-		.get('http://localhost:9000/_build/common/example/?module=radio')
-		.setFindTimeout(5000);
+	return remote.get('http://localhost:9000/_build/common/example/?module=radio').setFindTimeout(5000);
 }
 
 registerSuite('Radio Button', {
-
 	'radio button should be visible'() {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-1 .${css.root}:first-of-type`)
@@ -27,68 +24,67 @@ registerSuite('Radio Button', {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-1 .${css.root}:first-of-type`)
 			.getVisibleText()
-			.then(text => {
+			.then((text) => {
 				assert.strictEqual(text, 'First option');
 			})
 			.end();
-
 	},
 	'radio button can be selected by clicking on its label'() {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-1 .${css.root}:first-of-type`)
 			.click()
-				.findByCssSelector(`.${css.input}`)
-				.isSelected()
-				.then(selected => {
-					assert.isTrue(selected, '2nd radio button should be selected.');
-				})
-				.end()
+			.findByCssSelector(`.${css.input}`)
+			.isSelected()
+			.then((selected) => {
+				assert.isTrue(selected, '2nd radio button should be selected.');
+			})
+			.end()
 			.end();
 	},
 	'radio buttons should be selectable'() {
 		return getPage(this.remote)
 			.findByCssSelector('#example-1')
-				.findByCssSelector(`.${css.root}:first-of-type .${css.input}`)
-				.isSelected()
-				.then(checked => {
-					assert.isTrue(checked, 'Initially the first radio button should be selected');
-				})
-				.end()
+			.findByCssSelector(`.${css.root}:first-of-type .${css.input}`)
+			.isSelected()
+			.then((checked) => {
+				assert.isTrue(checked, 'Initially the first radio button should be selected');
+			})
+			.end()
 
-				.findByCssSelector(`.${css.root}:nth-of-type(3) .${css.input}`)
-				.isSelected()
-				.then(checked => {
-					assert.isFalse(checked, 'Initially the 3rd radio button should not be selected');
-				})
-				.click()
-				.isSelected()
-				.then(checked => {
-					assert.isTrue(checked);
-				})
-				.end()
+			.findByCssSelector(`.${css.root}:nth-of-type(3) .${css.input}`)
+			.isSelected()
+			.then((checked) => {
+				assert.isFalse(checked, 'Initially the 3rd radio button should not be selected');
+			})
+			.click()
+			.isSelected()
+			.then((checked) => {
+				assert.isTrue(checked);
+			})
+			.end()
 
-				.findByCssSelector(`.${css.root}:first-of-type .${css.input}`)
-				.isSelected()
-				.then(checked => {
-					assert.isFalse(checked);
-				})
-				.end()
+			.findByCssSelector(`.${css.root}:first-of-type .${css.input}`)
+			.isSelected()
+			.then((checked) => {
+				assert.isFalse(checked);
+			})
+			.end()
 			.end();
 	},
 	'disabled radio buttons should not be selectable'() {
 		return getPage(this.remote)
 			.findByCssSelector('#example-2')
-				.findByCssSelector(`.${css.root}:first-of-type .${css.input}`)
-				.isSelected()
-				.then(checked => {
-					assert.isFalse(checked, 'Initially the first radio button should not be selected');
-				})
-				.click()
-				.then(undefined, (err: Error) => {})
-				.isSelected()
-				.then(checked => {
-					assert.isFalse(checked);
-				})
+			.findByCssSelector(`.${css.root}:first-of-type .${css.input}`)
+			.isSelected()
+			.then((checked) => {
+				assert.isFalse(checked, 'Initially the first radio button should not be selected');
+			})
+			.click()
+			.then(undefined, (err: Error) => {})
+			.isSelected()
+			.then((checked) => {
+				assert.isFalse(checked);
+			})
 			.end();
 	}
 });

--- a/src/radio/tests/unit/Radio.ts
+++ b/src/radio/tests/unit/Radio.ts
@@ -19,7 +19,7 @@ const compareId = compareProperty((value: any) => {
 const expected = function(widget: Harness<Radio>, label = false) {
 	const radioVdom = v('div', { classes: css.inputWrapper }, [
 		v('input', {
-			id: <any> compareId,
+			id: <any>compareId,
 			classes: css.input,
 			checked: false,
 			'aria-describedby': undefined,
@@ -43,28 +43,37 @@ const expected = function(widget: Harness<Radio>, label = false) {
 		})
 	]);
 
-	return v('div', {
-		key: 'root',
-		classes: [ css.root, null, null, null, null, null, null, null ]
-	}, [
-		radioVdom,
-		label ? w(Label, {
-			theme: undefined,
-			disabled: undefined,
-			hidden: undefined,
-			invalid: undefined,
-			readOnly: undefined,
-			required: undefined,
-			forId: <any> compareId,
-			secondary: true
-		}, [ 'foo' ]) : null
-	]);
+	return v(
+		'div',
+		{
+			key: 'root',
+			classes: [css.root, null, null, null, null, null, null, null]
+		},
+		[
+			radioVdom,
+			label
+				? w(
+						Label,
+						{
+							theme: undefined,
+							disabled: undefined,
+							hidden: undefined,
+							invalid: undefined,
+							readOnly: undefined,
+							required: undefined,
+							forId: <any>compareId,
+							secondary: true
+						},
+						['foo']
+					)
+				: null
+		]
+	);
 };
 
 let widget: Harness<Radio>;
 
 registerSuite('Radio', {
-
 	beforeEach() {
 		widget = harness(Radio);
 	},
@@ -94,13 +103,13 @@ registerSuite('Radio', {
 				value: 'baz'
 			});
 			assignProperties(expectedVdom, {
-				classes: [ css.root, css.checked, null, null, null, null, null, null ]
+				classes: [css.root, css.checked, null, null, null, null, null, null]
 			});
 
 			widget.expectRender(expectedVdom);
 		},
 
-		'label'() {
+		label() {
 			widget.setProperties({
 				label: 'foo'
 			});
@@ -125,7 +134,7 @@ registerSuite('Radio', {
 				required: true
 			});
 			assignProperties(expectedVdom, {
-				classes: [ css.root, null, css.disabled, null, css.invalid, null, css.readonly, css.required ]
+				classes: [css.root, null, css.disabled, null, css.invalid, null, css.readonly, css.required]
 			});
 
 			widget.expectRender(expectedVdom, 'Widget should be invalid, disabled, read-only, and required');
@@ -144,7 +153,7 @@ registerSuite('Radio', {
 				required: false
 			});
 			assignProperties(expectedVdom, {
-				classes: [ css.root, null, null, null, null, css.valid, null, null ]
+				classes: [css.root, null, null, null, null, css.valid, null, null]
 			});
 
 			widget.expectRender(expectedVdom, 'State classes should be false, css.valid should be true');
@@ -176,16 +185,7 @@ registerSuite('Radio', {
 			});
 
 			assignProperties(expectedVdom, {
-				classes: [
-					css.root,
-					null,
-					css.disabled,
-					null,
-					css.invalid,
-					null,
-					css.readonly,
-					css.required
-				]
+				classes: [css.root, null, css.disabled, null, css.invalid, null, css.readonly, css.required]
 			});
 
 			widget.expectRender(expectedVdom);
@@ -198,7 +198,7 @@ registerSuite('Radio', {
 			widget.sendEvent('focus', { selector: 'input' });
 			expectedVdom = expected(widget);
 			assignProperties(expectedVdom, {
-				classes: [ css.root, null, null, css.focused, null, null, null, null ]
+				classes: [css.root, null, null, css.focused, null, null, null, null]
 			});
 			widget.expectRender(expectedVdom, 'Should have focused class after focus event');
 

--- a/src/select/Select.ts
+++ b/src/select/Select.ts
@@ -62,19 +62,21 @@ export default class Select<P extends SelectProperties = SelectProperties> exten
 		return getOptionLabel ? getOptionLabel(option) : fallback;
 	}
 
-	private _onBlur (event: FocusEvent) { this.properties.onBlur && this.properties.onBlur(this.properties.key || ''); }
-	private _onFocus (event: FocusEvent) { this.properties.onFocus && this.properties.onFocus(this.properties.key || ''); }
+	private _onBlur(event: FocusEvent) {
+		this.properties.onBlur && this.properties.onBlur(this.properties.key || '');
+	}
+	private _onFocus(event: FocusEvent) {
+		this.properties.onFocus && this.properties.onFocus(this.properties.key || '');
+	}
 
 	// native select events
-	private _onNativeChange (event: Event) {
-		const {
-			key,
-			getOptionValue,
-			options = [],
-			onChange
-		} = this.properties;
-		const value = (<HTMLInputElement> event.target).value;
-		const option = find(options, (option: any, index: number) => getOptionValue ? getOptionValue(option, index) === value : false);
+	private _onNativeChange(event: Event) {
+		const { key, getOptionValue, options = [], onChange } = this.properties;
+		const value = (<HTMLInputElement>event.target).value;
+		const option = find(
+			options,
+			(option: any, index: number) => (getOptionValue ? getOptionValue(option, index) === value : false)
+		);
 		option && onChange && onChange(option, key);
 	}
 
@@ -137,12 +139,7 @@ export default class Select<P extends SelectProperties = SelectProperties> exten
 	}
 
 	protected getRootClasses() {
-		const {
-			disabled,
-			invalid,
-			readOnly,
-			required
-		} = this.properties;
+		const { disabled, invalid, readOnly, required } = this.properties;
 
 		return [
 			css.root,
@@ -157,7 +154,7 @@ export default class Select<P extends SelectProperties = SelectProperties> exten
 	protected onElementUpdated(element: HTMLElement, key: string) {
 		if (key === 'root' && this._callListboxFocus) {
 			this._callListboxFocus = false;
-			const listbox = <HTMLElement> element.querySelector('[role="listbox"]');
+			const listbox = <HTMLElement>element.querySelector('[role="listbox"]');
 			listbox && listbox.focus();
 		}
 
@@ -169,8 +166,10 @@ export default class Select<P extends SelectProperties = SelectProperties> exten
 
 	protected renderExpandIcon(): DNode {
 		return v('span', { classes: this.theme(css.arrow) }, [
-			v('i', { classes: this.theme([ iconCss.icon, iconCss.downIcon ]),
-				role: 'presentation', 'aria-hidden': 'true'
+			v('i', {
+				classes: this.theme([iconCss.icon, iconCss.downIcon]),
+				role: 'presentation',
+				'aria-hidden': 'true'
 			})
 		]);
 	}
@@ -192,28 +191,38 @@ export default class Select<P extends SelectProperties = SelectProperties> exten
 		} = this.properties;
 
 		/* create option nodes */
-		const optionNodes = options.map((option, i) => v('option', {
-			value: getOptionValue ? getOptionValue(option, i) : '',
-			id: getOptionId ? getOptionId(option, i) : undefined,
-			disabled: getOptionDisabled ? getOptionDisabled(option, i) : undefined,
-			selected: getOptionSelected ? getOptionSelected(option, i) : undefined
-		}, [ this._getOptionLabel(option) ]));
+		const optionNodes = options.map((option, i) =>
+			v(
+				'option',
+				{
+					value: getOptionValue ? getOptionValue(option, i) : '',
+					id: getOptionId ? getOptionId(option, i) : undefined,
+					disabled: getOptionDisabled ? getOptionDisabled(option, i) : undefined,
+					selected: getOptionSelected ? getOptionSelected(option, i) : undefined
+				},
+				[this._getOptionLabel(option)]
+			)
+		);
 
 		return v('div', { classes: this.theme(css.inputWrapper) }, [
-			v('select', {
-				classes: this.theme(css.input),
-				'aria-describedby': describedBy,
-				disabled,
-				'aria-invalid': invalid ? 'true' : null,
-				name,
-				readOnly,
-				'aria-readonly': readOnly ? 'true' : null,
-				required,
-				value,
-				onblur: this._onBlur,
-				onchange: this._onNativeChange,
-				onfocus: this._onFocus
-			}, optionNodes),
+			v(
+				'select',
+				{
+					classes: this.theme(css.input),
+					'aria-describedby': describedBy,
+					disabled,
+					'aria-invalid': invalid ? 'true' : null,
+					name,
+					readOnly,
+					'aria-readonly': readOnly ? 'true' : null,
+					required,
+					value,
+					onblur: this._onBlur,
+					onchange: this._onNativeChange,
+					onfocus: this._onFocus
+				},
+				optionNodes
+			),
 			this.renderExpandIcon()
 		]);
 	}
@@ -231,47 +240,51 @@ export default class Select<P extends SelectProperties = SelectProperties> exten
 			onChange
 		} = this.properties;
 
-		const {
-			_open,
-			_focusedIndex,
-			_baseId
-		} = this;
+		const { _open, _focusedIndex, _baseId } = this;
 
 		// create dropdown trigger and select box
-		return v('div', {
-			key: 'wrapper',
-			classes: this.theme([ css.inputWrapper, _open ? css.open : null ])
-		}, [
-			...this.renderCustomTrigger(),
-			v('div', {
-				classes: this.theme(css.dropdown),
-				onfocusout: this._onListboxBlur,
-				onkeydown: this._onDropdownKeyDown
-			}, [
-				w(Listbox, {
-					key: 'listbox',
-					activeIndex: _focusedIndex,
-					describedBy,
-					id: _baseId,
-					optionData: options,
-					tabIndex: _open ? 0 : -1,
-					getOptionDisabled,
-					getOptionId,
-					getOptionLabel,
-					getOptionSelected,
-					theme,
-					onActiveIndexChange: (index: number) => {
-						this._focusedIndex = index;
-						this.invalidate();
+		return v(
+			'div',
+			{
+				key: 'wrapper',
+				classes: this.theme([css.inputWrapper, _open ? css.open : null])
+			},
+			[
+				...this.renderCustomTrigger(),
+				v(
+					'div',
+					{
+						classes: this.theme(css.dropdown),
+						onfocusout: this._onListboxBlur,
+						onkeydown: this._onDropdownKeyDown
 					},
-					onOptionSelect: (option: any) => {
-						onChange && onChange(option, key);
-						this._callTriggerFocus = true;
-						this._closeSelect();
-					}
-				})
-			])
-		]);
+					[
+						w(Listbox, {
+							key: 'listbox',
+							activeIndex: _focusedIndex,
+							describedBy,
+							id: _baseId,
+							optionData: options,
+							tabIndex: _open ? 0 : -1,
+							getOptionDisabled,
+							getOptionId,
+							getOptionLabel,
+							getOptionSelected,
+							theme,
+							onActiveIndexChange: (index: number) => {
+								this._focusedIndex = index;
+								this.invalidate();
+							},
+							onOptionSelect: (option: any) => {
+								onChange && onChange(option, key);
+								this._callTriggerFocus = true;
+								this._closeSelect();
+							}
+						})
+					]
+				)
+			]
+		);
 	}
 
 	protected renderCustomTrigger(): DNode[] {
@@ -296,31 +309,34 @@ export default class Select<P extends SelectProperties = SelectProperties> exten
 
 		if (selectedOption) {
 			label = this._getOptionLabel(selectedOption);
-		}
-		else {
+		} else {
 			isPlaceholder = true;
 			label = placeholder ? placeholder : this._getOptionLabel(options[0]);
 		}
 
 		return [
-			v('button', {
-				'aria-controls': this._baseId,
-				'aria-expanded': `${this._open}`,
-				'aria-haspopup': 'listbox',
-				'aria-invalid': invalid ? 'true' : null,
-				'aria-readonly': readOnly ? 'true' : null,
-				'aria-required': required ? 'true' : null,
-				classes: this.theme([ css.trigger, isPlaceholder ? css.placeholder : null ]),
-				describedBy,
-				disabled,
-				key: 'trigger',
-				value,
-				onblur: this._onTriggerBlur,
-				onclick: this._onTriggerClick,
-				onfocus: this._onFocus,
-				onkeydown: this._onTriggerKeyDown,
-				onmousedown: this._onTriggerMouseDown
-			}, [ label ]),
+			v(
+				'button',
+				{
+					'aria-controls': this._baseId,
+					'aria-expanded': `${this._open}`,
+					'aria-haspopup': 'listbox',
+					'aria-invalid': invalid ? 'true' : null,
+					'aria-readonly': readOnly ? 'true' : null,
+					'aria-required': required ? 'true' : null,
+					classes: this.theme([css.trigger, isPlaceholder ? css.placeholder : null]),
+					describedBy,
+					disabled,
+					key: 'trigger',
+					value,
+					onblur: this._onTriggerBlur,
+					onclick: this._onTriggerClick,
+					onfocus: this._onFocus,
+					onkeydown: this._onTriggerKeyDown,
+					onmousedown: this._onTriggerMouseDown
+				},
+				[label]
+			),
 			this.renderExpandIcon()
 		];
 	}
@@ -339,21 +355,31 @@ export default class Select<P extends SelectProperties = SelectProperties> exten
 		} = this.properties;
 
 		const children = [
-			label ? w(Label, {
-				theme,
-				disabled,
-				invalid,
-				readOnly,
-				required,
-				hidden: labelHidden,
-				forId: this._baseId
-			}, [ label ]) : null,
+			label
+				? w(
+						Label,
+						{
+							theme,
+							disabled,
+							invalid,
+							readOnly,
+							required,
+							hidden: labelHidden,
+							forId: this._baseId
+						},
+						[label]
+					)
+				: null,
 			useNativeElement ? this.renderNativeSelect() : this.renderCustomSelect()
 		];
 
-		return v('div', {
-			key: 'root',
-			classes: this.theme(this.getRootClasses())
-		}, labelAfter ? children.reverse() : children);
+		return v(
+			'div',
+			{
+				key: 'root',
+				classes: this.theme(this.getRootClasses())
+			},
+			labelAfter ? children.reverse() : children
+		);
 	}
 }

--- a/src/select/example/index.ts
+++ b/src/select/example/index.ts
@@ -56,7 +56,7 @@ export class App extends WidgetBase<WidgetProperties> {
 		}
 	];
 
-	_evenMoreSelectOptions = [ 'Maru', 'Garfield', 'Grumpy Cat', 'Hobbes' ];
+	_evenMoreSelectOptions = ['Maru', 'Garfield', 'Grumpy Cat', 'Hobbes'];
 
 	getOptionSettings(): Partial<SelectProperties> {
 		return {
@@ -67,7 +67,6 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render() {
-
 		return v('div', [
 			v('label', [
 				'Use Dojo Theme ',

--- a/src/select/tests/unit/Select.ts
+++ b/src/select/tests/unit/Select.ts
@@ -62,127 +62,166 @@ const testStateProperties: Partial<SelectProperties> = {
 
 const expectedNative = function(widget: Harness<Select>, useTestProperties = false) {
 	return v('div', { classes: css.inputWrapper }, [
-		v('select', {
-			classes: css.input,
-			'aria-describedby': useTestProperties ? 'foo' : undefined,
-			disabled: useTestProperties ? true : undefined,
-			'aria-invalid': useTestProperties ? 'true' : null,
-			name: useTestProperties ? 'foo' : undefined,
-			readOnly: useTestProperties ? true : undefined,
-			'aria-readonly': useTestProperties ? 'true' : null,
-			required: useTestProperties ? true : undefined,
-			value: useTestProperties ? 'two' : undefined,
-			onblur: widget.listener,
-			onchange: widget.listener,
-			onfocus: widget.listener
-		}, [
-			v('option', {
-				value: useTestProperties ? 'one' : '',
-				id: useTestProperties ? 'one' : undefined,
-				disabled: useTestProperties ? false : undefined,
-				selected: useTestProperties ? false : undefined
-			}, [ useTestProperties ? 'One' : `${testOptions[0]}` ]),
-			v('option', {
-				value: useTestProperties ? 'two' : '',
-				id: useTestProperties ? 'two' : undefined,
-				disabled: useTestProperties ? false : undefined,
-				selected: useTestProperties ? true : undefined
-			}, [ useTestProperties ? 'Two' : `${testOptions[1]}` ]),
-			v('option', {
-				value: useTestProperties ? 'three' : '',
-				id: useTestProperties ? 'three' : undefined,
+		v(
+			'select',
+			{
+				classes: css.input,
+				'aria-describedby': useTestProperties ? 'foo' : undefined,
 				disabled: useTestProperties ? true : undefined,
-				selected: useTestProperties ? false : undefined
-			}, [ useTestProperties ? 'Three' : `${testOptions[2]}` ])
-		]),
+				'aria-invalid': useTestProperties ? 'true' : null,
+				name: useTestProperties ? 'foo' : undefined,
+				readOnly: useTestProperties ? true : undefined,
+				'aria-readonly': useTestProperties ? 'true' : null,
+				required: useTestProperties ? true : undefined,
+				value: useTestProperties ? 'two' : undefined,
+				onblur: widget.listener,
+				onchange: widget.listener,
+				onfocus: widget.listener
+			},
+			[
+				v(
+					'option',
+					{
+						value: useTestProperties ? 'one' : '',
+						id: useTestProperties ? 'one' : undefined,
+						disabled: useTestProperties ? false : undefined,
+						selected: useTestProperties ? false : undefined
+					},
+					[useTestProperties ? 'One' : `${testOptions[0]}`]
+				),
+				v(
+					'option',
+					{
+						value: useTestProperties ? 'two' : '',
+						id: useTestProperties ? 'two' : undefined,
+						disabled: useTestProperties ? false : undefined,
+						selected: useTestProperties ? true : undefined
+					},
+					[useTestProperties ? 'Two' : `${testOptions[1]}`]
+				),
+				v(
+					'option',
+					{
+						value: useTestProperties ? 'three' : '',
+						id: useTestProperties ? 'three' : undefined,
+						disabled: useTestProperties ? true : undefined,
+						selected: useTestProperties ? false : undefined
+					},
+					[useTestProperties ? 'Three' : `${testOptions[2]}`]
+				)
+			]
+		),
 		v('span', { classes: css.arrow }, [
-			v('i', { classes: [ iconCss.icon, iconCss.downIcon ],
-				role: 'presentation', 'aria-hidden': 'true'
+			v('i', {
+				classes: [iconCss.icon, iconCss.downIcon],
+				role: 'presentation',
+				'aria-hidden': 'true'
 			})
 		])
 	]);
 };
 
 const expectedSingle = function(widget: Harness<Select>, useTestProperties = false, open = false) {
-	return v('div', {
-		classes: [ css.inputWrapper, open ? css.open : null ],
-		key: 'wrapper'
-	}, [
-		v('button', {
-			'aria-controls': <any> compareId,
-			'aria-expanded': open ? 'true' : 'false',
-			'aria-haspopup': 'listbox',
-			'aria-invalid': null,
-			'aria-readonly': null,
-			'aria-required': null,
-			classes: [ css.trigger, useTestProperties ? null : css.placeholder ],
-			describedBy: useTestProperties ? 'foo' : undefined,
-			disabled: undefined,
-			key: 'trigger',
-			value: useTestProperties ? 'two' : undefined,
-			onblur: widget.listener,
-			onclick: widget.listener,
-			onfocus: widget.listener,
-			onkeydown: widget.listener,
-			onmousedown: widget.listener
-		}, [ useTestProperties ? 'Two' : '' ]),
-		v('span', { classes: css.arrow }, [
-			v('i', {
-				classes: [ iconCss.icon, iconCss.downIcon ],
-				role: 'presentation',
-				'aria-hidden': 'true'
-			})
-		]),
-		v('div', {
-			classes: css.dropdown,
-			onfocusout: widget.listener,
-			onkeydown: widget.listener
-		}, [
-			w(Listbox, {
-				activeIndex: 0,
-				describedBy: useTestProperties ? 'foo' : undefined,
-				id: <any> compareId,
-				key: 'listbox',
-				optionData: useTestProperties ? testOptions : [],
-				tabIndex: open ? 0 : -1,
-				getOptionDisabled: useTestProperties ? widget.listener : undefined,
-				getOptionId: useTestProperties ? (widget.listener as any) : undefined,
-				getOptionLabel: useTestProperties ? (widget.listener as any) : undefined,
-				getOptionSelected: useTestProperties ? widget.listener : undefined,
-				theme: undefined,
-				onActiveIndexChange: widget.listener,
-				onOptionSelect: widget.listener
-			})
-		])
-	]);
+	return v(
+		'div',
+		{
+			classes: [css.inputWrapper, open ? css.open : null],
+			key: 'wrapper'
+		},
+		[
+			v(
+				'button',
+				{
+					'aria-controls': <any>compareId,
+					'aria-expanded': open ? 'true' : 'false',
+					'aria-haspopup': 'listbox',
+					'aria-invalid': null,
+					'aria-readonly': null,
+					'aria-required': null,
+					classes: [css.trigger, useTestProperties ? null : css.placeholder],
+					describedBy: useTestProperties ? 'foo' : undefined,
+					disabled: undefined,
+					key: 'trigger',
+					value: useTestProperties ? 'two' : undefined,
+					onblur: widget.listener,
+					onclick: widget.listener,
+					onfocus: widget.listener,
+					onkeydown: widget.listener,
+					onmousedown: widget.listener
+				},
+				[useTestProperties ? 'Two' : '']
+			),
+			v('span', { classes: css.arrow }, [
+				v('i', {
+					classes: [iconCss.icon, iconCss.downIcon],
+					role: 'presentation',
+					'aria-hidden': 'true'
+				})
+			]),
+			v(
+				'div',
+				{
+					classes: css.dropdown,
+					onfocusout: widget.listener,
+					onkeydown: widget.listener
+				},
+				[
+					w(Listbox, {
+						activeIndex: 0,
+						describedBy: useTestProperties ? 'foo' : undefined,
+						id: <any>compareId,
+						key: 'listbox',
+						optionData: useTestProperties ? testOptions : [],
+						tabIndex: open ? 0 : -1,
+						getOptionDisabled: useTestProperties ? widget.listener : undefined,
+						getOptionId: useTestProperties ? (widget.listener as any) : undefined,
+						getOptionLabel: useTestProperties ? (widget.listener as any) : undefined,
+						getOptionSelected: useTestProperties ? widget.listener : undefined,
+						theme: undefined,
+						onActiveIndexChange: widget.listener,
+						onOptionSelect: widget.listener
+					})
+				]
+			)
+		]
+	);
 };
 
 function isOpen(widget: any): boolean {
 	const vdom = widget.getRender();
 	const button = findKey(vdom, 'trigger');
-	return (<any> button)!.properties!['aria-expanded'] === 'true';
+	return (<any>button)!.properties!['aria-expanded'] === 'true';
 }
 
 const expected = function(widget: Harness<Select>, selectVdom: any, label = false) {
-	return v('div', {
-		key: 'root',
-		classes: [ css.root, null, null, null, null, null ]
-	}, [
-		label ? w(Label, {
-			theme: undefined,
-			disabled: undefined,
-			hidden: undefined,
-			invalid: undefined,
-			readOnly: undefined,
-			required: undefined,
-			forId: <any> compareId
-		}, [ 'foo' ]) : null,
-		selectVdom
-	]);
+	return v(
+		'div',
+		{
+			key: 'root',
+			classes: [css.root, null, null, null, null, null]
+		},
+		[
+			label
+				? w(
+						Label,
+						{
+							theme: undefined,
+							disabled: undefined,
+							hidden: undefined,
+							invalid: undefined,
+							readOnly: undefined,
+							required: undefined,
+							forId: <any>compareId
+						},
+						['foo']
+					)
+				: null,
+			selectVdom
+		]
+	);
 };
 
 registerSuite('Select', {
-
 	beforeEach() {
 		widget = harness(Select);
 	},
@@ -192,7 +231,6 @@ registerSuite('Select', {
 	},
 
 	tests: {
-
 		'Native Single Select': {
 			'default properties'() {
 				widget.setProperties({
@@ -213,7 +251,7 @@ registerSuite('Select', {
 				const selectVdom = expectedNative(widget, true);
 				const expectedVdom = expected(widget, selectVdom);
 				assignProperties(expectedVdom, {
-					classes: [ css.root, css.disabled, css.invalid, null, css.readonly, css.required ]
+					classes: [css.root, css.disabled, css.invalid, null, css.readonly, css.required]
 				});
 
 				widget.expectRender(expectedVdom);
@@ -245,7 +283,10 @@ registerSuite('Select', {
 				});
 
 				widget.sendEvent('change', { selector: 'option' });
-				assert.isTrue(onChange.calledWith(testOptions[0]), 'onChange should be called with the first entry in the testOptions array');
+				assert.isTrue(
+					onChange.calledWith(testOptions[0]),
+					'onChange should be called with the first entry in the testOptions array'
+				);
 			},
 
 			'events called with widget key'() {
@@ -289,12 +330,12 @@ registerSuite('Select', {
 				});
 				const expectedVdom = expected(widget, selectVdom);
 				assignProperties(expectedVdom, {
-					classes: [ css.root, css.disabled, css.invalid, null, css.readonly, css.required ]
+					classes: [css.root, css.disabled, css.invalid, null, css.readonly, css.required]
 				});
 				widget.expectRender(expectedVdom);
 			},
 
-			'placeholder'() {
+			placeholder() {
 				widget.setProperties({
 					...testProperties,
 					placeholder: 'foo'
@@ -311,11 +352,11 @@ registerSuite('Select', {
 				});
 
 				assignProperties(findKey(expectedVdom, 'trigger')!, {
-					classes: [ css.trigger, css.placeholder ]
+					classes: [css.trigger, css.placeholder]
 				});
 				expectedVdom = expected(widget, expectedSingle(widget, true));
 				assignProperties(findKey(expectedVdom, 'trigger')!, {
-					classes: [ css.trigger, css.placeholder ]
+					classes: [css.trigger, css.placeholder]
 				});
 				replaceChild(expectedVdom, '1,0,0', 'bar');
 
@@ -348,7 +389,7 @@ registerSuite('Select', {
 				widget.sendEvent('click', { key: 'trigger' });
 				assert.isTrue(isOpen(widget), 'Widget opens on button click');
 
-				widget.callListener('onOptionSelect', { args: [ testOptions[1] ], index: '0,2,0' });
+				widget.callListener('onOptionSelect', { args: [testOptions[1]], index: '0,2,0' });
 				assert.isFalse(isOpen(widget), 'Widget closes on option select');
 				assert.isTrue(onChange.calledOnce, 'onChange handler called when option selected');
 
@@ -364,7 +405,7 @@ registerSuite('Select', {
 			'change active option'() {
 				widget.setProperties(testProperties);
 				let selectVdom = expected(widget, expectedSingle(widget, true));
-				widget.callListener('onActiveIndexChange', { args: [ 1 ], key: 'listbox' });
+				widget.callListener('onActiveIndexChange', { args: [1], key: 'listbox' });
 
 				selectVdom = expected(widget, expectedSingle(widget, true));
 				assignProperties(findKey(selectVdom, 'listbox')!, { activeIndex: 1 });

--- a/src/slidepane/SlidePane.ts
+++ b/src/slidepane/SlidePane.ts
@@ -15,7 +15,7 @@ export const enum Align {
 	left = 'left',
 	right = 'right',
 	top = 'top'
-};
+}
 
 /**
  * @type SlidePaneProperties
@@ -40,7 +40,7 @@ export interface SlidePaneProperties extends ThemedProperties {
 	title?: string;
 	underlay?: boolean;
 	width?: number;
-};
+}
 
 /**
  * The default width of the slide pane
@@ -55,7 +55,7 @@ const SWIPE_THRESHOLD = 5;
 const enum Plane {
 	x,
 	y
-};
+}
 
 export const ThemedBase = ThemedMixin(WidgetBase);
 
@@ -81,8 +81,7 @@ export default class SlidePane<P extends SlidePaneProperties = SlidePaneProperti
 		if (this.plane === Plane.x) {
 			const currentX = event.type === eventType ? event.changedTouches[0].screenX : event.pageX;
 			return align === Align.right ? currentX - this._initialPosition : this._initialPosition - currentX;
-		}
-		else {
+		} else {
 			const currentY = event.type === eventType ? event.changedTouches[0].screenY : event.pageY;
 			return align === Align.bottom ? currentY - this._initialPosition : this._initialPosition - currentY;
 		}
@@ -98,8 +97,7 @@ export default class SlidePane<P extends SlidePaneProperties = SlidePaneProperti
 		// Cache initial pointer position
 		if (this.plane === Plane.x) {
 			this._initialPosition = event.type === 'touchstart' ? event.changedTouches[0].screenX : event.pageX;
-		}
-		else {
+		} else {
 			this._initialPosition = event.type === 'touchstart' ? event.changedTouches[0].screenY : event.pageY;
 		}
 
@@ -113,10 +111,7 @@ export default class SlidePane<P extends SlidePaneProperties = SlidePaneProperti
 			return;
 		}
 
-		const {
-			align = Align.left,
-			width = DEFAULT_WIDTH
-		} = this.properties;
+		const { align = Align.left, width = DEFAULT_WIDTH } = this.properties;
 
 		const delta = this._getDelta(event, 'touchmove');
 
@@ -130,20 +125,16 @@ export default class SlidePane<P extends SlidePaneProperties = SlidePaneProperti
 
 		// Move the pane
 		if (this.plane === Plane.x) {
-			this._content.style.transform = `translateX(${ align === Align.left ? '-' : '' }${ this._transform }%)`;
-		}
-		else {
-			this._content.style.transform = `translateY(${ align === Align.top ? '-' : '' }${ this._transform }%)`;
+			this._content.style.transform = `translateX(${align === Align.left ? '-' : ''}${this._transform}%)`;
+		} else {
+			this._content.style.transform = `translateY(${align === Align.top ? '-' : ''}${this._transform}%)`;
 		}
 	}
 
 	private _onSwipeEnd(event: MouseEvent & TouchEvent) {
 		this._swiping = false;
 
-		const {
-			onRequestClose,
-			width = DEFAULT_WIDTH
-		} = this.properties;
+		const { onRequestClose, width = DEFAULT_WIDTH } = this.properties;
 
 		const delta = this._getDelta(event, 'touchend');
 
@@ -152,13 +143,14 @@ export default class SlidePane<P extends SlidePaneProperties = SlidePaneProperti
 			// Cache the transform to apply on next render
 			this._transform = 100 * delta / width;
 			onRequestClose && onRequestClose();
-		}
-		// If the underlay was clicked
-		else if (Math.abs(delta) < SWIPE_THRESHOLD && (!this._content || !this._content.contains(event.target as HTMLElement))) {
+		} else if (
+			Math.abs(delta) < SWIPE_THRESHOLD &&
+			(!this._content || !this._content.contains(event.target as HTMLElement))
+		) {
+			// If the underlay was clicked
 			onRequestClose && onRequestClose();
-		}
-		// If pane was not swiped far enough to close
-		else if (delta > 0) {
+		} else if (delta > 0) {
+			// If pane was not swiped far enough to close
 			// Animate the pane back open
 			this._slideIn = true;
 			this.invalidate();
@@ -177,11 +169,7 @@ export default class SlidePane<P extends SlidePaneProperties = SlidePaneProperti
 	}
 
 	protected getStyles(): { [key: string]: string | null } {
-		const {
-			align = Align.left,
-			open = false,
-			width = DEFAULT_WIDTH
-		} = this.properties;
+		const { align = Align.left, open = false, width = DEFAULT_WIDTH } = this.properties;
 
 		let translate = '';
 		const translateAxis = this.plane === Plane.x ? 'X' : 'Y';
@@ -193,17 +181,14 @@ export default class SlidePane<P extends SlidePaneProperties = SlidePaneProperti
 
 		return {
 			transform: translate ? `translate${translateAxis}(${translate}%)` : '',
-			width: this.plane === Plane.x ? `${ width }px` : null,
-			height: this.plane === Plane.y ? `${ width }px` : null
+			width: this.plane === Plane.x ? `${width}px` : null,
+			height: this.plane === Plane.y ? `${width}px` : null
 		};
 	}
 
 	protected getFixedModifierClasses(): (string | null)[] {
-		const {
-			align = Align.left,
-			open = false
-		} = this.properties;
-		const alignCss: {[key: string]: any} = css;
+		const { align = Align.left, open = false } = this.properties;
+		const alignCss: { [key: string]: any } = css;
 
 		return [
 			open ? css.openFixed : null,
@@ -214,11 +199,8 @@ export default class SlidePane<P extends SlidePaneProperties = SlidePaneProperti
 	}
 
 	protected getModifierClasses(): (string | null)[] {
-		const {
-			align = Align.left,
-			open = false
-		} = this.properties;
-		const alignCss: {[key: string]: any} = css;
+		const { align = Align.left, open = false } = this.properties;
+		const alignCss: { [key: string]: any } = css;
 
 		return [
 			alignCss[align],
@@ -229,20 +211,22 @@ export default class SlidePane<P extends SlidePaneProperties = SlidePaneProperti
 	}
 
 	protected renderCloseIcon(): DNode {
-		return v('i', { classes: this.theme([ iconCss.icon, iconCss.closeIcon ]),
-			role: 'presentation', 'aria-hidden': 'true'
+		return v('i', {
+			classes: this.theme([iconCss.icon, iconCss.closeIcon]),
+			role: 'presentation',
+			'aria-hidden': 'true'
 		});
 	}
 
 	protected renderTitle(): DNode {
 		const { title = '' } = this.properties;
-		return v('div', { id: this._titleId }, [ title ]);
+		return v('div', { id: this._titleId }, [title]);
 	}
 
 	protected renderUnderlay(): DNode {
 		const { underlay = false } = this.properties;
 		return v('div', {
-			classes: [ this.theme(underlay ? css.underlayVisible : null), css.underlay ],
+			classes: [this.theme(underlay ? css.underlayVisible : null), css.underlay],
 			enterAnimation: animations.fadeIn,
 			exitAnimation: animations.fadeOut,
 			key: 'underlay'
@@ -250,12 +234,7 @@ export default class SlidePane<P extends SlidePaneProperties = SlidePaneProperti
 	}
 
 	render(): DNode {
-		const {
-			closeText = 'close pane',
-			onOpen,
-			open = false,
-			title = ''
-		} = this.properties;
+		const { closeText = 'close pane', onOpen, open = false, title = '' } = this.properties;
 
 		const contentStyles = this.getStyles();
 		const contentClasses = this.getModifierClasses();
@@ -269,37 +248,52 @@ export default class SlidePane<P extends SlidePaneProperties = SlidePaneProperti
 		this._wasOpen = open;
 		this._slideIn = false;
 
-		return v('div', {
-			'aria-labelledby': this._titleId,
-			classes: this.theme(css.root),
-			onmousedown: this._onSwipeStart,
-			onmousemove: this._onSwipeMove,
-			onmouseup: this._onSwipeEnd,
-			ontouchend: this._onSwipeEnd,
-			ontouchmove: this._onSwipeMove,
-			ontouchstart: this._onSwipeStart
-		}, [
-			open ? this.renderUnderlay() : null,
-			v('div', {
-				key: 'content',
-				classes: [ ...this.theme([ css.pane, ...contentClasses ]), css.paneFixed, ...fixedContentClasses ],
-				styles: contentStyles
-			}, [
-				title ? v('div', {
-					classes: this.theme(css.title),
-					key: 'title'
-				}, [
-					this.renderTitle(),
-					v('button', {
-						classes: this.theme(css.close),
-						onclick: this._onCloseClick
-					}, [
-						closeText,
-						this.renderCloseIcon()
-					])
-				]) : null,
-				this.getContent()
-			])
-		]);
+		return v(
+			'div',
+			{
+				'aria-labelledby': this._titleId,
+				classes: this.theme(css.root),
+				onmousedown: this._onSwipeStart,
+				onmousemove: this._onSwipeMove,
+				onmouseup: this._onSwipeEnd,
+				ontouchend: this._onSwipeEnd,
+				ontouchmove: this._onSwipeMove,
+				ontouchstart: this._onSwipeStart
+			},
+			[
+				open ? this.renderUnderlay() : null,
+				v(
+					'div',
+					{
+						key: 'content',
+						classes: [...this.theme([css.pane, ...contentClasses]), css.paneFixed, ...fixedContentClasses],
+						styles: contentStyles
+					},
+					[
+						title
+							? v(
+									'div',
+									{
+										classes: this.theme(css.title),
+										key: 'title'
+									},
+									[
+										this.renderTitle(),
+										v(
+											'button',
+											{
+												classes: this.theme(css.close),
+												onclick: this._onCloseClick
+											},
+											[closeText, this.renderCloseIcon()]
+										)
+									]
+								)
+							: null,
+						this.getContent()
+					]
+				)
+			]
+		);
 	}
 }

--- a/src/slidepane/createSlidePaneElement.ts
+++ b/src/slidepane/createSlidePaneElement.ts
@@ -14,20 +14,18 @@ export default function createSlidePaneElement(): CustomElementDescriptor {
 			},
 			{
 				attributeName: 'open',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'underlay',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'width',
-				value: value => Number(value)
+				value: (value) => Number(value)
 			}
 		],
-		properties: [
-			{ propertyName: 'theme' }
-		],
+		properties: [{ propertyName: 'theme' }],
 		events: [
 			{
 				propertyName: 'onOpen',
@@ -39,4 +37,4 @@ export default function createSlidePaneElement(): CustomElementDescriptor {
 			}
 		]
 	};
-};
+}

--- a/src/slidepane/example/index.ts
+++ b/src/slidepane/example/index.ts
@@ -35,22 +35,26 @@ export class App extends WidgetBase<WidgetProperties> {
 
 	render(): DNode {
 		return v('div', [
-			w(SlidePane, {
-				title: 'SlidePane',
-				key: 'pane',
-				open: this._open,
-				underlay: this._underlay,
-				align: this._align,
-				onRequestClose: () => {
-					this._open = false;
-					this.invalidate();
+			w(
+				SlidePane,
+				{
+					title: 'SlidePane',
+					key: 'pane',
+					open: this._open,
+					underlay: this._underlay,
+					align: this._align,
+					onRequestClose: () => {
+						this._open = false;
+						this.invalidate();
+					},
+					theme: this._theme
 				},
-				theme: this._theme
-			}, [
-				`Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+				[
+					`Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 				Quisque id purus ipsum. Aenean ac purus purus.
 				Nam sollicitudin varius augue, sed lacinia felis tempor in.`
-			]),
+				]
+			),
 			v('button', {
 				id: 'button',
 				innerHTML: 'open slidepane',

--- a/src/slidepane/tests/functional/SlidePane.ts
+++ b/src/slidepane/tests/functional/SlidePane.ts
@@ -12,20 +12,20 @@ function openSlidePane(remote: Remote, alignRight?: boolean) {
 		.get('http://localhost:9000/_build/common/example/?module=slidepane')
 		.setFindTimeout(5000)
 		.findById('underlay')
-			.click()
-			.end();
+		.click()
+		.end();
 
 	if (alignRight) {
 		promise = promise
 			.findById('alignRight')
-				.click()
-				.end();
+			.click()
+			.end();
 	}
 
 	return promise
 		.findById('button')
-			.click()
-			.end()
+		.click()
+		.end()
 		.sleep(DELAY);
 }
 
@@ -36,8 +36,7 @@ function swipeSlidePane(remote: Remote, distance?: number | boolean, alignRight?
 	if (typeof distance === 'boolean') {
 		alignRight = distance;
 		distance = 250;
-	}
-	else if (typeof distance === 'undefined') {
+	} else if (typeof distance === 'undefined') {
 		alignRight = undefined;
 		distance = 250;
 	}
@@ -64,45 +63,44 @@ function swipeSlidePane(remote: Remote, distance?: number | boolean, alignRight?
 }
 
 registerSuite('SlidePane', {
-
 	'the underlay should cover the screen'() {
-		let viewportSize: { height: number; width: number; };
+		let viewportSize: { height: number; width: number };
 
 		return openSlidePane(this.remote)
 			.getWindowSize()
-				.then(({ height, width }) => {
-					viewportSize = { height, width };
-				})
+			.then(({ height, width }) => {
+				viewportSize = { height, width };
+			})
 			.findByCssSelector(`.${css.underlay}`)
-				.getSize()
-				.then(({ height, width }) => {
-					assert.closeTo(height, viewportSize.height, viewportSize.height * 0.2);
-					assert.closeTo(width, viewportSize.width, viewportSize.width * 0.2);
-				});
+			.getSize()
+			.then(({ height, width }) => {
+				assert.closeTo(height, viewportSize.height, viewportSize.height * 0.2);
+				assert.closeTo(width, viewportSize.width, viewportSize.width * 0.2);
+			});
 	},
 
 	'the underlay should not be destroyed when the slidepane is clicked'() {
 		return openSlidePane(this.remote)
 			.findByCssSelector(`.${css.content}`)
-				.click()
-				.end()
+			.click()
+			.end()
 			.sleep(DELAY)
 			.findByCssSelector(`.${css.underlay}`)
-				.getAttribute('class')
-				.then((className: string) => {
-					assert.match(className, /slidePane-m__underlay/, 'the underlay should not be removed.');
-				});
+			.getAttribute('class')
+			.then((className: string) => {
+				assert.match(className, /slidePane-m__underlay/, 'the underlay should not be removed.');
+			});
 	},
 
 	'the slidepane should not be hidden when it is clicked'() {
 		return openSlidePane(this.remote)
 			.findByCssSelector(`.${css.content}`)
-				.click()
-				.sleep(DELAY)
-				.getPosition()
-					.then(({ x }) => {
-						assert.strictEqual(x, 0, 'The slidepane should be visible.');
-					});
+			.click()
+			.sleep(DELAY)
+			.getPosition()
+			.then(({ x }) => {
+				assert.strictEqual(x, 0, 'The slidepane should be visible.');
+			});
 	},
 
 	'a left-aligned slidepane should close when swiping from right to left'() {
@@ -120,14 +118,14 @@ registerSuite('SlidePane', {
 		let width = 0;
 		return swipeSlidePane(this.remote)
 			.findByCssSelector(`.${css.content}`)
-				.getSize()
-					.then(size => {
-						width = size.width;
-					})
-				.getPosition()
-					.then(({ x }) => {
-						assert.closeTo(x, -width, 15);
-					});
+			.getSize()
+			.then((size) => {
+				width = size.width;
+			})
+			.getPosition()
+			.then(({ x }) => {
+				assert.closeTo(x, -width, 15);
+			});
 	},
 
 	'a right-aligned slidepane should close when swiping from left to right'() {
@@ -145,17 +143,17 @@ registerSuite('SlidePane', {
 		let viewportWidth = 0;
 		return swipeSlidePane(this.remote, true)
 			.getWindowSize()
-				.then(({ width }) => {
-					viewportWidth = width;
-				})
+			.then(({ width }) => {
+				viewportWidth = width;
+			})
 			.findByCssSelector(`.${css.content}`)
-				.getPosition()
-				.then(({ x }) => {
-					// Edge/IE11/Chrome on Windows visually hide the slidepane correctly, but the position
-					// is slightly less than expected (the viewport width).
-					const expected = viewportWidth * 0.95;
-					assert.isAtLeast(x, expected, 'The slidepane should be hidden off to the right.');
-				});
+			.getPosition()
+			.then(({ x }) => {
+				// Edge/IE11/Chrome on Windows visually hide the slidepane correctly, but the position
+				// is slightly less than expected (the viewport width).
+				const expected = viewportWidth * 0.95;
+				assert.isAtLeast(x, expected, 'The slidepane should be hidden off to the right.');
+			});
 	},
 
 	'minor swipe movements should not close the slidepane'() {
@@ -172,9 +170,9 @@ registerSuite('SlidePane', {
 
 		return swipeSlidePane(this.remote, 50)
 			.findByCssSelector(`.${css.content}`)
-				.getPosition()
-					.then(({ x }) => {
-						assert.strictEqual(x, 0, 'The slidepane should be open.');
-					});
+			.getPosition()
+			.then(({ x }) => {
+				assert.strictEqual(x, 0, 'The slidepane should be open.');
+			});
 	}
 });

--- a/src/slidepane/tests/unit/SlidePane.ts
+++ b/src/slidepane/tests/unit/SlidePane.ts
@@ -21,7 +21,6 @@ const GREEKING = `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 	Nam sollicitudin varius augue, sed lacinia felis tempor in.`;
 
 registerSuite('SlidePane', {
-
 	beforeEach() {
 		widget = harness(SlidePane);
 	},
@@ -39,50 +38,64 @@ registerSuite('SlidePane', {
 				underlay: true
 			});
 
-			widget.setChildren([ GREEKING ]);
+			widget.setChildren([GREEKING]);
 
-			widget.expectRender(v('div', {
-				'aria-labelledby': compareId,
-				classes: css.root,
-				onmousedown: widget.listener,
-				onmousemove: widget.listener,
-				onmouseup: widget.listener,
-				ontouchend: widget.listener,
-				ontouchmove: widget.listener,
-				ontouchstart: widget.listener
-			}, [
-				v('div', {
-					classes: [ css.underlayVisible, css.underlay ],
-					enterAnimation: animations.fadeIn,
-					exitAnimation: animations.fadeOut,
-					key: 'underlay'
-				}),
-				v('div', {
-					key: 'content',
-					classes: [
-						css.pane,
-						undefined,
-						css.open,
-						css.slideIn,
-						null,
-						css.paneFixed,
-						css.openFixed,
-						css.leftFixed,
-						css.slideInFixed,
-						null
-					],
-					styles: {
-						transform: '',
-						width: '320px',
-						height: null
-					}
-				}, [
-					null,
-					v('div', {
-						classes: css.content
-					}, [ GREEKING ])
-				])
-			]));
+			widget.expectRender(
+				v(
+					'div',
+					{
+						'aria-labelledby': compareId,
+						classes: css.root,
+						onmousedown: widget.listener,
+						onmousemove: widget.listener,
+						onmouseup: widget.listener,
+						ontouchend: widget.listener,
+						ontouchmove: widget.listener,
+						ontouchstart: widget.listener
+					},
+					[
+						v('div', {
+							classes: [css.underlayVisible, css.underlay],
+							enterAnimation: animations.fadeIn,
+							exitAnimation: animations.fadeOut,
+							key: 'underlay'
+						}),
+						v(
+							'div',
+							{
+								key: 'content',
+								classes: [
+									css.pane,
+									undefined,
+									css.open,
+									css.slideIn,
+									null,
+									css.paneFixed,
+									css.openFixed,
+									css.leftFixed,
+									css.slideInFixed,
+									null
+								],
+								styles: {
+									transform: '',
+									width: '320px',
+									height: null
+								}
+							},
+							[
+								null,
+								v(
+									'div',
+									{
+										classes: css.content
+									},
+									[GREEKING]
+								)
+							]
+						)
+					]
+				)
+			);
 		},
 
 		'Render correct children'() {
@@ -91,43 +104,57 @@ registerSuite('SlidePane', {
 				underlay: false
 			});
 
-			widget.expectRender(v('div', {
-				'aria-labelledby': compareId,
-				onmousedown: widget.listener,
-				onmousemove: widget.listener,
-				onmouseup: widget.listener,
-				ontouchend: widget.listener,
-				ontouchmove: widget.listener,
-				ontouchstart: widget.listener,
-				classes: css.root
-			}, [
-				null,
-				v('div', {
-					key: 'content',
-					classes: [
-						css.pane,
-						undefined,
+			widget.expectRender(
+				v(
+					'div',
+					{
+						'aria-labelledby': compareId,
+						onmousedown: widget.listener,
+						onmousemove: widget.listener,
+						onmouseup: widget.listener,
+						ontouchend: widget.listener,
+						ontouchmove: widget.listener,
+						ontouchstart: widget.listener,
+						classes: css.root
+					},
+					[
 						null,
-						null,
-						null,
-						css.paneFixed,
-						null,
-						css.leftFixed,
-						null,
-						null
-					],
-					styles: {
-						transform: '',
-						width: '320px',
-						height: null
-					}
-				}, [
-					null,
-					v('div', {
-						classes: css.content
-					}, [])
-				])
-			]));
+						v(
+							'div',
+							{
+								key: 'content',
+								classes: [
+									css.pane,
+									undefined,
+									null,
+									null,
+									null,
+									css.paneFixed,
+									null,
+									css.leftFixed,
+									null,
+									null
+								],
+								styles: {
+									transform: '',
+									width: '320px',
+									height: null
+								}
+							},
+							[
+								null,
+								v(
+									'div',
+									{
+										classes: css.content
+									},
+									[]
+								)
+							]
+						)
+					]
+				)
+			);
 		},
 
 		onOpen() {
@@ -150,90 +177,118 @@ registerSuite('SlidePane', {
 				open: true
 			});
 
-			widget.expectRender(v('div', {
-				'aria-labelledby': compareId,
-				onmousedown: widget.listener,
-				onmousemove: widget.listener,
-				onmouseup: widget.listener,
-				ontouchend: widget.listener,
-				ontouchmove: widget.listener,
-				ontouchstart: widget.listener,
-				classes: css.root
-			}, [
-				v('div', {
-					classes: [ null, css.underlay ],
-					enterAnimation: animations.fadeIn,
-					exitAnimation: animations.fadeOut,
-					key: 'underlay'
-				}),
-				v('div', {
-					key: 'content',
-					classes: [
-						css.pane,
-						undefined,
-						css.open,
-						css.slideIn,
-						null,
-						css.paneFixed,
-						css.openFixed,
-						css.leftFixed,
-						css.slideInFixed,
-						null
-					],
-					styles: {
-						transform: '',
-						width: '320px',
-						height: null
-					}
-				}, [
-					null,
-					v('div', {
-						classes: css.content
-					}, [])
-				])
-			]));
+			widget.expectRender(
+				v(
+					'div',
+					{
+						'aria-labelledby': compareId,
+						onmousedown: widget.listener,
+						onmousemove: widget.listener,
+						onmouseup: widget.listener,
+						ontouchend: widget.listener,
+						ontouchmove: widget.listener,
+						ontouchstart: widget.listener,
+						classes: css.root
+					},
+					[
+						v('div', {
+							classes: [null, css.underlay],
+							enterAnimation: animations.fadeIn,
+							exitAnimation: animations.fadeOut,
+							key: 'underlay'
+						}),
+						v(
+							'div',
+							{
+								key: 'content',
+								classes: [
+									css.pane,
+									undefined,
+									css.open,
+									css.slideIn,
+									null,
+									css.paneFixed,
+									css.openFixed,
+									css.leftFixed,
+									css.slideInFixed,
+									null
+								],
+								styles: {
+									transform: '',
+									width: '320px',
+									height: null
+								}
+							},
+							[
+								null,
+								v(
+									'div',
+									{
+										classes: css.content
+									},
+									[]
+								)
+							]
+						)
+					]
+				)
+			);
 
 			widget.setProperties({
 				open: false
 			});
 
-			widget.expectRender(v('div', {
-				'aria-labelledby': compareId,
-				onmousedown: widget.listener,
-				onmousemove: widget.listener,
-				onmouseup: widget.listener,
-				ontouchend: widget.listener,
-				ontouchmove: widget.listener,
-				ontouchstart: widget.listener,
-				classes: css.root
-			}, [
-				null,
-				v('div', {
-					key: 'content',
-					classes: [
-						css.pane,
-						undefined,
+			widget.expectRender(
+				v(
+					'div',
+					{
+						'aria-labelledby': compareId,
+						onmousedown: widget.listener,
+						onmousemove: widget.listener,
+						onmouseup: widget.listener,
+						ontouchend: widget.listener,
+						ontouchmove: widget.listener,
+						ontouchstart: widget.listener,
+						classes: css.root
+					},
+					[
 						null,
-						null,
-						css.slideOut,
-						css.paneFixed,
-						null,
-						css.leftFixed,
-						null,
-						css.slideOutFixed
-					],
-					styles: {
-						transform: '',
-						width: '320px',
-						height: null
-					}
-				}, [
-					null,
-					v('div', {
-						classes: css.content
-					}, [])
-				])
-			]));
+						v(
+							'div',
+							{
+								key: 'content',
+								classes: [
+									css.pane,
+									undefined,
+									null,
+									null,
+									css.slideOut,
+									css.paneFixed,
+									null,
+									css.leftFixed,
+									null,
+									css.slideOutFixed
+								],
+								styles: {
+									transform: '',
+									width: '320px',
+									height: null
+								}
+							},
+							[
+								null,
+								v(
+									'div',
+									{
+										classes: css.content
+									},
+									[]
+								)
+							]
+						)
+					]
+				)
+			);
 		},
 
 		'click underlay to close'() {
@@ -247,14 +302,14 @@ registerSuite('SlidePane', {
 			});
 
 			widget.sendEvent('mousedown', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 300
 				},
 				selector: ':first-child' /* this should be the underlay */
 			});
 
 			widget.sendEvent('mouseup', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 300
 				},
 				selector: ':first-child' /* this should be the underlay */
@@ -299,15 +354,15 @@ registerSuite('SlidePane', {
 			});
 
 			widget.sendEvent('touchstart', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenX: 300 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenX: 300 }]
 				},
 				selector: ':first-child' /* this should be the underlay */
 			});
 
 			widget.sendEvent('touchend', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenX: 300 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenX: 300 }]
 				},
 
 				selector: ':first-child' /* this should be the underlay */
@@ -327,19 +382,19 @@ registerSuite('SlidePane', {
 			});
 
 			widget.sendEvent('mousedown', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 300
 				}
 			});
 
 			widget.sendEvent('mousemove', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 150
 				}
 			});
 
 			widget.sendEvent('mouseup', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 50
 				}
 			});
@@ -362,26 +417,26 @@ registerSuite('SlidePane', {
 			});
 
 			widget.sendEvent('touchmove', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenX: 150 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenX: 150 }]
 				}
 			});
 
 			widget.sendEvent('touchstart', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenX: 300 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenX: 300 }]
 				}
 			});
 
 			widget.sendEvent('touchmove', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenX: 150 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenX: 150 }]
 				}
 			});
 
 			widget.sendEvent('touchend', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenX: 50 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenX: 50 }]
 				}
 			});
 
@@ -404,26 +459,26 @@ registerSuite('SlidePane', {
 			});
 
 			widget.sendEvent('touchmove', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenY: 150 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenY: 150 }]
 				}
 			});
 
 			widget.sendEvent('touchstart', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenY: 300 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenY: 300 }]
 				}
 			});
 
 			widget.sendEvent('touchmove', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenY: 150 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenY: 150 }]
 				}
 			});
 
 			widget.sendEvent('touchend', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenY: 50 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenY: 50 }]
 				}
 			});
 
@@ -448,20 +503,20 @@ registerSuite('SlidePane', {
 			});
 
 			widget.sendEvent('touchstart', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenX: 300 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenX: 300 }]
 				}
 			});
 
 			widget.sendEvent('touchmove', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenX: 400 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenX: 400 }]
 				}
 			});
 
 			widget.sendEvent('touchend', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenX: 500 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenX: 500 }]
 				}
 			});
 
@@ -486,20 +541,20 @@ registerSuite('SlidePane', {
 			});
 
 			widget.sendEvent('touchstart', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenY: 300 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenY: 300 }]
 				}
 			});
 
 			widget.sendEvent('touchmove', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenY: 400 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenY: 400 }]
 				}
 			});
 
 			widget.sendEvent('touchend', {
-				eventInit: <MouseEventInit> {
-					changedTouches: [ { screenY: 500 } ]
+				eventInit: <MouseEventInit>{
+					changedTouches: [{ screenY: 500 }]
 				}
 			});
 
@@ -518,19 +573,19 @@ registerSuite('SlidePane', {
 			});
 
 			widget.sendEvent('mousedown', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 300
 				}
 			});
 
 			widget.sendEvent('mousemove', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 250
 				}
 			});
 
 			widget.sendEvent('mouseup', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 250
 				}
 			});
@@ -543,10 +598,10 @@ registerSuite('SlidePane', {
 				open: true
 			});
 
-			widget.setChildren([ GREEKING ]);
+			widget.setChildren([GREEKING]);
 
 			widget.sendEvent('mousedown', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 300
 				},
 
@@ -554,74 +609,88 @@ registerSuite('SlidePane', {
 			});
 
 			widget.sendEvent('mousemove', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 400
 				},
 
 				selector: ':last-child :first-child' /* this should be the content */
 			});
 
-			assert(!((<HTMLElement> widget.getDom().lastChild).style.transform));
+			assert(!(<HTMLElement>widget.getDom().lastChild).style.transform);
 
 			widget.sendEvent('mouseup', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 500
 				},
 
 				selector: ':last-child :first-child' /* this should be the content */
 			});
 
-			assert(!((<HTMLElement> widget.getDom().lastChild).style.transform));
+			assert(!(<HTMLElement>widget.getDom().lastChild).style.transform);
 		},
 
 		'classes removed after transition'() {
 			function expected(open: boolean, transitionDone?: boolean) {
-				return v('div', {
-					'aria-labelledby': compareId,
-					onmousedown: widget.listener,
-					onmousemove: widget.listener,
-					onmouseup: widget.listener,
-					ontouchend: widget.listener,
-					ontouchmove: widget.listener,
-					ontouchstart: widget.listener,
-					classes: css.root
-				}, [
-					open ? v('div', {
-						classes: [ null, css.underlay ],
-						enterAnimation: animations.fadeIn,
-						exitAnimation: animations.fadeOut,
-						key: 'underlay'
-					}) : null,
-					v('div', {
-						key: 'content',
-						classes: [
-							css.pane,
-							undefined,
-							open ? css.open : null,
-							transitionDone ? null : ( open ? css.slideIn : null),
-							transitionDone ? null : ( open ? null : css.slideOut),
-							css.paneFixed,
-							open ? css.openFixed : null,
-							css.leftFixed,
-							transitionDone ? null : ( open ? css.slideInFixed : null),
-							transitionDone ? null : ( open ? null : css.slideOutFixed)
-						],
-						styles: {
-							transform: '',
-							width: '320px',
-							height: null
-						}
-					}, [
-						null,
-						v('div', {
-							classes: css.content
-						}, [ GREEKING ])
-					])
-				]);
+				return v(
+					'div',
+					{
+						'aria-labelledby': compareId,
+						onmousedown: widget.listener,
+						onmousemove: widget.listener,
+						onmouseup: widget.listener,
+						ontouchend: widget.listener,
+						ontouchmove: widget.listener,
+						ontouchstart: widget.listener,
+						classes: css.root
+					},
+					[
+						open
+							? v('div', {
+									classes: [null, css.underlay],
+									enterAnimation: animations.fadeIn,
+									exitAnimation: animations.fadeOut,
+									key: 'underlay'
+								})
+							: null,
+						v(
+							'div',
+							{
+								key: 'content',
+								classes: [
+									css.pane,
+									undefined,
+									open ? css.open : null,
+									transitionDone ? null : open ? css.slideIn : null,
+									transitionDone ? null : open ? null : css.slideOut,
+									css.paneFixed,
+									open ? css.openFixed : null,
+									css.leftFixed,
+									transitionDone ? null : open ? css.slideInFixed : null,
+									transitionDone ? null : open ? null : css.slideOutFixed
+								],
+								styles: {
+									transform: '',
+									width: '320px',
+									height: null
+								}
+							},
+							[
+								null,
+								v(
+									'div',
+									{
+										classes: css.content
+									},
+									[GREEKING]
+								)
+							]
+						)
+					]
+				);
 			}
 
 			widget.setProperties({ open: true });
-			widget.setChildren([ GREEKING ]);
+			widget.setChildren([GREEKING]);
 			widget.expectRender(expected(true, false));
 			widget.sendEvent('transitionend', { selector: ':last-child' });
 			widget.expectRender(expected(true, true), '`css.slideIn` should be removed when the animation ends.');
@@ -640,51 +709,65 @@ registerSuite('SlidePane', {
 				open: true
 			});
 
-			widget.setChildren([ GREEKING ]);
+			widget.setChildren([GREEKING]);
 
 			function expected(closed: boolean, swipeState: any = {}) {
-				return v('div', {
-					'aria-labelledby': compareId,
-					onmousedown: widget.listener,
-					onmousemove: widget.listener,
-					onmouseup: widget.listener,
-					ontouchend: widget.listener,
-					ontouchmove: widget.listener,
-					ontouchstart: widget.listener,
-					classes: css.root
-				}, [
-					closed ? null : v('div', {
-						classes: [ null, css.underlay ],
-						enterAnimation: animations.fadeIn,
-						exitAnimation: animations.fadeOut,
-						key: 'underlay'
-					}),
-					v('div', {
-						key: 'content',
-						classes: swipeState.classes || [
-							css.pane,
-							undefined,
-							closed ? null : css.open,
-							css.slideIn,
-							null,
-							css.paneFixed,
-							closed ? null : css.openFixed,
-							css.leftFixed,
-							css.slideInFixed,
-							null
-						],
-						styles: swipeState.styles || {
-							transform: '',
-							width: '320px',
-							height: null
-						}
-					}, [
-						null,
-						v('div', {
-							classes: css.content
-						}, [ GREEKING ])
-					])
-				]);
+				return v(
+					'div',
+					{
+						'aria-labelledby': compareId,
+						onmousedown: widget.listener,
+						onmousemove: widget.listener,
+						onmouseup: widget.listener,
+						ontouchend: widget.listener,
+						ontouchmove: widget.listener,
+						ontouchstart: widget.listener,
+						classes: css.root
+					},
+					[
+						closed
+							? null
+							: v('div', {
+									classes: [null, css.underlay],
+									enterAnimation: animations.fadeIn,
+									exitAnimation: animations.fadeOut,
+									key: 'underlay'
+								}),
+						v(
+							'div',
+							{
+								key: 'content',
+								classes: swipeState.classes || [
+									css.pane,
+									undefined,
+									closed ? null : css.open,
+									css.slideIn,
+									null,
+									css.paneFixed,
+									closed ? null : css.openFixed,
+									css.leftFixed,
+									css.slideInFixed,
+									null
+								],
+								styles: swipeState.styles || {
+									transform: '',
+									width: '320px',
+									height: null
+								}
+							},
+							[
+								null,
+								v(
+									'div',
+									{
+										classes: css.content
+									},
+									[GREEKING]
+								)
+							]
+						)
+					]
+				);
 			}
 
 			widget.expectRender(expected(false));
@@ -694,45 +777,47 @@ registerSuite('SlidePane', {
 			});
 
 			widget.sendEvent('mousedown', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 300
 				},
 				selector: ':last-child'
 			});
 
 			widget.sendEvent('mousemove', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 150
 				},
 				selector: ':last-child'
 			});
 
 			widget.sendEvent('mouseup', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 50
 				},
 				selector: ':last-child'
 			});
 
-			widget.expectRender(expected(true, {
-				classes: [
-					css.pane,
-					undefined,
-					null,
-					null,
-					css.slideOut,
-					css.paneFixed,
-					null,
-					css.leftFixed,
-					null,
-					css.slideOutFixed
-				],
-				styles: {
-					transform: 'translateX(-78.125%)',
-					width: '320px',
-					height: null
-				}
-			}));
+			widget.expectRender(
+				expected(true, {
+					classes: [
+						css.pane,
+						undefined,
+						null,
+						null,
+						css.slideOut,
+						css.paneFixed,
+						null,
+						css.leftFixed,
+						null,
+						css.slideOutFixed
+					],
+					styles: {
+						transform: 'translateX(-78.125%)',
+						width: '320px',
+						height: null
+					}
+				})
+			);
 		},
 
 		'last transform is applied on next render if being swiped closed right'() {
@@ -741,51 +826,65 @@ registerSuite('SlidePane', {
 				open: true
 			});
 
-			widget.setChildren([ GREEKING ]);
+			widget.setChildren([GREEKING]);
 
 			function expected(closed: boolean, swipeState: any = {}) {
-				return v('div', {
-					'aria-labelledby': compareId,
-					onmousedown: widget.listener,
-					onmousemove: widget.listener,
-					onmouseup: widget.listener,
-					ontouchend: widget.listener,
-					ontouchmove: widget.listener,
-					ontouchstart: widget.listener,
-					classes: css.root
-				}, [
-					closed ? null : v('div', {
-						classes: [ null, css.underlay ],
-						enterAnimation: animations.fadeIn,
-						exitAnimation: animations.fadeOut,
-						key: 'underlay'
-					}),
-					v('div', {
-						key: 'content',
-						classes: swipeState.classes || [
-							css.pane,
-							undefined,
-							css.open,
-							css.slideIn,
-							null,
-							css.paneFixed,
-							css.openFixed,
-							css.rightFixed,
-							css.slideInFixed,
-							null
-						],
-						styles: swipeState.styles || {
-							transform: '',
-							width: '320px',
-							height: null
-						}
-					}, [
-						null,
-						v('div', {
-							classes: css.content
-						}, [ GREEKING ])
-					])
-				]);
+				return v(
+					'div',
+					{
+						'aria-labelledby': compareId,
+						onmousedown: widget.listener,
+						onmousemove: widget.listener,
+						onmouseup: widget.listener,
+						ontouchend: widget.listener,
+						ontouchmove: widget.listener,
+						ontouchstart: widget.listener,
+						classes: css.root
+					},
+					[
+						closed
+							? null
+							: v('div', {
+									classes: [null, css.underlay],
+									enterAnimation: animations.fadeIn,
+									exitAnimation: animations.fadeOut,
+									key: 'underlay'
+								}),
+						v(
+							'div',
+							{
+								key: 'content',
+								classes: swipeState.classes || [
+									css.pane,
+									undefined,
+									css.open,
+									css.slideIn,
+									null,
+									css.paneFixed,
+									css.openFixed,
+									css.rightFixed,
+									css.slideInFixed,
+									null
+								],
+								styles: swipeState.styles || {
+									transform: '',
+									width: '320px',
+									height: null
+								}
+							},
+							[
+								null,
+								v(
+									'div',
+									{
+										classes: css.content
+									},
+									[GREEKING]
+								)
+							]
+						)
+					]
+				);
 			}
 
 			widget.expectRender(expected(false));
@@ -796,45 +895,47 @@ registerSuite('SlidePane', {
 			});
 
 			widget.sendEvent('mousedown', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 300
 				},
 				selector: ':last-child'
 			});
 
 			widget.sendEvent('mousemove', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 400
 				},
 				selector: ':last-child'
 			});
 
 			widget.sendEvent('mouseup', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					pageX: 500
 				},
 				selector: ':last-child'
 			});
 
-			widget.expectRender(expected(true, {
-				classes: [
-					css.pane,
-					undefined,
-					null,
-					null,
-					css.slideOut,
-					css.paneFixed,
-					null,
-					css.rightFixed,
-					null,
-					css.slideOutFixed
-				],
-				styles: {
-					transform: 'translateX(62.5%)',
-					width: '320px',
-					height: null
-				}
-			}));
+			widget.expectRender(
+				expected(true, {
+					classes: [
+						css.pane,
+						undefined,
+						null,
+						null,
+						css.slideOut,
+						css.paneFixed,
+						null,
+						css.rightFixed,
+						null,
+						css.slideOutFixed
+					],
+					styles: {
+						transform: 'translateX(62.5%)',
+						width: '320px',
+						height: null
+					}
+				})
+			);
 		}
 	}
 });

--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -4,7 +4,13 @@ import Label from '../label/Label';
 import { v, w } from '@dojo/widget-core/d';
 import { DNode } from '@dojo/widget-core/interfaces';
 import uuid from '@dojo/core/uuid';
-import { LabeledProperties, InputEventProperties, InputProperties, PointerEventProperties, KeyEventProperties } from '../common/interfaces';
+import {
+	LabeledProperties,
+	InputEventProperties,
+	InputProperties,
+	PointerEventProperties,
+	KeyEventProperties
+} from '../common/interfaces';
 import * as css from './styles/slider.m.css';
 
 /**
@@ -20,7 +26,13 @@ import * as css from './styles/slider.m.css';
  * @property verticalHeight    Length of the vertical slider (only used if vertical is true)
  * @property value           The current value
  */
-export interface SliderProperties extends ThemedProperties, LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties, KeyEventProperties {
+export interface SliderProperties
+	extends ThemedProperties,
+		LabeledProperties,
+		InputProperties,
+		InputEventProperties,
+		PointerEventProperties,
+		KeyEventProperties {
 	max?: number;
 	min?: number;
 	output?(value: number): DNode;
@@ -38,28 +50,48 @@ export default class Slider<P extends SliderProperties = SliderProperties> exten
 	// id used to associate input with output
 	private _inputId = uuid();
 
-	private _onBlur (event: FocusEvent) { this.properties.onBlur && this.properties.onBlur(event); }
-	private _onChange (event: Event) { this.properties.onChange && this.properties.onChange(event); }
-	private _onClick (event: MouseEvent) { this.properties.onClick && this.properties.onClick(event); }
-	private _onFocus (event: FocusEvent) { this.properties.onFocus && this.properties.onFocus(event); }
-	private _onInput (event: Event) { this.properties.onInput && this.properties.onInput(event); }
-	private _onKeyDown (event: KeyboardEvent) { this.properties.onKeyDown && this.properties.onKeyDown(event); }
-	private _onKeyPress (event: KeyboardEvent) { this.properties.onKeyPress && this.properties.onKeyPress(event); }
-	private _onKeyUp (event: KeyboardEvent) { this.properties.onKeyUp && this.properties.onKeyUp(event); }
-	private _onMouseDown (event: MouseEvent) { this.properties.onMouseDown && this.properties.onMouseDown(event); }
-	private _onMouseUp (event: MouseEvent) { this.properties.onMouseUp && this.properties.onMouseUp(event); }
-	private _onTouchStart (event: TouchEvent) { this.properties.onTouchStart && this.properties.onTouchStart(event); }
-	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
-	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
+	private _onBlur(event: FocusEvent) {
+		this.properties.onBlur && this.properties.onBlur(event);
+	}
+	private _onChange(event: Event) {
+		this.properties.onChange && this.properties.onChange(event);
+	}
+	private _onClick(event: MouseEvent) {
+		this.properties.onClick && this.properties.onClick(event);
+	}
+	private _onFocus(event: FocusEvent) {
+		this.properties.onFocus && this.properties.onFocus(event);
+	}
+	private _onInput(event: Event) {
+		this.properties.onInput && this.properties.onInput(event);
+	}
+	private _onKeyDown(event: KeyboardEvent) {
+		this.properties.onKeyDown && this.properties.onKeyDown(event);
+	}
+	private _onKeyPress(event: KeyboardEvent) {
+		this.properties.onKeyPress && this.properties.onKeyPress(event);
+	}
+	private _onKeyUp(event: KeyboardEvent) {
+		this.properties.onKeyUp && this.properties.onKeyUp(event);
+	}
+	private _onMouseDown(event: MouseEvent) {
+		this.properties.onMouseDown && this.properties.onMouseDown(event);
+	}
+	private _onMouseUp(event: MouseEvent) {
+		this.properties.onMouseUp && this.properties.onMouseUp(event);
+	}
+	private _onTouchStart(event: TouchEvent) {
+		this.properties.onTouchStart && this.properties.onTouchStart(event);
+	}
+	private _onTouchEnd(event: TouchEvent) {
+		this.properties.onTouchEnd && this.properties.onTouchEnd(event);
+	}
+	private _onTouchCancel(event: TouchEvent) {
+		this.properties.onTouchCancel && this.properties.onTouchCancel(event);
+	}
 
 	protected getRootClasses(): (string | null)[] {
-		const {
-			disabled,
-			invalid,
-			readOnly,
-			required,
-			vertical = false
-		} = this.properties;
+		const { disabled, invalid, readOnly, required, vertical = false } = this.properties;
 
 		return [
 			css.root,
@@ -73,33 +105,30 @@ export default class Slider<P extends SliderProperties = SliderProperties> exten
 	}
 
 	protected renderControls(percentValue: number): DNode {
-		const {
-			vertical = false,
-			verticalHeight = '200px'
-		} = this.properties;
+		const { vertical = false, verticalHeight = '200px' } = this.properties;
 
-		return v('div', {
-			classes: [ this.theme(css.track), css.trackFixed ],
-			'aria-hidden': 'true',
-			styles: vertical ? { width: verticalHeight } : {}
-		}, [
-			v('span', {
-				classes: [ this.theme(css.fill), css.fillFixed ],
-				styles: { width: `${percentValue}%` }
-			}),
-			v('span', {
-				classes: [ this.theme(css.thumb), css.thumbFixed ],
-				styles: { left: `${percentValue}%` }
-			})
-		]);
+		return v(
+			'div',
+			{
+				classes: [this.theme(css.track), css.trackFixed],
+				'aria-hidden': 'true',
+				styles: vertical ? { width: verticalHeight } : {}
+			},
+			[
+				v('span', {
+					classes: [this.theme(css.fill), css.fillFixed],
+					styles: { width: `${percentValue}%` }
+				}),
+				v('span', {
+					classes: [this.theme(css.thumb), css.thumbFixed],
+					styles: { left: `${percentValue}%` }
+				})
+			]
+		);
 	}
 
 	protected renderOutput(value: number, percentValue: number): DNode {
-		const {
-			output,
-			outputIsTooltip = false,
-			vertical = false
-		} = this.properties;
+		const { output, outputIsTooltip = false, vertical = false } = this.properties;
 
 		const outputNode = output ? output(value) : `${value}`;
 
@@ -109,11 +138,15 @@ export default class Slider<P extends SliderProperties = SliderProperties> exten
 			outputStyles = vertical ? { top: `${100 - percentValue}%` } : { left: `${percentValue}%` };
 		}
 
-		return v('output', {
-			classes: [ this.theme(css.output), outputIsTooltip ? css.outputTooltip : null ],
-			for: this._inputId,
-			styles: outputStyles
-		}, [ outputNode ]);
+		return v(
+			'output',
+			{
+				classes: [this.theme(css.output), outputIsTooltip ? css.outputTooltip : null],
+				for: this._inputId,
+				styles: outputStyles
+			},
+			[outputNode]
+		);
 	}
 
 	render(): DNode {
@@ -135,70 +168,82 @@ export default class Slider<P extends SliderProperties = SliderProperties> exten
 			theme
 		} = this.properties;
 
-		let {
-			value = min
-		} = this.properties;
+		let { value = min } = this.properties;
 
 		value = value > max ? max : value;
 		value = value < min ? min : value;
 
 		const percentValue = (value - min) / (max - min) * 100;
 
-		const slider = v('div', {
-			classes: [ this.theme(css.inputWrapper), css.inputWrapperFixed ],
-			styles: vertical ? { height: verticalHeight } : {}
-		}, [
-			v('input', {
-				key: 'input',
-				classes: [ this.theme(css.input), css.nativeInput ],
-				'aria-describedby': describedBy,
-				disabled,
-				id: this._inputId,
-				'aria-invalid': invalid === true ? 'true' : null,
-				max: `${max}`,
-				min: `${min}`,
-				name,
-				readOnly,
-				'aria-readonly': readOnly === true ? 'true' : null,
-				required,
-				step: `${step}`,
-				styles: vertical ? { width: verticalHeight } : {},
-				type: 'range',
-				value: `${value}`,
-				onblur: this._onBlur,
-				onchange: this._onChange,
-				onclick: this._onClick,
-				onfocus: this._onFocus,
-				oninput: this._onInput,
-				onkeydown: this._onKeyDown,
-				onkeypress: this._onKeyPress,
-				onkeyup: this._onKeyUp,
-				onmousedown: this._onMouseDown,
-				onmouseup: this._onMouseUp,
-				ontouchstart: this._onTouchStart,
-				ontouchend: this._onTouchEnd,
-				ontouchcancel: this._onTouchCancel
-			}),
-			this.renderControls(percentValue),
-			this.renderOutput(value, percentValue)
-		]);
+		const slider = v(
+			'div',
+			{
+				classes: [this.theme(css.inputWrapper), css.inputWrapperFixed],
+				styles: vertical ? { height: verticalHeight } : {}
+			},
+			[
+				v('input', {
+					key: 'input',
+					classes: [this.theme(css.input), css.nativeInput],
+					'aria-describedby': describedBy,
+					disabled,
+					id: this._inputId,
+					'aria-invalid': invalid === true ? 'true' : null,
+					max: `${max}`,
+					min: `${min}`,
+					name,
+					readOnly,
+					'aria-readonly': readOnly === true ? 'true' : null,
+					required,
+					step: `${step}`,
+					styles: vertical ? { width: verticalHeight } : {},
+					type: 'range',
+					value: `${value}`,
+					onblur: this._onBlur,
+					onchange: this._onChange,
+					onclick: this._onClick,
+					onfocus: this._onFocus,
+					oninput: this._onInput,
+					onkeydown: this._onKeyDown,
+					onkeypress: this._onKeyPress,
+					onkeyup: this._onKeyUp,
+					onmousedown: this._onMouseDown,
+					onmouseup: this._onMouseUp,
+					ontouchstart: this._onTouchStart,
+					ontouchend: this._onTouchEnd,
+					ontouchcancel: this._onTouchCancel
+				}),
+				this.renderControls(percentValue),
+				this.renderOutput(value, percentValue)
+			]
+		);
 
 		const children = [
-			label ? w(Label, {
-				theme,
-				disabled,
-				invalid,
-				readOnly,
-				required,
-				hidden: labelHidden,
-				forId: this._inputId
-			}, [ label ]) : null,
+			label
+				? w(
+						Label,
+						{
+							theme,
+							disabled,
+							invalid,
+							readOnly,
+							required,
+							hidden: labelHidden,
+							forId: this._inputId
+						},
+						[label]
+					)
+				: null,
 			slider
 		];
 
-		return v('div', {
-			key: 'root',
-			classes: [...this.theme(this.getRootClasses()), css.rootFixed]
-		}, labelAfter ? children.reverse() : children);
+		return v(
+			'div',
+			{
+				key: 'root',
+				classes: [...this.theme(this.getRootClasses()), css.rootFixed]
+			},
+			labelAfter ? children.reverse() : children
+		);
 	}
 }

--- a/src/slider/example/index.ts
+++ b/src/slider/example/index.ts
@@ -46,18 +46,27 @@ export class App extends WidgetBase<WidgetProperties> {
 				})
 			]),
 			v('h1', {}, ['Slider with custom output']),
-			v('div', { id: 'example-s1'}, [
+			v('div', { id: 'example-s1' }, [
 				w(Slider, {
 					key: 's1',
 					label: 'How much do you like tribbles?',
 					min: 0,
 					max: 100,
 					output: (value: number) => {
-						if (value < 20) { return 'I am a Klingon'; }
-						if (value < 40) { return 'Tribbles only cause trouble'; }
-						if (value < 60) { return 'They\`re kind of cute'; }
-						if (value < 80) { return 'Most of my salary goes to tribble food'; }
-						else { return 'I permanently altered the ecology of a planet for my tribbles'; }
+						if (value < 20) {
+							return 'I am a Klingon';
+						}
+						if (value < 40) {
+							return 'Tribbles only cause trouble';
+						}
+						if (value < 60) {
+							return 'They\`re kind of cute';
+						}
+						if (value < 80) {
+							return 'Most of my salary goes to tribble food';
+						} else {
+							return 'I permanently altered the ecology of a planet for my tribbles';
+						}
 					},
 					step: 1,
 					value: tribbleValue,
@@ -67,7 +76,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				})
 			]),
 			v('h1', {}, ['Disabled slider']),
-			v('div', { id: 'example-s2'}, [
+			v('div', { id: 'example-s2' }, [
 				w(Slider, {
 					key: 's2',
 					label: 'Stuck at 30',
@@ -80,7 +89,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				})
 			]),
 			v('h1', {}, ['Vertical slider']),
-			v('div', { id: 'example-s3'}, [
+			v('div', { id: 'example-s3' }, [
 				w(Slider, {
 					key: 's3',
 					label: 'Vertical Slider with default properties. Anything over 50 is invalid:',

--- a/src/slider/tests/functional/Slider.ts
+++ b/src/slider/tests/functional/Slider.ts
@@ -8,12 +8,10 @@ import * as css from '../../styles/slider.m.css';
 function getPage(test: any) {
 	const { browserName } = test.remote.environmentType;
 	if (browserName.toLowerCase() === 'microsoftedge') {
-		test.skip('example page currently doesn\'t work in edge.');
+		test.skip("example page currently doesn't work in edge.");
 	}
 	const remote: Remote = test.remote;
-	return remote
-		.get('http://localhost:9000/_build/common/example/?module=slider')
-		.setFindTimeout(5000);
+	return remote.get('http://localhost:9000/_build/common/example/?module=slider').setFindTimeout(5000);
 }
 
 function checkValue(command: any, values?: number[]) {
@@ -21,33 +19,33 @@ function checkValue(command: any, values?: number[]) {
 	let currentValue: number;
 	return command
 		.findByCssSelector(`.${css.inputWrapper}`)
-			.findByCssSelector(`.${css.input}`)
-				.getProperty('value')
-				.then((value: string) => {
-					currentValue = parseInt(value, 10);
-				})
-			.end()
-			.findByCssSelector(`.${css.fill}`)
-				.getAttribute('style')
-				.then((style: string) => {
-					const absWidthRegex = /width:\s*(\d+)\.?\d*%/;
-					let result = style.match(absWidthRegex);
-					let width = result && result.length > 0 ? parseInt(result[1], 10) : -1;
-					assert.lengthOf(result!, 2);
-					notIE && assert.closeTo(width, currentValue, 1);
-				})
-			.end()
-			.findByCssSelector(`.${css.thumb}`)
-				.getAttribute('style')
-				.then((style: string) => {
-					const absWidthRegex = /left:\s*(\d+)\.?\d*%/;
-					let result = style.match(absWidthRegex);
-					let width = result && result.length > 0 ? parseInt(result[1], 10) : -1;
-					assert.lengthOf(result!, 2);
-					notIE && assert.closeTo(width, currentValue, 1);
-					values && values.push(width);
-				})
-			.end()
+		.findByCssSelector(`.${css.input}`)
+		.getProperty('value')
+		.then((value: string) => {
+			currentValue = parseInt(value, 10);
+		})
+		.end()
+		.findByCssSelector(`.${css.fill}`)
+		.getAttribute('style')
+		.then((style: string) => {
+			const absWidthRegex = /width:\s*(\d+)\.?\d*%/;
+			let result = style.match(absWidthRegex);
+			let width = result && result.length > 0 ? parseInt(result[1], 10) : -1;
+			assert.lengthOf(result!, 2);
+			notIE && assert.closeTo(width, currentValue, 1);
+		})
+		.end()
+		.findByCssSelector(`.${css.thumb}`)
+		.getAttribute('style')
+		.then((style: string) => {
+			const absWidthRegex = /left:\s*(\d+)\.?\d*%/;
+			let result = style.match(absWidthRegex);
+			let width = result && result.length > 0 ? parseInt(result[1], 10) : -1;
+			assert.lengthOf(result!, 2);
+			notIE && assert.closeTo(width, currentValue, 1);
+			values && values.push(width);
+		})
+		.end()
 		.end();
 }
 
@@ -66,36 +64,33 @@ function clickToFocus(test: any, selector: string) {
 	const remote = getPage(test);
 	return remote
 		.findByCssSelector(`#example-s1 .${css.root}`)
-			.findByCssSelector(selector)
-				.then((element) => {
-					return remote
-						.moveMouseTo(element)
-						.clickMouseButton(0);
-				})
-			.end()
+		.findByCssSelector(selector)
+		.then((element) => {
+			return remote.moveMouseTo(element).clickMouseButton(0);
+		})
+		.end()
 		.end()
 		.sleep(30)
 		.execute(`return document.activeElement === document.querySelector('#example-s1 .${css.root} input');`)
-		.then(isEqual => {
+		.then((isEqual) => {
 			assert.isTrue(isEqual);
 		});
 }
 
 function slide(command: any, x: number, y: number) {
-	return command.session.capabilities.brokenMouseEvents ?
-		command
-			.findByCssSelector(`.${css.thumb}`)
+	return command.session.capabilities.brokenMouseEvents
+		? command
+				.findByCssSelector(`.${css.thumb}`)
 				.moveMouseTo(x, y)
 				.pressMouseButton()
-			.end()
-		:
-		command
-			.findByCssSelector(`.${css.thumb}`)
+				.end()
+		: command
+				.findByCssSelector(`.${css.thumb}`)
 				.moveMouseTo()
 				.pressMouseButton()
 				.moveMouseTo(x, y)
 				.releaseMouseButton()
-			.end();
+				.end();
 }
 
 registerSuite('Slider', {
@@ -103,18 +98,18 @@ registerSuite('Slider', {
 		'each component of a slider should be visible'(this: any) {
 			return getPage(this)
 				.findByCssSelector(`#example-s1 .${css.root}`)
-					.isDisplayed()
-					.findByCssSelector(`.${css.input}`)
-					.isDisplayed()
+				.isDisplayed()
+				.findByCssSelector(`.${css.input}`)
+				.isDisplayed()
 				.end()
 				.findByCssSelector(`.${css.track}`)
-					.isDisplayed()
+				.isDisplayed()
 				.end()
 				.findByCssSelector(`.${css.output}`)
-					.isDisplayed()
+				.isDisplayed()
 				.end()
 				.getSize()
-				.then(({ height, width }: { height: number; width: number; }) => {
+				.then(({ height, width }: { height: number; width: number }) => {
 					assert.isAbove(height, 0, 'The height of the slider should be greater than zero.');
 					assert.isAbove(width, 0, 'The width of the slider should be greater than zero.');
 				})
@@ -123,10 +118,10 @@ registerSuite('Slider', {
 		'label should be as defined'(this: any) {
 			return getPage(this)
 				.findByCssSelector(`#example-s1 .${css.root}`)
-					.getVisibleText()
-					.then((text: string) => {
-						assert.include(text, 'How much do you like tribbles?');
-					})
+				.getVisibleText()
+				.then((text: string) => {
+					assert.include(text, 'How much do you like tribbles?');
+				})
 				.end();
 		},
 		'slider value should be consistent in different part of the UI'(this: any) {
@@ -139,7 +134,7 @@ registerSuite('Slider', {
 				this.skip('Test requires mouse interactions.');
 			}
 			if (browserName.toLowerCase() === 'internet explorer') {
-				this.skip('mouse movements doesn\'t work in IE.');
+				this.skip("mouse movements doesn't work in IE.");
 			}
 			if (browserName === 'firefox') {
 				this.skip('Fails in Firefox.');
@@ -171,12 +166,11 @@ registerSuite('Slider', {
 				this.skip('Arrow keys required for tests.');
 			}
 			if (browserName.toLowerCase() === 'safari' || browserName.toLowerCase() === 'internet explorer') {
-				this.skip('pressKeys with arrow keys doesn\'t work in iphone and IE.');
+				this.skip("pressKeys with arrow keys doesn't work in iphone and IE.");
 			}
 
 			let sliderValues: number[] = [];
-			let command = getPage(this)
-				.findByCssSelector(`#example-s1 .${css.root}`);
+			let command = getPage(this).findByCssSelector(`#example-s1 .${css.root}`);
 			command = checkValue(command, sliderValues)
 				.click()
 				.pressKeys(keys.ARROW_LEFT);
@@ -218,7 +212,7 @@ registerSuite('Slider', {
 				.end()
 
 				.getSize()
-				.then(({ height, width }: { height: number; width: number; }) => {
+				.then(({ height, width }: { height: number; width: number }) => {
 					assert.isAbove(height, 0, 'The height of the slider should be greater than zero.');
 					assert.isAbove(width, 0, 'The width of the slider should be greater than zero.');
 				})
@@ -235,10 +229,8 @@ registerSuite('Slider', {
 				.end();
 		},
 		'slider value should be consistent in different part of the UI'(this: any) {
-			let command = getPage(this)
-				.findByCssSelector(`#example-s2 .${css.root}`);
-			return checkValue(command)
-				.end();
+			let command = getPage(this).findByCssSelector(`#example-s2 .${css.root}`);
+			return checkValue(command).end();
 		},
 		'slider should be functional with mouse'(this: any) {
 			const { browserName, mouseEnabled } = this.remote.environmentType;
@@ -246,7 +238,7 @@ registerSuite('Slider', {
 				this.skip('Test requires mouse interactions.');
 			}
 			if (browserName.toLowerCase() === 'internet explorer') {
-				this.skip('mouse movements doesn\'t work in IE.');
+				this.skip("mouse movements doesn't work in IE.");
 			}
 			if (browserName === 'firefox') {
 				this.skip('Fails in Firefox.');
@@ -256,8 +248,7 @@ registerSuite('Slider', {
 			}
 
 			let sliderValues: number[] = [];
-			let command = getPage(this)
-				.findByCssSelector(`#example-s3 .${css.root}`);
+			let command = getPage(this).findByCssSelector(`#example-s3 .${css.root}`);
 			command = checkValue(command, sliderValues);
 
 			command = slide(command, 1, -30);

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -5,7 +5,13 @@ import * as sinon from 'sinon';
 
 import has from '@dojo/has/has';
 import { v, w } from '@dojo/widget-core/d';
-import { assignProperties, assignChildProperties, compareProperty, replaceChild, findKey } from '@dojo/test-extras/support/d';
+import {
+	assignProperties,
+	assignChildProperties,
+	compareProperty,
+	replaceChild,
+	findKey
+} from '@dojo/test-extras/support/d';
 import harness, { Harness } from '@dojo/test-extras/harness';
 
 import Label from '../../../label/Label';
@@ -17,83 +23,104 @@ const compareId = compareProperty((value: any) => {
 });
 
 const expected = function(widget: any, label = false, tooltip = false) {
-	const sliderVdom = v('div', {
-		classes: [ css.inputWrapper, css.inputWrapperFixed ],
-		styles: {}
-	}, [
-		v('input', {
-			key: 'input',
-			classes: [ css.input, css.nativeInput ],
-			'aria-describedby': undefined,
-			disabled: undefined,
-			id: <any> compareId,
-			'aria-invalid': null,
-			max: '100',
-			min: '0',
-			name: undefined,
-			readOnly: undefined,
-			'aria-readonly': null,
-			required: undefined,
-			step: '1',
-			styles: {},
-			type: 'range',
-			value: '0',
-			onblur: widget.listener,
-			onchange: widget.listener,
-			onclick: widget.listener,
-			onfocus: widget.listener,
-			oninput: widget.listener,
-			onkeydown: widget.listener,
-			onkeypress: widget.listener,
-			onkeyup: widget.listener,
-			onmousedown: widget.listener,
-			onmouseup: widget.listener,
-			ontouchstart: widget.listener,
-			ontouchend: widget.listener,
-			ontouchcancel: widget.listener
-		}),
-		v('div', {
-			classes: [ css.track, css.trackFixed ],
-			'aria-hidden': 'true',
+	const sliderVdom = v(
+		'div',
+		{
+			classes: [css.inputWrapper, css.inputWrapperFixed],
 			styles: {}
-		}, [
-			v('span', {
-				classes: [ css.fill, css.fillFixed ],
-				styles: { width: '0%' }
+		},
+		[
+			v('input', {
+				key: 'input',
+				classes: [css.input, css.nativeInput],
+				'aria-describedby': undefined,
+				disabled: undefined,
+				id: <any>compareId,
+				'aria-invalid': null,
+				max: '100',
+				min: '0',
+				name: undefined,
+				readOnly: undefined,
+				'aria-readonly': null,
+				required: undefined,
+				step: '1',
+				styles: {},
+				type: 'range',
+				value: '0',
+				onblur: widget.listener,
+				onchange: widget.listener,
+				onclick: widget.listener,
+				onfocus: widget.listener,
+				oninput: widget.listener,
+				onkeydown: widget.listener,
+				onkeypress: widget.listener,
+				onkeyup: widget.listener,
+				onmousedown: widget.listener,
+				onmouseup: widget.listener,
+				ontouchstart: widget.listener,
+				ontouchend: widget.listener,
+				ontouchcancel: widget.listener
 			}),
-			v('span', {
-				classes: [ css.thumb, css.thumbFixed ],
-				styles: { left: '0%' }
-			})
-		]),
-		v('output', {
-			classes: [ css.output, tooltip ? css.outputTooltip : null ],
-			for: <any> compareId,
-			styles: {}
-		}, [ '0' ])
-	]);
+			v(
+				'div',
+				{
+					classes: [css.track, css.trackFixed],
+					'aria-hidden': 'true',
+					styles: {}
+				},
+				[
+					v('span', {
+						classes: [css.fill, css.fillFixed],
+						styles: { width: '0%' }
+					}),
+					v('span', {
+						classes: [css.thumb, css.thumbFixed],
+						styles: { left: '0%' }
+					})
+				]
+			),
+			v(
+				'output',
+				{
+					classes: [css.output, tooltip ? css.outputTooltip : null],
+					for: <any>compareId,
+					styles: {}
+				},
+				['0']
+			)
+		]
+	);
 
-	return v('div', {
-		key: 'root',
-		classes: [ css.root, null, null, null, null, null, null, css.rootFixed ]
-	}, [
-		label ? w(Label, {
-			theme: undefined,
-			disabled: undefined,
-			hidden: undefined,
-			invalid: undefined,
-			readOnly: undefined,
-			required: undefined,
-			forId: <any> compareId
-		}, [ 'foo' ]) : null,
-		sliderVdom
-	]);
+	return v(
+		'div',
+		{
+			key: 'root',
+			classes: [css.root, null, null, null, null, null, null, css.rootFixed]
+		},
+		[
+			label
+				? w(
+						Label,
+						{
+							theme: undefined,
+							disabled: undefined,
+							hidden: undefined,
+							invalid: undefined,
+							readOnly: undefined,
+							required: undefined,
+							forId: <any>compareId
+						},
+						['foo']
+					)
+				: null,
+			sliderVdom
+		]
+	);
 };
 
 let widget: Harness<Slider>;
 
 registerSuite('Slider', {
-
 	beforeEach() {
 		widget = harness(Slider);
 	},
@@ -159,7 +186,7 @@ registerSuite('Slider', {
 					styles: { width: '200px' }
 				});
 				assignProperties(expectedVdom, {
-					classes: [ css.root, null, null, null, null, null, css.vertical, css.rootFixed ]
+					classes: [css.root, null, null, null, null, null, css.vertical, css.rootFixed]
 				});
 
 				widget.expectRender(expectedVdom);
@@ -199,7 +226,7 @@ registerSuite('Slider', {
 					styles: { top: '80%' }
 				});
 				assignProperties(expectedVdom, {
-					classes: [ css.root, null, null, null, null, null, css.vertical, css.rootFixed ]
+					classes: [css.root, null, null, null, null, null, css.vertical, css.rootFixed]
 				});
 
 				widget.expectRender(expectedVdom);
@@ -241,7 +268,7 @@ registerSuite('Slider', {
 			widget.expectRender(expectedVdom, 'If value property is below min, value is set to min');
 		},
 
-		'label'() {
+		label() {
 			widget.setProperties({
 				label: 'foo'
 			});
@@ -266,7 +293,7 @@ registerSuite('Slider', {
 				required: true
 			});
 			assignProperties(expectedVdom, {
-				classes: [ css.root, css.disabled, css.invalid, null, css.readonly, css.required, null, css.rootFixed ]
+				classes: [css.root, css.disabled, css.invalid, null, css.readonly, css.required, null, css.rootFixed]
 			});
 
 			widget.expectRender(expectedVdom, 'Widget should be invalid, disabled, read-only, and required');
@@ -285,7 +312,7 @@ registerSuite('Slider', {
 				required: false
 			});
 			assignProperties(expectedVdom, {
-				classes: [ css.root, null, null, css.valid, null, null, null, css.rootFixed ]
+				classes: [css.root, null, null, css.valid, null, null, null, css.rootFixed]
 			});
 
 			widget.expectRender(expectedVdom, 'State classes should be false, css.valid should be true');

--- a/src/splitpane/SplitPane.ts
+++ b/src/splitpane/SplitPane.ts
@@ -11,7 +11,7 @@ import * as css from './styles/splitPane.m.css';
 export const enum Direction {
 	column,
 	row
-};
+}
 
 /**
  * @type SplitPaneProperties
@@ -30,7 +30,7 @@ export interface SplitPaneProperties extends ThemedProperties {
 	onResize?(size: number): void;
 	size?: number;
 	trailing?: DNode;
-};
+}
 
 export const ThemedBase = ThemedMixin(WidgetBase);
 
@@ -60,14 +60,14 @@ export default class SplitPane<P extends SplitPaneProperties = SplitPaneProperti
 			{ event: 'mouseup', func: this._onDragEnd.bind(this) },
 			{ event: 'mousemove', func: this._onDragMove.bind(this) },
 			{ event: 'touchmove', func: this._onDragMove.bind(this) }
-		].forEach(object => {
+		].forEach((object) => {
 			document.addEventListener(object.event, object.func);
 			this._boundHandlers.push(object);
 		});
 	}
 
 	protected onDetach(): void {
-		this._boundHandlers.forEach(object => document.removeEventListener(object.event, object.func));
+		this._boundHandlers.forEach((object) => document.removeEventListener(object.event, object.func));
 	}
 
 	private _deselect() {
@@ -80,8 +80,7 @@ export default class SplitPane<P extends SplitPaneProperties = SplitPaneProperti
 
 		if (direction === Direction.row) {
 			return event.changedTouches ? event.changedTouches[0].clientX : event.clientX;
-		}
-		else {
+		} else {
 			return event.changedTouches ? event.changedTouches[0].clientY : event.clientY;
 		}
 	}
@@ -99,18 +98,15 @@ export default class SplitPane<P extends SplitPaneProperties = SplitPaneProperti
 
 		this._deselect();
 
-		const {
-			direction = Direction.row,
-			onResize,
-			size = DEFAULT_SIZE
-		} = this.properties;
+		const { direction = Direction.row, onResize, size = DEFAULT_SIZE } = this.properties;
 
 		const currentPosition = this._getPosition(event);
 		let newSize = (this._lastSize === undefined ? size : this._lastSize) + currentPosition - this._position;
 
-		const maxSize = direction === Direction.row ?
-			this._root.offsetWidth - this._divider.offsetWidth :
-			this._root.offsetHeight - this._divider.offsetHeight;
+		const maxSize =
+			direction === Direction.row
+				? this._root.offsetWidth - this._divider.offsetWidth
+				: this._root.offsetHeight - this._divider.offsetHeight;
 
 		this._lastSize = newSize;
 
@@ -128,15 +124,12 @@ export default class SplitPane<P extends SplitPaneProperties = SplitPaneProperti
 	}
 
 	protected getPaneContent(content: DNode): DNode[] {
-		return [ content ];
+		return [content];
 	}
 
-	protected getPaneStyles(): {[key: string]: string} {
-		const {
-			direction = Direction.row,
-			size = DEFAULT_SIZE
-		} = this.properties;
-		const styles: {[key: string]: string} = {};
+	protected getPaneStyles(): { [key: string]: string } {
+		const { direction = Direction.row, size = DEFAULT_SIZE } = this.properties;
+		const styles: { [key: string]: string } = {};
 
 		styles[direction === Direction.row ? 'width' : 'height'] = `${size}px`;
 		return styles;
@@ -152,48 +145,44 @@ export default class SplitPane<P extends SplitPaneProperties = SplitPaneProperti
 	}
 
 	render(): DNode {
-		const {
-			direction = Direction.row,
-			leading = null,
-			trailing = null
-		} = this.properties;
+		const { direction = Direction.row, leading = null, trailing = null } = this.properties;
 
-		return v('div', {
-			classes: [
-				...this.theme([
-					css.root,
-					direction === Direction.column ? css.column : css.row
-				]),
-				css.rootFixed,
-				direction === Direction.column ? css.columnFixed : css.rowFixed
-			],
-			key: 'root'
-		}, [
-			v('div', {
+		return v(
+			'div',
+			{
 				classes: [
-					this.theme(css.leading),
-					css.leadingFixed
+					...this.theme([css.root, direction === Direction.column ? css.column : css.row]),
+					css.rootFixed,
+					direction === Direction.column ? css.columnFixed : css.rowFixed
 				],
-				key: 'leading',
-				styles: this.getPaneStyles()
-			}, this.getPaneContent(leading)),
-			v('div', {
-				classes: [
-					this.theme(css.divider),
-					css.dividerFixed
-				],
-				key: 'divider',
-				onmousedown: this._onDragStart,
-				ontouchend: this._onDragEnd,
-				ontouchstart: this._onDragStart
-			}),
-			v('div', {
-				classes: [
-					this.theme(css.trailing),
-					css.trailingFixed
-				],
-				key: 'trailing'
-			}, this.getPaneContent(trailing))
-		]);
+				key: 'root'
+			},
+			[
+				v(
+					'div',
+					{
+						classes: [this.theme(css.leading), css.leadingFixed],
+						key: 'leading',
+						styles: this.getPaneStyles()
+					},
+					this.getPaneContent(leading)
+				),
+				v('div', {
+					classes: [this.theme(css.divider), css.dividerFixed],
+					key: 'divider',
+					onmousedown: this._onDragStart,
+					ontouchend: this._onDragEnd,
+					ontouchstart: this._onDragStart
+				}),
+				v(
+					'div',
+					{
+						classes: [this.theme(css.trailing), css.trailingFixed],
+						key: 'trailing'
+					},
+					this.getPaneContent(trailing)
+				)
+			]
+		);
 	}
 }

--- a/src/splitpane/createSplitPaneElement.ts
+++ b/src/splitpane/createSplitPaneElement.ts
@@ -16,11 +16,7 @@ export default function createSplitPaneElement(): CustomElementDescriptor {
 				attributeName: 'size'
 			}
 		],
-		properties: [
-			{ propertyName: 'leading' },
-			{ propertyName: 'trailing' },
-			{ propertyName: 'theme' }
-		],
+		properties: [{ propertyName: 'leading' }, { propertyName: 'trailing' }, { propertyName: 'theme' }],
 		events: [
 			{
 				propertyName: 'onResize',
@@ -28,4 +24,4 @@ export default function createSplitPaneElement(): CustomElementDescriptor {
 			}
 		]
 	};
-};
+}

--- a/src/splitpane/example/index.ts
+++ b/src/splitpane/example/index.ts
@@ -30,151 +30,183 @@ export class App extends WidgetBase<WidgetProperties> {
 			border: '1px solid rgba(170, 170, 170, 0.5)'
 		};
 
-		return v('div', {
-			styles: {
-				padding: '50px'
-			}
-		}, [
-			v('h1', ['SplitPane Examples']),
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
-			v('h3', ['Row']),
-			v('div', {
-				id: 'example-row',
-				styles: containerStyles
-			}, [
-				w(SplitPane, {
-					key: 'row',
-					direction: Direction.row,
-					onResize: (size: number) => {
-						this.setState({ rowSize: size });
-					},
-					size: this.state.rowSize,
-					theme: this._theme
-				})
-			]),
-			v('h3', ['Column']),
-			v('div', {
-				id: 'example-column',
-				styles: containerStyles
-			}, [
-				w(SplitPane, {
-					key: 'column',
-					direction: Direction.column,
-					onResize: (size: number) => {
-						this.setState({ columnSize: size });
-					},
-					size: this.state.columnSize,
-					theme: this._theme
-				})
-			]),
-			v('h3', ['Nested']),
-			v('div', {
-				id: 'example-nested',
-				styles: containerStyles
-			}, [
-				w(SplitPane, {
-					key: 'nested',
-					direction: Direction.row,
-					onResize: (size: number) => {
-						this.setState({ nestedSizeA: size });
-					},
-					size: this.state.nestedSizeA,
-					theme: this._theme,
-					trailing: w(SplitPane, {
-						direction: Direction.column,
-						onResize: (size: number) => {
-							this.setState({ nestedSizeB: size });
-						},
-						size: this.state.nestedSizeB,
-						theme: this._theme
+		return v(
+			'div',
+			{
+				styles: {
+					padding: '50px'
+				}
+			},
+			[
+				v('h1', ['SplitPane Examples']),
+				v('label', [
+					'Use Dojo Theme ',
+					v('input', {
+						type: 'checkbox',
+						onchange: this.themeChange
 					})
-				})
-			]),
-			v('h3', ['Multiple vertical nested']),
-			v('div', {
-				id: 'example-vertical-nested',
-				styles: containerStyles
-			}, [
-				w(SplitPane, {
-					key: 'verticalNested',
-					direction: Direction.row,
-					onResize: (size: number) => {
-						this.setState({ nestedSizeC: size });
+				]),
+				v('h3', ['Row']),
+				v(
+					'div',
+					{
+						id: 'example-row',
+						styles: containerStyles
 					},
-					size: this.state.nestedSizeC,
-					theme: this._theme,
-					trailing: w(SplitPane, {
-						direction: Direction.row,
-						onResize: (size: number) => {
-							this.setState({ nestedSizeD: size });
-						},
-						size: this.state.nestedSizeD,
-						theme: this._theme
-					})
-				})
-			]),
-			v('h3', ['Multiple horizontal nested']),
-			v('div', {
-				id: 'example-horizontal-nested',
-				styles: containerStyles
-			}, [
-				w(SplitPane, {
-					key: 'horizontalNested',
-					direction: Direction.column,
-					onResize: (size: number) => {
-						this.setState({ nestedSizeE: size });
+					[
+						w(SplitPane, {
+							key: 'row',
+							direction: Direction.row,
+							onResize: (size: number) => {
+								this.setState({ rowSize: size });
+							},
+							size: this.state.rowSize,
+							theme: this._theme
+						})
+					]
+				),
+				v('h3', ['Column']),
+				v(
+					'div',
+					{
+						id: 'example-column',
+						styles: containerStyles
 					},
-					size: this.state.nestedSizeE,
-					theme: this._theme,
-					trailing: w(SplitPane, {
-						direction: Direction.column,
-						onResize: (size: number) => {
-							this.setState({ nestedSizeF: size });
-						},
-						size: this.state.nestedSizeF,
-						theme: this._theme
-					})
-				})
-			]),
-			v('h3', ['Maximum size']),
-			v('div', {
-				id: 'example-max',
-				styles: containerStyles
-			}, [
-				w(SplitPane, {
-					key: 'maxSize',
-					direction: Direction.row,
-					onResize: (size: number) => {
-						size = size > 300 ? 300 : size;
-						this.setState({ maxSize: size });
+					[
+						w(SplitPane, {
+							key: 'column',
+							direction: Direction.column,
+							onResize: (size: number) => {
+								this.setState({ columnSize: size });
+							},
+							size: this.state.columnSize,
+							theme: this._theme
+						})
+					]
+				),
+				v('h3', ['Nested']),
+				v(
+					'div',
+					{
+						id: 'example-nested',
+						styles: containerStyles
 					},
-					size: this.state.maxSize,
-					theme: this._theme
-				})
-			]),
-			v('h3', ['Minimum size']),
-			v('div', {
-				id: 'example-min',
-				styles: containerStyles
-			}, [
-				w(SplitPane, {
-					key: 'minSize',
-					direction: Direction.row,
-					onResize: (size: number) => {
-						size = size < 100 ? 100 : size;
-						this.setState({ minSize: size });
+					[
+						w(SplitPane, {
+							key: 'nested',
+							direction: Direction.row,
+							onResize: (size: number) => {
+								this.setState({ nestedSizeA: size });
+							},
+							size: this.state.nestedSizeA,
+							theme: this._theme,
+							trailing: w(SplitPane, {
+								direction: Direction.column,
+								onResize: (size: number) => {
+									this.setState({ nestedSizeB: size });
+								},
+								size: this.state.nestedSizeB,
+								theme: this._theme
+							})
+						})
+					]
+				),
+				v('h3', ['Multiple vertical nested']),
+				v(
+					'div',
+					{
+						id: 'example-vertical-nested',
+						styles: containerStyles
 					},
-					size: this.state.minSize,
-					theme: this._theme
-				})
-			])
-		]);
+					[
+						w(SplitPane, {
+							key: 'verticalNested',
+							direction: Direction.row,
+							onResize: (size: number) => {
+								this.setState({ nestedSizeC: size });
+							},
+							size: this.state.nestedSizeC,
+							theme: this._theme,
+							trailing: w(SplitPane, {
+								direction: Direction.row,
+								onResize: (size: number) => {
+									this.setState({ nestedSizeD: size });
+								},
+								size: this.state.nestedSizeD,
+								theme: this._theme
+							})
+						})
+					]
+				),
+				v('h3', ['Multiple horizontal nested']),
+				v(
+					'div',
+					{
+						id: 'example-horizontal-nested',
+						styles: containerStyles
+					},
+					[
+						w(SplitPane, {
+							key: 'horizontalNested',
+							direction: Direction.column,
+							onResize: (size: number) => {
+								this.setState({ nestedSizeE: size });
+							},
+							size: this.state.nestedSizeE,
+							theme: this._theme,
+							trailing: w(SplitPane, {
+								direction: Direction.column,
+								onResize: (size: number) => {
+									this.setState({ nestedSizeF: size });
+								},
+								size: this.state.nestedSizeF,
+								theme: this._theme
+							})
+						})
+					]
+				),
+				v('h3', ['Maximum size']),
+				v(
+					'div',
+					{
+						id: 'example-max',
+						styles: containerStyles
+					},
+					[
+						w(SplitPane, {
+							key: 'maxSize',
+							direction: Direction.row,
+							onResize: (size: number) => {
+								size = size > 300 ? 300 : size;
+								this.setState({ maxSize: size });
+							},
+							size: this.state.maxSize,
+							theme: this._theme
+						})
+					]
+				),
+				v('h3', ['Minimum size']),
+				v(
+					'div',
+					{
+						id: 'example-min',
+						styles: containerStyles
+					},
+					[
+						w(SplitPane, {
+							key: 'minSize',
+							direction: Direction.row,
+							onResize: (size: number) => {
+								size = size < 100 ? 100 : size;
+								this.setState({ minSize: size });
+							},
+							size: this.state.minSize,
+							theme: this._theme
+						})
+					]
+				)
+			]
+		);
 	}
 }
 

--- a/src/splitpane/tests/functional/SplitPane.ts
+++ b/src/splitpane/tests/functional/SplitPane.ts
@@ -181,10 +181,6 @@ registerSuite('SplitPane', {
 	},
 	'a minimum size should not be exceeded'() {
 		let command: Command<Element | void> = getPage(this).findByCssSelector(`#example-max .${css.root}`);
-		let containerWidth = 0;
-		command = command.getSize().then(({ width }) => {
-			containerWidth = width;
-		});
 		command = testResizes(
 			command,
 			[{ x: 10, y: 0 }, { x: -9999, y: 0 }, { x: 10, y: 0 }],

--- a/src/splitpane/tests/functional/SplitPane.ts
+++ b/src/splitpane/tests/functional/SplitPane.ts
@@ -13,9 +13,7 @@ function getPage(test: Test): Command<void> {
 	if (browserName === 'safari' || browserName === 'firefox' || browserName.toLowerCase() === 'microsoftedge') {
 		test.skip('Tests do not run in these browsers.');
 	}
-	return test.remote
-		.get('http://localhost:9000/_build/common/example/?module=splitpane')
-		.setFindTimeout(5000);
+	return test.remote.get('http://localhost:9000/_build/common/example/?module=splitpane').setFindTimeout(5000);
 }
 
 interface Coord {
@@ -30,13 +28,13 @@ interface CoordTest {
 
 function resize(command: Command<Element | void>, x: number, y: number): Command<void> {
 	return command
-			.findByCssSelector(`.${css.divider}`)
-				.moveMouseTo()
-				.pressMouseButton(0)
-				.moveMouseTo(x, y)
-				.releaseMouseButton(0)
-				.sleep(DELAY)
-			.end();
+		.findByCssSelector(`.${css.divider}`)
+		.moveMouseTo()
+		.pressMouseButton(0)
+		.moveMouseTo(x, y)
+		.releaseMouseButton(0)
+		.sleep(DELAY)
+		.end();
 }
 
 function testResizes(command: Command<Element | void>, resizes: Coord[], expected: CoordTest[]) {
@@ -46,11 +44,11 @@ function testResizes(command: Command<Element | void>, resizes: Coord[], expecte
 	let currentY: number;
 	command = command
 		.findByCssSelector(`.${css.divider}`)
-			.getPosition()
-			.then(({ x, y }) => {
-				currentX = x;
-				currentY = y;
-			})
+		.getPosition()
+		.then(({ x, y }) => {
+			currentX = x;
+			currentY = y;
+		})
 		.end();
 
 	for (let i = 0; i < resizes.length; i++) {
@@ -58,23 +56,21 @@ function testResizes(command: Command<Element | void>, resizes: Coord[], expecte
 		const delta = expected[i];
 		command = resize(command, move.x, move.y)
 			.findByCssSelector(`.${css.divider}`)
-				.getPosition()
-				.then(({ x, y }) => {
-					if (typeof delta.x === 'function') {
-						assert.isTrue(delta.x(x), `Resize ${i} should pass x test.`);
-					}
-					else {
-						assert.closeTo(x, currentX + delta.x, 1, `Resize ${i} should move x by ${move.x}.`);
-					}
-					if (typeof delta.y === 'function') {
-						assert.isTrue(delta.y(y), `Resize ${i} should pass y test.`);
-					}
-					else {
-						assert.closeTo(y, currentY + delta.y, 1, `Resize ${i} should move y by ${move.y}.`);
-					}
-					currentX = x;
-					currentY = y;
-				})
+			.getPosition()
+			.then(({ x, y }) => {
+				if (typeof delta.x === 'function') {
+					assert.isTrue(delta.x(x), `Resize ${i} should pass x test.`);
+				} else {
+					assert.closeTo(x, currentX + delta.x, 1, `Resize ${i} should move x by ${move.x}.`);
+				}
+				if (typeof delta.y === 'function') {
+					assert.isTrue(delta.y(y), `Resize ${i} should pass y test.`);
+				} else {
+					assert.closeTo(y, currentY + delta.y, 1, `Resize ${i} should move y by ${move.y}.`);
+				}
+				currentX = x;
+				currentY = y;
+			})
 			.end();
 	}
 
@@ -85,77 +81,79 @@ registerSuite('SplitPane', {
 	'can slide horizontally'() {
 		return testResizes(
 			getPage(this).findByCssSelector(`#example-row .${css.root}`),
-			[ { x: -10, y: 0 }, { x: 20, y: 0 } ],
-			[ { x: -10, y: 0 }, { x: 20, y: 0 } ]
+			[{ x: -10, y: 0 }, { x: 20, y: 0 }],
+			[{ x: -10, y: 0 }, { x: 20, y: 0 }]
 		);
 	},
 	'can slide vertically'() {
 		return testResizes(
 			getPage(this).findByCssSelector(`#example-column .${css.root}`),
-			[ { x: 0, y: -10 }, { x: 0, y: 20 } ],
-			[ { x: 0, y: -10 }, { x: 0, y: 20 } ]
+			[{ x: 0, y: -10 }, { x: 0, y: 20 }],
+			[{ x: 0, y: -10 }, { x: 0, y: 20 }]
 		);
 	},
 	'can slide when nested'() {
 		let command: Command<Element | void> = getPage(this).findByCssSelector(`#example-nested .${css.root}`);
-		command = testResizes(
-			command,
-			[ { x: -10, y: 0 }, { x: 20, y: 0 } ],
-			[ { x: -10, y: 0 }, { x: 20, y: 0 } ]
-		);
+		command = testResizes(command, [{ x: -10, y: 0 }, { x: 20, y: 0 }], [{ x: -10, y: 0 }, { x: 20, y: 0 }]);
 		command = command.findByCssSelector(`.${css.trailing}`);
-			command = testResizes(
-				command,
-				[ { x: 0, y: -10 }, { x: 0, y: 20 } ],
-				[ { x: 0, y: -10 }, { x: 0, y: 20 } ]
-			);
+		command = testResizes(command, [{ x: 0, y: -10 }, { x: 0, y: 20 }], [{ x: 0, y: -10 }, { x: 0, y: 20 }]);
 		command = command.end();
 		return command;
 	},
 	'there are limits with multiple vertical nested'() {
 		let command: Command<Element | void> = getPage(this).findByCssSelector(`#example-vertical-nested .${css.root}`);
-		command = testResizes(
-			command,
-			[ { x: -10, y: 0 }, { x: 20, y: 0 } ],
-			[ { x: -10, y: 0 }, { x: 20, y: 0 } ]
-		);
+		command = testResizes(command, [{ x: -10, y: 0 }, { x: 20, y: 0 }], [{ x: -10, y: 0 }, { x: 20, y: 0 }]);
 		let minX: number;
 		command = command
 			.findByCssSelector(`.${css.divider}`)
-				.getPosition()
-				.then(({ x }) => {
-					minX = x;
-				})
+			.getPosition()
+			.then(({ x }) => {
+				minX = x;
+			})
 			.end();
 		command = command.findByCssSelector(`.${css.trailing}`);
 		command = testResizes(
 			command,
-			[ { x: -9999, y: 0 }, { x: 10, y: 0 } ],
-			[ { x: (x) => { return x > minX; }, y: 0 }, { x: 10, y: 0 } ]
+			[{ x: -9999, y: 0 }, { x: 10, y: 0 }],
+			[
+				{
+					x: (x) => {
+						return x > minX;
+					},
+					y: 0
+				},
+				{ x: 10, y: 0 }
+			]
 		);
 		command = command.end();
 		return command;
 	},
 	'there are limits with multiple horizontal nested'() {
-		let command: Command<Element | void> = getPage(this).findByCssSelector(`#example-horizontal-nested .${css.root}`);
-		command = testResizes(
-			command,
-			[ { x: 0, y: -10 }, { x: 0, y: 20 } ],
-			[ { x: 0, y: -10 }, { x: 0, y: 20 } ]
+		let command: Command<Element | void> = getPage(this).findByCssSelector(
+			`#example-horizontal-nested .${css.root}`
 		);
+		command = testResizes(command, [{ x: 0, y: -10 }, { x: 0, y: 20 }], [{ x: 0, y: -10 }, { x: 0, y: 20 }]);
 		let minY: number;
 		command = command
 			.findByCssSelector(`.${css.divider}`)
-				.getPosition()
-				.then(({ y }) => {
-					minY = y;
-				})
+			.getPosition()
+			.then(({ y }) => {
+				minY = y;
+			})
 			.end();
 		command = command.findByCssSelector(`.${css.trailing}`);
 		command = testResizes(
 			command,
-			[ { x: 0, y: -9999 }, { x: 0, y: 10 } ],
-			[ { x: 0 , y: (y) => { return y > minY; } }, { x: 0, y: 10 } ]
+			[{ x: 0, y: -9999 }, { x: 0, y: 10 }],
+			[
+				{
+					x: 0,
+					y: (y) => {
+						return y > minY;
+					}
+				},
+				{ x: 0, y: 10 }
+			]
 		);
 		command = command.end();
 		return command;
@@ -163,30 +161,43 @@ registerSuite('SplitPane', {
 	'a maximum size should not be exceeded'() {
 		let command: Command<Element | void> = getPage(this).findByCssSelector(`#example-max .${css.root}`);
 		let containerWidth = 0;
-		command = command
-			.getSize()
-			.then(({ width }) => {
-				containerWidth = width;
-			});
+		command = command.getSize().then(({ width }) => {
+			containerWidth = width;
+		});
 		command = testResizes(
 			command,
-			[ { x: 9999, y: 0 }, { x: -10, y: 0 } ],
-			[ { x: (x) => { return x < (containerWidth - 10); } , y: 0 }, { x: -10, y: 0 } ]
+			[{ x: 9999, y: 0 }, { x: -10, y: 0 }],
+			[
+				{
+					x: (x) => {
+						return x < containerWidth - 10;
+					},
+					y: 0
+				},
+				{ x: -10, y: 0 }
+			]
 		);
 		return command;
 	},
 	'a minimum size should not be exceeded'() {
 		let command: Command<Element | void> = getPage(this).findByCssSelector(`#example-max .${css.root}`);
 		let containerWidth = 0;
-		command = command
-		.getSize()
-		.then(({ width }) => {
+		command = command.getSize().then(({ width }) => {
 			containerWidth = width;
 		});
 		command = testResizes(
 			command,
-			[ { x: 10, y: 0 }, { x: -9999, y: 0 }, { x: 10, y: 0 } ],
-			[ { x: 10, y: 0 }, { x: (x) => { return x > 10; } , y: 0 }, { x: 10, y: 0 } ]
+			[{ x: 10, y: 0 }, { x: -9999, y: 0 }, { x: 10, y: 0 }],
+			[
+				{ x: 10, y: 0 },
+				{
+					x: (x) => {
+						return x > 10;
+					},
+					y: 0
+				},
+				{ x: 10, y: 0 }
+			]
 		);
 		return command;
 	}

--- a/src/splitpane/tests/unit/SplitPane.ts
+++ b/src/splitpane/tests/unit/SplitPane.ts
@@ -11,12 +11,13 @@ import SplitPane, { Direction } from '../../SplitPane';
 let widget: Harness<SplitPane>;
 
 registerSuite('SplitPane', {
-
 	beforeEach() {
 		widget = harness(SplitPane);
-		window.getSelection = window.getSelection || (() => ({
-			removeAllRanges() { }
-		}));
+		window.getSelection =
+			window.getSelection ||
+			(() => ({
+				removeAllRanges() {}
+			}));
 	},
 
 	afterEach() {
@@ -25,27 +26,41 @@ registerSuite('SplitPane', {
 
 	tests: {
 		'Should construct SplitPane with passed properties'() {
-			widget.expectRender(v('div', {
-				classes: [ css.root, css.row, css.rootFixed, css.rowFixed ],
-				key: 'root'
-			}, [
-				v('div', {
-					classes: [ css.leading, css.leadingFixed ],
-					key: 'leading',
-					styles: { width: '100px' }
-				}, [ null ]),
-				v('div', {
-					classes: [ css.divider, css.dividerFixed ],
-					key: 'divider',
-					onmousedown: widget.listener,
-					ontouchend: widget.listener,
-					ontouchstart: widget.listener
-				}),
-				v('div', {
-					classes: [ css.trailing, css.trailingFixed ],
-					key: 'trailing'
-				}, [ null ])
-			]));
+			widget.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, css.row, css.rootFixed, css.rowFixed],
+						key: 'root'
+					},
+					[
+						v(
+							'div',
+							{
+								classes: [css.leading, css.leadingFixed],
+								key: 'leading',
+								styles: { width: '100px' }
+							},
+							[null]
+						),
+						v('div', {
+							classes: [css.divider, css.dividerFixed],
+							key: 'divider',
+							onmousedown: widget.listener,
+							ontouchend: widget.listener,
+							ontouchstart: widget.listener
+						}),
+						v(
+							'div',
+							{
+								classes: [css.trailing, css.trailingFixed],
+								key: 'trailing'
+							},
+							[null]
+						)
+					]
+				)
+			);
 		},
 
 		'Should construct SplitPane with default properties'() {
@@ -57,50 +72,64 @@ registerSuite('SplitPane', {
 				trailing: 'def'
 			});
 
-			widget.expectRender(v('div', {
-				classes: [ css.root, css.column, css.rootFixed, css.columnFixed ],
-				key: 'root'
-			}, [
-				v('div', {
-					classes: [ css.leading, css.leadingFixed ],
-					key: 'leading',
-					styles: { height: '200px' }
-				}, [ 'abc' ]),
-				v('div', {
-					classes: [ css.divider, css.dividerFixed ],
-					key: 'divider',
-					onmousedown: widget.listener,
-					ontouchend: widget.listener,
-					ontouchstart: widget.listener
-				}),
-				v('div', {
-					classes: [ css.trailing, css.trailingFixed ],
-					key: 'trailing'
-				}, [ 'def' ])
-			]));
+			widget.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, css.column, css.rootFixed, css.columnFixed],
+						key: 'root'
+					},
+					[
+						v(
+							'div',
+							{
+								classes: [css.leading, css.leadingFixed],
+								key: 'leading',
+								styles: { height: '200px' }
+							},
+							['abc']
+						),
+						v('div', {
+							classes: [css.divider, css.dividerFixed],
+							key: 'divider',
+							onmousedown: widget.listener,
+							ontouchend: widget.listener,
+							ontouchstart: widget.listener
+						}),
+						v(
+							'div',
+							{
+								classes: [css.trailing, css.trailingFixed],
+								key: 'trailing'
+							},
+							['def']
+						)
+					]
+				)
+			);
 		},
 
 		'Pane should not be a negative size'() {
 			let setSize;
 
 			widget.setProperties({
-				onResize: size => setSize = size
+				onResize: (size) => (setSize = size)
 			});
 
 			widget.sendEvent('mousemove', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					clientX: 0
 				},
 				selector: ':nth-child(2)' /* this should be the divider */
 			});
 			widget.sendEvent('mousedown', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					clientX: 500
 				},
 				selector: ':nth-child(2)' /* this should be the divider */
 			});
 			widget.sendEvent('mousemove', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					clientX: 0
 				},
 				selector: ':nth-child(2)' /* this should be the divider */
@@ -116,17 +145,17 @@ registerSuite('SplitPane', {
 			let setSize;
 
 			widget.setProperties({
-				onResize: size => setSize = size
+				onResize: (size) => (setSize = size)
 			});
 
 			widget.sendEvent('mousedown', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					clientX: 0
 				},
 				selector: ':nth-child(2)' /* this should be the divider */
 			});
 			widget.sendEvent('mousemove', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					clientX: 500
 				},
 				selector: ':nth-child(2)' /* this should be the divider */
@@ -142,17 +171,17 @@ registerSuite('SplitPane', {
 			let called = false;
 
 			widget.setProperties({
-				onResize: () => called = true
+				onResize: () => (called = true)
 			});
 
 			widget.sendEvent('mousedown', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					clientX: 110
 				},
 				selector: ':nth-child(2)' /* this should be the divider */
 			});
 			widget.sendEvent('mousemove', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					clientX: 150
 				},
 				selector: ':nth-child(2)' /* this should be the divider */
@@ -168,18 +197,18 @@ registerSuite('SplitPane', {
 			let called = false;
 
 			widget.setProperties({
-				onResize: () => called = true,
+				onResize: () => (called = true),
 				direction: Direction.column
 			});
 
 			widget.sendEvent('mousedown', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					clientY: 110
 				},
 				selector: ':nth-child(2)' /* this should be the divider */
 			});
 			widget.sendEvent('mousemove', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					clientY: 150
 				},
 				selector: ':nth-child(2)' /* this should be the divider */
@@ -199,25 +228,25 @@ registerSuite('SplitPane', {
 			let called = false;
 
 			widget.setProperties({
-				onResize: () => called = true,
+				onResize: () => (called = true),
 				direction: Direction.row,
 				size: 100
 			});
 
 			widget.sendEvent('touchstart', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					changedTouches: [{ clientX: 110 }]
 				},
 				selector: ':nth-child(2)' /* this should be the divider */
 			});
 			widget.sendEvent('touchmove', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					changedTouches: [{ clientX: 150 }]
 				},
 				selector: ':nth-child(2)' /* this should be the divider */
 			});
 			widget.sendEvent('touchmove', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					changedTouches: [{ clientX: 150 }]
 				},
 				selector: ':nth-child(2)' /* this should be the divider */
@@ -242,13 +271,13 @@ registerSuite('SplitPane', {
 			});
 
 			widget.sendEvent('touchstart', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					changedTouches: [{ clientY: 110 }]
 				},
 				selector: ':nth-child(2)' /* this should be the divider */
 			});
 			widget.sendEvent('touchmove', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					changedTouches: [{ clientY: 150 }]
 				},
 				selector: ':nth-child(2)' /* this should be the divider */
@@ -257,13 +286,13 @@ registerSuite('SplitPane', {
 				selector: ':nth-child(2)' /* this should be the divider */
 			});
 			widget.sendEvent('touchstart', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					changedTouches: [{ clientY: 150 }]
 				},
 				selector: ':nth-child(2)' /* this should be the divider */
 			});
 			widget.sendEvent('touchmove', {
-				eventInit: <MouseEventInit> {
+				eventInit: <MouseEventInit>{
 					changedTouches: [{ clientY: 110 }]
 				},
 				selector: ':nth-child(2)' /* this should be the divider */

--- a/src/tabcontroller/Tab.ts
+++ b/src/tabcontroller/Tab.ts
@@ -24,23 +24,24 @@ export interface TabProperties extends ThemedProperties {
 	key: string;
 	label?: DNode;
 	labelledBy?: string;
-};
+}
 
 export const ThemedBase = ThemedMixin(WidgetBase);
 
 @theme(css)
 export default class Tab<P extends TabProperties = TabProperties> extends ThemedBase<P> {
 	render(): DNode {
-		const {
-			id,
-			labelledBy
-		} = this.properties;
+		const { id, labelledBy } = this.properties;
 
-		return v('div', {
-			'aria-labelledby': labelledBy,
-			classes: this.theme(css.tab),
-			id,
-			role: 'tabpanel'
-		}, this.children);
+		return v(
+			'div',
+			{
+				'aria-labelledby': labelledBy,
+				classes: this.theme(css.tab),
+				id,
+				role: 'tabpanel'
+			},
+			this.children
+		);
 	}
 }

--- a/src/tabcontroller/TabButton.ts
+++ b/src/tabcontroller/TabButton.ts
@@ -45,27 +45,20 @@ export interface TabButtonProperties extends ThemedProperties {
 	onLeftArrowPress?: () => void;
 	onRightArrowPress?: () => void;
 	onUpArrowPress?: () => void;
-};
+}
 
 export const ThemedBase = ThemedMixin(WidgetBase);
 
 @theme(css)
 export default class TabButton<P extends TabButtonProperties = TabButtonProperties> extends ThemedBase<P> {
 	private _onClick() {
-		const {
-			disabled,
-			index,
-			onClick
-		} = this.properties;
+		const { disabled, index, onClick } = this.properties;
 
 		!disabled && onClick && onClick(index);
 	}
 
 	private _onCloseClick(event: MouseEvent) {
-		const {
-			index,
-			onCloseClick
-		} = this.properties;
+		const { index, onCloseClick } = this.properties;
 
 		event.stopPropagation();
 		onCloseClick && onCloseClick(index);
@@ -135,21 +128,20 @@ export default class TabButton<P extends TabButtonProperties = TabButtonProperti
 
 		return [
 			...this.children,
-			closeable ? v('button', {
-				tabIndex: active ? 0 : -1,
-				classes: this.theme(css.close),
-				innerHTML: 'close tab',
-				onclick: this._onCloseClick
-			}) : null
+			closeable
+				? v('button', {
+						tabIndex: active ? 0 : -1,
+						classes: this.theme(css.close),
+						innerHTML: 'close tab',
+						onclick: this._onCloseClick
+					})
+				: null
 		];
 	}
 
 	protected getModifierClasses(): (string | null)[] {
 		const { active, disabled } = this.properties;
-		return [
-			active ? css.activeTabButton : null,
-			disabled ? css.disabledTabButton : null
-		];
+		return [active ? css.activeTabButton : null, disabled ? css.disabledTabButton : null];
 	}
 
 	protected onElementCreated(element: HTMLElement, key: string) {
@@ -161,24 +153,23 @@ export default class TabButton<P extends TabButtonProperties = TabButtonProperti
 	}
 
 	render(): DNode {
-		const {
-			active,
-			controls,
-			disabled,
-			id
-		} = this.properties;
+		const { active, controls, disabled, id } = this.properties;
 
-		return v('div', {
-			'aria-controls': controls,
-			'aria-disabled': disabled ? 'true' : 'false',
-			'aria-selected': active === true ? 'true' : 'false',
-			classes: this.theme([ css.tabButton, ...this.getModifierClasses() ]),
-			id,
-			key: 'tab-button',
-			onclick: this._onClick,
-			onkeydown: this._onKeyDown,
-			role: 'tab',
-			tabIndex: active === true ? 0 : -1
-		}, this.getContent());
+		return v(
+			'div',
+			{
+				'aria-controls': controls,
+				'aria-disabled': disabled ? 'true' : 'false',
+				'aria-selected': active === true ? 'true' : 'false',
+				classes: this.theme([css.tabButton, ...this.getModifierClasses()]),
+				id,
+				key: 'tab-button',
+				onclick: this._onClick,
+				onkeydown: this._onKeyDown,
+				role: 'tab',
+				tabIndex: active === true ? 0 : -1
+			},
+			this.getContent()
+		);
 	}
 }

--- a/src/tabcontroller/TabController.ts
+++ b/src/tabcontroller/TabController.ts
@@ -17,7 +17,7 @@ export const enum Align {
 	left,
 	right,
 	top
-};
+}
 
 /**
  * @type TabControllerProperties
@@ -34,17 +34,20 @@ export interface TabControllerProperties extends ThemedProperties {
 	alignButtons?: Align;
 	onRequestTabChange?(index: number, key: string): void;
 	onRequestTabClose?(index: number, key: string): void;
-};
+}
 
 export const ThemedBase = ThemedMixin(WidgetBase);
 
 @theme(css)
-export default class TabController<P extends TabControllerProperties = TabControllerProperties> extends ThemedBase<P, WNode<Tab>> {
+export default class TabController<P extends TabControllerProperties = TabControllerProperties> extends ThemedBase<
+	P,
+	WNode<Tab>
+> {
 	private _id = uuid();
 	private _callTabFocus = false;
 
 	private get _tabs(): WNode<Tab>[] {
-		return this.children.filter(child => child !== null) as WNode<Tab>[];
+		return this.children.filter((child) => child !== null) as WNode<Tab>[];
 	}
 
 	private _onDownArrowPress() {
@@ -78,7 +81,7 @@ export default class TabController<P extends TabControllerProperties = TabContro
 	private _validateIndex(currentIndex: number, backwards?: boolean) {
 		const tabs = this._tabs;
 
-		if (tabs.every(result => Boolean(result.properties.disabled))) {
+		if (tabs.every((result) => Boolean(result.properties.disabled))) {
 			return null;
 		}
 
@@ -107,39 +110,39 @@ export default class TabController<P extends TabControllerProperties = TabContro
 	}
 
 	protected renderButtonContent(label?: DNode): DNode[] {
-		return [ label || null ];
+		return [label || null];
 	}
 
 	protected renderTabButtons(): DNode[] {
 		return this._tabs.map((tab, i) => {
-			const {
-				closeable,
-				disabled,
-				key,
-				label,
-				theme
-			} = <TabProperties> tab.properties;
+			const { closeable, disabled, key, label, theme } = <TabProperties>tab.properties;
 
-			return w(TabButton, {
-				callFocus: this._callTabFocus &&  i === this.properties.activeIndex,
-				active: i === this.properties.activeIndex,
-				closeable,
-				controls: `${ this._id }-tab-${i}`,
-				disabled,
-				id: `${ this._id }-tabbutton-${i}`,
-				index: i,
-				key: `${ key }-tabbutton`,
-				onClick: this.selectIndex,
-				onCloseClick: this.closeIndex,
-				onDownArrowPress: this._onDownArrowPress,
-				onEndPress: this.selectLastIndex,
-				onFocusCalled: () => { this._callTabFocus = false; },
-				onHomePress: this.selectFirstIndex,
-				onLeftArrowPress: this._onLeftArrowPress,
-				onRightArrowPress: this._onRightArrowPress,
-				onUpArrowPress: this._onUpArrowPress,
-				theme
-			}, this.renderButtonContent(label));
+			return w(
+				TabButton,
+				{
+					callFocus: this._callTabFocus && i === this.properties.activeIndex,
+					active: i === this.properties.activeIndex,
+					closeable,
+					controls: `${this._id}-tab-${i}`,
+					disabled,
+					id: `${this._id}-tabbutton-${i}`,
+					index: i,
+					key: `${key}-tabbutton`,
+					onClick: this.selectIndex,
+					onCloseClick: this.closeIndex,
+					onDownArrowPress: this._onDownArrowPress,
+					onEndPress: this.selectLastIndex,
+					onFocusCalled: () => {
+						this._callTabFocus = false;
+					},
+					onHomePress: this.selectFirstIndex,
+					onLeftArrowPress: this._onLeftArrowPress,
+					onRightArrowPress: this._onRightArrowPress,
+					onUpArrowPress: this._onUpArrowPress,
+					theme
+				},
+				this.renderButtonContent(label)
+			);
 		});
 	}
 
@@ -152,8 +155,8 @@ export default class TabController<P extends TabControllerProperties = TabContro
 			})
 			.map((tab, i) => {
 				assign(tab.properties, {
-					id: `${ this._id }-tab-${i}`,
-					labelledBy: `${ this._id }-tabbutton-${i}`
+					id: `${this._id}-tab-${i}`,
+					labelledBy: `${this._id}-tabbutton-${i}`
 				});
 				return tab;
 			});
@@ -164,10 +167,7 @@ export default class TabController<P extends TabControllerProperties = TabContro
 	}
 
 	protected selectIndex(index: number, backwards?: boolean) {
-		const {
-			activeIndex,
-			onRequestTabChange
-		} = this.properties;
+		const { activeIndex, onRequestTabChange } = this.properties;
 
 		const validIndex = this._validateIndex(index, backwards);
 		this._callTabFocus = true;
@@ -205,14 +205,24 @@ export default class TabController<P extends TabControllerProperties = TabContro
 		}
 
 		const children = [
-			v('div', {
-				key: 'buttons',
-				classes: this.theme(css.tabButtons)
-			}, this.renderTabButtons()),
-			tabs.length ? v('div', {
-				key: 'tabs',
-				classes: this.theme(css.tabs)
-			}, tabs) : null
+			v(
+				'div',
+				{
+					key: 'buttons',
+					classes: this.theme(css.tabButtons)
+				},
+				this.renderTabButtons()
+			),
+			tabs.length
+				? v(
+						'div',
+						{
+							key: 'tabs',
+							classes: this.theme(css.tabs)
+						},
+						tabs
+					)
+				: null
 		];
 
 		let alignClass;
@@ -234,13 +244,14 @@ export default class TabController<P extends TabControllerProperties = TabContro
 				break;
 		}
 
-		return v('div', {
-			'aria-orientation': orientation,
-			classes: this.theme([
-				alignClass ? alignClass : null,
-				css.root
-			]),
-			role: 'tablist'
-		}, children);
+		return v(
+			'div',
+			{
+				'aria-orientation': orientation,
+				classes: this.theme([alignClass ? alignClass : null, css.root]),
+				role: 'tablist'
+			},
+			children
+		);
 	}
 }

--- a/src/tabcontroller/createTabControllerElement.ts
+++ b/src/tabcontroller/createTabControllerElement.ts
@@ -12,17 +12,15 @@ export default function createTabControllerElement(): CustomElementDescriptor {
 			{
 				attributeName: 'activeindex',
 				propertyName: 'activeIndex',
-				value: value => Number(value)
+				value: (value) => Number(value)
 			},
 			{
 				attributeName: 'alignbuttons',
 				propertyName: 'alignButtons',
-				value: value => Number(value)
+				value: (value) => Number(value)
 			}
 		],
-		properties: [
-			{ propertyName: 'theme' }
-		],
+		properties: [{ propertyName: 'theme' }],
 		events: [
 			{
 				propertyName: 'onRequestTabChange',
@@ -34,4 +32,4 @@ export default function createTabControllerElement(): CustomElementDescriptor {
 			}
 		]
 	};
-};
+}

--- a/src/tabcontroller/createTabElement.ts
+++ b/src/tabcontroller/createTabElement.ts
@@ -12,19 +12,16 @@ export default function createTabElement(): CustomElementDescriptor {
 		attributes: [
 			{
 				attributeName: 'closeable',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'disabled',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'key'
 			}
 		],
-		properties: [
-			{ propertyName: 'label' },
-			{ propertyName: 'theme' }
-		]
+		properties: [{ propertyName: 'label' }, { propertyName: 'theme' }]
 	};
-};
+}

--- a/src/tabcontroller/example/index.ts
+++ b/src/tabcontroller/example/index.ts
@@ -64,94 +64,124 @@ export class App extends WidgetBase<WidgetProperties> {
 		this.setState({ align: align });
 	}
 	render(): DNode {
-		const {
-			activeIndex = 0,
-			align,
-			closedKeys = [],
-			loading
-		} = this._state;
+		const { activeIndex = 0, align, closedKeys = [], loading } = this._state;
 
-		return v('div', {
-			classes: 'example'
-		}, [
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
-			v('select', {
-				styles: { marginBottom: '20px' },
-				onchange: this.onAlignChange
-			}, [
-				v('option', { selected: true, value: 'top' }, [ 'Top' ]),
-				v('option', { value: 'left' }, [ 'Left' ]),
-				v('option', { value: 'right' }, [ 'Right' ]),
-				v('option', { value: 'bottom' }, [ 'Bottom' ])
-			]),
-			w(TabController, {
-				theme: this._theme,
-				activeIndex: activeIndex,
-				alignButtons: align,
-				onRequestTabClose: (index: number, key: string) => {
-					this.setState({ closedKeys: [...closedKeys, key] });
-				},
-				onRequestTabChange: (index: number, key: string) => {
-					refresh && refresh.cancel();
-					if (key === 'async') {
-						this.setState({
-							activeIndex: 2,
-							loading: true
-						});
-						refresh = refreshData().then(() => {
-							this.setState({ loading: false });
-						});
-					}
-					else {
-						this.setState({ activeIndex: index });
-					}
-				}
-			}, [
-				w(Tab, {
-					theme: this._theme,
-					key: 'default',
-					label: 'Default'
-				}, [
-					'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer in ex pharetra, iaculis turpis eget, tincidunt lorem. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.'
+		return v(
+			'div',
+			{
+				classes: 'example'
+			},
+			[
+				v('label', [
+					'Use Dojo Theme ',
+					v('input', {
+						type: 'checkbox',
+						onchange: this.themeChange
+					})
 				]),
-				w(Tab, {
-					theme: this._theme,
-					disabled: true,
-					key: 'disabled',
-					label: 'Disabled'
-				}, [
-					'Sed nibh est, sollicitudin consectetur porta finibus, condimentum gravida purus. Phasellus varius fringilla erat, a dignissim nunc iaculis et. Curabitur eu neque erat. Integer id lacus nulla. Phasellus ut sem eget enim interdum interdum ac ac orci.'
-				]),
-				w(Tab, {
-					theme: this._theme,
-					key: 'async',
-					label: 'Async'
-				}, [
-					loading ? 'Loading...' : 'Curabitur id elit a tellus consequat maximus in non lorem. Donec sagittis porta aliquam. Nulla facilisi. Quisque sed mauris justo. Donec eu fringilla urna. Aenean vulputate ipsum imperdiet orci ornare tempor.'
-				]),
-				!includes(closedKeys, 'closeable') ? w(Tab, {
-					theme: this._theme,
-					closeable: true,
-					key: 'closeable',
-					label: 'Closeable'
-				}, [
-					'Nullam congue, massa in egestas sagittis, diam neque rutrum tellus, nec egestas metus tellus vel odio. Vivamus tincidunt quam nisl, sit amet venenatis purus bibendum eget. Phasellus fringilla ex vitae odio hendrerit, non volutpat orci rhoncus.'
-				]) : null,
-				w(Tab, {
-					theme: this._theme,
-					key: 'foo',
-					label: 'Foobar'
-				}, [
-					'Sed nibh est, sollicitudin consectetur porta finibus, condimentum gravida purus. Phasellus varius fringilla erat, a dignissim nunc iaculis et. Curabitur eu neque erat. Integer id lacus nulla. Phasellus ut sem eget enim interdum interdum ac ac orci.'
-				])
-			])
-		]);
+				v(
+					'select',
+					{
+						styles: { marginBottom: '20px' },
+						onchange: this.onAlignChange
+					},
+					[
+						v('option', { selected: true, value: 'top' }, ['Top']),
+						v('option', { value: 'left' }, ['Left']),
+						v('option', { value: 'right' }, ['Right']),
+						v('option', { value: 'bottom' }, ['Bottom'])
+					]
+				),
+				w(
+					TabController,
+					{
+						theme: this._theme,
+						activeIndex: activeIndex,
+						alignButtons: align,
+						onRequestTabClose: (index: number, key: string) => {
+							this.setState({ closedKeys: [...closedKeys, key] });
+						},
+						onRequestTabChange: (index: number, key: string) => {
+							refresh && refresh.cancel();
+							if (key === 'async') {
+								this.setState({
+									activeIndex: 2,
+									loading: true
+								});
+								refresh = refreshData().then(() => {
+									this.setState({ loading: false });
+								});
+							} else {
+								this.setState({ activeIndex: index });
+							}
+						}
+					},
+					[
+						w(
+							Tab,
+							{
+								theme: this._theme,
+								key: 'default',
+								label: 'Default'
+							},
+							[
+								'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Integer in ex pharetra, iaculis turpis eget, tincidunt lorem. Class aptent taciti sociosqu ad litora torquent per conubia nostra, per inceptos himenaeos.'
+							]
+						),
+						w(
+							Tab,
+							{
+								theme: this._theme,
+								disabled: true,
+								key: 'disabled',
+								label: 'Disabled'
+							},
+							[
+								'Sed nibh est, sollicitudin consectetur porta finibus, condimentum gravida purus. Phasellus varius fringilla erat, a dignissim nunc iaculis et. Curabitur eu neque erat. Integer id lacus nulla. Phasellus ut sem eget enim interdum interdum ac ac orci.'
+							]
+						),
+						w(
+							Tab,
+							{
+								theme: this._theme,
+								key: 'async',
+								label: 'Async'
+							},
+							[
+								loading
+									? 'Loading...'
+									: 'Curabitur id elit a tellus consequat maximus in non lorem. Donec sagittis porta aliquam. Nulla facilisi. Quisque sed mauris justo. Donec eu fringilla urna. Aenean vulputate ipsum imperdiet orci ornare tempor.'
+							]
+						),
+						!includes(closedKeys, 'closeable')
+							? w(
+									Tab,
+									{
+										theme: this._theme,
+										closeable: true,
+										key: 'closeable',
+										label: 'Closeable'
+									},
+									[
+										'Nullam congue, massa in egestas sagittis, diam neque rutrum tellus, nec egestas metus tellus vel odio. Vivamus tincidunt quam nisl, sit amet venenatis purus bibendum eget. Phasellus fringilla ex vitae odio hendrerit, non volutpat orci rhoncus.'
+									]
+								)
+							: null,
+						w(
+							Tab,
+							{
+								theme: this._theme,
+								key: 'foo',
+								label: 'Foobar'
+							},
+							[
+								'Sed nibh est, sollicitudin consectetur porta finibus, condimentum gravida purus. Phasellus varius fringilla erat, a dignissim nunc iaculis et. Curabitur eu neque erat. Integer id lacus nulla. Phasellus ut sem eget enim interdum interdum ac ac orci.'
+							]
+						)
+					]
+				)
+			]
+		);
 	}
 }
 

--- a/src/tabcontroller/tests/functional/TabController.ts
+++ b/src/tabcontroller/tests/functional/TabController.ts
@@ -5,13 +5,10 @@ import { Remote } from 'intern/lib/executors/Node';
 import * as css from '../../styles/tabController.m.css';
 
 function getPage(remote: Remote) {
-	return remote
-		.get('http://localhost:9000/_build/common/example/?module=tabcontroller')
-		.setFindTimeout(5000);
+	return remote.get('http://localhost:9000/_build/common/example/?module=tabcontroller').setFindTimeout(5000);
 }
 
 registerSuite('TabController', {
-
 	'tab pane should be visible'() {
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.root}`)
@@ -25,19 +22,19 @@ registerSuite('TabController', {
 	'tabs should be changable'() {
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.root}`)
-				.findByCssSelector(`.${css.tabButton}:last-child`)
-					.getProperty('className')
-					.then((className: string) => {
-						assert.notInclude(className, css.activeTabButton, 'The last tab should not be selected initially.');
-					})
-					.click()
-				.end()
-				.findByCssSelector(`.${css.tabButton}:last-child`)
-					.getProperty('className')
-					.then((className: string) => {
-						assert.include(className, css.activeTabButton, 'The last tab should be selected after being clicked.');
-					})
-				.end()
+			.findByCssSelector(`.${css.tabButton}:last-child`)
+			.getProperty('className')
+			.then((className: string) => {
+				assert.notInclude(className, css.activeTabButton, 'The last tab should not be selected initially.');
+			})
+			.click()
+			.end()
+			.findByCssSelector(`.${css.tabButton}:last-child`)
+			.getProperty('className')
+			.then((className: string) => {
+				assert.include(className, css.activeTabButton, 'The last tab should be selected after being clicked.');
+			})
+			.end()
 			.end();
 	},
 
@@ -45,63 +42,67 @@ registerSuite('TabController', {
 		let tabContent: string;
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.root}`)
-				.findByCssSelector(`.${css.tab}`)
-					.getVisibleText()
-					.then(text => {
-						tabContent = text;
-					})
-				.end()
+			.findByCssSelector(`.${css.tab}`)
+			.getVisibleText()
+			.then((text) => {
+				tabContent = text;
+			})
+			.end()
 
-				.findByCssSelector(`.${css.tabButton}:last-child`)
-					.click()
-				.end()
+			.findByCssSelector(`.${css.tabButton}:last-child`)
+			.click()
+			.end()
 
-				.sleep(300)
+			.sleep(300)
 
-				.findByCssSelector(`.${css.tab}`)
-					.getVisibleText()
-					.then(text => {
-						assert.notStrictEqual(text, tabContent);
-					})
-				.end()
+			.findByCssSelector(`.${css.tab}`)
+			.getVisibleText()
+			.then((text) => {
+				assert.notStrictEqual(text, tabContent);
+			})
+			.end()
 			.end();
 	},
 	'disabled tab should not be selectable'() {
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.root}`)
-				.findByCssSelector(`.${css.disabledTabButton}`)
-					.getProperty('className')
-					.then((className: string) => {
-						assert.notInclude(className, css.activeTabButton, 'Disabled tab should not be selected.');
-					})
-					.click()
-				.end()
-				.findByCssSelector(`.${css.disabledTabButton}`)
-					.getProperty('className')
-					.then((className: string) => {
-						assert.notInclude(className, css.activeTabButton, 'Disabled tab should be selected after being clicked.');
-					})
-				.end()
+			.findByCssSelector(`.${css.disabledTabButton}`)
+			.getProperty('className')
+			.then((className: string) => {
+				assert.notInclude(className, css.activeTabButton, 'Disabled tab should not be selected.');
+			})
+			.click()
+			.end()
+			.findByCssSelector(`.${css.disabledTabButton}`)
+			.getProperty('className')
+			.then((className: string) => {
+				assert.notInclude(
+					className,
+					css.activeTabButton,
+					'Disabled tab should be selected after being clicked.'
+				);
+			})
+			.end()
 			.end();
 	},
 	'tabs should be closeable'() {
 		let childElementCount: number;
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.tabButtons}`)
-				.getProperty('childElementCount')
-				.then((count: number) => {
-					childElementCount = count;
-				})
-				.findByCssSelector(`.${css.close}`)
-					.click()
-				.end()
+			.getProperty('childElementCount')
+			.then((count: number) => {
+				childElementCount = count;
+			})
+			.findByCssSelector(`.${css.close}`)
+			.click()
+			.end()
 			.end()
 			.sleep(300)
 			.findByCssSelector(`.${css.tabButtons}`)
-				.getProperty('childElementCount')
-				.then((count: number) => {
-					assert.strictEqual(count, childElementCount - 1);
-				})
+			.getProperty('childElementCount')
+			.then((count: number) => {
+				assert.strictEqual(count, childElementCount - 1);
+			})
 			.end();
 	}
 });

--- a/src/tabcontroller/tests/unit/Tab.ts
+++ b/src/tabcontroller/tests/unit/Tab.ts
@@ -9,7 +9,6 @@ import * as css from '../../styles/tabController.m.css';
 let widget: Harness<Tab>;
 
 registerSuite('Tab', {
-
 	beforeEach() {
 		widget = harness(Tab);
 	},
@@ -21,19 +20,22 @@ registerSuite('Tab', {
 	tests: {
 		'default properties'() {
 			widget.setProperties({ key: 'foo' });
-			widget.expectRender(v('div', {
-				'aria-labelledby': undefined,
-				classes: css.tab,
-				id: undefined,
-				role: 'tabpanel'
-			}, []));
+			widget.expectRender(
+				v(
+					'div',
+					{
+						'aria-labelledby': undefined,
+						classes: css.tab,
+						id: undefined,
+						role: 'tabpanel'
+					},
+					[]
+				)
+			);
 		},
 
 		'custom properties and children'() {
-			const testChildren = [
-				v('p', ['lorem ipsum']),
-				v('a', { href: '#foo'}, [ 'foo' ])
-			];
+			const testChildren = [v('p', ['lorem ipsum']), v('a', { href: '#foo' }, ['foo'])];
 			widget.setProperties({
 				closeable: true,
 				disabled: true,
@@ -44,12 +46,18 @@ registerSuite('Tab', {
 			});
 			widget.setChildren(testChildren);
 
-			widget.expectRender(v('div', {
-				'aria-labelledby': 'id',
-				classes: css.tab,
-				id: 'foo',
-				role: 'tabpanel'
-			}, testChildren));
+			widget.expectRender(
+				v(
+					'div',
+					{
+						'aria-labelledby': 'id',
+						classes: css.tab,
+						id: 'foo',
+						role: 'tabpanel'
+					},
+					testChildren
+				)
+			);
 		}
 	}
 });

--- a/src/tabcontroller/tests/unit/TabButton.ts
+++ b/src/tabcontroller/tests/unit/TabButton.ts
@@ -17,46 +17,51 @@ interface KeyboardEventInit extends EventInit {
 }
 
 const props = function(props = {}) {
-	return assign({
-		controls: 'foo',
-		id: 'foo',
-		index: 0
-	}, props);
+	return assign(
+		{
+			controls: 'foo',
+			id: 'foo',
+			index: 0
+		},
+		props
+	);
 };
 
-const testChildren = [
-	v('p', ['lorem ipsum']),
-	v('a', { href: '#foo'}, [ 'foo' ])
-];
+const testChildren = [v('p', ['lorem ipsum']), v('a', { href: '#foo' }, ['foo'])];
 
 const expected = function(widget: any, closeable = false, children: any[] = []) {
 	children.push(
-		closeable ? v('button', {
-			tabIndex: -1,
-			classes: css.close,
-			innerHTML: 'close tab',
-			onclick: widget.listener
-		}) : null
+		closeable
+			? v('button', {
+					tabIndex: -1,
+					classes: css.close,
+					innerHTML: 'close tab',
+					onclick: widget.listener
+				})
+			: null
 	);
 
-	return v('div', {
-		'aria-controls': 'foo',
-		'aria-disabled': 'false',
-		'aria-selected': 'false',
-		classes: [ css.tabButton, null, null ],
-		id: 'foo',
-		key: 'tab-button',
-		onclick: widget.listener,
-		onkeydown: widget.listener,
-		role: 'tab',
-		tabIndex: -1
-	}, children);
+	return v(
+		'div',
+		{
+			'aria-controls': 'foo',
+			'aria-disabled': 'false',
+			'aria-selected': 'false',
+			classes: [css.tabButton, null, null],
+			id: 'foo',
+			key: 'tab-button',
+			onclick: widget.listener,
+			onkeydown: widget.listener,
+			role: 'tab',
+			tabIndex: -1
+		},
+		children
+	);
 };
 
 let widget: Harness<TabButton>;
 
 registerSuite('TabButton', {
-
 	beforeEach() {
 		widget = harness(TabButton);
 	},
@@ -72,39 +77,45 @@ registerSuite('TabButton', {
 		},
 
 		'custom properties'() {
-			widget.setProperties(props({
-				closeable: true,
-				disabled: true
-			}));
+			widget.setProperties(
+				props({
+					closeable: true,
+					disabled: true
+				})
+			);
 			widget.setChildren(testChildren);
 			const expectedVdom = expected(widget, true, [...testChildren]);
 			assignProperties(expectedVdom, {
 				'aria-disabled': 'true',
-				classes: [ css.tabButton, null, css.disabledTabButton ]
+				classes: [css.tabButton, null, css.disabledTabButton]
 			});
 			widget.expectRender(expectedVdom);
 		},
 
 		'active tab'() {
-			widget.setProperties(props({
-				active: true
-			}));
+			widget.setProperties(
+				props({
+					active: true
+				})
+			);
 			let expectedVdom = expected(widget);
 			assignProperties(expectedVdom, {
 				'aria-selected': 'true',
-				classes: [ css.tabButton, css.activeTabButton, null ],
+				classes: [css.tabButton, css.activeTabButton, null],
 				tabIndex: 0
 			});
 			widget.expectRender(expectedVdom, 'Selected tab render without close button');
 
-			widget.setProperties(props({
-				active: true,
-				closeable: true
-			}));
+			widget.setProperties(
+				props({
+					active: true,
+					closeable: true
+				})
+			);
 			expectedVdom = expected(widget, true);
 			assignProperties(expectedVdom, {
 				'aria-selected': 'true',
-				classes: [ css.tabButton, css.activeTabButton, null ],
+				classes: [css.tabButton, css.activeTabButton, null],
 				tabIndex: 0
 			});
 			assignChildProperties(expectedVdom, '0', {
@@ -115,10 +126,12 @@ registerSuite('TabButton', {
 
 		onCloseClick() {
 			const onCloseClick = sinon.stub();
-			widget.setProperties(props({
-				closeable: true,
-				onCloseClick
-			}));
+			widget.setProperties(
+				props({
+					closeable: true,
+					onCloseClick
+				})
+			);
 
 			widget.sendEvent('click', { selector: 'button' });
 			assert.isTrue(onCloseClick.called, 'onCloseClick handler called when close button clicked');
@@ -131,10 +144,12 @@ registerSuite('TabButton', {
 			assert.isTrue(onClick.calledOnce, 'onClick handler called when tab is clicked');
 			assert.isTrue(onClick.calledWith(0), 'onClick called with index as argument');
 
-			widget.setProperties(props({
-				disabled: true,
-				onClick
-			}));
+			widget.setProperties(
+				props({
+					disabled: true,
+					onClick
+				})
+			);
 			widget.getRender();
 			widget.sendEvent('click');
 			assert.isTrue(onClick.calledOnce, 'onClick handler not called when tab is disabled');
@@ -148,14 +163,16 @@ registerSuite('TabButton', {
 			const onRightArrowPress = sinon.stub();
 			const onUpArrowPress = sinon.stub();
 
-			widget.setProperties(props({
-				onDownArrowPress,
-				onEndPress,
-				onHomePress,
-				onLeftArrowPress,
-				onRightArrowPress,
-				onUpArrowPress
-			}));
+			widget.setProperties(
+				props({
+					onDownArrowPress,
+					onEndPress,
+					onHomePress,
+					onLeftArrowPress,
+					onRightArrowPress,
+					onUpArrowPress
+				})
+			);
 
 			widget.sendEvent<KeyboardEventInit>('keydown', {
 				eventInit: { which: Keys.Down }
@@ -182,15 +199,17 @@ registerSuite('TabButton', {
 			});
 			assert.isTrue(onUpArrowPress.calledOnce, 'Up arrow event handler called on up arrow press');
 
-			widget.setProperties(props({
-				disabled: true,
-				onDownArrowPress,
-				onEndPress,
-				onHomePress,
-				onLeftArrowPress,
-				onRightArrowPress,
-				onUpArrowPress
-			}));
+			widget.setProperties(
+				props({
+					disabled: true,
+					onDownArrowPress,
+					onEndPress,
+					onHomePress,
+					onLeftArrowPress,
+					onRightArrowPress,
+					onUpArrowPress
+				})
+			);
 			widget.getRender();
 			widget.sendEvent<KeyboardEventInit>('keydown', {
 				eventInit: { which: Keys.Down }
@@ -200,19 +219,23 @@ registerSuite('TabButton', {
 
 		'Escape should close tab'() {
 			const onCloseClick = sinon.stub();
-			widget.setProperties(props({
-				onCloseClick
-			}));
+			widget.setProperties(
+				props({
+					onCloseClick
+				})
+			);
 
 			widget.sendEvent<KeyboardEventInit>('keydown', {
 				eventInit: { which: Keys.Escape }
 			});
 			assert.isFalse(onCloseClick.called, 'onCloseClick not called if closeable is false');
 
-			widget.setProperties(props({
-				closeable: true,
-				onCloseClick
-			}));
+			widget.setProperties(
+				props({
+					closeable: true,
+					onCloseClick
+				})
+			);
 			widget.getRender();
 			widget.sendEvent<KeyboardEventInit>('keydown', {
 				eventInit: { which: Keys.Escape }
@@ -222,17 +245,21 @@ registerSuite('TabButton', {
 
 		'Focus is restored after render'() {
 			const onFocusCalled = sinon.stub();
-			widget.setProperties(props({
-				callFocus: true,
-				onFocusCalled
-			}));
+			widget.setProperties(
+				props({
+					callFocus: true,
+					onFocusCalled
+				})
+			);
 			widget.getRender();
 			assert.isTrue(onFocusCalled.calledOnce, 'onFocusCalled called on render if callFocus is true');
 
-			widget.setProperties(props({
-				callFocus: false,
-				onFocusCalled
-			}));
+			widget.setProperties(
+				props({
+					callFocus: false,
+					onFocusCalled
+				})
+			);
 			widget.getRender();
 			assert.isTrue(onFocusCalled.calledOnce, 'onFocusCalled not called if callFocus is false');
 		}

--- a/src/tabcontroller/tests/unit/TabController.ts
+++ b/src/tabcontroller/tests/unit/TabController.ts
@@ -19,22 +19,36 @@ const compareId = compareProperty((value: any) => {
 
 const tabChildren = function(tabs = 2) {
 	const children = [
-		w(Tab, {
-			key: '0'
-		}, [ 'tab content 1' ]),
-		w(Tab, {
-			closeable: true,
-			disabled: true,
-			key: '1',
-			label: 'foo'
-		}, [ 'tab content 2' ])
+		w(
+			Tab,
+			{
+				key: '0'
+			},
+			['tab content 1']
+		),
+		w(
+			Tab,
+			{
+				closeable: true,
+				disabled: true,
+				key: '1',
+				label: 'foo'
+			},
+			['tab content 2']
+		)
 	];
 
 	if (tabs > 2) {
 		for (let i = 2; i < tabs; i++) {
-			children.push(w(Tab, {
-				key: `${i}`
-			}, [ `tab content ${i}` ]));
+			children.push(
+				w(
+					Tab,
+					{
+						key: `${i}`
+					},
+					[`tab content ${i}`]
+				)
+			);
 		}
 	}
 
@@ -43,57 +57,73 @@ const tabChildren = function(tabs = 2) {
 
 const expectedTabButtons = function(empty = false): DNode {
 	if (empty) {
-		return v('div', {
-			key: 'buttons',
-			classes: css.tabButtons
-		}, [ ]);
+		return v(
+			'div',
+			{
+				key: 'buttons',
+				classes: css.tabButtons
+			},
+			[]
+		);
 	}
 
-	return v('div', {
-		key: 'buttons',
-		classes: css.tabButtons
-	}, [
-		w(TabButton, {
-			callFocus: false,
-			active: true,
-			closeable: undefined,
-			controls: <any> compareId,
-			disabled: undefined,
-			id: <any> compareId,
-			index: 0,
-			key: '0-tabbutton',
-			onClick: widget.listener,
-			onCloseClick: widget.listener,
-			onDownArrowPress: widget.listener,
-			onEndPress: widget.listener,
-			onFocusCalled: widget.listener,
-			onHomePress: widget.listener,
-			onLeftArrowPress: widget.listener,
-			onRightArrowPress: widget.listener,
-			onUpArrowPress: widget.listener,
-			theme: undefined
-		}, [ null ]),
-		w(TabButton, {
-			callFocus: false,
-			active: false,
-			closeable: true,
-			controls: <any> compareId,
-			disabled: true,
-			id: <any> compareId,
-			index: 1,
-			key: '1-tabbutton',
-			onClick: widget.listener,
-			onCloseClick: widget.listener,
-			onDownArrowPress: widget.listener,
-			onEndPress: widget.listener,
-			onFocusCalled: widget.listener,
-			onHomePress: widget.listener,
-			onLeftArrowPress: widget.listener,
-			onRightArrowPress: widget.listener,
-			onUpArrowPress: widget.listener,
-			theme: undefined
-		}, [ 'foo' ])
-	]);
+	return v(
+		'div',
+		{
+			key: 'buttons',
+			classes: css.tabButtons
+		},
+		[
+			w(
+				TabButton,
+				{
+					callFocus: false,
+					active: true,
+					closeable: undefined,
+					controls: <any>compareId,
+					disabled: undefined,
+					id: <any>compareId,
+					index: 0,
+					key: '0-tabbutton',
+					onClick: widget.listener,
+					onCloseClick: widget.listener,
+					onDownArrowPress: widget.listener,
+					onEndPress: widget.listener,
+					onFocusCalled: widget.listener,
+					onHomePress: widget.listener,
+					onLeftArrowPress: widget.listener,
+					onRightArrowPress: widget.listener,
+					onUpArrowPress: widget.listener,
+					theme: undefined
+				},
+				[null]
+			),
+			w(
+				TabButton,
+				{
+					callFocus: false,
+					active: false,
+					closeable: true,
+					controls: <any>compareId,
+					disabled: true,
+					id: <any>compareId,
+					index: 1,
+					key: '1-tabbutton',
+					onClick: widget.listener,
+					onCloseClick: widget.listener,
+					onDownArrowPress: widget.listener,
+					onEndPress: widget.listener,
+					onFocusCalled: widget.listener,
+					onHomePress: widget.listener,
+					onLeftArrowPress: widget.listener,
+					onRightArrowPress: widget.listener,
+					onUpArrowPress: widget.listener,
+					theme: undefined
+				},
+				['foo']
+			)
+		]
+	);
 };
 
 const expectedTabContent = function(index = 0): DNode {
@@ -102,38 +132,53 @@ const expectedTabContent = function(index = 0): DNode {
 	}
 
 	const tabs = [
-		w(Tab, {
-			key: '0',
-			id: <any> compareId,
-			labelledBy: <any> compareId
-		}, [ 'tab content 1' ]),
-		w(Tab, {
-			closeable: true,
-			disabled: true,
-			key: '1',
-			label: 'foo',
-			id: <any> compareId,
-			labelledBy: <any> compareId
-		}, [ 'tab content 2' ])
+		w(
+			Tab,
+			{
+				key: '0',
+				id: <any>compareId,
+				labelledBy: <any>compareId
+			},
+			['tab content 1']
+		),
+		w(
+			Tab,
+			{
+				closeable: true,
+				disabled: true,
+				key: '1',
+				label: 'foo',
+				id: <any>compareId,
+				labelledBy: <any>compareId
+			},
+			['tab content 2']
+		)
 	];
-	return v('div', {
-		key: 'tabs',
-		classes: css.tabs
-	}, [ tabs[index] ]);
+	return v(
+		'div',
+		{
+			key: 'tabs',
+			classes: css.tabs
+		},
+		[tabs[index]]
+	);
 };
 
 const expected = function(children: DNode[] = []) {
-	return v('div', {
-		'aria-orientation': 'horizontal',
-		classes: [ null, css.root ],
-		role: 'tablist'
-	}, children);
+	return v(
+		'div',
+		{
+			'aria-orientation': 'horizontal',
+			classes: [null, css.root],
+			role: 'tablist'
+		},
+		children
+	);
 };
 
 let widget: Harness<TabController>;
 
 registerSuite('TabController', {
-
 	beforeEach() {
 		widget = harness(TabController);
 	},
@@ -150,13 +195,13 @@ registerSuite('TabController', {
 			let tabButtons = expectedTabButtons(true);
 			let tabContent = null;
 
-			widget.expectRender(expected([ tabButtons, tabContent ]), 'Empty tab controller');
+			widget.expectRender(expected([tabButtons, tabContent]), 'Empty tab controller');
 
 			widget.setChildren(tabChildren());
 			tabButtons = expectedTabButtons();
 			tabContent = expectedTabContent();
 
-			widget.expectRender(expected([ tabButtons, tabContent ]), 'Tab controller with tabs');
+			widget.expectRender(expected([tabButtons, tabContent]), 'Tab controller with tabs');
 		},
 
 		'custom orientation'() {
@@ -168,9 +213,9 @@ registerSuite('TabController', {
 
 			let tabButtons = expectedTabButtons();
 			let tabContent = expectedTabContent();
-			let expectedVdom = expected([ tabContent, tabButtons ]);
+			let expectedVdom = expected([tabContent, tabButtons]);
 			assignProperties(expectedVdom, {
-				classes: [ css.alignBottom, css.root ]
+				classes: [css.alignBottom, css.root]
 			});
 			widget.expectRender(expectedVdom, 'tabs aligned bottom');
 
@@ -181,10 +226,10 @@ registerSuite('TabController', {
 			widget.setChildren(tabChildren());
 			tabButtons = expectedTabButtons();
 			tabContent = expectedTabContent();
-			expectedVdom = expected([ tabContent, tabButtons ]);
+			expectedVdom = expected([tabContent, tabButtons]);
 			assignProperties(expectedVdom, {
 				'aria-orientation': 'vertical',
-				classes: [ css.alignRight, css.root ]
+				classes: [css.alignRight, css.root]
 			});
 			widget.expectRender(expectedVdom, 'tabs aligned right');
 
@@ -195,10 +240,10 @@ registerSuite('TabController', {
 			widget.setChildren(tabChildren());
 			tabButtons = expectedTabButtons();
 			tabContent = expectedTabContent();
-			expectedVdom = expected([ tabButtons, tabContent ]);
+			expectedVdom = expected([tabButtons, tabContent]);
 			assignProperties(expectedVdom, {
 				'aria-orientation': 'vertical',
-				classes: [ css.alignLeft, css.root ]
+				classes: [css.alignLeft, css.root]
 			});
 			widget.expectRender(expectedVdom, 'tabs aligned left');
 		},
@@ -211,20 +256,23 @@ registerSuite('TabController', {
 			});
 			widget.setChildren(tabChildren(3));
 			widget.callListener('onClick', {
-				args: [ 0 ],
+				args: [0],
 				key: '0-tabbutton'
 			});
 			assert.isTrue(onRequestTabChange.calledOnce, 'onRequestTabChange called when tab is clicked');
-			assert.isTrue(onRequestTabChange.calledWith(0, '0'), 'onRequestTabChange called with correct index and key');
+			assert.isTrue(
+				onRequestTabChange.calledWith(0, '0'),
+				'onRequestTabChange called with correct index and key'
+			);
 
 			widget.callListener('onClick', {
-				args: [ 1 ],
+				args: [1],
 				key: '1-tabbutton'
 			});
 			assert.isTrue(onRequestTabChange.calledOnce, 'onRequestTabChange not called on disabled tabs');
 
 			widget.callListener('onClick', {
-				args: [ 2 ],
+				args: [2],
 				key: '2-tabbutton'
 			});
 			assert.isTrue(onRequestTabChange.calledOnce, 'onRequestTabChange not called on the active tab');
@@ -239,11 +287,11 @@ registerSuite('TabController', {
 			widget.setChildren(tabChildren(3));
 
 			widget.callListener('onCloseClick', {
-				args: [ 2 ],
+				args: [2],
 				key: '2-tabbutton'
 			});
 
-			assert.isTrue(onRequestTabClose.calledOnce, 'onRequestTabClose called when a tab\'s onCloseClick fires');
+			assert.isTrue(onRequestTabClose.calledOnce, "onRequestTabClose called when a tab's onCloseClick fires");
 			assert.isTrue(onRequestTabClose.calledWith(2, '2'), 'onRequestTabClose called with correct index and key');
 		},
 
@@ -256,37 +304,41 @@ registerSuite('TabController', {
 			widget.setChildren(tabChildren(5));
 
 			widget.callListener('onRightArrowPress', {
-				args: [ 2 ],
+				args: [2],
 				key: '2-tabbutton'
 			});
 			assert.strictEqual(onRequestTabChange.getCall(0).args[0], 3, 'Right arrow moves to next tab');
 
 			widget.callListener('onDownArrowPress', {
-				args: [ 2 ],
+				args: [2],
 				key: '2-tabbutton'
 			});
 			assert.isTrue(onRequestTabChange.calledOnce, 'Down arrow does nothing on horizontal tabs');
 
 			widget.callListener('onLeftArrowPress', {
-				args: [ 2 ],
+				args: [2],
 				key: '2-tabbutton'
 			});
-			assert.strictEqual(onRequestTabChange.getCall(1).args[0], 0, 'Left arrow moves to previous tab, skipping disabled tab');
+			assert.strictEqual(
+				onRequestTabChange.getCall(1).args[0],
+				0,
+				'Left arrow moves to previous tab, skipping disabled tab'
+			);
 
 			widget.callListener('onUpArrowPress', {
-				args: [ 2 ],
+				args: [2],
 				key: '2-tabbutton'
 			});
 			assert.isTrue(onRequestTabChange.calledTwice, 'Up arrow does nothing on horizontal tabs');
 
 			widget.callListener('onHomePress', {
-				args: [ 2 ],
+				args: [2],
 				key: '2-tabbutton'
 			});
 			assert.strictEqual(onRequestTabChange.getCall(2).args[0], 0, 'Home moves to first tab');
 
 			widget.callListener('onEndPress', {
-				args: [ 2 ],
+				args: [2],
 				key: '2-tabbutton'
 			});
 			assert.strictEqual(onRequestTabChange.getCall(3).args[0], 4, 'End moves to last tab');
@@ -300,7 +352,7 @@ registerSuite('TabController', {
 			});
 			widget.setChildren(tabChildren(3));
 			widget.callListener('onLeftArrowPress', {
-				args: [ 0 ],
+				args: [0],
 				key: '0-tabbutton'
 			});
 			assert.isTrue(onRequestTabChange.calledWith(2), 'Left arrow wraps from first to last tab');
@@ -311,7 +363,7 @@ registerSuite('TabController', {
 			});
 			widget.getRender();
 			widget.callListener('onRightArrowPress', {
-				args: [ 2 ],
+				args: [2],
 				key: '2-tabbutton'
 			});
 			assert.isTrue(onRequestTabChange.calledWith(0), 'Right arrow wraps from last to first tab');
@@ -327,25 +379,29 @@ registerSuite('TabController', {
 			widget.setChildren(tabChildren(5));
 
 			widget.callListener('onDownArrowPress', {
-				args: [ 0 ],
+				args: [0],
 				key: '0-tabbutton'
 			});
-			assert.strictEqual(onRequestTabChange.getCall(0).args[0], 2, 'Down arrow moves to next tab, skipping disabled tab');
+			assert.strictEqual(
+				onRequestTabChange.getCall(0).args[0],
+				2,
+				'Down arrow moves to next tab, skipping disabled tab'
+			);
 
 			widget.callListener('onRightArrowPress', {
-				args: [ 0 ],
+				args: [0],
 				key: '0-tabbutton'
 			});
 			assert.strictEqual(onRequestTabChange.getCall(1).args[0], 2, 'Right arrow works on vertical tabs');
 
 			widget.callListener('onUpArrowPress', {
-				args: [ 0 ],
+				args: [0],
 				key: '0-tabbutton'
 			});
 			assert.strictEqual(onRequestTabChange.getCall(2).args[0], 4, 'Up arrow moves to previous tab');
 
 			widget.callListener('onLeftArrowPress', {
-				args: [ 0 ],
+				args: [0],
 				key: '0-tabbutton'
 			});
 			assert.strictEqual(onRequestTabChange.getCall(3).args[0], 4, 'Left arrow works on vertical tabs');
@@ -357,7 +413,7 @@ registerSuite('TabController', {
 			});
 			widget.getRender();
 			widget.callListener('onDownArrowPress', {
-				args: [ 0 ],
+				args: [0],
 				key: '0-tabbutton'
 			});
 			assert.strictEqual(onRequestTabChange.getCall(4).args[0], 2, 'Down arrow works on left-aligned tabs');
@@ -392,22 +448,30 @@ registerSuite('TabController', {
 				activeIndex: 1
 			});
 			widget.setChildren([
-				w(Tab, {
-					key: '0'
-				}, [ 'tab content 1' ]),
-				w(Tab, {
-					closeable: true,
-					key: '1',
-					label: 'foo'
-				}, [ 'tab content 2' ])
+				w(
+					Tab,
+					{
+						key: '0'
+					},
+					['tab content 1']
+				),
+				w(
+					Tab,
+					{
+						closeable: true,
+						key: '1',
+						label: 'foo'
+					},
+					['tab content 2']
+				)
 			]);
 
 			let tabButtons = expectedTabButtons();
 			let tabContent = expectedTabContent();
-			let expectedVdom = expected([ tabButtons, tabContent ]);
+			let expectedVdom = expected([tabButtons, tabContent]);
 
 			widget.callListener('onClick', {
-				args: [ 0 ],
+				args: [0],
 				key: '0-tabbutton'
 			});
 			widget.setProperties({
@@ -416,20 +480,20 @@ registerSuite('TabController', {
 
 			tabButtons = expectedTabButtons();
 			tabContent = expectedTabContent();
-			assignChildProperties((<any> tabButtons), '0', { callFocus: true });
-			assignChildProperties((<any> tabButtons), '1', { disabled: undefined });
-			expectedVdom = expected([ tabButtons, tabContent ]);
+			assignChildProperties(<any>tabButtons, '0', { callFocus: true });
+			assignChildProperties(<any>tabButtons, '1', { disabled: undefined });
+			expectedVdom = expected([tabButtons, tabContent]);
 
 			widget.expectRender(expectedVdom, 'Clicking tab button updates callFocus property to true');
 
 			widget.callListener('onFocusCalled', {
-				args: [ 0 ],
+				args: [0],
 				key: '0-tabbutton'
 			});
 			widget.setChildren(tabChildren());
 			tabButtons = expectedTabButtons();
 			tabContent = expectedTabContent();
-			expectedVdom = expected([ tabButtons, tabContent ]);
+			expectedVdom = expected([tabButtons, tabContent]);
 			widget.expectRender(expectedVdom, 'onFocusCalled updates callFocus to false');
 		}
 	}

--- a/src/textarea/Textarea.ts
+++ b/src/textarea/Textarea.ts
@@ -3,7 +3,13 @@ import { DNode } from '@dojo/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import { v, w } from '@dojo/widget-core/d';
 import Label from '../label/Label';
-import { InputProperties, LabeledProperties, InputEventProperties, PointerEventProperties, KeyEventProperties } from '../common/interfaces';
+import {
+	InputProperties,
+	LabeledProperties,
+	InputEventProperties,
+	PointerEventProperties,
+	KeyEventProperties
+} from '../common/interfaces';
 import uuid from '@dojo/core/uuid';
 import * as css from './styles/textarea.m.css';
 
@@ -20,7 +26,13 @@ import * as css from './styles/textarea.m.css';
  * @property placeholder    Placeholder text
  * @property value           The current value
  */
-export interface TextareaProperties extends ThemedProperties, InputProperties, LabeledProperties, InputEventProperties, KeyEventProperties, PointerEventProperties {
+export interface TextareaProperties
+	extends ThemedProperties,
+		InputProperties,
+		LabeledProperties,
+		InputEventProperties,
+		KeyEventProperties,
+		PointerEventProperties {
 	columns?: number;
 	rows?: number;
 	wrapText?: 'hard' | 'soft' | 'off';
@@ -34,19 +46,45 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 
 @theme(css)
 export default class Textarea<P extends TextareaProperties = TextareaProperties> extends ThemedBase<P, null> {
-	private _onBlur (event: FocusEvent) { this.properties.onBlur && this.properties.onBlur(event); }
-	private _onChange (event: Event) { this.properties.onChange && this.properties.onChange(event); }
-	private _onClick (event: MouseEvent) { this.properties.onClick && this.properties.onClick(event); }
-	private _onFocus (event: FocusEvent) { this.properties.onFocus && this.properties.onFocus(event); }
-	private _onInput (event: Event) { this.properties.onInput && this.properties.onInput(event); }
-	private _onKeyDown (event: KeyboardEvent) { this.properties.onKeyDown && this.properties.onKeyDown(event); }
-	private _onKeyPress (event: KeyboardEvent) { this.properties.onKeyPress && this.properties.onKeyPress(event); }
-	private _onKeyUp (event: KeyboardEvent) { this.properties.onKeyUp && this.properties.onKeyUp(event); }
-	private _onMouseDown (event: MouseEvent) { this.properties.onMouseDown && this.properties.onMouseDown(event); }
-	private _onMouseUp (event: MouseEvent) { this.properties.onMouseUp && this.properties.onMouseUp(event); }
-	private _onTouchStart (event: TouchEvent) { this.properties.onTouchStart && this.properties.onTouchStart(event); }
-	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
-	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
+	private _onBlur(event: FocusEvent) {
+		this.properties.onBlur && this.properties.onBlur(event);
+	}
+	private _onChange(event: Event) {
+		this.properties.onChange && this.properties.onChange(event);
+	}
+	private _onClick(event: MouseEvent) {
+		this.properties.onClick && this.properties.onClick(event);
+	}
+	private _onFocus(event: FocusEvent) {
+		this.properties.onFocus && this.properties.onFocus(event);
+	}
+	private _onInput(event: Event) {
+		this.properties.onInput && this.properties.onInput(event);
+	}
+	private _onKeyDown(event: KeyboardEvent) {
+		this.properties.onKeyDown && this.properties.onKeyDown(event);
+	}
+	private _onKeyPress(event: KeyboardEvent) {
+		this.properties.onKeyPress && this.properties.onKeyPress(event);
+	}
+	private _onKeyUp(event: KeyboardEvent) {
+		this.properties.onKeyUp && this.properties.onKeyUp(event);
+	}
+	private _onMouseDown(event: MouseEvent) {
+		this.properties.onMouseDown && this.properties.onMouseDown(event);
+	}
+	private _onMouseUp(event: MouseEvent) {
+		this.properties.onMouseUp && this.properties.onMouseUp(event);
+	}
+	private _onTouchStart(event: TouchEvent) {
+		this.properties.onTouchStart && this.properties.onTouchStart(event);
+	}
+	private _onTouchEnd(event: TouchEvent) {
+		this.properties.onTouchEnd && this.properties.onTouchEnd(event);
+	}
+	private _onTouchCancel(event: TouchEvent) {
+		this.properties.onTouchCancel && this.properties.onTouchCancel(event);
+	}
 
 	private _uuid: string;
 
@@ -56,12 +94,7 @@ export default class Textarea<P extends TextareaProperties = TextareaProperties>
 	}
 
 	protected getRootClasses(): (string | null)[] {
-		const {
-			disabled,
-			invalid,
-			readOnly,
-			required
-		} = this.properties;
+		const { disabled, invalid, readOnly, required } = this.properties;
 		return [
 			css.root,
 			disabled ? css.disabled : null,
@@ -94,15 +127,21 @@ export default class Textarea<P extends TextareaProperties = TextareaProperties>
 		} = this.properties;
 
 		const children = [
-			label ? w(Label, {
-				theme,
-				disabled,
-				invalid,
-				readOnly,
-				required,
-				hidden: labelHidden,
-				forId: this._uuid
-			}, [ label ]) : null,
+			label
+				? w(
+						Label,
+						{
+							theme,
+							disabled,
+							invalid,
+							readOnly,
+							required,
+							hidden: labelHidden,
+							forId: this._uuid
+						},
+						[label]
+					)
+				: null,
 			v('div', { classes: this.theme(css.inputWrapper) }, [
 				v('textarea', {
 					id: this._uuid,
@@ -139,9 +178,13 @@ export default class Textarea<P extends TextareaProperties = TextareaProperties>
 			])
 		];
 
-		return v('div', {
-			key: 'root',
-			classes: this.theme(this.getRootClasses())
-		}, labelAfter ? children.reverse() : children);
+		return v(
+			'div',
+			{
+				key: 'root',
+				classes: this.theme(this.getRootClasses())
+			},
+			labelAfter ? children.reverse() : children
+		);
 	}
 }

--- a/src/textarea/example/index.ts
+++ b/src/textarea/example/index.ts
@@ -27,7 +27,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					onchange: this.themeChange
 				})
 			]),
-			v('div', { id: 'example-t1'}, [
+			v('div', { id: 'example-t1' }, [
 				w(Textarea, {
 					key: 't1',
 					columns: 40,
@@ -43,19 +43,19 @@ export class App extends WidgetBase<WidgetProperties> {
 				})
 			]),
 			v('h3', {}, ['Disabled Textarea']),
-			v('div', { id: 'example-t2'}, [
+			v('div', { id: 'example-t2' }, [
 				w(Textarea, {
 					key: 't2',
 					columns: 40,
 					rows: 3,
-					label: 'Can\'t type here',
+					label: "Can't type here",
 					value: 'Initial value',
 					disabled: true,
 					theme: this._theme
 				})
 			]),
 			v('h3', {}, ['Validated, Required Textarea']),
-			v('div', { id: 'example-t3'}, [
+			v('div', { id: 'example-t3' }, [
 				w(Textarea, {
 					key: 't3',
 					columns: 40,
@@ -74,7 +74,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				})
 			]),
 			v('h3', {}, ['Hidden Label Textarea']),
-			v('div', { id: 'example-t4'}, [
+			v('div', { id: 'example-t4' }, [
 				w(Textarea, {
 					key: 't4',
 					columns: 40,

--- a/src/textarea/tests/functional/Textarea.ts
+++ b/src/textarea/tests/functional/Textarea.ts
@@ -7,23 +7,21 @@ import * as css from '../../styles/textarea.m.css';
 import * as baseCss from '../../../common/styles/base.m.css';
 
 function getPage(remote: Remote) {
-	return remote
-		.get('http://localhost:9000/_build/common/example/?module=textarea')
-		.setFindTimeout(5000);
+	return remote.get('http://localhost:9000/_build/common/example/?module=textarea').setFindTimeout(5000);
 }
 
 registerSuite('Textarea', {
 	'should be visible'() {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-t1 .${css.root}`)
-				.isDisplayed()
-				.findByCssSelector(`.${css.input}`)
-					.getSize()
-					.then(({ height, width }) => {
-						assert.isAbove(height, 0, 'The height of the textarea should be greater than zero.');
-						assert.isAbove(width, 0, 'The width of the textarea should be greater than zero.');
-					})
-				.end()
+			.isDisplayed()
+			.findByCssSelector(`.${css.input}`)
+			.getSize()
+			.then(({ height, width }) => {
+				assert.isAbove(height, 0, 'The height of the textarea should be greater than zero.');
+				assert.isAbove(width, 0, 'The width of the textarea should be greater than zero.');
+			})
+			.end()
 			.end();
 	},
 	'label should be as defined'() {
@@ -34,10 +32,10 @@ registerSuite('Textarea', {
 
 		return getPage(this.remote)
 			.findByCssSelector(`#example-t1 .${css.root}`)
-				.getVisibleText()
-				.then(text => {
-					assert.strictEqual(text, 'Type Something');
-				})
+			.getVisibleText()
+			.then((text) => {
+				assert.strictEqual(text, 'Type Something');
+			})
 			.end();
 	},
 	'should gain focus when clicking on the label'() {
@@ -48,11 +46,11 @@ registerSuite('Textarea', {
 
 		return getPage(this.remote)
 			.findByCssSelector(`#example-t1 .${css.root} label`)
-				.click()
-				.sleep(1000)
+			.click()
+			.sleep(1000)
 			.end()
 			.execute(`return document.activeElement === document.querySelector('#example-t1 .${css.input}');`)
-			.then(isEqual => {
+			.then((isEqual) => {
 				assert.isTrue(isEqual);
 			});
 	},
@@ -65,33 +63,36 @@ registerSuite('Textarea', {
 		const testInput = 'test text';
 		return getPage(this.remote)
 			.findByCssSelector(`#example-t1 .${css.input}`)
-				.click()
-				.type(testInput)
-				.getProperty('value')
-				.then((value: string) => {
-					assert.strictEqual(value, testInput);
-				})
+			.click()
+			.type(testInput)
+			.getProperty('value')
+			.then((value: string) => {
+				assert.strictEqual(value, testInput);
+			})
 			.end();
 	},
 	'disabled should not allow input to be typed'() {
 		const initValue = 'Initial value';
 		return getPage(this.remote)
 			.findByCssSelector(`#example-t2 .${css.root} .${css.input}`)
-				.click()
-				.then(null, () => {})
-				.type('text')
-				.then(null, () => {})
-				.getProperty('value')
-				.then((value: string) => {
-					assert.strictEqual(value, initValue);
-				})
+			.click()
+			.then(null, () => {})
+			.type('text')
+			.then(null, () => {})
+			.getProperty('value')
+			.then((value: string) => {
+				assert.strictEqual(value, initValue);
+			})
 			.end();
 	},
 	'validated should update style based on validity'() {
 		const { browserName, version } = this.remote.session.capabilities;
 		// Validated working manually in both safari and edge but functional just does not work
 		if (browserName === 'safari' || browserName!.toLowerCase() === 'microsoftedge') {
-			this.skip('Classes are not being updated for this unit test in Safari or Edge, have been validated manually' + version);
+			this.skip(
+				'Classes are not being updated for this unit test in Safari or Edge, have been validated manually' +
+					version
+			);
 		}
 
 		const validText = 'exists';
@@ -100,60 +101,62 @@ registerSuite('Textarea', {
 			backspaces.push(keys.BACKSPACE);
 		}
 
-		return getPage(this.remote)
-			.findByCssSelector(`#example-t3 .${css.root}`)
+		return (
+			getPage(this.remote)
+				.findByCssSelector(`#example-t3 .${css.root}`)
 				.getProperty('className')
 				.then((className: string) => {
 					assert.notInclude(className, css.invalid);
 					assert.notInclude(className, css.valid);
 				})
 				.findByCssSelector(`.${css.input}`)
-					.click()
-					.type(validText)
-				.end()
-			.end()
-			// focus another input
-			.findByCssSelector(`#example-t1 .${css.root} .${css.input}`)
 				.click()
-			.end()
-			.sleep(500)
-			// enter invalid value
-			.findByCssSelector(`#example-t3 .${css.root}`)
+				.type(validText)
+				.end()
+				.end()
+				// focus another input
+				.findByCssSelector(`#example-t1 .${css.root} .${css.input}`)
+				.click()
+				.end()
+				.sleep(500)
+				// enter invalid value
+				.findByCssSelector(`#example-t3 .${css.root}`)
 				.getProperty('className')
 				.then((className: string) => {
 					assert.notInclude(className, css.invalid);
 					assert.include(className, css.valid);
 				})
 				.findByCssSelector(`.${css.input}`)
-					.click()
-					.type(backspaces)
-				.end()
-			.end()
-			// focus another input
-			.findByCssSelector(`#example-t1 .${css.root} .${css.input}`)
 				.click()
-			.end()
-			.sleep(500)
-			.findByCssSelector(`#example-t3 .${css.root}`)
+				.type(backspaces)
+				.end()
+				.end()
+				// focus another input
+				.findByCssSelector(`#example-t1 .${css.root} .${css.input}`)
+				.click()
+				.end()
+				.sleep(500)
+				.findByCssSelector(`#example-t3 .${css.root}`)
 				.getProperty('className')
 				.then((className: string) => {
 					assert.notInclude(className, css.valid);
 					assert.include(className, css.invalid);
 				})
-			.end();
+				.end()
+		);
 	},
 	'hidden label should not be displayed'() {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-t4 .${css.root}`)
-				.getVisibleText()
-				.then(text => {
-					assert.isTrue(text && text.length > 0);
-				})
-				.findByCssSelector(`.${baseCss.visuallyHidden}`)
-					.then(element => {
-						assert(element, 'element with specified class "visuallyHidden" should exist.`');
-					})
-				.end()
+			.getVisibleText()
+			.then((text) => {
+				assert.isTrue(text && text.length > 0);
+			})
+			.findByCssSelector(`.${baseCss.visuallyHidden}`)
+			.then((element) => {
+				assert(element, 'element with specified class "visuallyHidden" should exist.`');
+			})
+			.end()
 			.end();
 	}
 });

--- a/src/textarea/tests/unit/Textarea.ts
+++ b/src/textarea/tests/unit/Textarea.ts
@@ -17,60 +17,69 @@ const compareId = compareProperty((value: any) => {
 });
 
 const expected = function(label = false) {
-	return v('div', {
-		key: 'root',
-		classes: [ css.root, null, null, null, null, null ]
-	}, [
-		label ? w(Label, {
-			theme: undefined,
-			disabled: undefined,
-			hidden: undefined,
-			invalid: undefined,
-			readOnly: undefined,
-			required: undefined,
-			forId: <any> compareId
-		}, [ 'foo' ]) : null,
-		v('div', { classes: css.inputWrapper }, [
-			v('textarea', {
-				classes: css.input,
-				id: <any> compareId,
-				key: 'input',
-				cols: null,
-				'aria-describedby': undefined,
-				disabled: undefined,
-				'aria-invalid': null,
-				maxlength: null,
-				minlength: null,
-				name: undefined,
-				placeholder: undefined,
-				readOnly: undefined,
-				'aria-readonly': null,
-				required: undefined,
-				rows: null,
-				value: undefined,
-				wrap: undefined,
-				onblur: widget.listener,
-				onchange: widget.listener,
-				onclick: widget.listener,
-				onfocus: widget.listener,
-				oninput: widget.listener,
-				onkeydown: widget.listener,
-				onkeypress: widget.listener,
-				onkeyup: widget.listener,
-				onmousedown: widget.listener,
-				onmouseup: widget.listener,
-				ontouchstart: widget.listener,
-				ontouchend: widget.listener,
-				ontouchcancel: widget.listener
-			})
-		])
-	]);
+	return v(
+		'div',
+		{
+			key: 'root',
+			classes: [css.root, null, null, null, null, null]
+		},
+		[
+			label
+				? w(
+						Label,
+						{
+							theme: undefined,
+							disabled: undefined,
+							hidden: undefined,
+							invalid: undefined,
+							readOnly: undefined,
+							required: undefined,
+							forId: <any>compareId
+						},
+						['foo']
+					)
+				: null,
+			v('div', { classes: css.inputWrapper }, [
+				v('textarea', {
+					classes: css.input,
+					id: <any>compareId,
+					key: 'input',
+					cols: null,
+					'aria-describedby': undefined,
+					disabled: undefined,
+					'aria-invalid': null,
+					maxlength: null,
+					minlength: null,
+					name: undefined,
+					placeholder: undefined,
+					readOnly: undefined,
+					'aria-readonly': null,
+					required: undefined,
+					rows: null,
+					value: undefined,
+					wrap: undefined,
+					onblur: widget.listener,
+					onchange: widget.listener,
+					onclick: widget.listener,
+					onfocus: widget.listener,
+					oninput: widget.listener,
+					onkeydown: widget.listener,
+					onkeypress: widget.listener,
+					onkeyup: widget.listener,
+					onmousedown: widget.listener,
+					onmouseup: widget.listener,
+					ontouchstart: widget.listener,
+					ontouchend: widget.listener,
+					ontouchcancel: widget.listener
+				})
+			])
+		]
+	);
 };
 
 let widget: Harness<Textarea>;
 
 registerSuite('Textarea', {
-
 	beforeEach() {
 		widget = harness(Textarea);
 	},
@@ -113,7 +122,7 @@ registerSuite('Textarea', {
 			widget.expectRender(expectedVdom);
 		},
 
-		'label'() {
+		label() {
 			widget.setProperties({
 				label: 'foo'
 			});
@@ -138,7 +147,7 @@ registerSuite('Textarea', {
 				required: true
 			});
 			assignProperties(expectedVdom, {
-				classes: [ css.root, css.disabled, css.invalid, null, css.readonly, css.required ]
+				classes: [css.root, css.disabled, css.invalid, null, css.readonly, css.required]
 			});
 
 			widget.expectRender(expectedVdom, 'Widget should be invalid, disabled, read-only, and required');
@@ -157,7 +166,7 @@ registerSuite('Textarea', {
 				required: false
 			});
 			assignProperties(expectedVdom, {
-				classes: [ css.root, null, null, css.valid, null, null ]
+				classes: [css.root, null, null, css.valid, null, null]
 			});
 
 			widget.expectRender(expectedVdom, 'State classes should be false, css.valid should be true');

--- a/src/textinput/TextInput.ts
+++ b/src/textinput/TextInput.ts
@@ -3,7 +3,13 @@ import { DNode } from '@dojo/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import { v, w } from '@dojo/widget-core/d';
 import Label from '../label/Label';
-import { InputProperties, LabeledProperties, PointerEventProperties, KeyEventProperties, InputEventProperties } from '../common/interfaces';
+import {
+	InputProperties,
+	LabeledProperties,
+	PointerEventProperties,
+	KeyEventProperties,
+	InputEventProperties
+} from '../common/interfaces';
 import uuid from '@dojo/core/uuid';
 import * as css from './styles/textinput.m.css';
 
@@ -21,7 +27,13 @@ export type TextInputType = 'text' | 'email' | 'number' | 'password' | 'search' 
  * @property placeholder    Placeholder text
  * @property value           The current value
  */
-export interface TextInputProperties extends ThemedProperties, InputProperties, LabeledProperties, PointerEventProperties, KeyEventProperties, InputEventProperties {
+export interface TextInputProperties
+	extends ThemedProperties,
+		InputProperties,
+		LabeledProperties,
+		PointerEventProperties,
+		KeyEventProperties,
+		InputEventProperties {
 	controls?: string;
 	type?: TextInputType;
 	maxLength?: number | string;
@@ -34,19 +46,45 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 
 @theme(css)
 export default class TextInput<P extends TextInputProperties = TextInputProperties> extends ThemedBase<P, null> {
-	private _onBlur (event: FocusEvent) { this.properties.onBlur && this.properties.onBlur(event); }
-	private _onChange (event: Event) { this.properties.onChange && this.properties.onChange(event); }
-	private _onClick (event: MouseEvent) { this.properties.onClick && this.properties.onClick(event); }
-	private _onFocus (event: FocusEvent) { this.properties.onFocus && this.properties.onFocus(event); }
-	private _onInput (event: Event) { this.properties.onInput && this.properties.onInput(event); }
-	private _onKeyDown (event: KeyboardEvent) { this.properties.onKeyDown && this.properties.onKeyDown(event); }
-	private _onKeyPress (event: KeyboardEvent) { this.properties.onKeyPress && this.properties.onKeyPress(event); }
-	private _onKeyUp (event: KeyboardEvent) { this.properties.onKeyUp && this.properties.onKeyUp(event); }
-	private _onMouseDown (event: MouseEvent) { this.properties.onMouseDown && this.properties.onMouseDown(event); }
-	private _onMouseUp (event: MouseEvent) { this.properties.onMouseUp && this.properties.onMouseUp(event); }
-	private _onTouchStart (event: TouchEvent) { this.properties.onTouchStart && this.properties.onTouchStart(event); }
-	private _onTouchEnd (event: TouchEvent) { this.properties.onTouchEnd && this.properties.onTouchEnd(event); }
-	private _onTouchCancel (event: TouchEvent) { this.properties.onTouchCancel && this.properties.onTouchCancel(event); }
+	private _onBlur(event: FocusEvent) {
+		this.properties.onBlur && this.properties.onBlur(event);
+	}
+	private _onChange(event: Event) {
+		this.properties.onChange && this.properties.onChange(event);
+	}
+	private _onClick(event: MouseEvent) {
+		this.properties.onClick && this.properties.onClick(event);
+	}
+	private _onFocus(event: FocusEvent) {
+		this.properties.onFocus && this.properties.onFocus(event);
+	}
+	private _onInput(event: Event) {
+		this.properties.onInput && this.properties.onInput(event);
+	}
+	private _onKeyDown(event: KeyboardEvent) {
+		this.properties.onKeyDown && this.properties.onKeyDown(event);
+	}
+	private _onKeyPress(event: KeyboardEvent) {
+		this.properties.onKeyPress && this.properties.onKeyPress(event);
+	}
+	private _onKeyUp(event: KeyboardEvent) {
+		this.properties.onKeyUp && this.properties.onKeyUp(event);
+	}
+	private _onMouseDown(event: MouseEvent) {
+		this.properties.onMouseDown && this.properties.onMouseDown(event);
+	}
+	private _onMouseUp(event: MouseEvent) {
+		this.properties.onMouseUp && this.properties.onMouseUp(event);
+	}
+	private _onTouchStart(event: TouchEvent) {
+		this.properties.onTouchStart && this.properties.onTouchStart(event);
+	}
+	private _onTouchEnd(event: TouchEvent) {
+		this.properties.onTouchEnd && this.properties.onTouchEnd(event);
+	}
+	private _onTouchCancel(event: TouchEvent) {
+		this.properties.onTouchCancel && this.properties.onTouchCancel(event);
+	}
 
 	private _uuid: string;
 
@@ -56,12 +94,7 @@ export default class TextInput<P extends TextInputProperties = TextInputProperti
 	}
 
 	protected getRootClasses(): (string | null)[] {
-		const {
-			disabled,
-			invalid,
-			readOnly,
-			required
-		} = this.properties;
+		const { disabled, invalid, readOnly, required } = this.properties;
 		return [
 			css.root,
 			disabled ? css.disabled : null,
@@ -122,9 +155,7 @@ export default class TextInput<P extends TextInputProperties = TextInputProperti
 	}
 
 	protected renderInputWrapper(): DNode {
-		return v('div', { classes: this.theme(css.inputWrapper) }, [
-			this.renderInput()
-		]);
+		return v('div', { classes: this.theme(css.inputWrapper) }, [this.renderInput()]);
 	}
 
 	render(): DNode {
@@ -140,21 +171,31 @@ export default class TextInput<P extends TextInputProperties = TextInputProperti
 		} = this.properties;
 
 		const children = [
-			label ? w(Label, {
-				theme,
-				disabled,
-				invalid,
-				readOnly,
-				required,
-				hidden: labelHidden,
-				forId: this._uuid
-			}, [ label ]) : null,
+			label
+				? w(
+						Label,
+						{
+							theme,
+							disabled,
+							invalid,
+							readOnly,
+							required,
+							hidden: labelHidden,
+							forId: this._uuid
+						},
+						[label]
+					)
+				: null,
 			this.renderInputWrapper()
 		];
 
-		return v('div', {
-			key: 'root',
-			classes: this.theme(this.getRootClasses())
-		}, labelAfter ? children.reverse() : children);
+		return v(
+			'div',
+			{
+				key: 'root',
+				classes: this.theme(this.getRootClasses())
+			},
+			labelAfter ? children.reverse() : children
+		);
 	}
 }

--- a/src/textinput/example/index.ts
+++ b/src/textinput/example/index.ts
@@ -20,95 +20,99 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render() {
-		return v('div', {
-			styles: { maxWidth: '256px' }
-		}, [
-			v('h2', {}, ['Text Input Examples']),
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			]),
-			v('div', { id: 'example-text' }, [
-				v('h3', {}, ['String label']),
-				w(TextInput, {
-					key: 't1',
-					label: 'Name',
-					type: 'text',
-					placeholder: 'Hello, World',
-					value: this._value1,
-					onChange: (event: Event) => {
-						this._value1 = (event.target as HTMLInputElement).value;
-						this.invalidate();
-					},
-					theme: this._theme
-				})
-			]),
-			v('div', { id: 'example-email' }, [
-				v('h3', {}, ['Label before the input']),
-				w(TextInput, {
-					key: 't2',
-					type: 'email',
-					label: 'Email (required)',
-					required: true,
-					value: this._value2,
-					onChange: (event: Event) => {
-						this._value2 = (event.target as HTMLInputElement).value;
-						this.invalidate();
-					},
-					theme: this._theme
-				})
-			]),
-			v('div', { id: 'example-hidden-label' }, [
-				v('h3', {}, ['Hidden accessible label']),
-				w(TextInput, {
-					key: 't3',
-					type: 'text',
-					placeholder: 'Type something...',
-					label: 'Try listening to me!',
-					labelAfter: true,
-					labelHidden: true,
-					value: this._value3,
-					onChange: (event: Event) => {
-						this._value3 = (event.target as HTMLInputElement).value;
-						this.invalidate();
-					},
-					theme: this._theme
-				})
-			]),
-			v('div', { id: 'example-disabled' }, [
-				v('h3', {}, ['Disabled text input']),
-				w(TextInput, {
-					key: 't4',
-					type: 'text',
-					label: 'Can\'t type here',
-					value: 'Initial value',
-					disabled: true,
-					readOnly: true,
-					theme: this._theme
-				})
-			]),
-			v('div', { id: 'example-validated' }, [
-				v('h3', {}, ['Validated Input']),
-				w(TextInput, {
-					key: 't5',
-					type: 'text',
-					label: 'Type "foo" or "bar"',
-					value: this._value4,
-					invalid: this._invalid,
-					onInput: (event: Event) => {
-						const target = event.target as HTMLInputElement;
-						const value = target.value;
-						this._value4 = value;
-						this._invalid = value.toLowerCase() !== 'foo' && value.toLowerCase() !== 'bar';
-						this.invalidate();
-					},
-					theme: this._theme
-				})
-			])
-		]);
+		return v(
+			'div',
+			{
+				styles: { maxWidth: '256px' }
+			},
+			[
+				v('h2', {}, ['Text Input Examples']),
+				v('label', [
+					'Use Dojo Theme ',
+					v('input', {
+						type: 'checkbox',
+						onchange: this.themeChange
+					})
+				]),
+				v('div', { id: 'example-text' }, [
+					v('h3', {}, ['String label']),
+					w(TextInput, {
+						key: 't1',
+						label: 'Name',
+						type: 'text',
+						placeholder: 'Hello, World',
+						value: this._value1,
+						onChange: (event: Event) => {
+							this._value1 = (event.target as HTMLInputElement).value;
+							this.invalidate();
+						},
+						theme: this._theme
+					})
+				]),
+				v('div', { id: 'example-email' }, [
+					v('h3', {}, ['Label before the input']),
+					w(TextInput, {
+						key: 't2',
+						type: 'email',
+						label: 'Email (required)',
+						required: true,
+						value: this._value2,
+						onChange: (event: Event) => {
+							this._value2 = (event.target as HTMLInputElement).value;
+							this.invalidate();
+						},
+						theme: this._theme
+					})
+				]),
+				v('div', { id: 'example-hidden-label' }, [
+					v('h3', {}, ['Hidden accessible label']),
+					w(TextInput, {
+						key: 't3',
+						type: 'text',
+						placeholder: 'Type something...',
+						label: 'Try listening to me!',
+						labelAfter: true,
+						labelHidden: true,
+						value: this._value3,
+						onChange: (event: Event) => {
+							this._value3 = (event.target as HTMLInputElement).value;
+							this.invalidate();
+						},
+						theme: this._theme
+					})
+				]),
+				v('div', { id: 'example-disabled' }, [
+					v('h3', {}, ['Disabled text input']),
+					w(TextInput, {
+						key: 't4',
+						type: 'text',
+						label: "Can't type here",
+						value: 'Initial value',
+						disabled: true,
+						readOnly: true,
+						theme: this._theme
+					})
+				]),
+				v('div', { id: 'example-validated' }, [
+					v('h3', {}, ['Validated Input']),
+					w(TextInput, {
+						key: 't5',
+						type: 'text',
+						label: 'Type "foo" or "bar"',
+						value: this._value4,
+						invalid: this._invalid,
+						onInput: (event: Event) => {
+							const target = event.target as HTMLInputElement;
+							const value = target.value;
+							this._value4 = value;
+							this._invalid = value.toLowerCase() !== 'foo' && value.toLowerCase() !== 'bar';
+							this.invalidate();
+						},
+						theme: this._theme
+					})
+				])
+			]
+		);
 	}
 }
 

--- a/src/textinput/tests/functional/TextInput.ts
+++ b/src/textinput/tests/functional/TextInput.ts
@@ -6,52 +6,49 @@ import * as css from '../../styles/textinput.m.css';
 import * as baseCss from '../../../common/styles/base.m.css';
 
 function getPage(remote: Remote) {
-	return remote
-		.get('http://localhost:9000/_build/common/example/?module=textinput')
-		.setFindTimeout(5000);
+	return remote.get('http://localhost:9000/_build/common/example/?module=textinput').setFindTimeout(5000);
 }
 
 registerSuite('TextInput', {
 	'TextInput should be visible'() {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-text .${css.root}`)
-				.isDisplayed()
-				.findByCssSelector(`.${css.input}`)
-					.getSize()
-					.then(({ height, width }) => {
-						assert.isAbove(height, 0, 'The height of the input should be greater than zero.');
-						assert.isAbove(width, 0, 'The width of the input should be greater than zero.');
-					})
-				.end()
+			.isDisplayed()
+			.findByCssSelector(`.${css.input}`)
+			.getSize()
+			.then(({ height, width }) => {
+				assert.isAbove(height, 0, 'The height of the input should be greater than zero.');
+				assert.isAbove(width, 0, 'The width of the input should be greater than zero.');
+			})
+			.end()
 			.end();
 	},
 	'TextInput label should be as defined'() {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-text .${css.root}`)
-				.getVisibleText()
-				.then(text => {
-					assert.strictEqual(text, 'Name');
-				});
+			.getVisibleText()
+			.then((text) => {
+				assert.strictEqual(text, 'Name');
+			});
 	},
 	'TextInput should gain focus when clicking on the label'() {
 		const { remote: { session: { capabilities: { browserName } } } } = this;
 
 		return getPage(this.remote)
 			.findByCssSelector(`#example-text .${css.root} label`)
-				.then(element => {
-					if (browserName === 'firefox') {
-						return this.remote
-							.moveMouseTo(element, 5, 5)
-							.clickMouseButton(0);
-					}
-					else {
-						return element.click();
-					}
-				})
+			.then((element) => {
+				if (browserName === 'firefox') {
+					return this.remote.moveMouseTo(element, 5, 5).clickMouseButton(0);
+				} else {
+					return element.click();
+				}
+			})
 			.end()
 			.sleep(250)
-			.execute(`return document.activeElement === document.querySelector('#example-text .${css.root} .${css.input}');`)
-			.then(isEqual => {
+			.execute(
+				`return document.activeElement === document.querySelector('#example-text .${css.root} .${css.input}');`
+			)
+			.then((isEqual) => {
 				assert.isTrue(isEqual);
 			});
 	},
@@ -59,42 +56,42 @@ registerSuite('TextInput', {
 		const testInput = 'test text';
 		return getPage(this.remote)
 			.findByCssSelector(`#example-hidden-label .${css.root}`)
-				.click()
-				.findByCssSelector(`.${css.input}`)
-					.type(testInput)
-					.getProperty('value')
-					.then((value: string) => {
-						assert.strictEqual(value, testInput);
-					})
-				.end()
+			.click()
+			.findByCssSelector(`.${css.input}`)
+			.type(testInput)
+			.getProperty('value')
+			.then((value: string) => {
+				assert.strictEqual(value, testInput);
+			})
+			.end()
 			.end();
 	},
 	'Hidden label should not be displayed'() {
 		return getPage(this.remote)
 			.findByCssSelector(`#example-hidden-label .${css.root}`)
-				.getVisibleText()
-				.then(text => {
-					assert.isTrue(text && text.length > 0);
-				})
-				.findByCssSelector(`.${baseCss.visuallyHidden}`)
-					.then(element => {
-						assert(element, 'element with specified class "visuallyHidden" should exist.`');
-					})
-				.end()
+			.getVisibleText()
+			.then((text) => {
+				assert.isTrue(text && text.length > 0);
+			})
+			.findByCssSelector(`.${baseCss.visuallyHidden}`)
+			.then((element) => {
+				assert(element, 'element with specified class "visuallyHidden" should exist.`');
+			})
+			.end()
 			.end();
 	},
 	'Disabled TextInput should not allow input to be typed'() {
 		const initValue = 'Initial value';
 		return getPage(this.remote)
 			.findByCssSelector(`#example-disabled .${css.root} .${css.input}`)
-				.click()
-				.then(null, () => {})
-				.type('text')
-				.then(null, () => {})
-				.getProperty('value')
-				.then((value: string) => {
-					assert.strictEqual(value, initValue);
-				})
+			.click()
+			.then(null, () => {})
+			.type('text')
+			.then(null, () => {})
+			.getProperty('value')
+			.then((value: string) => {
+				assert.strictEqual(value, initValue);
+			})
 			.end();
 	},
 	'Validated TextInput should update style based on validity'() {
@@ -103,30 +100,30 @@ registerSuite('TextInput', {
 
 		return getPage(this.remote)
 			.findByCssSelector(`#example-validated .${css.root}`)
-				.getProperty('className')
-				.then((className: string) => {
-					assert.notInclude(className, css.invalid);
-					assert.notInclude(className, css.valid);
-				})
-				.findByCssSelector(`.${css.input}`)
-					.click()
-					.type(validText)
-				.end()
+			.getProperty('className')
+			.then((className: string) => {
+				assert.notInclude(className, css.invalid);
+				assert.notInclude(className, css.valid);
+			})
+			.findByCssSelector(`.${css.input}`)
+			.click()
+			.type(validText)
+			.end()
 			.sleep(10)
-				.getProperty('className')
-				.then((className: string) => {
-					assert.notInclude(className, css.invalid);
-					assert.include(className, css.valid);
-				})
-				.findByCssSelector(`.${css.input}`)
-					.type(invalidText)
-				.end()
+			.getProperty('className')
+			.then((className: string) => {
+				assert.notInclude(className, css.invalid);
+				assert.include(className, css.valid);
+			})
+			.findByCssSelector(`.${css.input}`)
+			.type(invalidText)
+			.end()
 			.sleep(10)
-				.getProperty('className')
-				.then((className: string) => {
-					assert.notInclude(className, css.valid);
-					assert.include(className, css.invalid);
-				})
+			.getProperty('className')
+			.then((className: string) => {
+				assert.notInclude(className, css.valid);
+				assert.include(className, css.invalid);
+			})
 			.end();
 	}
 });

--- a/src/textinput/tests/unit/TextInput.ts
+++ b/src/textinput/tests/unit/TextInput.ts
@@ -16,60 +16,69 @@ const compareId = compareProperty((value: any) => {
 	return typeof value === 'string';
 });
 
-const expected = function(label = false, classes: (string | null)[] = [ css.root, null, null, null, null, null ]) {
-	return v('div', {
-		key: 'root',
-		classes
-	}, [
-		label ? w(Label, {
-			theme: undefined,
-			disabled: undefined,
-			hidden: false,
-			invalid: undefined,
-			readOnly: undefined,
-			required: undefined,
-			forId: <any> compareId
-		}, [ 'foo' ]) : null,
-		v('div', { classes: css.inputWrapper }, [
-			v('input', {
-				key: 'input',
-				classes: css.input,
-				id: <any> compareId,
-				'aria-controls': undefined,
-				'aria-describedby': undefined,
-				disabled: undefined,
-				'aria-invalid': null,
-				maxlength: null,
-				minlength: null,
-				name: undefined,
-				placeholder: undefined,
-				readOnly: undefined,
-				'aria-readonly': null,
-				required: undefined,
-				type: 'text',
-				value: undefined,
-				onblur: widget.listener,
-				onchange: widget.listener,
-				onclick: widget.listener,
-				onfocus: widget.listener,
-				oninput: widget.listener,
-				onkeydown: widget.listener,
-				onkeypress: widget.listener,
-				onkeyup: widget.listener,
-				onmousedown: widget.listener,
-				onmouseup: widget.listener,
-				ontouchstart: widget.listener,
-				ontouchend: widget.listener,
-				ontouchcancel: widget.listener
-			})
-		])
-	]);
+const expected = function(label = false, classes: (string | null)[] = [css.root, null, null, null, null, null]) {
+	return v(
+		'div',
+		{
+			key: 'root',
+			classes
+		},
+		[
+			label
+				? w(
+						Label,
+						{
+							theme: undefined,
+							disabled: undefined,
+							hidden: false,
+							invalid: undefined,
+							readOnly: undefined,
+							required: undefined,
+							forId: <any>compareId
+						},
+						['foo']
+					)
+				: null,
+			v('div', { classes: css.inputWrapper }, [
+				v('input', {
+					key: 'input',
+					classes: css.input,
+					id: <any>compareId,
+					'aria-controls': undefined,
+					'aria-describedby': undefined,
+					disabled: undefined,
+					'aria-invalid': null,
+					maxlength: null,
+					minlength: null,
+					name: undefined,
+					placeholder: undefined,
+					readOnly: undefined,
+					'aria-readonly': null,
+					required: undefined,
+					type: 'text',
+					value: undefined,
+					onblur: widget.listener,
+					onchange: widget.listener,
+					onclick: widget.listener,
+					onfocus: widget.listener,
+					oninput: widget.listener,
+					onkeydown: widget.listener,
+					onkeypress: widget.listener,
+					onkeyup: widget.listener,
+					onmousedown: widget.listener,
+					onmouseup: widget.listener,
+					ontouchstart: widget.listener,
+					ontouchend: widget.listener,
+					ontouchcancel: widget.listener
+				})
+			])
+		]
+	);
 };
 
 let widget: Harness<TextInput>;
 
 registerSuite('TextInput', {
-
 	beforeEach() {
 		widget = harness(TextInput);
 	},
@@ -97,7 +106,7 @@ registerSuite('TextInput', {
 
 			const expectedVdom = expected();
 			assignProperties(expectedVdom, {
-				classes: [ css.root, null, null, null, null, null ]
+				classes: [css.root, null, null, null, null, null]
 			});
 			assignProperties(findKey(expectedVdom, 'input')!, {
 				'aria-controls': 'foo',
@@ -113,7 +122,7 @@ registerSuite('TextInput', {
 			widget.expectRender(expectedVdom);
 		},
 
-		'label'() {
+		label() {
 			widget.setProperties({
 				label: 'foo'
 			});
@@ -129,7 +138,7 @@ registerSuite('TextInput', {
 				required: true
 			});
 
-			let expectedVdom = expected(false, [ css.root, css.disabled, css.invalid, null, css.readonly, css.required ]);
+			let expectedVdom = expected(false, [css.root, css.disabled, css.invalid, null, css.readonly, css.required]);
 			assignProperties(findKey(expectedVdom, 'input')!, {
 				disabled: true,
 				'aria-invalid': 'true',
@@ -154,7 +163,7 @@ registerSuite('TextInput', {
 				required: false
 			});
 			assignProperties(expectedVdom, {
-				classes: [ css.root, null, null, css.valid, null, null ]
+				classes: [css.root, null, null, css.valid, null, null]
 			});
 
 			widget.expectRender(expectedVdom, 'State classes should be false, css.valid should be true');

--- a/src/timepicker/TimePicker.ts
+++ b/src/timepicker/TimePicker.ts
@@ -139,13 +139,13 @@ function getTime(units: TimeUnits, date = new Date()) {
  * @param value   A standard time string or an object with `hour`, `minute`, and `second` properties.
  * @return        An object containing `hour`, `second`, and `number` properties.
  */
-export function parseUnits (value: string | TimeUnits): TimeUnits {
+export function parseUnits(value: string | TimeUnits): TimeUnits {
 	if (typeof value === 'string') {
 		if (!TIME_PATTERN.test(value)) {
 			throw new Error('Time strings must be in the format HH:mm or HH:mm:ss');
 		}
 
-		const [ hour, minute, second = 0 ] = value.split(':').map(unit => parseInt(unit, 10));
+		const [hour, minute, second = 0] = value.split(':').map((unit) => parseInt(unit, 10));
 		return { hour, minute, second } as TimeUnits;
 	}
 
@@ -169,8 +169,8 @@ export class TimePicker<P extends TimePickerProperties = TimePickerProperties> e
 		const { step = 60 } = this.properties;
 		const { hour, minute, second } = units;
 
-		return (step >= 60 ? [ hour, minute ] : [ hour, minute, second ])
-			.map(unit => padStart(String(unit), 2, '0'))
+		return (step >= 60 ? [hour, minute] : [hour, minute, second])
+			.map((unit) => padStart(String(unit), 2, '0'))
 			.join(':');
 	}
 
@@ -197,12 +197,7 @@ export class TimePicker<P extends TimePickerProperties = TimePickerProperties> e
 	}
 
 	protected getRootClasses(): (string | null)[] {
-		const {
-			disabled,
-			invalid,
-			readOnly,
-			required
-		} = this.properties;
+		const { disabled, invalid, readOnly, required } = this.properties;
 		return [
 			css.root,
 			disabled ? css.disabled : null,
@@ -296,15 +291,21 @@ export class TimePicker<P extends TimePickerProperties = TimePickerProperties> e
 		} = this.properties;
 
 		const children = [
-			label ? w(Label, {
-				theme,
-				disabled,
-				invalid,
-				readOnly,
-				required,
-				hidden: labelHidden,
-				forId: this._uuid
-			}, [ label ]) : null,
+			label
+				? w(
+						Label,
+						{
+							theme,
+							disabled,
+							invalid,
+							readOnly,
+							required,
+							hidden: labelHidden,
+							forId: this._uuid
+						},
+						[label]
+					)
+				: null,
 			v('input', {
 				id: this._uuid,
 				'aria-describedby': inputProperties && inputProperties.describedBy,
@@ -328,10 +329,14 @@ export class TimePicker<P extends TimePickerProperties = TimePickerProperties> e
 			})
 		];
 
-		return v('div', {
-			key: 'root',
-			classes: this.theme(this.getRootClasses())
-		}, labelAfter ? children.reverse() : children);
+		return v(
+			'div',
+			{
+				key: 'root',
+				classes: this.theme(this.getRootClasses())
+			},
+			labelAfter ? children.reverse() : children
+		);
 	}
 
 	render(): DNode {

--- a/src/timepicker/example/index.ts
+++ b/src/timepicker/example/index.ts
@@ -39,7 +39,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 
 	render(): DNode {
 		return v('div', [
-			v('h1', [ 'TimePicker Examples' ]),
+			v('h1', ['TimePicker Examples']),
 			v('label', [
 				'Use Dojo Theme ',
 				v('input', {
@@ -48,12 +48,16 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 				})
 			]),
 
-			v('p', {
-				id: 'description1',
-				classes: baseCss.visuallyHidden
-			}, [ 'Accepts 24-hour time with a leading zero, rounded to the nearest half hour.' ]),
+			v(
+				'p',
+				{
+					id: 'description1',
+					classes: baseCss.visuallyHidden
+				},
+				['Accepts 24-hour time with a leading zero, rounded to the nearest half hour.']
+			),
 
-			v('h3', [ 'Filter options on input' ]),
+			v('h3', ['Filter options on input']),
 			v('div', { id: 'example-filter-on-input' }, [
 				w(TimePicker, {
 					inputProperties: {
@@ -67,10 +71,8 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 					onRequestOptions: (value: string, options: TimeUnits[]) => {
 						if (!value) {
 							this._options = options;
-						}
-						else {
-
-							const matching = options.filter(option => {
+						} else {
+							const matching = options.filter((option) => {
 								const { hour, minute = 0 } = option;
 								const hours = hour >= 10 ? hour : `0${hour}`;
 								const minutes = minute >= 10 ? minute : `0${minute}`;
@@ -88,7 +90,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 				})
 			]),
 
-			v('h3', [ 'Open on focus' ]),
+			v('h3', ['Open on focus']),
 			v('div', { id: 'example-open-on-focus' }, [
 				w(TimePicker, {
 					inputProperties: {
@@ -108,11 +110,15 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 				})
 			]),
 
-			v('h3', [ 'Disabled menu items' ]),
-			v('p', {
-				id: 'description2',
-				classes: baseCss.visuallyHidden
-			}, [ 'Accepts 24-hour time with a leading zero, rounded to the nearest hour.' ]),
+			v('h3', ['Disabled menu items']),
+			v(
+				'p',
+				{
+					id: 'description2',
+					classes: baseCss.visuallyHidden
+				},
+				['Accepts 24-hour time with a leading zero, rounded to the nearest hour.']
+			),
 			v('div', { id: 'example-disabled-items' }, [
 				w(TimePicker, {
 					inputProperties: {
@@ -132,7 +138,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 				})
 			]),
 
-			v('h3', [ 'Disabled' ]),
+			v('h3', ['Disabled']),
 			v('div', { id: 'example-disabled' }, [
 				w(TimePicker, {
 					inputProperties: {
@@ -145,7 +151,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 				})
 			]),
 
-			v('h3', [ 'Read Only' ]),
+			v('h3', ['Read Only']),
 			v('div', { id: 'example-readonly' }, [
 				w(TimePicker, {
 					inputProperties: {
@@ -158,7 +164,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 				})
 			]),
 
-			v('h3', [ 'Labeled' ]),
+			v('h3', ['Labeled']),
 			v('div', { id: 'example-labeled' }, [
 				w(TimePicker, {
 					key: '6',
@@ -177,7 +183,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 				})
 			]),
 
-			v('h3', [ 'Required and validated' ]),
+			v('h3', ['Required and validated']),
 			v('div', { id: 'example-required-validated' }, [
 				w(TimePicker, {
 					inputProperties: {
@@ -203,11 +209,15 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 				})
 			]),
 
-			v('h3', [ 'One second increment' ]),
-			v('p', {
-				id: 'description8',
-				classes: baseCss.visuallyHidden
-			}, [ 'Accepts 24-hour time with a leading zero, rounded to the nearest second.' ]),
+			v('h3', ['One second increment']),
+			v(
+				'p',
+				{
+					id: 'description8',
+					classes: baseCss.visuallyHidden
+				},
+				['Accepts 24-hour time with a leading zero, rounded to the nearest second.']
+			),
 			v('div', { id: 'example-every-second' }, [
 				w(TimePicker, {
 					end: '12:00:59',
@@ -228,11 +238,15 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 				})
 			]),
 
-			v('h3', [ 'Use 12-hour time' ]),
-			v('p', {
-				id: 'description9',
-				classes: baseCss.visuallyHidden
-			}, [ 'Accepts 12-hour time without a leading zero, rounded to the nearest half hour.' ]),
+			v('h3', ['Use 12-hour time']),
+			v(
+				'p',
+				{
+					id: 'description9',
+					classes: baseCss.visuallyHidden
+				},
+				['Accepts 12-hour time without a leading zero, rounded to the nearest half hour.']
+			),
 			v('div', { id: 'example-12-hour' }, [
 				w(TimePicker, {
 					getOptionLabel: (option: TimeUnits) => {
@@ -246,7 +260,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 					},
 					key: '9',
 					onChange: (value: string) => {
-						this._setValue('value9', value );
+						this._setValue('value9', value);
 					},
 					onRequestOptions: this.onRequestOptions,
 					options: this._options,
@@ -256,7 +270,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 				})
 			]),
 
-			v('h3', [ 'Native `<input type="time">`' ]),
+			v('h3', ['Native `<input type="time">`']),
 			v('div', { id: 'example-native' }, [
 				w(TimePicker, {
 					key: '10',

--- a/src/timepicker/tests/functional/TimePicker.ts
+++ b/src/timepicker/tests/functional/TimePicker.ts
@@ -21,41 +21,49 @@ function getPage(remote: Remote, exampleId: string) {
 function testDisabledPicker(remote: Remote, exampleId: string) {
 	return getPage(remote, exampleId)
 		.findByCssSelector(`.${comboBoxCss.controls} .${textinputCss.input}`)
-			.click()
-			.sleep(DELAY)
-			.execute(`return document.activeElement === document.querySelector('#${exampleId} .${comboBoxCss.controls} .${textinputCss.input}');`)
-			.then(function (this: Command<Element>, isEqual) {
-				if (isEqual) {
-					return (<Command<Element>> this.parent)
-						.type('1')
-						.sleep(DELAY)
-						.getProperty('value')
-						.then((value) => {
-							assert.strictEqual(value, '', 'The input should not allow text entry.');
-						});
-				}
-			})
+		.click()
+		.sleep(DELAY)
+		.execute(
+			`return document.activeElement === document.querySelector('#${exampleId} .${comboBoxCss.controls} .${
+				textinputCss.input
+			}');`
+		)
+		.then(function(this: Command<Element>, isEqual) {
+			if (isEqual) {
+				return (<Command<Element>>this.parent)
+					.type('1')
+					.sleep(DELAY)
+					.getProperty('value')
+					.then((value) => {
+						assert.strictEqual(value, '', 'The input should not allow text entry.');
+					});
+			}
+		})
 		.end()
 		.setFindTimeout(100)
 		.findAllByCssSelector(`.${comboBoxCss.dropdown}`)
-			.then((elements) => {
-				assert.strictEqual(elements.length, 0);
-			})
+		.then((elements) => {
+			assert.strictEqual(elements.length, 0);
+		})
 		.end()
 		.setFindTimeout(5000)
 		.findByCssSelector(`.${comboBoxCss.controls} .${comboBoxCss.trigger}`)
-			.click()
+		.click()
 		.end()
 		.sleep(DELAY)
-		.execute(`return document.activeElement === document.querySelector('#${exampleId} .${comboBoxCss.controls} .${textinputCss.input}');`)
-		.then(isEqual => {
+		.execute(
+			`return document.activeElement === document.querySelector('#${exampleId} .${comboBoxCss.controls} .${
+				textinputCss.input
+			}');`
+		)
+		.then((isEqual) => {
 			assert.isFalse(isEqual, 'Input should not gain focus when dropdown trigger is clicked.');
 		})
 		.setFindTimeout(100)
 		.findAllByCssSelector(`.${comboBoxCss.dropdown}`)
-			.then((elements) => {
-				assert.strictEqual(elements.length, 0);
-			})
+		.then((elements) => {
+			assert.strictEqual(elements.length, 0);
+		})
 		.end();
 }
 
@@ -64,18 +72,22 @@ registerSuite('TimePicker', {
 		const exampleId = 'example-filter-on-input';
 		return getPage(this.remote, exampleId)
 			.findByCssSelector(`.${comboBoxCss.controls} .${textinputCss.input}`)
-				.type('1')
+			.type('1')
 			.end()
 			.sleep(DELAY)
-			.execute(`return document.activeElement === document.querySelector('#${exampleId} .${comboBoxCss.controls} .${textinputCss.input}');`)
-			.then(isEqual => {
+			.execute(
+				`return document.activeElement === document.querySelector('#${exampleId} .${comboBoxCss.controls} .${
+					textinputCss.input
+				}');`
+			)
+			.then((isEqual) => {
 				assert.isTrue(isEqual);
 			})
 			.findByCssSelector(`.${comboBoxCss.dropdown}`)
-				.getSize()
-				.then(({ height }) => {
-					assert.isAbove(height, 0);
-				})
+			.getSize()
+			.then(({ height }) => {
+				assert.isAbove(height, 0);
+			})
 			.end();
 	},
 	'picker opens on focus'() {
@@ -87,51 +99,59 @@ registerSuite('TimePicker', {
 		const exampleId = 'example-open-on-focus';
 		return getPage(this.remote, exampleId)
 			.findByCssSelector(`.${comboBoxCss.controls} .${textinputCss.input}`)
-				.click()
+			.click()
 			.end()
 			.sleep(DELAY)
-			.execute(`return document.activeElement === document.querySelector('#${exampleId} .${comboBoxCss.controls} .${textinputCss.input}');`)
-			.then(isEqual => {
+			.execute(
+				`return document.activeElement === document.querySelector('#${exampleId} .${comboBoxCss.controls} .${
+					textinputCss.input
+				}');`
+			)
+			.then((isEqual) => {
 				assert.isTrue(isEqual);
 			})
 			.findByCssSelector(`.${comboBoxCss.dropdown}`)
-				.getSize()
-				.then(({ height }) => {
-					assert.isAbove(height, 0);
-				})
+			.getSize()
+			.then(({ height }) => {
+				assert.isAbove(height, 0);
+			})
 			.end();
 	},
 	'disabled menu items cannot be clicked'() {
 		const exampleId = 'example-disabled-items';
 		return getPage(this.remote, exampleId)
 			.findByCssSelector(`.${comboBoxCss.controls} .${comboBoxCss.trigger}`)
-				.click()
+			.click()
 			.end()
 			.sleep(DELAY)
-			.execute(`return document.activeElement === document.querySelector('#${exampleId} .${comboBoxCss.controls} .${textinputCss.input}');`)
-			.then(isEqual => {
+			.execute(
+				`return document.activeElement === document.querySelector('#${exampleId} .${comboBoxCss.controls} .${
+					textinputCss.input
+				}');`
+			)
+			.then((isEqual) => {
 				assert.isTrue(isEqual);
 			})
 			.findByCssSelector(`.${comboBoxCss.dropdown}`)
-				.getSize()
-				.then(({ height }) => {
-					assert.isAbove(height, 0);
-				})
+			.getSize()
+			.then(({ height }) => {
+				assert.isAbove(height, 0);
+			})
 			.end()
 			.findByCssSelector(`.${comboBoxCss.dropdown} .${listboxCss.disabledOption}`)
-				.click()
+			.click()
 			.end()
 			.findByCssSelector(`.${comboBoxCss.controls} .${textinputCss.input}`)
-				.getProperty('value')
-				.then((value) => {
-					assert.strictEqual(value, '', 'The input value should not contain the disabled value.');
-				})
+			.getProperty('value')
+			.then((value) => {
+				assert.strictEqual(value, '', 'The input value should not contain the disabled value.');
+			})
 			.end()
 			.findByCssSelector(`.${comboBoxCss.dropdown}`)
-				.getSize()
-				.then(({ height }) => {
-					assert.isAbove(height, 0, 'The dropdown should remain open.');
-				})
+			.getSize()
+			.then(({ height }) => {
+				assert.isAbove(height, 0, 'The dropdown should remain open.');
+			})
 			.end();
 	},
 	'disabled timepickers cannot be opened'() {
@@ -154,30 +174,30 @@ registerSuite('TimePicker', {
 		const exampleId = 'example-required-validated';
 		return getPage(this.remote, exampleId)
 			.findByCssSelector(`.${comboBoxCss.controls} .${textinputCss.root}`)
-				.findByCssSelector(`.${textinputCss.input}`)
-					.click()
-				.end()
-				.sleep(DELAY)
-				.getProperty('className')
-				.then((className: string) => {
-					assert.notInclude(className, textinputCss.invalid);
-				})
-				.findByCssSelector(`.${textinputCss.input}`)
-					.type('1')
-				.end()
-				.sleep(DELAY)
-				.getProperty('className')
-				.then((className: string) => {
-					assert.notInclude(className, textinputCss.invalid);
-				})
-				.findByCssSelector(`.${textinputCss.input}`)
-					.type(keys.BACKSPACE)
-				.end()
-				.sleep(DELAY)
-				.getProperty('className')
-				.then((className: string) => {
-					assert.include(className, textinputCss.invalid);
-				})
+			.findByCssSelector(`.${textinputCss.input}`)
+			.click()
+			.end()
+			.sleep(DELAY)
+			.getProperty('className')
+			.then((className: string) => {
+				assert.notInclude(className, textinputCss.invalid);
+			})
+			.findByCssSelector(`.${textinputCss.input}`)
+			.type('1')
+			.end()
+			.sleep(DELAY)
+			.getProperty('className')
+			.then((className: string) => {
+				assert.notInclude(className, textinputCss.invalid);
+			})
+			.findByCssSelector(`.${textinputCss.input}`)
+			.type(keys.BACKSPACE)
+			.end()
+			.sleep(DELAY)
+			.getProperty('className')
+			.then((className: string) => {
+				assert.include(className, textinputCss.invalid);
+			})
 			.end();
 	},
 	'validated inputs update on focus change'() {
@@ -192,26 +212,26 @@ registerSuite('TimePicker', {
 		const exampleId = 'example-required-validated';
 		return getPage(this.remote, exampleId)
 			.findByCssSelector(`.${comboBoxCss.controls} .${textinputCss.root}`)
-				.findByCssSelector(`.${textinputCss.input}`)
-					.click()
-				.end()
-				.sleep(DELAY)
-				.getProperty('className')
-				.then((className: string) => {
-					assert.notInclude(className, textinputCss.invalid);
-				})
-			.end()
-		.end()
-		.findByCssSelector(`#example-filter-on-input .${comboBoxCss.controls} .${textinputCss.root}`)
+			.findByCssSelector(`.${textinputCss.input}`)
 			.click()
-		.end()
-		.sleep(DELAY)
-		.findById(exampleId)
+			.end()
+			.sleep(DELAY)
+			.getProperty('className')
+			.then((className: string) => {
+				assert.notInclude(className, textinputCss.invalid);
+			})
+			.end()
+			.end()
+			.findByCssSelector(`#example-filter-on-input .${comboBoxCss.controls} .${textinputCss.root}`)
+			.click()
+			.end()
+			.sleep(DELAY)
+			.findById(exampleId)
 			.findByCssSelector(`.${comboBoxCss.controls} .${textinputCss.root}`)
-				.getProperty('className')
-				.then((className: string) => {
-					assert.include(className, textinputCss.invalid);
-				})
+			.getProperty('className')
+			.then((className: string) => {
+				assert.include(className, textinputCss.invalid);
+			})
 			.end();
 	}
 });

--- a/src/timepicker/tests/unit/TimePicker.ts
+++ b/src/timepicker/tests/unit/TimePicker.ts
@@ -15,7 +15,6 @@ const compareId = compareProperty((value: any) => {
 });
 
 registerSuite('TimePicker', {
-
 	getOptions: {
 		'Should include each minute for a full day by default'() {
 			const options = getOptions();
@@ -56,11 +55,15 @@ registerSuite('TimePicker', {
 			minute: 0,
 			second: 0
 		});
-		assert.deepEqual(parseUnits('55:98:72'), {
-			hour: 55,
-			minute: 98,
-			second: 72
-		}, 'does not check for invalid units');
+		assert.deepEqual(
+			parseUnits('55:98:72'),
+			{
+				hour: 55,
+				minute: 98,
+				second: 72
+			},
+			'does not check for invalid units'
+		);
 	},
 
 	'Custom input': {
@@ -81,7 +84,7 @@ registerSuite('TimePicker', {
 				w(ComboBox, {
 					clearable: true,
 					disabled: false,
-					getResultLabel: <any> picker.listener,
+					getResultLabel: <any>picker.listener,
 					inputProperties: undefined,
 					invalid: true,
 					isResultDisabled: undefined,
@@ -159,7 +162,11 @@ registerSuite('TimePicker', {
 			assert.sameDeepMembers(actualOptions, expectedOptions);
 
 			vnode.properties.onRequestResults('12:34:56');
-			assert.strictEqual(actualOptions, onRequestOptions.secondCall.args[1], 'The options array should be cached.');
+			assert.strictEqual(
+				actualOptions,
+				onRequestOptions.secondCall.args[1],
+				'The options array should be cached.'
+			);
 
 			picker.destroy();
 		}
@@ -173,33 +180,39 @@ registerSuite('TimePicker', {
 				name: 'some-field',
 				useNativeElement: true
 			});
-			picker.expectRender(v('div', {
-				classes: [ css.root, null, null, null, null ],
-				key: 'root'
-			}, [
-				null,
-				v('input', {
-					'aria-describedby': undefined,
-					'aria-invalid': null,
-					'aria-readonly': null,
-					classes: css.input,
-					disabled: undefined,
-					invalid: undefined,
-					key: 'native-input',
-					id: <any> compareId,
-					max: undefined,
-					min: undefined,
-					name: 'some-field',
-					onblur: picker.listener,
-					onchange: picker.listener,
-					onfocus: picker.listener,
-					readOnly: undefined,
-					required: undefined,
-					step: undefined,
-					type: 'time',
-					value: undefined
-				})
-			]));
+			picker.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, null, null, null, null],
+						key: 'root'
+					},
+					[
+						null,
+						v('input', {
+							'aria-describedby': undefined,
+							'aria-invalid': null,
+							'aria-readonly': null,
+							classes: css.input,
+							disabled: undefined,
+							invalid: undefined,
+							key: 'native-input',
+							id: <any>compareId,
+							max: undefined,
+							min: undefined,
+							name: 'some-field',
+							onblur: picker.listener,
+							onchange: picker.listener,
+							onfocus: picker.listener,
+							readOnly: undefined,
+							required: undefined,
+							step: undefined,
+							type: 'time',
+							value: undefined
+						})
+					]
+				)
+			);
 
 			picker.destroy();
 		},
@@ -220,38 +233,39 @@ registerSuite('TimePicker', {
 				value: '11:30'
 			});
 
-			picker.expectRender(v('div', {
-				classes: [ css.root,
-					css.disabled,
-					css.invalid,
-					css.readonly,
-					css.required
-				],
-				key: 'root'
-			}, [
-				null,
-				v('input', {
-					'aria-describedby': 'Some descriptive text',
-					'aria-invalid': 'true',
-					'aria-readonly': 'true',
-					classes: css.input,
-					id: <any> compareId,
-					disabled: true,
-					invalid: true,
-					key: 'native-input',
-					max: '12:00',
-					min: '10:00',
-					name: 'some-field',
-					onblur: picker.listener,
-					onchange: picker.listener,
-					onfocus: picker.listener,
-					readOnly: true,
-					required: true,
-					step: 60,
-					type: 'time',
-					value: '11:30'
-				})
-			]));
+			picker.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, css.disabled, css.invalid, css.readonly, css.required],
+						key: 'root'
+					},
+					[
+						null,
+						v('input', {
+							'aria-describedby': 'Some descriptive text',
+							'aria-invalid': 'true',
+							'aria-readonly': 'true',
+							classes: css.input,
+							id: <any>compareId,
+							disabled: true,
+							invalid: true,
+							key: 'native-input',
+							max: '12:00',
+							min: '10:00',
+							name: 'some-field',
+							onblur: picker.listener,
+							onchange: picker.listener,
+							onfocus: picker.listener,
+							readOnly: true,
+							required: true,
+							step: 60,
+							type: 'time',
+							value: '11:30'
+						})
+					]
+				)
+			);
 
 			picker.destroy();
 		},
@@ -262,41 +276,51 @@ registerSuite('TimePicker', {
 				label: 'foo',
 				useNativeElement: true
 			});
-			picker.expectRender(v('div', {
-				classes: [ css.root, null, null, null, null ],
-				key: 'root'
-			}, [
-				w(Label, {
-					theme: undefined,
-					disabled: undefined,
-					hidden: false,
-					invalid: undefined,
-					readOnly: undefined,
-					required: undefined,
-					forId: <any> compareId
-				}, [ 'foo' ]),
-				v('input', {
-					'aria-describedby': undefined,
-					'aria-invalid': null,
-					'aria-readonly': null,
-					classes: css.input,
-					disabled: undefined,
-					invalid: undefined,
-					key: 'native-input',
-					id: <any> compareId,
-					max: undefined,
-					min: undefined,
-					name: undefined,
-					onblur: picker.listener,
-					onchange: picker.listener,
-					onfocus: picker.listener,
-					readOnly: undefined,
-					required: undefined,
-					step: undefined,
-					type: 'time',
-					value: undefined
-				})
-			]));
+			picker.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, null, null, null, null],
+						key: 'root'
+					},
+					[
+						w(
+							Label,
+							{
+								theme: undefined,
+								disabled: undefined,
+								hidden: false,
+								invalid: undefined,
+								readOnly: undefined,
+								required: undefined,
+								forId: <any>compareId
+							},
+							['foo']
+						),
+						v('input', {
+							'aria-describedby': undefined,
+							'aria-invalid': null,
+							'aria-readonly': null,
+							classes: css.input,
+							disabled: undefined,
+							invalid: undefined,
+							key: 'native-input',
+							id: <any>compareId,
+							max: undefined,
+							min: undefined,
+							name: undefined,
+							onblur: picker.listener,
+							onchange: picker.listener,
+							onfocus: picker.listener,
+							readOnly: undefined,
+							required: undefined,
+							step: undefined,
+							type: 'time',
+							value: undefined
+						})
+					]
+				)
+			);
 
 			picker.destroy();
 		},

--- a/src/titlepane/TitlePane.ts
+++ b/src/titlepane/TitlePane.ts
@@ -26,7 +26,7 @@ export interface TitlePaneProperties extends ThemedProperties {
 	onRequestOpen?(key: string | number | undefined): void;
 	open?: boolean;
 	title: string;
-};
+}
 
 export const ThemedBase = ThemedMixin(WidgetBase);
 
@@ -45,7 +45,7 @@ export default class TitlePane<P extends TitlePaneProperties = TitlePaneProperti
 		requestAnimationFrame(() => {
 			const { open = true } = this.properties;
 			const height = element.offsetHeight;
-			element.style.marginTop = open ? '0px' : `-${ height }px`;
+			element.style.marginTop = open ? '0px' : `-${height}px`;
 		});
 	}
 
@@ -54,13 +54,7 @@ export default class TitlePane<P extends TitlePaneProperties = TitlePaneProperti
 	}
 
 	private _toggle() {
-		const {
-			closeable = true,
-			key,
-			onRequestClose,
-			onRequestOpen,
-			open = true
-		} = this.properties;
+		const { closeable = true, key, onRequestClose, onRequestOpen, open = true } = this.properties;
 
 		if (!closeable) {
 			return;
@@ -68,8 +62,7 @@ export default class TitlePane<P extends TitlePaneProperties = TitlePaneProperti
 
 		if (open) {
 			onRequestClose && onRequestClose(key);
-		}
-		else {
+		} else {
 			onRequestOpen && onRequestOpen(key);
 		}
 	}
@@ -88,16 +81,12 @@ export default class TitlePane<P extends TitlePaneProperties = TitlePaneProperti
 
 	protected getFixedModifierClasses(): (string | null)[] {
 		const { closeable = true } = this.properties;
-		return [
-			closeable ? css.closeableFixed : null
-		];
+		return [closeable ? css.closeableFixed : null];
 	}
 
 	protected getModifierClasses(): (string | null)[] {
 		const { closeable = true } = this.properties;
-		return [
-			closeable ? css.closeable : null
-		];
+		return [closeable ? css.closeable : null];
 	}
 
 	protected getPaneContent(): DNode[] {
@@ -107,53 +96,59 @@ export default class TitlePane<P extends TitlePaneProperties = TitlePaneProperti
 	protected renderExpandIcon(): DNode {
 		const { open = true } = this.properties;
 		return v('i', {
-			classes: this.theme([
-				css.arrow,
-				iconCss.icon,
-				open ? iconCss.downIcon : iconCss.rightIcon
-			]),
+			classes: this.theme([css.arrow, iconCss.icon, open ? iconCss.downIcon : iconCss.rightIcon]),
 			role: 'presentation',
 			'aria-hidden': 'true'
 		});
 	}
 
 	render(): DNode {
-		const {
-			closeable = true,
-			headingLevel,
-			open = true
-		} = this.properties;
+		const { closeable = true, headingLevel, open = true } = this.properties;
 
-		return v('div', {
-			classes: [ ...this.theme([
-				css.root,
-				open ? css.open : null
-			]), css.rootFixed ]
-		}, [
-			v('div', {
-				'aria-level': headingLevel ? String(headingLevel) : null,
-				classes: [ ...this.theme([ css.title, ...this.getModifierClasses() ]), css.titleFixed, ...this.getFixedModifierClasses() ],
-				role: 'heading'
-			}, [
-				v('button', {
-					'aria-controls': this._contentId,
-					'aria-expanded': String(open),
-					disabled: !closeable,
-					classes: this.theme(css.titleButton),
-					id: this._titleId,
-					onclick: this._onTitleClick
-				}, [
-					this.renderExpandIcon(),
-					this.getButtonContent()
-				])
-			]),
-			v('div', {
-				'aria-hidden': open ? null : 'true',
-				'aria-labelledby': this._titleId,
-				classes: this.theme(css.content),
-				id: this._contentId,
-				key: 'content'
-			}, this.getPaneContent())
-		]);
+		return v(
+			'div',
+			{
+				classes: [...this.theme([css.root, open ? css.open : null]), css.rootFixed]
+			},
+			[
+				v(
+					'div',
+					{
+						'aria-level': headingLevel ? String(headingLevel) : null,
+						classes: [
+							...this.theme([css.title, ...this.getModifierClasses()]),
+							css.titleFixed,
+							...this.getFixedModifierClasses()
+						],
+						role: 'heading'
+					},
+					[
+						v(
+							'button',
+							{
+								'aria-controls': this._contentId,
+								'aria-expanded': String(open),
+								disabled: !closeable,
+								classes: this.theme(css.titleButton),
+								id: this._titleId,
+								onclick: this._onTitleClick
+							},
+							[this.renderExpandIcon(), this.getButtonContent()]
+						)
+					]
+				),
+				v(
+					'div',
+					{
+						'aria-hidden': open ? null : 'true',
+						'aria-labelledby': this._titleId,
+						classes: this.theme(css.content),
+						id: this._contentId,
+						key: 'content'
+					},
+					this.getPaneContent()
+				)
+			]
+		);
 	}
 }

--- a/src/titlepane/createTitlePaneElement.ts
+++ b/src/titlepane/createTitlePaneElement.ts
@@ -11,23 +11,21 @@ export default function createTitlePaneElement(): CustomElementDescriptor {
 		attributes: [
 			{
 				attributeName: 'headinglevel',
-				value: value => Number(value)
+				value: (value) => Number(value)
 			},
 			{
 				attributeName: 'closeable',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'open',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'title'
 			}
 		],
-		properties: [
-			{ propertyName: 'theme' }
-		],
+		properties: [{ propertyName: 'theme' }],
 		events: [
 			{
 				propertyName: 'onRequestClose',

--- a/src/titlepane/example/index.ts
+++ b/src/titlepane/example/index.ts
@@ -18,70 +18,88 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render() {
-		const {
-			_t2Open,
-			_t3Open
-		} = this;
+		const { _t2Open, _t3Open } = this;
 
-		return v('div', {
-			styles: {
-				margin: '20px',
-				maxWidth: '350px'
-			}
-		}, [
-			v('div', {
-				classes: 'option',
-				style: 'margin-bottom: 20px;'
-			}, [
-				v('label', [
-					'Use Dojo Theme ',
-					v('input', {
-						type: 'checkbox',
-						onchange: this.themeChange
-					})
-				])
-			]),
+		return v(
+			'div',
+			{
+				styles: {
+					margin: '20px',
+					maxWidth: '350px'
+				}
+			},
+			[
+				v(
+					'div',
+					{
+						classes: 'option',
+						style: 'margin-bottom: 20px;'
+					},
+					[
+						v('label', [
+							'Use Dojo Theme ',
+							v('input', {
+								type: 'checkbox',
+								onchange: this.themeChange
+							})
+						])
+					]
+				),
 
-			v('div', {
-				id: 'titlePane1',
-				styles: { 'margin-bottom': '15px' }
-			}, [
-				w(TitlePane, {
-					headingLevel: 1,
-					closeable: false,
-					key: 'titlePane1',
-					theme: this._theme,
-					title: 'TitlePanel Widget With closeable=false'
-				}, [
-					v('div', {
-						innerHTML: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+				v(
+					'div',
+					{
+						id: 'titlePane1',
+						styles: { 'margin-bottom': '15px' }
+					},
+					[
+						w(
+							TitlePane,
+							{
+								headingLevel: 1,
+								closeable: false,
+								key: 'titlePane1',
+								theme: this._theme,
+								title: 'TitlePanel Widget With closeable=false'
+							},
+							[
+								v('div', {
+									innerHTML: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 							Quisque id purus ipsum. Aenean ac purus purus.
 							Nam sollicitudin varius augue, sed lacinia felis tempor in.`
-					})
-				])
-			]),
+								})
+							]
+						)
+					]
+				),
 
-			v('div', {
-				id: 'titlePane2',
-				styles: { 'margin-bottom': '15px' }
-			}, [
-				w(TitlePane, {
-					headingLevel: 2,
-					key: 'titlePane2',
-					open: _t2Open,
-					theme: this._theme,
-					title: 'TitlePanel Widget (closeable)',
-					onRequestClose: () => {
-						this._t2Open = false;
-						this.invalidate();
+				v(
+					'div',
+					{
+						id: 'titlePane2',
+						styles: { 'margin-bottom': '15px' }
 					},
-					onRequestOpen: () => {
-						this._t2Open = true;
-						this.invalidate();
-					}
-				}, [
-					v('div', {
-						innerHTML: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+					[
+						w(
+							TitlePane,
+							{
+								headingLevel: 2,
+								key: 'titlePane2',
+								open: _t2Open,
+								theme: this._theme,
+								title: 'TitlePanel Widget (closeable)',
+								onRequestClose: () => {
+									this._t2Open = false;
+									this.invalidate();
+								},
+								onRequestOpen: () => {
+									this._t2Open = true;
+									this.invalidate();
+								}
+							},
+							[
+								v('div', {
+									innerHTML: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 							Quisque id purus ipsum. Aenean ac purus purus.
 							Nam sollicitudin varius augue, sed lacinia felis tempor in.
 							<br>
@@ -92,33 +110,40 @@ export class App extends WidgetBase<WidgetProperties> {
 							Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 							Quisque id purus ipsum. Aenean ac purus purus.
 							Nam sollicitudin varius augue, sed lacinia felis tempor in.`
-					})
-				])
-			]),
+								})
+							]
+						)
+					]
+				),
 
-			v('div', { id: 'titlePane3' }, [
-				w(TitlePane, {
-					key: 'titlePane3',
-					open: _t3Open,
-					theme: this._theme,
-					title: 'TitlePanel Widget with open=false',
-					onRequestClose: () => {
-						this._t3Open = false;
-						this.invalidate();
-					},
-					onRequestOpen: () => {
-						this._t3Open = true;
-						this.invalidate();
-					}
-				}, [
-					v('div', {
-						innerHTML: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+				v('div', { id: 'titlePane3' }, [
+					w(
+						TitlePane,
+						{
+							key: 'titlePane3',
+							open: _t3Open,
+							theme: this._theme,
+							title: 'TitlePanel Widget with open=false',
+							onRequestClose: () => {
+								this._t3Open = false;
+								this.invalidate();
+							},
+							onRequestOpen: () => {
+								this._t3Open = true;
+								this.invalidate();
+							}
+						},
+						[
+							v('div', {
+								innerHTML: `Lorem ipsum dolor sit amet, consectetur adipiscing elit.
 							Quisque id purus ipsum. Aenean ac purus purus.
 							Nam sollicitudin varius augue, sed lacinia felis tempor in.`
-					})
+							})
+						]
+					)
 				])
-			])
-		]);
+			]
+		);
 	}
 }
 

--- a/src/titlepane/tests/functional/TitlePane.ts
+++ b/src/titlepane/tests/functional/TitlePane.ts
@@ -4,22 +4,19 @@ const { assert } = intern.getPlugin('chai');
 import { Remote } from 'intern/lib/executors/Node';
 
 function getPage(remote: Remote) {
-	return remote
-		.get('http://localhost:9000/_build/common/example/?module=titlepane')
-		.setFindTimeout(5000);
+	return remote.get('http://localhost:9000/_build/common/example/?module=titlepane').setFindTimeout(5000);
 }
 
 const DELAY = 400;
 
 registerSuite('TitlePane', {
-
 	'Should be fully visible when `open`'() {
 		return getPage(this.remote)
 			.findByCssSelector('#titlePane2 > div > :last-child')
-				.getComputedStyle('margin-top')
-				.then(marginTop => {
-					assert.strictEqual(marginTop, '0px');
-				});
+			.getComputedStyle('margin-top')
+			.then((marginTop) => {
+				assert.strictEqual(marginTop, '0px');
+			});
 	},
 
 	'Should be hidden when not `open`'() {
@@ -27,19 +24,19 @@ registerSuite('TitlePane', {
 
 		return getPage(this.remote)
 			.findByCssSelector('#titlePane2 > div > :last-child')
-				.getSize()
-				.then(size => {
-					height = size.height;
-				})
+			.getSize()
+			.then((size) => {
+				height = size.height;
+			})
 			.end()
 			.findByCssSelector('#titlePane2 button')
-				.click()
+			.click()
 			.end()
 			.sleep(DELAY)
 			.findByCssSelector('#titlePane2 > div > :last-child')
-				.getComputedStyle('margin-top')
-				.then(marginTop => {
-					assert.closeTo(parseInt(marginTop, 10), -height, 2);
-				});
+			.getComputedStyle('margin-top')
+			.then((marginTop) => {
+				assert.closeTo(parseInt(marginTop, 10), -height, 2);
+			});
 	}
 });

--- a/src/titlepane/tests/unit/TitlePane.ts
+++ b/src/titlepane/tests/unit/TitlePane.ts
@@ -12,10 +12,6 @@ const isNonEmptyString = compareProperty((value: any) => {
 	return typeof value === 'string' && value.length > 0;
 });
 
-interface TestEventInit extends EventInit {
-	keyCode: number;
-}
-
 let titlePane: Harness<TitlePane>;
 registerSuite('TitlePane', {
 	beforeEach() {

--- a/src/titlepane/tests/unit/TitlePane.ts
+++ b/src/titlepane/tests/unit/TitlePane.ts
@@ -18,7 +18,6 @@ interface TestEventInit extends EventInit {
 
 let titlePane: Harness<TitlePane>;
 registerSuite('TitlePane', {
-
 	beforeEach() {
 		titlePane = harness(TitlePane);
 	},
@@ -33,42 +32,56 @@ registerSuite('TitlePane', {
 				title: 'test'
 			});
 
-			titlePane.expectRender(v('div', {
-				classes: [ css.root, css.open, css.rootFixed ]
-			}, [
-				v('div', {
-					'aria-level': null,
-					classes: [ css.title, css.closeable, css.titleFixed, css.closeableFixed ],
-					role: 'heading'
-				}, [
-					v('button', {
-						'aria-controls': isNonEmptyString,
-						'aria-expanded': 'true',
-						classes: css.titleButton,
-						disabled: false,
-						id: <any> isNonEmptyString,
-						onclick: titlePane.listener
-					}, [
-						v('i', {
-							classes: [
-								css.arrow,
-								iconCss.icon,
-								iconCss.downIcon
-							],
-							role: 'presentation',
-							'aria-hidden': 'true'
-						}),
-						'test'
-					])
-				]),
-				v('div', {
-					'aria-hidden': null,
-					'aria-labelledby': isNonEmptyString,
-					classes: css.content,
-					id: <any> isNonEmptyString,
-					key: 'content'
-				}, [ ])
-			]));
+			titlePane.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, css.open, css.rootFixed]
+					},
+					[
+						v(
+							'div',
+							{
+								'aria-level': null,
+								classes: [css.title, css.closeable, css.titleFixed, css.closeableFixed],
+								role: 'heading'
+							},
+							[
+								v(
+									'button',
+									{
+										'aria-controls': isNonEmptyString,
+										'aria-expanded': 'true',
+										classes: css.titleButton,
+										disabled: false,
+										id: <any>isNonEmptyString,
+										onclick: titlePane.listener
+									},
+									[
+										v('i', {
+											classes: [css.arrow, iconCss.icon, iconCss.downIcon],
+											role: 'presentation',
+											'aria-hidden': 'true'
+										}),
+										'test'
+									]
+								)
+							]
+						),
+						v(
+							'div',
+							{
+								'aria-hidden': null,
+								'aria-labelledby': isNonEmptyString,
+								classes: css.content,
+								id: <any>isNonEmptyString,
+								key: 'content'
+							},
+							[]
+						)
+					]
+				)
+			);
 		},
 
 		'Should construct with the passed properties'() {
@@ -79,42 +92,56 @@ registerSuite('TitlePane', {
 				title: 'test'
 			});
 
-			titlePane.expectRender(v('div', {
-				classes: [ css.root, null, css.rootFixed ]
-			}, [
-				v('div', {
-					'aria-level': '5',
-					classes: [ css.title, null, css.titleFixed, null ],
-					role: 'heading'
-				}, [
-					v('button', {
-						'aria-controls': isNonEmptyString,
-						'aria-expanded': 'false',
-						classes: css.titleButton,
-						disabled: true,
-						id: <any> isNonEmptyString,
-						onclick: titlePane.listener
-					}, [
-						v('i', {
-							classes: [
-								css.arrow,
-								iconCss.icon,
-								iconCss.rightIcon
-							],
-							role: 'presentation',
-							'aria-hidden': 'true'
-						}),
-						'test'
-					])
-				]),
-				v('div', {
-					'aria-hidden': 'true',
-					'aria-labelledby': isNonEmptyString,
-					classes: css.content,
-					id: <any> isNonEmptyString,
-					key: 'content'
-				}, [])
-			]));
+			titlePane.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, null, css.rootFixed]
+					},
+					[
+						v(
+							'div',
+							{
+								'aria-level': '5',
+								classes: [css.title, null, css.titleFixed, null],
+								role: 'heading'
+							},
+							[
+								v(
+									'button',
+									{
+										'aria-controls': isNonEmptyString,
+										'aria-expanded': 'false',
+										classes: css.titleButton,
+										disabled: true,
+										id: <any>isNonEmptyString,
+										onclick: titlePane.listener
+									},
+									[
+										v('i', {
+											classes: [css.arrow, iconCss.icon, iconCss.rightIcon],
+											role: 'presentation',
+											'aria-hidden': 'true'
+										}),
+										'test'
+									]
+								)
+							]
+						),
+						v(
+							'div',
+							{
+								'aria-hidden': 'true',
+								'aria-labelledby': isNonEmptyString,
+								classes: css.content,
+								id: <any>isNonEmptyString,
+								key: 'content'
+							},
+							[]
+						)
+					]
+				)
+			);
 		},
 
 		'click title to close'() {

--- a/src/toolbar/Toolbar.ts
+++ b/src/toolbar/Toolbar.ts
@@ -14,7 +14,7 @@ import * as iconCss from '../common/styles/icons.m.css';
 export const enum Position {
 	bottom = 'onBottomFixed',
 	top = 'onTopFixed'
-};
+}
 
 /**
  * @type ToolbarProperties
@@ -35,7 +35,7 @@ export interface ToolbarProperties extends WidgetProperties {
 	onCollapse?(collapsed: boolean): void;
 	position?: Position;
 	title?: DNode;
-};
+}
 
 export const ThemedBase = ThemedMixin(WidgetBase);
 
@@ -63,13 +63,12 @@ export default class Toolbar extends ThemedBase<ToolbarProperties> {
 			this._collapsed = false;
 			onCollapse && onCollapse(this._collapsed);
 			this.invalidate();
-		}
-		else if (width <= collapseWidth && this._collapsed === false) {
+		} else if (width <= collapseWidth && this._collapsed === false) {
 			this._collapsed = true;
 			onCollapse && onCollapse(this._collapsed);
 			this.invalidate();
 		}
-	}
+	};
 
 	private _toggleMenu() {
 		this._open = !this._open;
@@ -78,19 +77,11 @@ export default class Toolbar extends ThemedBase<ToolbarProperties> {
 
 	protected getFixedRootClasses(): (string | null)[] {
 		const { fixed, position = Position.top } = this.properties;
-		return [
-			css.rootFixed,
-			fixed ? css.stickyFixed : null,
-			(css as any)[position]
-		];
+		return [css.rootFixed, fixed ? css.stickyFixed : null, (css as any)[position]];
 	}
 
 	protected getRootClasses(): (string | null)[] {
-		return [
-			css.root,
-			this._collapsed ? css.collapsed : null,
-			this.properties.fixed ? css.sticky : null
-		];
+		return [css.root, this._collapsed ? css.collapsed : null, this.properties.fixed ? css.sticky : null];
 	}
 
 	protected onAttach() {
@@ -104,68 +95,105 @@ export default class Toolbar extends ThemedBase<ToolbarProperties> {
 	protected renderActions(): DNode {
 		const { actions = [], theme } = this.properties;
 
-		const actionsElements = actions.map((action, index) => v('div', {
-			classes: [ this.theme(css.action) ],
-			key: index
-		}, [ action ]));
+		const actionsElements = actions.map((action, index) =>
+			v(
+				'div',
+				{
+					classes: [this.theme(css.action)],
+					key: index
+				},
+				[action]
+			)
+		);
 
 		if (actionsElements.length === 0) {
 			return null;
 		}
 
-		return this._collapsed ? w(SlidePane, {
-			align: Align.right,
-			closeText: 'close menu',
-			key: 'slide-pane-menu',
-			onRequestClose: this._closeMenu,
-			open: this._open,
-			theme,
-			title: 'Menu'
-		}, actionsElements) : v('div', {
-			classes: [ this.theme(css.actions), css.actionsFixed ],
-			key: 'menu'
-		}, actionsElements);
+		return this._collapsed
+			? w(
+					SlidePane,
+					{
+						align: Align.right,
+						closeText: 'close menu',
+						key: 'slide-pane-menu',
+						onRequestClose: this._closeMenu,
+						open: this._open,
+						theme,
+						title: 'Menu'
+					},
+					actionsElements
+				)
+			: v(
+					'div',
+					{
+						classes: [this.theme(css.actions), css.actionsFixed],
+						key: 'menu'
+					},
+					actionsElements
+				);
 	}
 
 	protected renderButton(): DNode {
-		return this._collapsed ? v('button', {
-			classes: [ this.theme(css.menuButton), css.menuButtonFixed ],
-			onclick: this._toggleMenu
-		}, [
-			'open menu',
-			v('i', {
-				classes: this.theme([ iconCss.icon, iconCss.barsIcon ]),
-				role: 'presentation', 'aria-hidden': 'true'
-			})
-		]) : null;
+		return this._collapsed
+			? v(
+					'button',
+					{
+						classes: [this.theme(css.menuButton), css.menuButtonFixed],
+						onclick: this._toggleMenu
+					},
+					[
+						'open menu',
+						v('i', {
+							classes: this.theme([iconCss.icon, iconCss.barsIcon]),
+							role: 'presentation',
+							'aria-hidden': 'true'
+						})
+					]
+				)
+			: null;
 	}
 
 	protected renderTitle(): DNode {
 		const { title } = this.properties;
 
-		return title ? v('div', {
-			classes: [ this.theme(css.title), css.titleFixed ]
-		}, [ title ]) : null;
+		return title
+			? v(
+					'div',
+					{
+						classes: [this.theme(css.title), css.titleFixed]
+					},
+					[title]
+				)
+			: null;
 	}
 
 	render(): DNode {
 		const classes = this.getRootClasses();
 		const fixedClasses = this.getFixedRootClasses();
 
-		return v('div', {
-			classes: [ ...this.theme(classes), ...fixedClasses ],
-			key: 'root'
-		}, [
-			v('div', {
-				classes: [ this.theme(css.toolbar), css.toolbarFixed ]
-			}, [
-				this.renderTitle(),
-				this.renderActions(),
-				this.renderButton()
-			]),
-			v('div', {
-				classes: [ this.theme(css.content), css.contentFixed ]
-			}, this.children)
-		]);
+		return v(
+			'div',
+			{
+				classes: [...this.theme(classes), ...fixedClasses],
+				key: 'root'
+			},
+			[
+				v(
+					'div',
+					{
+						classes: [this.theme(css.toolbar), css.toolbarFixed]
+					},
+					[this.renderTitle(), this.renderActions(), this.renderButton()]
+				),
+				v(
+					'div',
+					{
+						classes: [this.theme(css.content), css.contentFixed]
+					},
+					this.children
+				)
+			]
+		);
 	}
 }

--- a/src/toolbar/createToolbarElement.ts
+++ b/src/toolbar/createToolbarElement.ts
@@ -11,20 +11,17 @@ export default function createToolbarElement(): CustomElementDescriptor {
 		attributes: [
 			{
 				attributeName: 'collapseWidth',
-				value: value => Number(value)
+				value: (value) => Number(value)
 			},
 			{
 				attributeName: 'fixed',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'title'
 			}
 		],
-		properties: [
-			{ propertyName: 'actions' },
-			{ propertyName: 'theme' }
-		],
+		properties: [{ propertyName: 'actions' }, { propertyName: 'theme' }],
 		events: [
 			{
 				propertyName: 'onCollapse',

--- a/src/toolbar/example/index.ts
+++ b/src/toolbar/example/index.ts
@@ -23,26 +23,30 @@ export class App extends WidgetBase<WidgetProperties> {
 	}
 
 	render() {
-		return w(Toolbar, {
-			actions: [
-				v('a', { href: '/#home' }, [ 'Home' ]),
-				v('a', { href: '/#about' }, [ 'About' ]),
-				v('a', { href: '/#contact' }, [ 'Contact' ])
-			],
-			collapseWidth: 700,
-			fixed: true,
-			theme: this._theme,
-			title: 'Foobar'
-		}, [
-			v('h2', [ 'Toolbar Examples' ]),
-			v('label', [
-				'Use Dojo Theme ',
-				v('input', {
-					type: 'checkbox',
-					onchange: this.themeChange
-				})
-			])
-		]);
+		return w(
+			Toolbar,
+			{
+				actions: [
+					v('a', { href: '/#home' }, ['Home']),
+					v('a', { href: '/#about' }, ['About']),
+					v('a', { href: '/#contact' }, ['Contact'])
+				],
+				collapseWidth: 700,
+				fixed: true,
+				theme: this._theme,
+				title: 'Foobar'
+			},
+			[
+				v('h2', ['Toolbar Examples']),
+				v('label', [
+					'Use Dojo Theme ',
+					v('input', {
+						type: 'checkbox',
+						onchange: this.themeChange
+					})
+				])
+			]
+		);
 	}
 }
 

--- a/src/toolbar/tests/functional/Toolbar.ts
+++ b/src/toolbar/tests/functional/Toolbar.ts
@@ -3,9 +3,7 @@ const { assert } = intern.getPlugin('chai');
 import { Remote } from 'intern/lib/executors/Node';
 
 function getPage(remote: Remote) {
-	return remote
-		.get('http://localhost:9000/_build/common/example/?module=toolbar')
-		.setFindTimeout(5000);
+	return remote.get('http://localhost:9000/_build/common/example/?module=toolbar').setFindTimeout(5000);
 }
 
 const DELAY = 1000;
@@ -22,14 +20,14 @@ registerSuite('Toolbar', {
 			.setWindowSize(WIDTH, HEIGHT)
 			.sleep(DELAY)
 			.findByCssSelector('button:nth-child(3)')
-				.click()
+			.click()
 			.end()
 			.sleep(DELAY)
 			.findByCssSelector('body > div:last-child > div:first-child > div:nth-child(2) > div')
-				.isDisplayed()
-				.then(displayed => {
-					assert.isTrue(displayed);
-				});
+			.isDisplayed()
+			.then((displayed) => {
+				assert.isTrue(displayed);
+			});
 	},
 
 	'Should close menu when button is clicked'() {
@@ -40,17 +38,17 @@ registerSuite('Toolbar', {
 		return getPage(this.remote)
 			.setWindowSize(WIDTH, HEIGHT)
 			.findByCssSelector('body > div:last-child > div:first-child > button')
-				.click()
+			.click()
 			.end()
 			.sleep(DELAY)
 			.findByCssSelector('body > div:last-child > div:first-child > div:nth-child(2) > div button')
-				.click()
+			.click()
 			.end()
 			.sleep(DELAY)
 			.findByCssSelector('body > div:last-child > div:first-child > div:nth-child(2) > div')
-				.getPosition()
-				.then(position => {
-					assert.isAbove(position.x, WIDTH - 50);
-				});
+			.getPosition()
+			.then((position) => {
+				assert.isAbove(position.x, WIDTH - 50);
+			});
 	}
 });

--- a/src/toolbar/tests/unit/Toolbar.ts
+++ b/src/toolbar/tests/unit/Toolbar.ts
@@ -10,7 +10,6 @@ import * as iconCss from '../../../common/styles/icons.m.css';
 
 let toolbar: Harness<Toolbar>;
 registerSuite('Toolbar', {
-
 	beforeEach() {
 		toolbar = harness(Toolbar);
 	},
@@ -21,52 +20,60 @@ registerSuite('Toolbar', {
 
 	tests: {
 		'default rendering'() {
-			toolbar.expectRender(v('div', {
-				classes: [
-					css.root,
-					css.rootFixed,
-					css.onTopFixed
-				],
-				key: 'root'
-			}, [
-				v('div', {
-					classes: [
-						css.toolbar,
-						css.toolbarFixed
+			toolbar.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, css.rootFixed, css.onTopFixed],
+						key: 'root'
+					},
+					[
+						v(
+							'div',
+							{
+								classes: [css.toolbar, css.toolbarFixed]
+							},
+							[null, null, null]
+						),
+						v(
+							'div',
+							{
+								classes: [css.content, css.contentFixed]
+							},
+							[]
+						)
 					]
-				}, [ null, null, null]),
-				v('div', {
-					classes: [
-						css.content,
-						css.contentFixed
-					]
-				}, [])
-			]));
+				)
+			);
 		},
 
 		'bottom-positioned rendering'() {
 			toolbar.setProperties({ position: Position.bottom });
-			toolbar.expectRender(v('div', {
-				classes: [
-					css.root,
-					css.rootFixed,
-					css.onBottomFixed
-				],
-				key: 'root'
-			}, [
-				v('div', {
-					classes: [
-						css.toolbar,
-						css.toolbarFixed
+			toolbar.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, css.rootFixed, css.onBottomFixed],
+						key: 'root'
+					},
+					[
+						v(
+							'div',
+							{
+								classes: [css.toolbar, css.toolbarFixed]
+							},
+							[null, null, null]
+						),
+						v(
+							'div',
+							{
+								classes: [css.content, css.contentFixed]
+							},
+							[]
+						)
 					]
-				}, [ null, null, null]),
-				v('div', {
-					classes: [
-						css.content,
-						css.contentFixed
-					]
-				}, [])
-			]));
+				)
+			);
 		},
 
 		'expanded rendering'() {
@@ -81,122 +88,148 @@ registerSuite('Toolbar', {
 					};
 				}
 			});
-			toolbar.expectRender(v('div', {
-				classes: [
-					css.root,
-					css.rootFixed,
-					css.onTopFixed
-				],
-				key: 'root'
-			}, [
-				v('div', {
-					classes: [
-						css.toolbar,
-						css.toolbarFixed
+			toolbar.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, css.rootFixed, css.onTopFixed],
+						key: 'root'
+					},
+					[
+						v(
+							'div',
+							{
+								classes: [css.toolbar, css.toolbarFixed]
+							},
+							[null, null, null]
+						),
+						v(
+							'div',
+							{
+								classes: [css.content, css.contentFixed]
+							},
+							[]
+						)
 					]
-				}, [ null, null, null]),
-				v('div', {
-					classes: [
-						css.content,
-						css.contentFixed
-					]
-				}, [])
-			]));
+				)
+			);
 		},
 
 		'fixed rendering'() {
 			toolbar.setProperties({ fixed: true });
-			toolbar.expectRender(v('div', {
-				classes: [
-					css.root,
-					css.rootFixed,
-					css.onTopFixed,
-					css.sticky,
-					css.stickyFixed
-				],
-				key: 'root'
-			}, [
-				v('div', {
-					classes: [
-						css.toolbar,
-						css.toolbarFixed
+			toolbar.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, css.rootFixed, css.onTopFixed, css.sticky, css.stickyFixed],
+						key: 'root'
+					},
+					[
+						v(
+							'div',
+							{
+								classes: [css.toolbar, css.toolbarFixed]
+							},
+							[null, null, null]
+						),
+						v(
+							'div',
+							{
+								classes: [css.content, css.contentFixed]
+							},
+							[]
+						)
 					]
-				}, [ null, null, null]),
-				v('div', {
-					classes: [
-						css.content,
-						css.contentFixed
-					]
-				}, [])
-			]));
+				)
+			);
 		},
 
 		'custom title rendering'() {
 			toolbar.setProperties({ title: 'test' });
-			toolbar.expectRender(v('div', {
-				classes: [
-					css.root,
-					css.rootFixed,
-					css.onTopFixed
-				],
-				key: 'root'
-			}, [
-				v('div', {
-					classes: [
-						css.toolbar,
-						css.toolbarFixed
+			toolbar.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, css.rootFixed, css.onTopFixed],
+						key: 'root'
+					},
+					[
+						v(
+							'div',
+							{
+								classes: [css.toolbar, css.toolbarFixed]
+							},
+							[
+								v(
+									'div',
+									{
+										classes: [css.title, css.titleFixed]
+									},
+									['test']
+								),
+								null,
+								null
+							]
+						),
+						v(
+							'div',
+							{
+								classes: [css.content, css.contentFixed]
+							},
+							[]
+						)
 					]
-				}, [
-					v('div', {
-						classes: [ css.title, css.titleFixed ]
-					}, [ 'test' ]),
-					null,
-					null
-				]),
-				v('div', {
-					classes: [
-						css.content,
-						css.contentFixed
-					]
-				}, [])
-			]));
+				)
+			);
 		},
 
 		'actions rendering'() {
-			toolbar.setProperties({ actions: [ 'test' ] });
-			toolbar.expectRender(v('div', {
-				classes: [
-					css.root,
-					css.rootFixed,
-					css.onTopFixed
-				],
-				key: 'root'
-			}, [
-				v('div', {
-					classes: [
-						css.toolbar,
-						css.toolbarFixed
+			toolbar.setProperties({ actions: ['test'] });
+			toolbar.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, css.rootFixed, css.onTopFixed],
+						key: 'root'
+					},
+					[
+						v(
+							'div',
+							{
+								classes: [css.toolbar, css.toolbarFixed]
+							},
+							[
+								null,
+								v(
+									'div',
+									{
+										classes: [css.actions, css.actionsFixed],
+										key: 'menu'
+									},
+									[
+										v(
+											'div',
+											{
+												classes: [css.action],
+												key: 0
+											},
+											['test']
+										)
+									]
+								),
+								null
+							]
+						),
+						v(
+							'div',
+							{
+								classes: [css.content, css.contentFixed]
+							},
+							[]
+						)
 					]
-				}, [
-					null,
-					v('div', {
-						classes: [ css.actions, css.actionsFixed ],
-						key: 'menu'
-					}, [
-						v('div', {
-							classes: [ css.action ],
-							key: 0
-						}, [ 'test' ])
-					]),
-					null
-				]),
-				v('div', {
-					classes: [
-						css.content,
-						css.contentFixed
-					]
-				}, [])
-			]));
+				)
+			);
 		},
 
 		'open and close menu'() {
@@ -212,115 +245,129 @@ registerSuite('Toolbar', {
 				}
 			});
 
-			const slidePaneVDom = w(SlidePane, {
-				align: Align.right,
-				closeText: 'close menu',
-				key: 'slide-pane-menu',
-				onRequestClose: toolbar.listener,
-				open: false,
-				theme: undefined,
-				title: 'Menu'
-			}, [
-				v('div', {
-					classes: [ css.action ],
-					key: 0
-				}, [ 'test' ])
-			]);
+			const slidePaneVDom = w(
+				SlidePane,
+				{
+					align: Align.right,
+					closeText: 'close menu',
+					key: 'slide-pane-menu',
+					onRequestClose: toolbar.listener,
+					open: false,
+					theme: undefined,
+					title: 'Menu'
+				},
+				[
+					v(
+						'div',
+						{
+							classes: [css.action],
+							key: 0
+						},
+						['test']
+					)
+				]
+			);
 
-			const buttonVDom = v('button', {
-				classes: [ css.menuButton, css.menuButtonFixed ],
-				onclick: toolbar.listener
-			}, [
-				'open menu',
-				v('i', {
-					classes: [ iconCss.icon, iconCss.barsIcon ],
-					role: 'presentation',
-					'aria-hidden': 'true'
-				})
-			]);
+			const buttonVDom = v(
+				'button',
+				{
+					classes: [css.menuButton, css.menuButtonFixed],
+					onclick: toolbar.listener
+				},
+				[
+					'open menu',
+					v('i', {
+						classes: [iconCss.icon, iconCss.barsIcon],
+						role: 'presentation',
+						'aria-hidden': 'true'
+					})
+				]
+			);
 
 			toolbar.setProperties({ onCollapse: () => {} });
 
-			toolbar.expectRender(v('div', {
-				classes: [
-					css.root,
-					css.rootFixed,
-					css.onTopFixed
-				],
-				key: 'root'
-			}, [
-				v('div', {
-					classes: [
-						css.toolbar,
-						css.toolbarFixed
+			toolbar.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, css.rootFixed, css.onTopFixed],
+						key: 'root'
+					},
+					[
+						v(
+							'div',
+							{
+								classes: [css.toolbar, css.toolbarFixed]
+							},
+							[null, null, null]
+						),
+						v(
+							'div',
+							{
+								classes: [css.content, css.contentFixed]
+							},
+							[]
+						)
 					]
-				}, [ null, null, null]),
-				v('div', {
-					classes: [
-						css.content,
-						css.contentFixed
-					]
-				}, [])
-			]));
+				)
+			);
 
-			toolbar.setProperties({ actions: [ 'test' ] });
-			toolbar.expectRender(v('div', {
-				classes: [
-					css.root,
-					css.rootFixed,
-					css.collapsed,
-					css.onTopFixed
-				],
-				key: 'root'
-			}, [
-				v('div', {
-					classes: [
-						css.toolbar,
-						css.toolbarFixed
+			toolbar.setProperties({ actions: ['test'] });
+			toolbar.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, css.rootFixed, css.collapsed, css.onTopFixed],
+						key: 'root'
+					},
+					[
+						v(
+							'div',
+							{
+								classes: [css.toolbar, css.toolbarFixed]
+							},
+							[null, slidePaneVDom, buttonVDom]
+						),
+						v(
+							'div',
+							{
+								classes: [css.content, css.contentFixed]
+							},
+							[]
+						)
 					]
-				}, [
-					null,
-					slidePaneVDom,
-					buttonVDom
-				]),
-				v('div', {
-					classes: [
-						css.content,
-						css.contentFixed
-					]
-				}, [])
-			]));
+				)
+			);
 
 			toolbar.sendEvent('click', { selector: `.${css.menuButton}` });
 			toolbar.getRender();
 
 			toolbar.callListener('onRequestClose', { key: 'slide-pane-menu' });
-			toolbar.expectRender(v('div', {
-				classes: [
-					css.root,
-					css.rootFixed,
-					css.collapsed,
-					css.onTopFixed
-				],
-				key: 'root'
-			}, [
-				v('div', {
-					classes: [
-						css.toolbar,
-						css.toolbarFixed
+			toolbar.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.root, css.rootFixed, css.collapsed, css.onTopFixed],
+						key: 'root'
+					},
+					[
+						v(
+							'div',
+							{
+								classes: [css.toolbar, css.toolbarFixed]
+							},
+							[null, slidePaneVDom, buttonVDom]
+						),
+						v(
+							'div',
+							{
+								classes: [css.content, css.contentFixed]
+							},
+							[]
+						)
 					]
-				}, [
-					null,
-					slidePaneVDom,
-					buttonVDom
-				]),
-				v('div', {
-					classes: [
-						css.content,
-						css.contentFixed
-					]
-				}, [])
-			]));
+				)
+			);
 		}
 	}
 });

--- a/src/tooltip/Tooltip.ts
+++ b/src/tooltip/Tooltip.ts
@@ -18,7 +18,7 @@ export interface TooltipProperties extends WidgetProperties {
 	content: DNode;
 	orientation?: Orientation;
 	open?: boolean;
-};
+}
 
 // Enum used to position the Tooltip
 export const enum Orientation {
@@ -26,9 +26,9 @@ export const enum Orientation {
 	left = 'left',
 	right = 'right',
 	top = 'top'
-};
+}
 
-const orientationCss: {[key: string]: any} = css;
+const orientationCss: { [key: string]: any } = css;
 
 export const ThemedBase = ThemedMixin(WidgetBase);
 
@@ -37,25 +37,24 @@ export default class Tooltip<P extends TooltipProperties = TooltipProperties> ex
 	protected getFixedModifierClasses(): (string | null)[] {
 		const { orientation = Orientation.right } = this.properties;
 
-		return [
-			css.rootFixed,
-			orientationCss[`${orientation}Fixed`]
-		];
+		return [css.rootFixed, orientationCss[`${orientation}Fixed`]];
 	}
 
 	protected getModifierClasses(): (string | null)[] {
 		const { orientation = Orientation.right } = this.properties;
 
-		return [
-			orientationCss[orientation]
-		];
+		return [orientationCss[orientation]];
 	}
 
 	protected renderContent(): DNode {
-		return v('div', {
-			classes: [ this.theme(css.content), css.contentFixed ],
-			key: 'content'
-		}, [ this.properties.content ]);
+		return v(
+			'div',
+			{
+				classes: [this.theme(css.content), css.contentFixed],
+				key: 'content'
+			},
+			[this.properties.content]
+		);
 	}
 
 	protected renderTarget(): DNode {
@@ -67,11 +66,12 @@ export default class Tooltip<P extends TooltipProperties = TooltipProperties> ex
 		const classes = this.getModifierClasses();
 		const fixedClasses = this.getFixedModifierClasses();
 
-		return v('div', {
-			classes: [ ...this.theme(classes), ...fixedClasses ]
-		}, [
-			this.renderTarget(),
-			open ? this.renderContent() : null
-		]);
+		return v(
+			'div',
+			{
+				classes: [...this.theme(classes), ...fixedClasses]
+			},
+			[this.renderTarget(), open ? this.renderContent() : null]
+		);
 	}
 }

--- a/src/tooltip/createTooltipElement.ts
+++ b/src/tooltip/createTooltipElement.ts
@@ -11,15 +11,12 @@ export default function createTooltipElement(): CustomElementDescriptor {
 		attributes: [
 			{
 				attributeName: 'open',
-				value: value => value === 'false' || value === '0' ? false : true
+				value: (value) => (value === 'false' || value === '0' ? false : true)
 			},
 			{
 				attributeName: 'orientation'
 			}
 		],
-		properties: [
-			{ propertyName: 'content' },
-			{ propertyName: 'theme' }
-		]
+		properties: [{ propertyName: 'content' }, { propertyName: 'theme' }]
 	};
-};
+}

--- a/src/tooltip/example/index.ts
+++ b/src/tooltip/example/index.ts
@@ -32,7 +32,7 @@ export class App extends WidgetBase<WidgetProperties> {
 
 	render() {
 		return v('div', [
-			v('h2', [ 'Tooltip Examples' ]),
+			v('h2', ['Tooltip Examples']),
 			v('label', [
 				'Use Dojo Theme ',
 				v('input', {
@@ -41,37 +41,53 @@ export class App extends WidgetBase<WidgetProperties> {
 				})
 			]),
 			v('div', { id: 'example-1' }, [
-				w(Tooltip, {
-					key: 'foo',
-					content: 'This is a right-oriented tooltip that opens and closes based on child click.',
-					orientation: Orientation.right,
-					open: this._open.has('foo'),
-					theme: this._theme
-				}, [
-					w(Button, {
-						theme: this._theme,
-						onClick: () => {
-							const exists = this._open.has('foo');
-							exists ? this.onHide('foo') : this.onShow('foo');
-						}
-					}, [ 'Click me' ])
-				])
+				w(
+					Tooltip,
+					{
+						key: 'foo',
+						content: 'This is a right-oriented tooltip that opens and closes based on child click.',
+						orientation: Orientation.right,
+						open: this._open.has('foo'),
+						theme: this._theme
+					},
+					[
+						w(
+							Button,
+							{
+								theme: this._theme,
+								onClick: () => {
+									const exists = this._open.has('foo');
+									exists ? this.onHide('foo') : this.onShow('foo');
+								}
+							},
+							['Click me']
+						)
+					]
+				)
 			]),
 			v('div', { id: 'example-2' }, [
-				w(Tooltip, {
-					key: 'bar',
-					content: 'This is a right-oriented tooltip that opens and closes based on child focus.',
-					orientation: Orientation.right,
-					open: this._open.has('bar'),
-					theme: this._theme
-				}, [
-					w(TextInput, {
-						theme: this._theme,
-						placeholder: 'Focus me',
-						onFocus: () => { this.onShow('bar'); },
-						onBlur: () => { this.onHide('bar'); }
-					})
-				])
+				w(
+					Tooltip,
+					{
+						key: 'bar',
+						content: 'This is a right-oriented tooltip that opens and closes based on child focus.',
+						orientation: Orientation.right,
+						open: this._open.has('bar'),
+						theme: this._theme
+					},
+					[
+						w(TextInput, {
+							theme: this._theme,
+							placeholder: 'Focus me',
+							onFocus: () => {
+								this.onShow('bar');
+							},
+							onBlur: () => {
+								this.onHide('bar');
+							}
+						})
+					]
+				)
 			])
 		]);
 	}

--- a/src/tooltip/tests/functional/Tooltip.ts
+++ b/src/tooltip/tests/functional/Tooltip.ts
@@ -4,9 +4,7 @@ const { assert } = intern.getPlugin('chai');
 import { Remote } from 'intern/lib/executors/Node';
 
 function getPage(remote: Remote) {
-	return remote
-		.get('http://localhost:9000/_build/common/example/?module=tooltip')
-		.setFindTimeout(5000);
+	return remote.get('http://localhost:9000/_build/common/example/?module=tooltip').setFindTimeout(5000);
 }
 
 const DELAY = 750;
@@ -16,14 +14,16 @@ registerSuite('Tooltip', {
 		return getPage(this.remote)
 			.sleep(DELAY)
 			.findByCssSelector('#example-1 button')
-				.click()
-				.sleep(DELAY)
-				.end()
+			.click()
+			.sleep(DELAY)
+			.end()
 			.findByCssSelector('#example-1 > div:first-child > div:last-child')
-				.getVisibleText()
-				.then((text: string) => {
-					assert.strictEqual(text,
-						'This is a right-oriented tooltip that opens and closes based on child click.');
-				});
+			.getVisibleText()
+			.then((text: string) => {
+				assert.strictEqual(
+					text,
+					'This is a right-oriented tooltip that opens and closes based on child click.'
+				);
+			});
 	}
 });

--- a/src/tooltip/tests/unit/Tooltip.ts
+++ b/src/tooltip/tests/unit/Tooltip.ts
@@ -19,12 +19,15 @@ registerSuite('Tooltip', {
 
 	tests: {
 		'should construct Tooltip'() {
-			widget.expectRender(v('div', {
-				classes: [ css.right, css.rootFixed, css.rightFixed ]
-			}, [
-				v('div', { key: 'target' }, []),
-				null
-			]));
+			widget.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.right, css.rootFixed, css.rightFixed]
+					},
+					[v('div', { key: 'target' }, []), null]
+				)
+			);
 		},
 
 		'should render content if open'() {
@@ -33,15 +36,25 @@ registerSuite('Tooltip', {
 				open: true
 			});
 
-			widget.expectRender(v('div', {
-				classes: [ css.right, css.rootFixed, css.rightFixed ]
-			}, [
-				v('div', { key: 'target' }, []),
-				v('div', {
-					key: 'content',
-					classes: [ css.content, css.contentFixed ]
-				}, [ 'foobar' ])
-			]));
+			widget.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.right, css.rootFixed, css.rightFixed]
+					},
+					[
+						v('div', { key: 'target' }, []),
+						v(
+							'div',
+							{
+								key: 'content',
+								classes: [css.content, css.contentFixed]
+							},
+							['foobar']
+						)
+					]
+				)
+			);
 		},
 
 		'should render correct orientation'() {
@@ -50,12 +63,15 @@ registerSuite('Tooltip', {
 				content: 'foobar'
 			});
 
-			widget.expectRender(v('div', {
-				classes: [ css.bottom, css.rootFixed, css.bottomFixed ]
-			}, [
-				v('div', { key: 'target' }, []),
-				null
-			]));
+			widget.expectRender(
+				v(
+					'div',
+					{
+						classes: [css.bottom, css.rootFixed, css.bottomFixed]
+					},
+					[v('div', { key: 'target' }, []), null]
+				)
+			);
 		}
 	}
 });

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,7 @@
 		],
 		"module": "umd",
 		"moduleResolution": "node",
+		"noUnusedLocals": true,
 		"importHelpers": true,
 		"downlevelIteration": true,
 		"outDir": "_build/",

--- a/tslint.json
+++ b/tslint.json
@@ -1,5 +1,7 @@
 {
+	"rulesDirectory": ["tslint-plugin-prettier"],
 	"rules": {
+		"prettier": true,
 		"align": false,
 		"ban": [],
 		"class-name": true,

--- a/tslint.json
+++ b/tslint.json
@@ -35,7 +35,6 @@
 		"no-var-requires": false,
 		"object-literal-sort-keys": false,
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
-		"quotemark": [ true, "single" ],
 		"radix": true,
 		"trailing-comma": [ true, {
 			"multiline": "never",

--- a/tslint.json
+++ b/tslint.json
@@ -30,7 +30,6 @@
 		"no-switch-case-fall-through": false,
 		"no-trailing-whitespace": true,
 		"no-unused-expression": false,
-		"no-unused-variable": true,
 		"no-use-before-declare": false,
 		"no-var-keyword": true,
 		"no-var-requires": false,
@@ -38,7 +37,6 @@
 		"one-line": [ true, "check-open-brace", "check-whitespace" ],
 		"quotemark": [ true, "single" ],
 		"radix": true,
-		"semicolon": [ true, "always" ],
 		"trailing-comma": [ true, {
 			"multiline": "never",
 			"singleline": "never"
@@ -58,8 +56,6 @@
 			"property-declaration": "onespace",
 			"variable-declaration": "onespace"
 		} ],
-		"use-strict": false,
-		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ],
-		"whitespace": [ true, "check-branch", "check-decl", "check-operator", "check-module", "check-separator", "check-type", "check-typecast" ]
+		"variable-name": [ true, "check-format", "allow-leading-underscore", "ban-keywords", "allow-pascal-case" ]
 	}
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Adds support for `Prettier` to for code style rules and formatting. Include precommit hook that runs prettier on all `.ts` files and an npm script that runs prettier against the codebase.

Related to https://github.com/dojo/meta/issues/206
