### PR TITLE
Custom aria interface and implementation

### DIFF
--- a/src/button/Button.ts
+++ b/src/button/Button.ts
@@ -4,7 +4,8 @@ import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/T
 import { v } from '@dojo/widget-core/d';
 import * as css from '../theme/button/button.m.css';
 import * as iconCss from '../theme/common/icons.m.css';
-import { InputEventProperties, PointerEventProperties, KeyEventProperties } from '../common/interfaces';
+import { CustomAriaProperties, InputEventProperties, PointerEventProperties, KeyEventProperties } from '../common/interfaces';
+import { formatAriaProperties } from '../common/util';
 
 export type ButtonType = 'submit' | 'reset' | 'button' | 'menu';
 
@@ -13,7 +14,6 @@ export type ButtonType = 'submit' | 'reset' | 'button' | 'menu';
  *
  * Properties that can be set on a Button component
  *
- * @property describedBy    ID of element with descriptive text
  * @property disabled       Whether the button is disabled or clickable
  * @property popup       		Controls aria-haspopup, aria-expanded, and aria-controls for popup buttons
  * @property name           The button's name attribute
@@ -21,8 +21,7 @@ export type ButtonType = 'submit' | 'reset' | 'button' | 'menu';
  * @property type           Button type can be "submit", "reset", "button", or "menu"
  * @property value          Defines a value for the button submitted with form data
  */
-export interface ButtonProperties extends ThemedProperties, InputEventProperties, PointerEventProperties, KeyEventProperties {
-	describedBy?: string;
+export interface ButtonProperties extends ThemedProperties, InputEventProperties, PointerEventProperties, KeyEventProperties, CustomAriaProperties {
 	disabled?: boolean;
 	id?: string;
 	popup?: { expanded?: boolean; id?: string; } | boolean;
@@ -75,7 +74,7 @@ export default class Button<P extends ButtonProperties = ButtonProperties> exten
 
 	render(): DNode {
 		let {
-			describedBy,
+			aria = {},
 			disabled,
 			id,
 			popup = false,
@@ -107,11 +106,11 @@ export default class Button<P extends ButtonProperties = ButtonProperties> exten
 			ontouchstart: this._onTouchStart,
 			ontouchend: this._onTouchEnd,
 			ontouchcancel: this._onTouchCancel,
+			...formatAriaProperties(aria),
 			'aria-haspopup': popup ? 'true' : null,
 			'aria-controls': popup ? popup.id : null,
 			'aria-expanded': popup ? popup.expanded + '' : null,
-			'aria-pressed': typeof pressed === 'boolean' ? pressed.toString() : null,
-			'aria-describedby': describedBy
+			'aria-pressed': typeof pressed === 'boolean' ? pressed.toString() : null
 		}, [
 			...this.getContent(),
 			popup ? this.renderPopupIcon() : null

--- a/src/button/tests/unit/Button.ts
+++ b/src/button/tests/unit/Button.ts
@@ -24,7 +24,6 @@ registerSuite('Button', {
 		'no content'() {
 			widget.expectRender(v('button', {
 				'aria-controls': null,
-				'aria-describedby': undefined,
 				'aria-expanded': null,
 				'aria-haspopup': null,
 				'aria-pressed': null,
@@ -53,7 +52,9 @@ registerSuite('Button', {
 				type: 'submit',
 				name: 'bar',
 				id: 'qux',
-				describedBy: 'baz',
+				aria: {
+					describedBy: 'baz'
+				},
 				disabled: true,
 				popup: {
 					expanded: true,
@@ -67,7 +68,7 @@ registerSuite('Button', {
 
 			widget.expectRender(v('button', {
 				'aria-controls': (<any> buttonProperties.popup).id,
-				'aria-describedby': buttonProperties.describedBy,
+				'aria-describedby': 'baz',
 				'aria-expanded': String((<any> buttonProperties.popup).expanded),
 				'aria-haspopup': 'true',
 				'aria-pressed': String(buttonProperties.pressed),
@@ -105,7 +106,6 @@ registerSuite('Button', {
 
 			widget.expectRender(v('button', {
 				'aria-controls': '',
-				'aria-describedby': undefined,
 				'aria-expanded': 'false',
 				'aria-haspopup': 'true',
 				'aria-pressed': null,

--- a/src/calendar/Calendar.ts
+++ b/src/calendar/Calendar.ts
@@ -6,7 +6,8 @@ import { DNode } from '@dojo/widget-core/interfaces';
 import uuid from '@dojo/core/uuid';
 import commonBundle from '../common/nls/common';
 import { CommonMessages } from '../common/interfaces';
-import { Keys } from '../common/util';
+import { CustomAriaProperties } from '../common/interfaces';
+import { formatAriaProperties, Keys } from '../common/util';
 import CalendarCell from './CalendarCell';
 import DatePicker, { Paging } from './DatePicker';
 import calendarBundle from './nls/Calendar';
@@ -33,7 +34,7 @@ export type CalendarMessages = typeof calendarBundle.messages;
  * @property onYearChange      Function called when the year changes
  * @property onDateSelect      Function called when the user selects a date
  */
-export interface CalendarProperties extends ThemedProperties {
+export interface CalendarProperties extends ThemedProperties, CustomAriaProperties {
 	labels?: CalendarMessages;
 	month?: number;
 	monthNames?: { short: string; long: string; }[];
@@ -377,6 +378,7 @@ export default class Calendar<P extends CalendarProperties = CalendarProperties>
 		const commonMessages = this.localizeBundle(commonBundle);
 		const {
 			labels = this.localizeBundle(calendarBundle),
+			aria = {},
 			selectedDate,
 			weekdayNames = this._getWeekdays(commonMessages)
 		} = this.properties;
@@ -392,7 +394,10 @@ export default class Calendar<P extends CalendarProperties = CalendarProperties>
 			]));
 		}
 
-		return v('div', { classes: this.theme(css.root) }, [
+		return v('div', {
+			classes: this.theme(css.root),
+			...formatAriaProperties(aria)
+		}, [
 			// header
 			this.renderDatePicker(commonMessages, labels),
 			// date table

--- a/src/calendar/tests/unit/Calendar.ts
+++ b/src/calendar/tests/unit/Calendar.ts
@@ -192,6 +192,7 @@ registerSuite('Calendar', {
 
 		'Renders with custom properties'() {
 			widget.setProperties({
+				aria: { describedBy: 'foo' },
 				labels: DEFAULT_LABELS,
 				month: testDate.getMonth(),
 				monthNames: DEFAULT_MONTHS,
@@ -207,6 +208,9 @@ registerSuite('Calendar', {
 			for (let i = 0; i < 7; i++) {
 				replaceChild(expectedVdom, `1,0,0,${i},0`, 'Bar');
 			}
+			assignProperties(expectedVdom, {
+				'aria-describedby': 'foo'
+			});
 			assignProperties(findKey(expectedVdom, 'date-4')!, {
 				selected: true
 			});

--- a/src/checkbox/Checkbox.ts
+++ b/src/checkbox/Checkbox.ts
@@ -2,7 +2,8 @@ import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { DNode } from '@dojo/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import Label from '../label/Label';
-import { LabeledProperties, InputProperties, InputEventProperties, KeyEventProperties, PointerEventProperties } from '../common/interfaces';
+import { CustomAriaProperties, LabeledProperties, InputProperties, InputEventProperties, KeyEventProperties, PointerEventProperties } from '../common/interfaces';
+import { formatAriaProperties } from '../common/util';
 import { v, w } from '@dojo/widget-core/d';
 import uuid from '@dojo/core/uuid';
 import * as css from '../theme/checkbox/checkbox.m.css';
@@ -18,7 +19,7 @@ import * as css from '../theme/checkbox/checkbox.m.css';
  * @property onLabel        Label to show in the "on" positin of a toggle
  * @property value           The current value
  */
-export interface CheckboxProperties extends ThemedProperties, InputProperties, LabeledProperties, InputEventProperties, KeyEventProperties, PointerEventProperties {
+export interface CheckboxProperties extends ThemedProperties, InputProperties, LabeledProperties, InputEventProperties, KeyEventProperties, PointerEventProperties, CustomAriaProperties {
 	checked?: boolean;
 	mode?: Mode;
 	offLabel?: DNode;
@@ -110,8 +111,8 @@ export default class Checkbox<P extends CheckboxProperties = CheckboxProperties>
 
 	protected render(): DNode {
 		const {
+			aria = {},
 			checked = false,
-			describedBy,
 			disabled,
 			invalid,
 			label,
@@ -129,9 +130,9 @@ export default class Checkbox<P extends CheckboxProperties = CheckboxProperties>
 				...this.renderToggle(),
 				v('input', {
 					id: this._uuid,
+					...formatAriaProperties(aria),
 					classes: this.theme(css.input),
 					checked,
-					'aria-describedby': describedBy,
 					disabled,
 					'aria-invalid': invalid === true ? 'true' : null,
 					name,

--- a/src/checkbox/tests/unit/Checkbox.ts
+++ b/src/checkbox/tests/unit/Checkbox.ts
@@ -54,7 +54,6 @@ const expected = function(widget: Harness<Checkbox>, label = false, toggle = fal
 				id: <any> compareId,
 				classes: css.input,
 				checked: false,
-				'aria-describedby': undefined,
 				disabled: undefined,
 				'aria-invalid': null,
 				name: undefined,
@@ -110,8 +109,10 @@ registerSuite('Checkbox', {
 
 		'custom properties'() {
 			widget.setProperties({
+				aria: {
+					describedBy: 'foo'
+				},
 				checked: true,
-				describedBy: 'foo',
 				name: 'bar',
 				value: 'baz'
 			});

--- a/src/combobox/ComboBox.ts
+++ b/src/combobox/ComboBox.ts
@@ -412,7 +412,7 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 			v('div', {
 				classes: this.theme(css.controls)
 			}, [
-				this.renderInput(),
+				this.renderInput(results),
 				clearable ? this.renderClearButton(messages) : null,
 				this.renderMenuButton(messages)
 			]),

--- a/src/combobox/ComboBox.ts
+++ b/src/combobox/ComboBox.ts
@@ -265,7 +265,7 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 		}
 	}
 
-	protected renderInput(): DNode {
+	protected renderInput(results: any[]): DNode {
 		const {
 			disabled,
 			inputProperties = {},
@@ -280,9 +280,9 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 			...inputProperties,
 			key: 'textinput',
 			aria: {
-				'aria-activedescendant': this._getResultId(results[this._activeIndex], this._activeIndex),
-				'aria-controls': this._getMenuId(),
-				'aria-owns': this._getMenuId()
+				activedescendant: this._getResultId(results[this._activeIndex], this._activeIndex),
+				controls: this._getMenuId(),
+				owns: this._getMenuId()
 			},
 			disabled,
 			invalid,
@@ -380,7 +380,7 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 
 	render(): DNode {
 		const {
-			clearable,
+			clearable = false,
 			id,
 			invalid,
 			label,
@@ -428,6 +428,7 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 			classes: this.theme([
 				css.root,
 				this._open ? css.open : null,
+				clearable ? css.clearable : null,
 				invalid === true ? css.invalid : null,
 				invalid === false ? css.valid : null
 			]),

--- a/src/combobox/ComboBox.ts
+++ b/src/combobox/ComboBox.ts
@@ -279,7 +279,11 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 		return w(TextInput, {
 			...inputProperties,
 			key: 'textinput',
-			controls: this._getMenuId(),
+			aria: {
+				'aria-activedescendant': this._getResultId(results[this._activeIndex], this._activeIndex),
+				'aria-controls': this._getMenuId(),
+				'aria-owns': this._getMenuId()
+			},
 			disabled,
 			invalid,
 			onBlur: this._onInputBlur,
@@ -418,8 +422,8 @@ export default class ComboBox<P extends ComboBoxProperties = ComboBoxProperties>
 		return v('div', {
 			'aria-expanded': this._open ? 'true' : 'false',
 			'aria-haspopup': 'true',
-			'aria-readonly': readOnly ? 'true' : 'false',
-			'aria-required': required ? 'true' : 'false',
+			'aria-readonly': readOnly ? 'true' : null,
+			'aria-required': required ? 'true' : null,
 			id,
 			classes: this.theme([
 				css.root,

--- a/src/combobox/styles/comboBox.m.css
+++ b/src/combobox/styles/comboBox.m.css
@@ -1,5 +1,0 @@
-@import '../../common/styles/variables.css';
-
-.clearable {
-	padding-right: 4em;
-}

--- a/src/combobox/styles/comboBox.m.css.d.ts
+++ b/src/combobox/styles/comboBox.m.css.d.ts
@@ -1,5 +1,1 @@
-export const option: string;
-export const disabledOption: string;
-export const input: string;
 export const clearable: string;
-export const selected: string;

--- a/src/combobox/styles/comboBox.m.css.d.ts
+++ b/src/combobox/styles/comboBox.m.css.d.ts
@@ -1,1 +1,0 @@
-export const clearable: string;

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -148,6 +148,7 @@ const getExpectedVdom = function(widget: Harness<ComboBox>, useTestProperties = 
 		classes: [
 			css.root,
 			open ? css.open : null,
+			useTestProperties ? css.clearable : null,
 			null,
 			null
 		],
@@ -586,7 +587,7 @@ registerSuite('ComboBox', {
 			assignProperties(expected, {
 				'aria-readonly': 'true',
 				'aria-required': 'true',
-				classes: [ css.root, null, css.invalid, null ]
+				classes: [ css.root, null, css.clearable, css.invalid, null ]
 			});
 			widget.expectRender(expected, 'disabled, invalid, readOnly, and required render');
 

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -53,9 +53,9 @@ const getExpectedControls = function(widget: Harness<ComboBox>, useTestPropertie
 		w(TextInput, <any> {
 			key: 'textinput',
 			aria: {
-				'aria-activedescendant': <any> compareId,
-				'aria-controls': <any> compareId,
-				'aria-owns': <any> compareId
+				activedescendant: <any> compareId,
+				controls: <any> compareId,
+				owns: <any> compareId
 			},
 			disabled: undefined,
 			invalid: undefined,
@@ -597,7 +597,7 @@ registerSuite('ComboBox', {
 				invalid: false
 			});
 			assignProperties(expected, {
-				classes: [ css.root, null, null, css.valid ]
+				classes: [ css.root, null, null, null, css.valid ]
 			});
 			widget.expectRender(expected, 'valid render');
 		},

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -52,7 +52,11 @@ const getExpectedControls = function(widget: Harness<ComboBox>, useTestPropertie
 	}, [
 		w(TextInput, <any> {
 			key: 'textinput',
-			controls: <any> compareId,
+			aria: {
+				'aria-activedescendant': <any> compareId,
+				'aria-controls': <any> compareId,
+				'aria-owns': <any> compareId
+			},
 			disabled: undefined,
 			invalid: undefined,
 			readOnly: undefined,

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -50,12 +50,12 @@ const getExpectedControls = function(widget: Harness<ComboBox>, useTestPropertie
 	const controlsVdom = v('div', {
 		classes: css.controls
 	}, [
-		w(TextInput, <any> {
+		w(TextInput, {
 			key: 'textinput',
 			aria: {
-				activedescendant: <any> compareId,
-				controls: <any> compareId,
-				owns: <any> compareId
+				activedescendant: compareId,
+				controls: compareId,
+				owns: compareId
 			},
 			disabled: undefined,
 			invalid: undefined,
@@ -69,7 +69,7 @@ const getExpectedControls = function(widget: Harness<ComboBox>, useTestPropertie
 			onKeyDown: widget.listener
 		}),
 		useTestProperties ? v('button', {
-			'aria-controls': <any> compareId,
+			'aria-controls': compareId as any,
 			key: 'clear',
 			classes: css.clear,
 			disabled: undefined,
@@ -103,7 +103,7 @@ const getExpectedControls = function(widget: Harness<ComboBox>, useTestPropertie
 
 function isOpen(widget: Harness<ComboBox>): boolean {
 	const vdom = widget.getRender();
-	return (<any> vdom)!.properties!['aria-expanded'] === 'true';
+	return (vdom as any)!.properties!['aria-expanded'] === 'true';
 }
 
 const getExpectedMenu = function(widget: Harness<ComboBox>, useTestProperties: boolean, open: boolean) {
@@ -119,7 +119,7 @@ const getExpectedMenu = function(widget: Harness<ComboBox>, useTestProperties: b
 	}, [
 		w(Listbox, {
 			activeIndex: 0,
-			id: <any> compareId,
+			id: compareId as any,
 			key: 'listbox',
 			visualFocus: false,
 			optionData: testOptions,
@@ -164,7 +164,7 @@ const getExpectedVdom = function(widget: Harness<ComboBox>, useTestProperties = 
 			invalid: undefined,
 			readOnly: undefined,
 			required: undefined,
-			forId: <any> compareId
+			forId: compareId
 		}, [ 'foo' ]) : null,
 		controlsVdom,
 		menuVdom

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -141,8 +141,8 @@ const getExpectedVdom = function(widget: Harness<ComboBox>, useTestProperties = 
 	return v('div', {
 		'aria-expanded': open ? 'true' : 'false',
 		'aria-haspopup': 'true',
-		'aria-readonly': 'false',
-		'aria-required': 'false',
+		'aria-readonly': null,
+		'aria-required': null,
 		dir: null,
 		id: useTestProperties ? 'foo' : undefined,
 		classes: [

--- a/src/common/example/example.css
+++ b/src/common/example/example.css
@@ -4,7 +4,6 @@
 @import '../../theme/button/button.m.css';
 @import '../../theme/calendar/calendar.m.css';
 @import '../../theme/checkbox/checkbox.m.css';
-@import '../../combobox/styles/comboBox.m.css';
 @import '../../theme/combobox/comboBox.m.css';
 @import '../../dialog/styles/dialog.m.css';
 @import '../../theme/dialog/dialog.m.css';

--- a/src/common/interfaces.d.ts
+++ b/src/common/interfaces.d.ts
@@ -2,10 +2,12 @@ import commonBundle from './nls/common';
 
 export type CommonMessages = typeof commonBundle.messages;
 
+export type AriaPropertyObject = {
+	[key: string]: string;
+};
+
 export interface CustomAriaProperties {
-	aria?: {
-		[key: string]: string;
-	};
+	aria?: AriaPropertyObject;
 }
 
 /**

--- a/src/common/interfaces.d.ts
+++ b/src/common/interfaces.d.ts
@@ -5,7 +5,7 @@ export type CommonMessages = typeof commonBundle.messages;
 export interface CustomAriaProperties {
 	aria?: {
 		[key: string]: string;
-	}
+	};
 }
 
 /**

--- a/src/common/interfaces.d.ts
+++ b/src/common/interfaces.d.ts
@@ -2,10 +2,10 @@ import commonBundle from './nls/common';
 
 export type CommonMessages = typeof commonBundle.messages;
 
-export interface LabeledProperties {
-	labelAfter?: boolean;
-	labelHidden?: boolean;
-	label?: string;
+export interface CustomAriaProperties {
+	aria?: {
+		[key: string]: string;
+	}
 }
 
 /**
@@ -44,6 +44,30 @@ export interface InputEventProperties {
 }
 
 /**
+ * @type KeyEventProperties
+ * @property onKeyDown      Called on the input's keydown event
+ * @property onKeyPress     Called on the input's keypress event
+ * @property onKeyUp        Called on the input's keyup event
+ */
+export interface KeyEventProperties {
+	onKeyDown?(event: KeyboardEvent): void;
+	onKeyPress?(event: KeyboardEvent): void;
+	onKeyUp?(event: KeyboardEvent): void;
+}
+
+/**
+ * @type LabeledProperties
+ * @property labelAfter     If false, moves the label before the input
+ * @property labelHidden    If true, the label will be accessible but visually hidden
+ * @property label          String value for the label
+ */
+export interface LabeledProperties {
+	labelAfter?: boolean;
+	labelHidden?: boolean;
+	label?: string;
+}
+
+/**
  * @type PointerEventProperties
  * @property onClick        Called when the input is clicked
  * @property onMouseDown    Called on the input's mousedown event
@@ -59,16 +83,4 @@ export interface PointerEventProperties {
 	onTouchStart?(event: TouchEvent): void;
 	onTouchEnd?(event: TouchEvent): void;
 	onTouchCancel?(event: TouchEvent): void;
-}
-
-/**
- * @type KeyEventProperties
- * @property onKeyDown      Called on the input's keydown event
- * @property onKeyPress     Called on the input's keypress event
- * @property onKeyUp        Called on the input's keyup event
- */
-export interface KeyEventProperties {
-	onKeyDown?(event: KeyboardEvent): void;
-	onKeyPress?(event: KeyboardEvent): void;
-	onKeyUp?(event: KeyboardEvent): void;
 }

--- a/src/common/interfaces.d.ts
+++ b/src/common/interfaces.d.ts
@@ -13,7 +13,6 @@ export interface CustomAriaProperties {
  *
  * Properties that can be set on a input component
  *
- * @property describedBy    ID of an element that provides more descriptive text
  * @property disabled       Prevents the user from interacting with the form field
  * @property invalid        Indicates the value entered in the form field is invalid
  * @property name           The form widget's name
@@ -21,7 +20,6 @@ export interface CustomAriaProperties {
  * @property required       Whether or not a value is required
  */
 export interface InputProperties {
-	describedBy?: string;
 	disabled?: boolean;
 	invalid?: boolean;
 	name?: string;

--- a/src/common/tests/unit/util.ts
+++ b/src/common/tests/unit/util.ts
@@ -1,7 +1,7 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
-import { Keys } from '../../util';
+import { formatAriaProperties, Keys } from '../../util';
 
 registerSuite('util', {
 
@@ -18,5 +18,18 @@ registerSuite('util', {
 		assert.strictEqual(Keys.Space, 32);
 		assert.strictEqual(Keys.Tab, 9);
 		assert.strictEqual(Keys.Up, 38);
+	},
+
+	formatAriaProperties() {
+		assert.deepEqual(formatAriaProperties({}), {}, 'handles empty object');
+
+		const aria = {
+			describedBy: 'foo',
+			controls: 'bar'
+		};
+		const formattedAria = formatAriaProperties(aria);
+		assert.strictEqual(Object.keys(formattedAria).length, 2);
+		assert.strictEqual(formattedAria['aria-describedby'], 'foo');
+		assert.strictEqual(formattedAria['aria-controls'], 'bar');
 	}
 });

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -12,3 +12,11 @@ export const enum Keys {
 	Tab = 9,
 	Up = 38
 }
+
+export function formatAriaProperties(aria: { [key: string]: string }): { [key: string]: string } {
+	const formattedAria: { [key: string]: string } = {};
+	Object.keys(aria).forEach((key: string) => {
+		formattedAria[`aria-${key.toLowerCase()}`] = aria[key];
+	});
+	return formattedAria;
+}

--- a/src/common/util.ts
+++ b/src/common/util.ts
@@ -1,3 +1,5 @@
+import { AriaPropertyObject } from './interfaces';
+
 export const enum Keys {
 	Down = 40,
 	End = 35,
@@ -13,10 +15,10 @@ export const enum Keys {
 	Up = 38
 }
 
-export function formatAriaProperties(aria: { [key: string]: string }): { [key: string]: string } {
-	const formattedAria: { [key: string]: string } = {};
-	Object.keys(aria).forEach((key: string) => {
-		formattedAria[`aria-${key.toLowerCase()}`] = aria[key];
-	});
+export function formatAriaProperties(aria: AriaPropertyObject): AriaPropertyObject {
+	const formattedAria = Object.keys(aria).reduce((a: AriaPropertyObject, key: string) => {
+		a[`aria-${key.toLowerCase()}`] = aria[key];
+		return a;
+	}, {});
 	return formattedAria;
 }

--- a/src/dialog/Dialog.ts
+++ b/src/dialog/Dialog.ts
@@ -4,7 +4,8 @@ import { I18nMixin } from '@dojo/widget-core/mixins/I18n';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import { v } from '@dojo/widget-core/d';
 import uuid from '@dojo/core/uuid';
-import { Keys } from '../common/util';
+import { CustomAriaProperties } from '../common/interfaces';
+import { formatAriaProperties, Keys } from '../common/util';
 import commonBundle from '../common/nls/common';
 
 import * as fixedCss from './styles/dialog.m.css';
@@ -34,7 +35,7 @@ export type RoleType = 'dialog' | 'alertdialog';
  * @property title              Title to show in the dialog title bar
  * @property underlay           Determines whether a semi-transparent background shows behind the dialog
  */
-export interface DialogProperties extends ThemedProperties {
+export interface DialogProperties extends ThemedProperties, CustomAriaProperties {
 	closeable?: boolean;
 	closeText?: string;
 	enterAnimation?: string;
@@ -115,6 +116,7 @@ export default class Dialog<P extends DialogProperties = DialogProperties> exten
 
 	render(): DNode {
 		let {
+			aria = {},
 			closeable = true,
 			closeText,
 			enterAnimation = animations.fadeIn,
@@ -139,6 +141,7 @@ export default class Dialog<P extends DialogProperties = DialogProperties> exten
 		}, open ? [
 			this.renderUnderlay(),
 			v('div', {
+				...formatAriaProperties(aria),
 				'aria-labelledby': this._titleId,
 				classes: this.theme(css.main),
 				enterAnimation,

--- a/src/dialog/tests/unit/Dialog.ts
+++ b/src/dialog/tests/unit/Dialog.ts
@@ -100,6 +100,7 @@ registerSuite('Dialog', {
 
 			// set tested properties
 			widget.setProperties({
+				aria: { describedBy: 'foo' },
 				closeable: true,
 				closeText: 'foo',
 				enterAnimation: 'fooAnimation',
@@ -121,6 +122,7 @@ registerSuite('Dialog', {
 				classes: [ css.underlayVisible, fixedCss.underlay ]
 			});
 			assignChildProperties(expectedVdom, '1', {
+				'aria-describedby': 'foo',
 				enterAnimation: 'fooAnimation',
 				exitAnimation: 'barAnimation',
 				role: 'alertdialog'

--- a/src/enhancedtextinput/example/index.ts
+++ b/src/enhancedtextinput/example/index.ts
@@ -33,7 +33,9 @@ export class App extends WidgetBase<WidgetProperties> {
 				w(EnhancedTextInput, {
 					key: 't1',
 					addonBefore: [ '@' ],
-					describedBy: 'twitter-desc',
+					aria: {
+						describedBy: 'twitter-desc'
+					},
 					label: 'Twitter Username',
 					type: 'text',
 					placeholder: 'username',

--- a/src/enhancedtextinput/tests/unit/EnhancedTextInput.ts
+++ b/src/enhancedtextinput/tests/unit/EnhancedTextInput.ts
@@ -20,8 +20,6 @@ const compareId = compareProperty((value: any) => {
 const expected = function(label = false, addonBefore = false, addonAfter = false, classes: (string | null)[] = [ textInputCss.root, null, null, null, null, null ]) {
 	const children = [
 		v('input', {
-			'aria-controls': undefined,
-			'aria-describedby': undefined,
 			'aria-invalid': null,
 			classes: css.input,
 			disabled: undefined,
@@ -121,8 +119,10 @@ registerSuite('EnhancedTextInput', {
 
 			'custom properties'() {
 				widget.setProperties({
-					controls: 'foo',
-					describedBy: 'bar',
+					aria: {
+						controls: 'foo',
+						describedBy: 'bar'
+					},
 					maxLength: 50,
 					minLength: 10,
 					name: 'baz',

--- a/src/label/Label.ts
+++ b/src/label/Label.ts
@@ -2,6 +2,8 @@ import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { DNode } from '@dojo/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import { v } from '@dojo/widget-core/d';
+import { CustomAriaProperties } from '../common/interfaces';
+import { formatAriaProperties } from '../common/util';
 import * as css from '../theme/label/label.m.css';
 import * as baseCss from '../common/styles/base.m.css';
 
@@ -18,7 +20,7 @@ import * as baseCss from '../common/styles/base.m.css';
  * @property hidden
  * @property secondary
  */
-export interface LabelProperties extends ThemedProperties {
+export interface LabelProperties extends ThemedProperties, CustomAriaProperties {
 	forId?: string;
 	disabled?: boolean;
 	readOnly?: boolean;
@@ -53,9 +55,10 @@ export default class Label<P extends LabelProperties = LabelProperties> extends 
 	}
 
 	render(): DNode {
-		const { forId, hidden } = this.properties;
+		const { aria = {}, forId, hidden } = this.properties;
 
 		return v('label', {
+			...formatAriaProperties(aria),
 			classes: [
 				...this.theme(this.getRootClasses()),
 				hidden ? baseCss.visuallyHidden : null

--- a/src/label/tests/unit/Label.ts
+++ b/src/label/tests/unit/Label.ts
@@ -39,6 +39,37 @@ registerSuite('Label', {
 			]));
 		},
 
+		custom() {
+			widget.setProperties({
+				forId: 'foo',
+				aria: {
+					describedBy: 'bar'
+				},
+				disabled: true,
+				readOnly: true,
+				required: true,
+				invalid: true,
+				secondary: true
+			});
+			widget.setChildren([ 'baz' ]);
+
+			widget.expectRender(v('label', {
+				classes: [
+					css.root,
+					css.disabled,
+					css.invalid,
+					null,
+					css.readonly,
+					css.required,
+					css.secondary
+				],
+				for: 'foo',
+				'aria-describedby': 'bar'
+			}, [
+				'baz'
+			]));
+		},
+
 		hidden() {
 			widget.setProperties({
 				hidden: true

--- a/src/listbox/Listbox.ts
+++ b/src/listbox/Listbox.ts
@@ -2,7 +2,8 @@ import { auto, reference } from '@dojo/widget-core/diff';
 import { diffProperty } from '@dojo/widget-core/decorators/diffProperty';
 import Dimensions from '@dojo/widget-core/meta/Dimensions';
 import { DNode } from '@dojo/widget-core/interfaces';
-import { Keys } from '../common/util';
+import { CustomAriaProperties } from '../common/interfaces';
+import { formatAriaProperties, Keys } from '../common/util';
 import MetaBase from '@dojo/widget-core/meta/Base';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import uuid from '@dojo/core/uuid';
@@ -28,7 +29,6 @@ export class ScrollMeta extends MetaBase {
  * Properties that can be set on a Listbox component
  *
  * @property activeIndex          Index of the currently active listbox option
- * @property describedBy          ID of an element that provides more descriptive text
  * @property getOptionLabel       Function to return string label based on option data
  * @property getOptionDisabled    Function that accepts option data and returns a boolean for disabled/not disabled
  * @property getOptionId          Function that accepts option data and returns a string ID
@@ -42,9 +42,8 @@ export class ScrollMeta extends MetaBase {
  * @property onOptionSelect       Called with the option data of the new requested selected item
  */
 
-export interface ListboxProperties extends ThemedProperties {
+export interface ListboxProperties extends ThemedProperties, CustomAriaProperties {
 	activeIndex?: number;
-	describedBy?: string;
 	getOptionDisabled?(option: any, index: number): boolean;
 	getOptionId?(option: any, index: number): string;
 	getOptionLabel?(option: any, index: number): DNode;
@@ -206,17 +205,17 @@ export default class Listbox<P extends ListboxProperties = ListboxProperties> ex
 	protected render(): DNode {
 		const {
 			activeIndex = 0,
-			describedBy,
+			aria = {},
 			id,
 			multiselect = false,
 			tabIndex = 0
 		} = this.properties;
 
 		return v('div', {
+			...formatAriaProperties(aria),
 			'aria-activedescendant': this._getOptionId(activeIndex),
 			'aria-multiselectable': multiselect ? 'true' : null,
 			classes: this.theme([ css.root, ...this.getModifierClasses() ]),
-			describedBy,
 			id,
 			key: 'root',
 			role: 'listbox',

--- a/src/listbox/tests/unit/Listbox.ts
+++ b/src/listbox/tests/unit/Listbox.ts
@@ -96,7 +96,6 @@ const expectedVdom = function(widget: Harness<Listbox>, options: DNode[]) {
 		'aria-activedescendant': compareId,
 		'aria-multiselectable': null,
 		classes: [ css.root, null ],
-		describedBy: undefined,
 		id: undefined,
 		key: 'root',
 		role: 'listbox',
@@ -134,7 +133,7 @@ registerSuite('Listbox', {
 		'custom properties'() {
 			widget.setProperties({
 				activeIndex: 0,
-				describedBy: 'foo',
+				aria: { describedBy: 'foo' },
 				visualFocus: true,
 				id: 'bar',
 				multiselect: true,
@@ -150,9 +149,9 @@ registerSuite('Listbox', {
 			const vdom = expectedVdom(widget, expectedOptions(widget));
 			assignProperties(vdom, {
 				'aria-activedescendant': 'first',
+				'aria-describedby': 'foo',
 				'aria-multiselectable': 'true',
 				classes: [ css.root, css.focused ],
-				describedBy: 'foo',
 				id: 'bar',
 				tabIndex: -1
 			});

--- a/src/progress/Progress.ts
+++ b/src/progress/Progress.ts
@@ -1,6 +1,8 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import { v } from '@dojo/widget-core/d';
+import { CustomAriaProperties } from '../common/interfaces';
+import { formatAriaProperties } from '../common/util';
 import { DNode } from '@dojo/widget-core/interfaces';
 import * as css from '../theme/progress/progress.m.css';
 
@@ -16,7 +18,7 @@ import * as css from '../theme/progress/progress.m.css';
  * @property min            Value used to calculate percent width
  * @property id             Value used to supply a dom id
  */
-export interface ProgressProperties extends ThemedProperties {
+export interface ProgressProperties extends ThemedProperties, CustomAriaProperties {
 	value: number;
 	output?(value: number, percent: number): string;
 	showOutput?: boolean;
@@ -47,6 +49,7 @@ export default class Progress extends ProgressBase<ProgressProperties> {
 
 	protected render(): DNode {
 		const {
+			aria = {},
 			value,
 			showOutput = true,
 			max = 100,
@@ -59,6 +62,7 @@ export default class Progress extends ProgressBase<ProgressProperties> {
 
 		return v('div', { classes: this.theme(css.root) }, [
 			v('div', {
+				...formatAriaProperties(aria),
 				classes: this.theme(css.bar),
 				role: 'progressbar',
 				'aria-valuemin': `${min}`,

--- a/src/progress/tests/unit/Progress.ts
+++ b/src/progress/tests/unit/Progress.ts
@@ -1,6 +1,7 @@
 const { beforeEach, afterEach, describe, it} = intern.getInterface('bdd');
 import { v } from '@dojo/widget-core/d';
 import harness, { Harness } from '@dojo/test-extras/harness';
+import { assignChildProperties } from '@dojo/test-extras/support/d';
 import Progress from '../../Progress';
 import * as css from '../../../theme/progress/progress.m.css';
 
@@ -109,5 +110,21 @@ describe('Progress', () => {
 		});
 
 		widget.expectRender(expectedVDom({ width: 50, output: '50%', value: 50, id: 'my-id' }));
+	});
+
+	it('accepts aria properties', () => {
+		widget.setProperties({
+			value: 50,
+			aria: {
+				describedBy: 'foo',
+				valueNow: 'overridden'
+			}
+		});
+
+		const expected = expectedVDom({ width: 50, output: '50%', value: 50 });
+		assignChildProperties(expected, '0', {
+			'aria-describedby': 'foo'
+		});
+		widget.expectRender(expected);
 	});
 });

--- a/src/radio/Radio.ts
+++ b/src/radio/Radio.ts
@@ -2,7 +2,8 @@ import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { DNode } from '@dojo/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import Label from '../label/Label';
-import { LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties } from '../common/interfaces';
+import { CustomAriaProperties, LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties } from '../common/interfaces';
+import { formatAriaProperties } from '../common/util';
 import { v, w } from '@dojo/widget-core/d';
 import uuid from '@dojo/core/uuid';
 import * as css from '../theme/radio/radio.m.css';
@@ -15,7 +16,7 @@ import * as css from '../theme/radio/radio.m.css';
  * @property checked          Checked/unchecked property of the radio
  * @property value           The current value
  */
-export interface RadioProperties extends ThemedProperties, LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties {
+export interface RadioProperties extends ThemedProperties, LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties, CustomAriaProperties {
 	checked?: boolean;
 	value?: string;
 }
@@ -68,8 +69,8 @@ export default class Radio<P extends RadioProperties = RadioProperties> extends 
 
 	render(): DNode {
 		const {
+			aria = {},
 			checked = false,
-			describedBy,
 			disabled,
 			invalid,
 			label,
@@ -86,9 +87,9 @@ export default class Radio<P extends RadioProperties = RadioProperties> extends 
 			v('div', { classes: this.theme(css.inputWrapper) }, [
 				v('input', {
 					id: this._uuid,
+					...formatAriaProperties(aria),
 					classes: this.theme(css.input),
 					checked,
-					'aria-describedby': describedBy,
 					disabled,
 					'aria-invalid': invalid === true ? 'true' : null,
 					name,

--- a/src/radio/tests/unit/Radio.ts
+++ b/src/radio/tests/unit/Radio.ts
@@ -22,7 +22,6 @@ const expected = function(widget: Harness<Radio>, label = false) {
 			id: <any> compareId,
 			classes: css.input,
 			checked: false,
-			'aria-describedby': undefined,
 			disabled: undefined,
 			'aria-invalid': null,
 			name: undefined,
@@ -80,8 +79,8 @@ registerSuite('Radio', {
 
 		'custom properties'() {
 			widget.setProperties({
+				aria: { describedBy: 'foo' },
 				checked: true,
-				describedBy: 'foo',
 				name: 'bar',
 				value: 'baz'
 			});

--- a/src/select/Select.ts
+++ b/src/select/Select.ts
@@ -6,8 +6,8 @@ import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/T
 import { v, w } from '@dojo/widget-core/d';
 import uuid from '@dojo/core/uuid';
 import { find } from '@dojo/shim/array';
-import { Keys } from '../common/util';
-import { LabeledProperties, InputProperties } from '../common/interfaces';
+import { formatAriaProperties, Keys } from '../common/util';
+import { CustomAriaProperties, LabeledProperties, InputProperties } from '../common/interfaces';
 import Label from '../label/Label';
 import Listbox from '../listbox/Listbox';
 import * as css from '../theme/select/select.m.css';
@@ -28,7 +28,7 @@ import * as iconCss from '../theme/common/icons.m.css';
  * @property useNativeElement  Use the native <select> element if true
  * @property value           The current value
  */
-export interface SelectProperties extends ThemedProperties, InputProperties, LabeledProperties {
+export interface SelectProperties extends ThemedProperties, InputProperties, LabeledProperties, CustomAriaProperties {
 	getOptionDisabled?(option: any, index: number): boolean;
 	getOptionId?(option: any, index: number): string;
 	getOptionLabel?(option: any): DNode;
@@ -182,7 +182,7 @@ export default class Select<P extends SelectProperties = SelectProperties> exten
 
 	protected renderNativeSelect(): DNode {
 		const {
-			describedBy,
+			aria = {},
 			disabled,
 			getOptionDisabled,
 			getOptionId,
@@ -206,8 +206,8 @@ export default class Select<P extends SelectProperties = SelectProperties> exten
 
 		return v('div', { classes: this.theme(css.inputWrapper) }, [
 			v('select', {
+				...formatAriaProperties(aria),
 				classes: this.theme(css.input),
-				'aria-describedby': describedBy,
 				disabled,
 				'aria-invalid': invalid ? 'true' : null,
 				name,
@@ -225,7 +225,6 @@ export default class Select<P extends SelectProperties = SelectProperties> exten
 
 	protected renderCustomSelect(): DNode {
 		const {
-			describedBy,
 			getOptionDisabled,
 			getOptionId,
 			getOptionLabel,
@@ -256,7 +255,6 @@ export default class Select<P extends SelectProperties = SelectProperties> exten
 				w(Listbox, {
 					key: 'listbox',
 					activeIndex: _focusedIndex,
-					describedBy,
 					id: _baseId,
 					optionData: options,
 					tabIndex: _open ? 0 : -1,
@@ -281,7 +279,7 @@ export default class Select<P extends SelectProperties = SelectProperties> exten
 
 	protected renderCustomTrigger(): DNode[] {
 		const {
-			describedBy,
+			aria = {},
 			disabled,
 			getOptionSelected = this._getOptionSelected,
 			invalid,
@@ -309,6 +307,7 @@ export default class Select<P extends SelectProperties = SelectProperties> exten
 
 		return [
 			v('button', {
+				...formatAriaProperties(aria),
 				'aria-controls': this._baseId,
 				'aria-expanded': `${this._open}`,
 				'aria-haspopup': 'listbox',
@@ -316,7 +315,6 @@ export default class Select<P extends SelectProperties = SelectProperties> exten
 				'aria-readonly': readOnly ? 'true' : null,
 				'aria-required': required ? 'true' : null,
 				classes: this.theme([ css.trigger, isPlaceholder ? css.placeholder : null ]),
-				describedBy,
 				disabled,
 				key: 'trigger',
 				value,

--- a/src/select/tests/unit/Select.ts
+++ b/src/select/tests/unit/Select.ts
@@ -4,7 +4,7 @@ const { assert } = intern.getPlugin('chai');
 import * as sinon from 'sinon';
 
 import harness, { Harness } from '@dojo/test-extras/harness';
-import { assignProperties, compareProperty, findKey, replaceChild } from '@dojo/test-extras/support/d';
+import { assignProperties, assignChildProperties, compareProperty, findKey, replaceChild } from '@dojo/test-extras/support/d';
 import { v, w } from '@dojo/widget-core/d';
 import { Keys } from '../../../common/util';
 
@@ -41,7 +41,7 @@ const testOptions: any[] = [
 ];
 
 const testProperties: Partial<SelectProperties> = {
-	describedBy: 'foo',
+	aria: { describedBy: 'foo' },
 	getOptionDisabled: (option: any, index: number) => !!option.disabled,
 	getOptionId: (option: any, index: number) => option.value,
 	getOptionLabel: (option: any) => option.label,
@@ -61,10 +61,9 @@ const testStateProperties: Partial<SelectProperties> = {
 };
 
 const expectedNative = function(widget: Harness<Select>, useTestProperties = false) {
-	return v('div', { classes: css.inputWrapper }, [
+	const vdom = v('div', { classes: css.inputWrapper }, [
 		v('select', {
 			classes: css.input,
-			'aria-describedby': useTestProperties ? 'foo' : undefined,
 			disabled: useTestProperties ? true : undefined,
 			'aria-invalid': useTestProperties ? 'true' : null,
 			name: useTestProperties ? 'foo' : undefined,
@@ -101,10 +100,16 @@ const expectedNative = function(widget: Harness<Select>, useTestProperties = fal
 			})
 		])
 	]);
+
+	if (useTestProperties) {
+		assignChildProperties(vdom, '0', {'aria-describedby': 'foo'});
+	}
+
+	return vdom;
 };
 
 const expectedSingle = function(widget: Harness<Select>, useTestProperties = false, open = false) {
-	return v('div', {
+	const vdom = v('div', {
 		classes: [ css.inputWrapper, open ? css.open : null ],
 		key: 'wrapper'
 	}, [
@@ -116,7 +121,6 @@ const expectedSingle = function(widget: Harness<Select>, useTestProperties = fal
 			'aria-readonly': null,
 			'aria-required': null,
 			classes: [ css.trigger, useTestProperties ? null : css.placeholder ],
-			describedBy: useTestProperties ? 'foo' : undefined,
 			disabled: undefined,
 			key: 'trigger',
 			value: useTestProperties ? 'two' : undefined,
@@ -140,7 +144,6 @@ const expectedSingle = function(widget: Harness<Select>, useTestProperties = fal
 		}, [
 			w(Listbox, {
 				activeIndex: 0,
-				describedBy: useTestProperties ? 'foo' : undefined,
 				id: <any> compareId,
 				key: 'listbox',
 				optionData: useTestProperties ? testOptions : [],
@@ -155,6 +158,12 @@ const expectedSingle = function(widget: Harness<Select>, useTestProperties = fal
 			})
 		])
 	]);
+
+	if (useTestProperties) {
+		assignProperties(findKey(vdom, 'trigger')!, {'aria-describedby': 'foo'});
+	}
+
+	return vdom;
 };
 
 function isOpen(widget: any): boolean {

--- a/src/select/tests/unit/Select.ts
+++ b/src/select/tests/unit/Select.ts
@@ -399,7 +399,6 @@ registerSuite('Select', {
 							'aria-readonly': null,
 							'aria-required': null,
 							classes: [ css.trigger, null ],
-							describedBy: undefined,
 							disabled: undefined,
 							key: 'trigger',
 							value: 'two',
@@ -423,7 +422,6 @@ registerSuite('Select', {
 						}, [
 							w(Listbox, {
 								activeIndex: 0,
-								describedBy: undefined,
 								id: <any> compareId,
 								key: 'listbox',
 								optionData: simpleOptions,

--- a/src/slidepane/SlidePane.ts
+++ b/src/slidepane/SlidePane.ts
@@ -4,6 +4,8 @@ import { I18nMixin } from '@dojo/widget-core/mixins/I18n';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import { v } from '@dojo/widget-core/d';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
+import { CustomAriaProperties } from '../common/interfaces';
+import { formatAriaProperties } from '../common/util';
 import * as animations from '../common/styles/animations.m.css';
 import commonBundle from '../common/nls/common';
 import * as fixedCss from './styles/slidePane.m.css';
@@ -34,7 +36,7 @@ export const enum Align {
  * @property underlay         Determines whether a semi-transparent background shows behind the pane
  * @property width            Width of the pane in pixels
  */
-export interface SlidePaneProperties extends ThemedProperties {
+export interface SlidePaneProperties extends ThemedProperties, CustomAriaProperties {
 	align?: Align;
 	closeText?: string;
 	onOpen?(): void;
@@ -254,6 +256,7 @@ export default class SlidePane<P extends SlidePaneProperties = SlidePaneProperti
 
 	render(): DNode {
 		let {
+			aria = {},
 			closeText,
 			onOpen,
 			open = false,
@@ -289,6 +292,7 @@ export default class SlidePane<P extends SlidePaneProperties = SlidePaneProperti
 		}, [
 			open ? this.renderUnderlay() : null,
 			v('div', {
+				...formatAriaProperties(aria),
 				key: 'content',
 				classes: [ ...this.theme([ css.pane, ...contentClasses ]), fixedCss.paneFixed, ...fixedContentClasses ],
 				styles: contentStyles

--- a/src/slidepane/tests/unit/SlidePane.ts
+++ b/src/slidepane/tests/unit/SlidePane.ts
@@ -36,6 +36,7 @@ registerSuite('SlidePane', {
 			widget.setProperties({
 				key: 'foo',
 				align: Align.left,
+				aria: { describedBy: 'foo' },
 				open: true,
 				underlay: true
 			});
@@ -62,6 +63,7 @@ registerSuite('SlidePane', {
 				}),
 				v('div', {
 					key: 'content',
+					'aria-describedby': 'foo',
 					classes: [
 						css.pane,
 						css.left,

--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -4,7 +4,8 @@ import Label from '../label/Label';
 import { v, w } from '@dojo/widget-core/d';
 import { DNode } from '@dojo/widget-core/interfaces';
 import uuid from '@dojo/core/uuid';
-import { LabeledProperties, InputEventProperties, InputProperties, PointerEventProperties, KeyEventProperties } from '../common/interfaces';
+import { CustomAriaProperties, LabeledProperties, InputEventProperties, InputProperties, PointerEventProperties, KeyEventProperties } from '../common/interfaces';
+import { formatAriaProperties } from '../common/util';
 import * as fixedCss from './styles/slider.m.css';
 import * as css from '../theme/slider/slider.m.css';
 
@@ -21,7 +22,7 @@ import * as css from '../theme/slider/slider.m.css';
  * @property verticalHeight    Length of the vertical slider (only used if vertical is true)
  * @property value           The current value
  */
-export interface SliderProperties extends ThemedProperties, LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties, KeyEventProperties {
+export interface SliderProperties extends ThemedProperties, LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties, KeyEventProperties, CustomAriaProperties {
 	max?: number;
 	min?: number;
 	output?(value: number): DNode;
@@ -119,7 +120,7 @@ export default class Slider<P extends SliderProperties = SliderProperties> exten
 
 	render(): DNode {
 		const {
-			describedBy,
+			aria = {},
 			disabled,
 			invalid,
 			label,
@@ -151,8 +152,8 @@ export default class Slider<P extends SliderProperties = SliderProperties> exten
 		}, [
 			v('input', {
 				key: 'input',
+				...formatAriaProperties(aria),
 				classes: [ this.theme(css.input), fixedCss.nativeInput ],
-				'aria-describedby': describedBy,
 				disabled,
 				id: this._inputId,
 				'aria-invalid': invalid === true ? 'true' : null,

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -25,7 +25,6 @@ const expected = function(widget: any, label = false, tooltip = false) {
 		v('input', {
 			key: 'input',
 			classes: [ css.input, fixedCss.nativeInput ],
-			'aria-describedby': undefined,
 			disabled: undefined,
 			id: <any> compareId,
 			'aria-invalid': null,
@@ -110,7 +109,7 @@ registerSuite('Slider', {
 
 		'custom properties'() {
 			widget.setProperties({
-				describedBy: 'foo',
+				aria: { describedBy: 'foo' },
 				max: 60,
 				min: 10,
 				name: 'bar',

--- a/src/tabcontroller/Tab.ts
+++ b/src/tabcontroller/Tab.ts
@@ -2,6 +2,8 @@ import { DNode } from '@dojo/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import { v } from '@dojo/widget-core/d';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
+import { CustomAriaProperties } from '../common/interfaces';
+import { formatAriaProperties } from '../common/util';
 
 import * as css from '../theme/tabcontroller/tabController.m.css';
 
@@ -17,7 +19,7 @@ import * as css from '../theme/tabcontroller/tabController.m.css';
  * @property label        Content to show in the TabController control bar for this tab
  * @property labelledBy   ID of DOM element that serves as a label for this tab
  */
-export interface TabProperties extends ThemedProperties {
+export interface TabProperties extends ThemedProperties, CustomAriaProperties {
 	closeable?: boolean;
 	disabled?: boolean;
 	id?: string;
@@ -32,11 +34,13 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 export default class Tab<P extends TabProperties = TabProperties> extends ThemedBase<P> {
 	render(): DNode {
 		const {
+			aria = {},
 			id,
 			labelledBy
 		} = this.properties;
 
 		return v('div', {
+			...formatAriaProperties(aria),
 			'aria-labelledby': labelledBy,
 			classes: this.theme(css.tab),
 			id,

--- a/src/tabcontroller/TabController.ts
+++ b/src/tabcontroller/TabController.ts
@@ -6,6 +6,8 @@ import { v, w } from '@dojo/widget-core/d';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import TabButton from './TabButton';
 import uuid from '@dojo/core/uuid';
+import { CustomAriaProperties } from '../common/interfaces';
+import { formatAriaProperties } from '../common/util';
 
 import * as css from '../theme/tabcontroller/tabController.m.css';
 
@@ -29,7 +31,7 @@ export const enum Align {
  * @property onRequestTabChange    Called when a new tab button is clicked
  * @property onRequestTabClose     Called when a tab close button is clicked
  */
-export interface TabControllerProperties extends ThemedProperties {
+export interface TabControllerProperties extends ThemedProperties, CustomAriaProperties {
 	activeIndex: number;
 	alignButtons?: Align;
 	onRequestTabChange?(index: number, key: string): void;
@@ -195,7 +197,7 @@ export default class TabController<P extends TabControllerProperties = TabContro
 	}
 
 	render(): DNode {
-		const { activeIndex } = this.properties;
+		const { activeIndex, aria = {} } = this.properties;
 		const validIndex = this._validateIndex(activeIndex);
 		const tabs = this.renderTabs();
 
@@ -235,6 +237,7 @@ export default class TabController<P extends TabControllerProperties = TabContro
 		}
 
 		return v('div', {
+			...formatAriaProperties(aria),
 			'aria-orientation': orientation,
 			classes: this.theme([
 				alignClass ? alignClass : null,

--- a/src/tabcontroller/tests/unit/Tab.ts
+++ b/src/tabcontroller/tests/unit/Tab.ts
@@ -35,6 +35,7 @@ registerSuite('Tab', {
 				v('a', { href: '#foo'}, [ 'foo' ])
 			];
 			widget.setProperties({
+				aria: { describedBy: 'foo' },
 				closeable: true,
 				disabled: true,
 				id: 'foo',
@@ -46,6 +47,7 @@ registerSuite('Tab', {
 
 			widget.expectRender(v('div', {
 				'aria-labelledby': 'id',
+				'aria-describedby': 'foo',
 				classes: css.tab,
 				id: 'foo',
 				role: 'tabpanel'

--- a/src/tabcontroller/tests/unit/TabController.ts
+++ b/src/tabcontroller/tests/unit/TabController.ts
@@ -159,6 +159,21 @@ registerSuite('TabController', {
 			widget.expectRender(expected([ tabButtons, tabContent ]), 'Tab controller with tabs');
 		},
 
+		'aria properties'() {
+			widget.setProperties({
+				activeIndex: 0,
+				aria: {
+					describedBy: 'foo',
+					orientation: 'overridden'
+				}
+			});
+
+			const expectedVdom = expected([ expectedTabButtons(true), null ]);
+			assignProperties(expectedVdom, { 'aria-describedby': 'foo' });
+
+			widget.expectRender(expectedVdom);
+		},
+
 		'custom orientation'() {
 			widget.setProperties({
 				activeIndex: 0,

--- a/src/textarea/Textarea.ts
+++ b/src/textarea/Textarea.ts
@@ -3,7 +3,8 @@ import { DNode } from '@dojo/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import { v, w } from '@dojo/widget-core/d';
 import Label from '../label/Label';
-import { InputProperties, LabeledProperties, InputEventProperties, PointerEventProperties, KeyEventProperties } from '../common/interfaces';
+import { CustomAriaProperties, InputProperties, LabeledProperties, InputEventProperties, PointerEventProperties, KeyEventProperties } from '../common/interfaces';
+import { formatAriaProperties } from '../common/util';
 import uuid from '@dojo/core/uuid';
 import * as css from '../theme/textarea/textarea.m.css';
 
@@ -20,7 +21,7 @@ import * as css from '../theme/textarea/textarea.m.css';
  * @property placeholder    Placeholder text
  * @property value           The current value
  */
-export interface TextareaProperties extends ThemedProperties, InputProperties, LabeledProperties, InputEventProperties, KeyEventProperties, PointerEventProperties {
+export interface TextareaProperties extends ThemedProperties, InputProperties, LabeledProperties, InputEventProperties, KeyEventProperties, PointerEventProperties, CustomAriaProperties {
 	columns?: number;
 	rows?: number;
 	wrapText?: 'hard' | 'soft' | 'off';
@@ -74,8 +75,8 @@ export default class Textarea<P extends TextareaProperties = TextareaProperties>
 
 	render(): DNode {
 		const {
+			aria = {},
 			columns,
-			describedBy,
 			disabled,
 			invalid,
 			label,
@@ -107,9 +108,9 @@ export default class Textarea<P extends TextareaProperties = TextareaProperties>
 				v('textarea', {
 					id: this._uuid,
 					key: 'input',
+					...formatAriaProperties(aria),
 					classes: this.theme(css.input),
 					cols: columns ? `${columns}` : null,
-					'aria-describedby': describedBy,
 					disabled,
 					'aria-invalid': invalid ? 'true' : null,
 					maxlength: maxLength ? `${maxLength}` : null,

--- a/src/textarea/tests/unit/Textarea.ts
+++ b/src/textarea/tests/unit/Textarea.ts
@@ -36,7 +36,6 @@ const expected = function(label = false) {
 				id: <any> compareId,
 				key: 'input',
 				cols: null,
-				'aria-describedby': undefined,
 				disabled: undefined,
 				'aria-invalid': null,
 				maxlength: null,
@@ -86,8 +85,8 @@ registerSuite('Textarea', {
 
 		'custom properties'() {
 			widget.setProperties({
+				aria: { describedBy: 'foo' },
 				columns: 15,
-				describedBy: 'foo',
 				maxLength: 50,
 				minLength: 10,
 				name: 'bar',

--- a/src/textinput/TextInput.ts
+++ b/src/textinput/TextInput.ts
@@ -3,7 +3,7 @@ import { DNode } from '@dojo/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import { v, w } from '@dojo/widget-core/d';
 import Label from '../label/Label';
-import { InputProperties, LabeledProperties, PointerEventProperties, KeyEventProperties, InputEventProperties } from '../common/interfaces';
+import { CustomAriaProperties, InputProperties, LabeledProperties, PointerEventProperties, KeyEventProperties, InputEventProperties } from '../common/interfaces';
 import uuid from '@dojo/core/uuid';
 import * as css from '../theme/textinput/textinput.m.css';
 
@@ -21,7 +21,8 @@ export type TextInputType = 'text' | 'email' | 'number' | 'password' | 'search' 
  * @property placeholder    Placeholder text
  * @property value           The current value
  */
-export interface TextInputProperties extends ThemedProperties, InputProperties, LabeledProperties, PointerEventProperties, KeyEventProperties, InputEventProperties {
+
+export interface TextInputProperties extends ThemedProperties, InputProperties, LabeledProperties, PointerEventProperties, KeyEventProperties, InputEventProperties, CustomAriaProperties {
 	controls?: string;
 	type?: TextInputType;
 	maxLength?: number | string;
@@ -74,8 +75,7 @@ export default class TextInput<P extends TextInputProperties = TextInputProperti
 
 	protected renderInput(): DNode {
 		const {
-			controls,
-			describedBy,
+			aria = {},
 			disabled,
 			invalid,
 			maxLength,
@@ -89,6 +89,7 @@ export default class TextInput<P extends TextInputProperties = TextInputProperti
 		} = this.properties;
 
 		return v('input', {
+			...aria,
 			'aria-controls': controls,
 			'aria-describedby': describedBy,
 			'aria-invalid': invalid ? 'true' : null,

--- a/src/textinput/TextInput.ts
+++ b/src/textinput/TextInput.ts
@@ -4,6 +4,7 @@ import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/T
 import { v, w } from '@dojo/widget-core/d';
 import Label from '../label/Label';
 import { CustomAriaProperties, InputProperties, LabeledProperties, PointerEventProperties, KeyEventProperties, InputEventProperties } from '../common/interfaces';
+import { formatAriaProperties } from '../common/util';
 import uuid from '@dojo/core/uuid';
 import * as css from '../theme/textinput/textinput.m.css';
 
@@ -89,9 +90,7 @@ export default class TextInput<P extends TextInputProperties = TextInputProperti
 		} = this.properties;
 
 		return v('input', {
-			...aria,
-			'aria-controls': controls,
-			'aria-describedby': describedBy,
+			...formatAriaProperties(aria),
 			'aria-invalid': invalid ? 'true' : null,
 			classes: this.theme(css.input),
 			disabled,

--- a/src/textinput/tests/unit/TextInput.ts
+++ b/src/textinput/tests/unit/TextInput.ts
@@ -85,12 +85,14 @@ registerSuite('TextInput', {
 
 		'custom properties'() {
 			widget.setProperties({
-				controls: 'foo',
-				describedBy: 'bar',
+				aria: {
+					controls: 'foo',
+					describedBy: 'bar'
+				},
 				maxLength: 50,
 				minLength: 10,
-				name: 'baz',
-				placeholder: 'qux',
+				name: 'bar',
+				placeholder: 'baz',
 				type: 'email',
 				value: 'hello world'
 			});
@@ -104,8 +106,8 @@ registerSuite('TextInput', {
 				'aria-describedby': 'bar',
 				maxlength: '50',
 				minlength: '10',
-				name: 'baz',
-				placeholder: 'qux',
+				name: 'bar',
+				placeholder: 'baz',
 				type: 'email',
 				value: 'hello world'
 			});

--- a/src/textinput/tests/unit/TextInput.ts
+++ b/src/textinput/tests/unit/TextInput.ts
@@ -35,8 +35,6 @@ const expected = function(label = false, classes: (string | null)[] = [ css.root
 				key: 'input',
 				classes: css.input,
 				id: <any> compareId,
-				'aria-controls': undefined,
-				'aria-describedby': undefined,
 				disabled: undefined,
 				'aria-invalid': null,
 				maxlength: null,

--- a/src/theme/combobox/comboBox.m.css
+++ b/src/theme/combobox/comboBox.m.css
@@ -11,6 +11,10 @@
 	box-sizing: border-box;
 }
 
+.clearable {
+	padding-right: 4em;
+}
+
 .controls {
 	position: relative;
 }

--- a/src/theme/combobox/comboBox.m.css.d.ts
+++ b/src/theme/combobox/comboBox.m.css.d.ts
@@ -1,4 +1,5 @@
 export const root: string;
+export const clearable: string;
 export const controls: string;
 export const dropdown: string;
 export const clear: string;

--- a/src/themes/dojo/comboBox.m.css
+++ b/src/themes/dojo/comboBox.m.css
@@ -20,6 +20,10 @@
 	width: 100%;
 }
 
+.clearable input {
+	padding-right: calc(var(--spacing-regular) * 8);
+}
+
 .trigger {
 	appearance: none;
 	background-color: transparent;

--- a/src/timepicker/TimePicker.ts
+++ b/src/timepicker/TimePicker.ts
@@ -7,6 +7,7 @@ import { diffProperty } from '@dojo/widget-core/decorators/diffProperty';
 import { auto } from '@dojo/widget-core/diff';
 import ComboBox from '../combobox/ComboBox';
 import { LabeledProperties, InputProperties } from '../common/interfaces';
+import { formatAriaProperties } from '../common/util';
 import { TextInputProperties } from '../textinput/TextInput';
 import Label from '../label/Label';
 import uuid from '@dojo/core/uuid';
@@ -281,7 +282,7 @@ export class TimePicker<P extends TimePickerProperties = TimePickerProperties> e
 		const {
 			disabled,
 			end,
-			inputProperties: { customAria } = { customAria: {} },
+			inputProperties = {},
 			invalid,
 			name,
 			readOnly,
@@ -295,6 +296,10 @@ export class TimePicker<P extends TimePickerProperties = TimePickerProperties> e
 			labelAfter = false
 		} = this.properties;
 
+		let { aria } = inputProperties;
+
+		aria = aria ? formatAriaProperties(aria) : {};
+
 		const children = [
 			label ? w(Label, {
 				theme,
@@ -307,7 +312,7 @@ export class TimePicker<P extends TimePickerProperties = TimePickerProperties> e
 			}, [ label ]) : null,
 			v('input', {
 				id: this._uuid,
-				'aria-describedby': customAria && customAria['aria-describedby'],
+				...aria,
 				'aria-invalid': invalid === true ? 'true' : null,
 				'aria-readonly': readOnly === true ? 'true' : null,
 				classes: this.theme(css.input),

--- a/src/timepicker/TimePicker.ts
+++ b/src/timepicker/TimePicker.ts
@@ -296,9 +296,7 @@ export class TimePicker<P extends TimePickerProperties = TimePickerProperties> e
 			labelAfter = false
 		} = this.properties;
 
-		let { aria } = inputProperties;
-
-		aria = aria ? formatAriaProperties(aria) : {};
+		const { aria = {} } = inputProperties;
 
 		const children = [
 			label ? w(Label, {
@@ -312,7 +310,7 @@ export class TimePicker<P extends TimePickerProperties = TimePickerProperties> e
 			}, [ label ]) : null,
 			v('input', {
 				id: this._uuid,
-				...aria,
+				...formatAriaProperties(aria),
 				'aria-invalid': invalid === true ? 'true' : null,
 				'aria-readonly': readOnly === true ? 'true' : null,
 				classes: this.theme(css.input),

--- a/src/timepicker/TimePicker.ts
+++ b/src/timepicker/TimePicker.ts
@@ -281,7 +281,7 @@ export class TimePicker<P extends TimePickerProperties = TimePickerProperties> e
 		const {
 			disabled,
 			end,
-			inputProperties,
+			inputProperties: { customAria } = { customAria: {} },
 			invalid,
 			name,
 			readOnly,
@@ -307,7 +307,7 @@ export class TimePicker<P extends TimePickerProperties = TimePickerProperties> e
 			}, [ label ]) : null,
 			v('input', {
 				id: this._uuid,
-				'aria-describedby': inputProperties && inputProperties.describedBy,
+				'aria-describedby': customAria && customAria['aria-describedby'],
 				'aria-invalid': invalid === true ? 'true' : null,
 				'aria-readonly': readOnly === true ? 'true' : null,
 				classes: this.theme(css.input),

--- a/src/timepicker/example/index.ts
+++ b/src/timepicker/example/index.ts
@@ -57,7 +57,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 			v('div', { id: 'example-filter-on-input' }, [
 				w(TimePicker, {
 					inputProperties: {
-						describedBy: 'description1',
+						customAria: { 'aria-describedby': 'description1' },
 						placeholder: 'Enter a value'
 					},
 					key: '1',
@@ -92,7 +92,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 			v('div', { id: 'example-open-on-focus' }, [
 				w(TimePicker, {
 					inputProperties: {
-						describedBy: 'description1',
+						customAria: { 'aria-describedby': 'description1' },
 						placeholder: 'Enter a value'
 					},
 					key: '2',
@@ -116,7 +116,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 			v('div', { id: 'example-disabled-items' }, [
 				w(TimePicker, {
 					inputProperties: {
-						describedBy: 'description2',
+						customAria: { 'aria-describedby': 'description2' },
 						placeholder: 'Enter a value'
 					},
 					isOptionDisabled: (option: TimeUnits) => option.hour >= 12,
@@ -136,7 +136,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 			v('div', { id: 'example-disabled' }, [
 				w(TimePicker, {
 					inputProperties: {
-						describedBy: 'description1',
+						customAria: { 'aria-describedby': 'description1' },
 						placeholder: 'Enter a value'
 					},
 					key: '4',
@@ -149,7 +149,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 			v('div', { id: 'example-readonly' }, [
 				w(TimePicker, {
 					inputProperties: {
-						describedBy: 'description1',
+						customAria: { 'aria-describedby': 'description1' },
 						placeholder: 'Enter a value'
 					},
 					key: '5',
@@ -163,7 +163,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 				w(TimePicker, {
 					key: '6',
 					inputProperties: {
-						describedBy: 'description1'
+						customAria: { 'aria-describedby': 'description1' }
 					},
 					label: 'Enter a value',
 					onChange: (value: string) => {
@@ -181,7 +181,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 			v('div', { id: 'example-required-validated' }, [
 				w(TimePicker, {
 					inputProperties: {
-						describedBy: 'description1',
+						customAria: { 'aria-describedby': 'description1' },
 						placeholder: 'Enter a value'
 					},
 					invalid: this._invalid,
@@ -212,7 +212,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 				w(TimePicker, {
 					end: '12:00:59',
 					inputProperties: {
-						describedBy: 'description8',
+						customAria: { 'aria-describedby': 'description8' },
 						placeholder: 'Enter a value'
 					},
 					key: '8',
@@ -241,7 +241,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 						return getEnglishTime(TODAY);
 					},
 					inputProperties: {
-						describedBy: 'description9',
+						customAria: { 'aria-describedby': 'description9' },
 						placeholder: 'Enter a value'
 					},
 					key: '9',
@@ -261,7 +261,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 				w(TimePicker, {
 					key: '10',
 					inputProperties: {
-						describedBy: 'description',
+						customAria: { 'aria-describedby': 'description1' },
 						placeholder: 'Enter a value'
 					},
 					onChange: (value: string) => {

--- a/src/timepicker/tests/unit/TimePicker.ts
+++ b/src/timepicker/tests/unit/TimePicker.ts
@@ -179,7 +179,6 @@ registerSuite('TimePicker', {
 			}, [
 				null,
 				v('input', {
-					'aria-describedby': undefined,
 					'aria-invalid': null,
 					'aria-readonly': null,
 					classes: css.input,
@@ -278,7 +277,6 @@ registerSuite('TimePicker', {
 					forId: <any> compareId
 				}, [ 'foo' ]),
 				v('input', {
-					'aria-describedby': undefined,
 					'aria-invalid': null,
 					'aria-readonly': null,
 					classes: css.input,

--- a/src/timepicker/tests/unit/TimePicker.ts
+++ b/src/timepicker/tests/unit/TimePicker.ts
@@ -209,7 +209,9 @@ registerSuite('TimePicker', {
 			picker.setProperties({
 				disabled: true,
 				end: '12:00',
-				inputProperties: { describedBy: 'Some descriptive text' },
+				inputProperties: {
+					aria: { describedBy: 'Some descriptive text' }
+				},
 				invalid: true,
 				name: 'some-field',
 				readOnly: true,

--- a/src/tooltip/Tooltip.ts
+++ b/src/tooltip/Tooltip.ts
@@ -1,7 +1,9 @@
-import { DNode, WidgetProperties } from '@dojo/widget-core/interfaces';
-import { ThemedMixin, theme } from '@dojo/widget-core/mixins/Themed';
+import { DNode } from '@dojo/widget-core/interfaces';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import { v } from '@dojo/widget-core/d';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
+import { CustomAriaProperties } from '../common/interfaces';
+import { formatAriaProperties } from '../common/util';
 
 import * as fixedCss from './styles/tooltip.m.css';
 import * as css from '../theme/tooltip/tooltip.m.css';
@@ -15,7 +17,7 @@ import * as css from '../theme/tooltip/tooltip.m.css';
  * @property orientation       Where this tooltip should render relative to its child
  * @property open              Determines if this tooltip is visible
  */
-export interface TooltipProperties extends WidgetProperties {
+export interface TooltipProperties extends ThemedProperties, CustomAriaProperties {
 	content: DNode;
 	orientation?: Orientation;
 	open?: boolean;
@@ -54,7 +56,9 @@ export default class Tooltip<P extends TooltipProperties = TooltipProperties> ex
 	}
 
 	protected renderContent(): DNode {
+		const { aria = {} } = this.properties;
 		return v('div', {
+			...formatAriaProperties(aria),
 			classes: [ this.theme(css.content), fixedCss.contentFixed ],
 			key: 'content'
 		}, [ this.properties.content ]);

--- a/src/tooltip/tests/unit/Tooltip.ts
+++ b/src/tooltip/tests/unit/Tooltip.ts
@@ -57,6 +57,25 @@ registerSuite('Tooltip', {
 				v('div', { key: 'target' }, []),
 				null
 			]));
+		},
+
+		'should render aria properties'() {
+			widget.setProperties({
+				aria: { describedBy: 'foo' },
+				content: 'bar',
+				open: true
+			});
+
+			widget.expectRender(v('div', {
+				classes: [ css.right, css.rootFixed, css.rightFixed ]
+			}, [
+				v('div', { key: 'target' }, []),
+				v('div', {
+					key: 'content',
+					'aria-describedby': 'foo',
+					classes: [ css.content, css.contentFixed ]
+				}, [ 'bar' ])
+			]));
 		}
 	}
 });

--- a/src/tooltip/tests/unit/Tooltip.ts
+++ b/src/tooltip/tests/unit/Tooltip.ts
@@ -67,13 +67,13 @@ registerSuite('Tooltip', {
 			});
 
 			widget.expectRender(v('div', {
-				classes: [ css.right, css.rootFixed, css.rightFixed ]
+				classes: [ css.right, fixedCss.rootFixed, fixedCss.rightFixed ]
 			}, [
 				v('div', { key: 'target' }, []),
 				v('div', {
 					key: 'content',
 					'aria-describedby': 'foo',
-					classes: [ css.content, css.contentFixed ]
+					classes: [ css.content, fixedCss.contentFixed ]
 				}, [ 'bar' ])
 			]));
 		}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #392 and #376. Adds an interface for a custom `aria` bucket, and a util to format properties passed through it. Leaves implementation up to widget authors.
