### PR TITLE
Add `id` property to form widgets

### DIFF
--- a/src/checkbox/Checkbox.ts
+++ b/src/checkbox/Checkbox.ts
@@ -21,6 +21,7 @@ import * as css from '../theme/checkbox/checkbox.m.css';
  */
 export interface CheckboxProperties extends ThemedProperties, InputProperties, LabeledProperties, InputEventProperties, KeyEventProperties, PointerEventProperties, CustomAriaProperties {
 	checked?: boolean;
+	id?: string;
 	mode?: Mode;
 	offLabel?: DNode;
 	onLabel?: DNode;
@@ -114,6 +115,7 @@ export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> ext
 			aria = {},
 			checked = false,
 			disabled,
+			id = this._uuid,
 			invalid,
 			label,
 			labelAfter = true,
@@ -129,7 +131,7 @@ export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> ext
 			v('div', { classes: this.theme(css.inputWrapper) }, [
 				...this.renderToggle(),
 				v('input', {
-					id: this._uuid,
+					id,
 					...formatAriaProperties(aria),
 					classes: this.theme(css.input),
 					checked,
@@ -159,7 +161,7 @@ export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> ext
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: this._uuid,
+				forId: id,
 				secondary: true
 			}, [ label ]) : null
 		];

--- a/src/checkbox/Checkbox.ts
+++ b/src/checkbox/Checkbox.ts
@@ -21,7 +21,6 @@ import * as css from '../theme/checkbox/checkbox.m.css';
  */
 export interface CheckboxProperties extends ThemedProperties, InputProperties, LabeledProperties, InputEventProperties, KeyEventProperties, PointerEventProperties, CustomAriaProperties {
 	checked?: boolean;
-	id?: string;
 	mode?: Mode;
 	offLabel?: DNode;
 	onLabel?: DNode;

--- a/src/checkbox/tests/unit/Checkbox.ts
+++ b/src/checkbox/tests/unit/Checkbox.ts
@@ -113,6 +113,7 @@ registerSuite('Checkbox', {
 					describedBy: 'foo'
 				},
 				checked: true,
+				id: 'foo',
 				name: 'bar',
 				value: 'baz'
 			});
@@ -121,6 +122,7 @@ registerSuite('Checkbox', {
 			assignChildProperties(expectedVdom, '0,0', {
 				checked: true,
 				'aria-describedby': 'foo',
+				id: 'foo',
 				name: 'bar',
 				value: 'baz'
 			});

--- a/src/combobox/ComboBox.ts
+++ b/src/combobox/ComboBox.ts
@@ -268,6 +268,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 	protected renderInput(results: any[]): DNode {
 		const {
 			disabled,
+			id = this._idBase,
 			inputProperties = {},
 			invalid,
 			readOnly,
@@ -285,6 +286,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 				owns: this._getMenuId()
 			},
 			disabled,
+			id,
 			invalid,
 			onBlur: this._onInputBlur,
 			onFocus: this._onInputFocus,
@@ -424,7 +426,6 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 			'aria-haspopup': 'true',
 			'aria-readonly': readOnly ? 'true' : null,
 			'aria-required': required ? 'true' : null,
-			id,
 			classes: this.theme([
 				css.root,
 				this._open ? css.open : null,

--- a/src/combobox/ComboBox.ts
+++ b/src/combobox/ComboBox.ts
@@ -381,7 +381,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 	render(): DNode {
 		const {
 			clearable = false,
-			id,
+			id = this._idBase,
 			invalid,
 			label,
 			readOnly,

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -144,7 +144,7 @@ const getExpectedVdom = function(widget: Harness<ComboBox>, useTestProperties = 
 		'aria-readonly': null,
 		'aria-required': null,
 		dir: null,
-		id: useTestProperties ? 'foo' : undefined,
+		id: useTestProperties ? 'foo' : compareId as any,
 		classes: [
 			css.root,
 			open ? css.open : null,
@@ -164,7 +164,7 @@ const getExpectedVdom = function(widget: Harness<ComboBox>, useTestProperties = 
 			invalid: undefined,
 			readOnly: undefined,
 			required: undefined,
-			forId: compareId as any
+			forId: useTestProperties ? 'foo' : compareId as any
 		}, [ 'foo' ]) : null,
 		controlsVdom,
 		menuVdom

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -58,6 +58,7 @@ const getExpectedControls = function(widget: Harness<ComboBox>, useTestPropertie
 				owns: compareId as any
 			},
 			disabled: undefined,
+			id: useTestProperties ? 'foo' : compareId as any,
 			invalid: undefined,
 			readOnly: undefined,
 			required: undefined,
@@ -144,7 +145,6 @@ const getExpectedVdom = function(widget: Harness<ComboBox>, useTestProperties = 
 		'aria-readonly': null,
 		'aria-required': null,
 		dir: null,
-		id: useTestProperties ? 'foo' : compareId as any,
 		classes: [
 			css.root,
 			open ? css.open : null,

--- a/src/common/interfaces.d.ts
+++ b/src/common/interfaces.d.ts
@@ -16,6 +16,7 @@ export interface CustomAriaProperties {
  * Properties that can be set on a input component
  *
  * @property disabled       Prevents the user from interacting with the form field
+ * @property id             Adds an id property to the input node so custom labels are possible
  * @property invalid        Indicates the value entered in the form field is invalid
  * @property name           The form widget's name
  * @property readOnly       Allows or prevents user interaction
@@ -23,6 +24,7 @@ export interface CustomAriaProperties {
  */
 export interface InputProperties {
 	disabled?: boolean;
+	id?: string;
 	invalid?: boolean;
 	name?: string;
 	readOnly?: boolean;

--- a/src/listbox/tests/functional/Listbox.ts
+++ b/src/listbox/tests/functional/Listbox.ts
@@ -6,6 +6,7 @@ import keys from '@theintern/leadfoot/keys';
 import * as css from '../../../theme/listbox/listbox.m.css';
 
 const DELAY = 300;
+const ERROR_MARGIN = 5;
 
 function getPage(remote: Remote) {
 	return remote
@@ -76,8 +77,8 @@ registerSuite('Listbox', {
 				})
 				.getPosition()
 				.then(({ y }: { y: number; }) => {
-					assert.isAtLeast(y, menuTop);
-					assert.isAtMost(Math.floor(y), Math.ceil(menuBottom - itemHeight), 'scrolled down');
+					assert.isAtLeast(y, menuTop - ERROR_MARGIN);
+					assert.isAtMost(Math.floor(y), Math.ceil(menuBottom - itemHeight) + ERROR_MARGIN, 'scrolled down');
 				})
 				.end()
 			.pressKeys(keys.ARROW_DOWN)
@@ -91,7 +92,7 @@ registerSuite('Listbox', {
 			.findByCssSelector(`.${css.activeOption}`)
 				.getPosition()
 				.then(({ y }: { y: number; }) => {
-					assert.isAtLeast(y, menuTop, 'scroll back up');
+					assert.isAtLeast(y, menuTop - ERROR_MARGIN, 'scroll back up');
 				});
 	},
 

--- a/src/radio/Radio.ts
+++ b/src/radio/Radio.ts
@@ -18,7 +18,6 @@ import * as css from '../theme/radio/radio.m.css';
  */
 export interface RadioProperties extends ThemedProperties, LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties, CustomAriaProperties {
 	checked?: boolean;
-	id?: string;
 	value?: string;
 }
 

--- a/src/radio/Radio.ts
+++ b/src/radio/Radio.ts
@@ -18,6 +18,7 @@ import * as css from '../theme/radio/radio.m.css';
  */
 export interface RadioProperties extends ThemedProperties, LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties, CustomAriaProperties {
 	checked?: boolean;
+	id?: string;
 	value?: string;
 }
 
@@ -72,6 +73,7 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 			aria = {},
 			checked = false,
 			disabled,
+			id = this._uuid,
 			invalid,
 			label,
 			labelAfter = true,
@@ -86,7 +88,7 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 		const children = [
 			v('div', { classes: this.theme(css.inputWrapper) }, [
 				v('input', {
-					id: this._uuid,
+					id,
 					...formatAriaProperties(aria),
 					classes: this.theme(css.input),
 					checked,
@@ -116,7 +118,7 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: this._uuid,
+				forId: id,
 				secondary: true
 			}, [ label ]) : null
 		];

--- a/src/radio/tests/unit/Radio.ts
+++ b/src/radio/tests/unit/Radio.ts
@@ -81,6 +81,7 @@ registerSuite('Radio', {
 			widget.setProperties({
 				aria: { describedBy: 'foo' },
 				checked: true,
+				id: 'foo',
 				name: 'bar',
 				value: 'baz'
 			});
@@ -89,6 +90,7 @@ registerSuite('Radio', {
 			assignChildProperties(expectedVdom, '0,0', {
 				checked: true,
 				'aria-describedby': 'foo',
+				id: 'foo',
 				name: 'bar',
 				value: 'baz'
 			});

--- a/src/select/Select.ts
+++ b/src/select/Select.ts
@@ -34,7 +34,6 @@ export interface SelectProperties extends ThemedProperties, InputProperties, Lab
 	getOptionLabel?(option: any): DNode;
 	getOptionSelected?(option: any, index: number): boolean;
 	getOptionValue?(option: any, index: number): string;
-	id?: string;
 	options?: any[];
 	placeholder?: string;
 	useNativeElement?: boolean;

--- a/src/select/Select.ts
+++ b/src/select/Select.ts
@@ -34,6 +34,7 @@ export interface SelectProperties extends ThemedProperties, InputProperties, Lab
 	getOptionLabel?(option: any): DNode;
 	getOptionSelected?(option: any, index: number): boolean;
 	getOptionValue?(option: any, index: number): string;
+	id?: string;
 	options?: any[];
 	placeholder?: string;
 	useNativeElement?: boolean;
@@ -188,6 +189,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 			getOptionId,
 			getOptionSelected,
 			getOptionValue,
+			id = this._baseId,
 			invalid,
 			name,
 			options = [],
@@ -210,6 +212,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 				classes: this.theme(css.input),
 				disabled,
 				'aria-invalid': invalid ? 'true' : null,
+				id,
 				name,
 				readOnly,
 				'aria-readonly': readOnly ? 'true' : null,
@@ -229,6 +232,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 			getOptionId,
 			getOptionLabel,
 			getOptionSelected = this._getOptionSelected,
+			id = this._baseId,
 			key,
 			options = [],
 			theme,
@@ -237,8 +241,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 
 		const {
 			_open,
-			_focusedIndex,
-			_baseId
+			_focusedIndex
 		} = this;
 
 		// create dropdown trigger and select box
@@ -255,7 +258,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 				w(Listbox, {
 					key: 'listbox',
 					activeIndex: _focusedIndex,
-					id: _baseId,
+					id,
 					optionData: options,
 					tabIndex: _open ? 0 : -1,
 					getOptionDisabled,
@@ -334,6 +337,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 			labelHidden,
 			labelAfter,
 			disabled,
+			id = this._baseId,
 			invalid,
 			readOnly,
 			required,
@@ -349,7 +353,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: this._baseId
+				forId: id
 			}, [ label ]) : null,
 			useNativeElement ? this.renderNativeSelect() : this.renderCustomSelect()
 		];

--- a/src/select/tests/unit/Select.ts
+++ b/src/select/tests/unit/Select.ts
@@ -47,6 +47,7 @@ const testProperties: Partial<SelectProperties> = {
 	getOptionLabel: (option: any) => option.label,
 	getOptionSelected: (option: any, index: number) => option.value === 'two',
 	getOptionValue: (option: any, index: number) => option.value,
+	id: 'foo',
 	name: 'foo',
 	options: testOptions,
 	value: 'two'
@@ -66,6 +67,7 @@ const expectedNative = function(widget: Harness<Select>, useTestProperties = fal
 			classes: css.input,
 			disabled: useTestProperties ? true : undefined,
 			'aria-invalid': useTestProperties ? 'true' : null,
+			id: useTestProperties ? 'foo' : compareId as any,
 			name: useTestProperties ? 'foo' : undefined,
 			readOnly: useTestProperties ? true : undefined,
 			'aria-readonly': useTestProperties ? 'true' : null,
@@ -144,7 +146,7 @@ const expectedSingle = function(widget: Harness<Select>, useTestProperties = fal
 		}, [
 			w(Listbox, {
 				activeIndex: 0,
-				id: <any> compareId,
+				id: useTestProperties ? 'foo' : compareId as any,
 				key: 'listbox',
 				optionData: useTestProperties ? testOptions : [],
 				tabIndex: open ? 0 : -1,

--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -23,7 +23,6 @@ import * as css from '../theme/slider/slider.m.css';
  * @property value           The current value
  */
 export interface SliderProperties extends ThemedProperties, LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties, KeyEventProperties, CustomAriaProperties {
-	id?: string;
 	max?: number;
 	min?: number;
 	output?(value: number): DNode;

--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -23,6 +23,7 @@ import * as css from '../theme/slider/slider.m.css';
  * @property value           The current value
  */
 export interface SliderProperties extends ThemedProperties, LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties, KeyEventProperties, CustomAriaProperties {
+	id?: string;
 	max?: number;
 	min?: number;
 	output?(value: number): DNode;
@@ -122,6 +123,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 		const {
 			aria = {},
 			disabled,
+			id = this._inputId,
 			invalid,
 			label,
 			labelAfter,
@@ -155,7 +157,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 				...formatAriaProperties(aria),
 				classes: [ this.theme(css.input), fixedCss.nativeInput ],
 				disabled,
-				id: this._inputId,
+				id,
 				'aria-invalid': invalid === true ? 'true' : null,
 				max: `${max}`,
 				min: `${min}`,
@@ -193,7 +195,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: this._inputId
+				forId: id
 			}, [ label ]) : null,
 			slider
 		];

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -110,6 +110,7 @@ registerSuite('Slider', {
 		'custom properties'() {
 			widget.setProperties({
 				aria: { describedBy: 'foo' },
+				id: 'foo',
 				max: 60,
 				min: 10,
 				name: 'bar',
@@ -122,6 +123,7 @@ registerSuite('Slider', {
 			const expectedVdom = expected(widget, false, true);
 			assignProperties(findKey(expectedVdom, 'input')!, {
 				'aria-describedby': 'foo',
+				id: 'foo',
 				max: '60',
 				min: '10',
 				name: 'bar',

--- a/src/splitpane/tests/functional/SplitPane.ts
+++ b/src/splitpane/tests/functional/SplitPane.ts
@@ -7,6 +7,7 @@ import Test from 'intern/lib/Test';
 import * as css from '../../../theme/splitpane/splitPane.m.css';
 
 const DELAY = 300;
+const ERROR_MARGIN = 5;
 
 function getPage(test: Test): Command<void> {
 	const { browserName = '' } = test.remote.environmentType!;
@@ -64,13 +65,13 @@ function testResizes(command: Command<Element | void>, resizes: Coord[], expecte
 						assert.isTrue(delta.x(x), `Resize ${i} should pass x test.`);
 					}
 					else {
-						assert.closeTo(x, currentX + delta.x, 1, `Resize ${i} should move x by ${move.x}.`);
+						assert.closeTo(x, currentX + delta.x, ERROR_MARGIN, `Resize ${i} should move x by ${move.x}.`);
 					}
 					if (typeof delta.y === 'function') {
 						assert.isTrue(delta.y(y), `Resize ${i} should pass y test.`);
 					}
 					else {
-						assert.closeTo(y, currentY + delta.y, 1, `Resize ${i} should move y by ${move.y}.`);
+						assert.closeTo(y, currentY + delta.y, ERROR_MARGIN, `Resize ${i} should move y by ${move.y}.`);
 					}
 					currentX = x;
 					currentY = y;

--- a/src/textarea/Textarea.ts
+++ b/src/textarea/Textarea.ts
@@ -23,7 +23,6 @@ import * as css from '../theme/textarea/textarea.m.css';
  */
 export interface TextareaProperties extends ThemedProperties, InputProperties, LabeledProperties, InputEventProperties, KeyEventProperties, PointerEventProperties, CustomAriaProperties {
 	columns?: number;
-	id?: string;
 	rows?: number;
 	wrapText?: 'hard' | 'soft' | 'off';
 	maxLength?: number | string;

--- a/src/textarea/Textarea.ts
+++ b/src/textarea/Textarea.ts
@@ -23,6 +23,7 @@ import * as css from '../theme/textarea/textarea.m.css';
  */
 export interface TextareaProperties extends ThemedProperties, InputProperties, LabeledProperties, InputEventProperties, KeyEventProperties, PointerEventProperties, CustomAriaProperties {
 	columns?: number;
+	id?: string;
 	rows?: number;
 	wrapText?: 'hard' | 'soft' | 'off';
 	maxLength?: number | string;
@@ -78,6 +79,7 @@ export class TextareaBase<P extends TextareaProperties = TextareaProperties> ext
 			aria = {},
 			columns,
 			disabled,
+			id = this._uuid,
 			invalid,
 			label,
 			maxLength,
@@ -102,11 +104,11 @@ export class TextareaBase<P extends TextareaProperties = TextareaProperties> ext
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: this._uuid
+				forId: id
 			}, [ label ]) : null,
 			v('div', { classes: this.theme(css.inputWrapper) }, [
 				v('textarea', {
-					id: this._uuid,
+					id,
 					key: 'input',
 					...formatAriaProperties(aria),
 					classes: this.theme(css.input),

--- a/src/textarea/tests/unit/Textarea.ts
+++ b/src/textarea/tests/unit/Textarea.ts
@@ -87,6 +87,7 @@ registerSuite('Textarea', {
 			widget.setProperties({
 				aria: { describedBy: 'foo' },
 				columns: 15,
+				id: 'foo',
 				maxLength: 50,
 				minLength: 10,
 				name: 'bar',
@@ -100,6 +101,7 @@ registerSuite('Textarea', {
 			assignProperties(findKey(expectedVdom, 'input')!, {
 				cols: '15',
 				'aria-describedby': 'foo',
+				id: 'foo',
 				maxlength: '50',
 				minlength: '10',
 				name: 'bar',

--- a/src/textinput/TextInput.ts
+++ b/src/textinput/TextInput.ts
@@ -25,7 +25,6 @@ export type TextInputType = 'text' | 'email' | 'number' | 'password' | 'search' 
 
 export interface TextInputProperties extends ThemedProperties, InputProperties, LabeledProperties, PointerEventProperties, KeyEventProperties, InputEventProperties, CustomAriaProperties {
 	controls?: string;
-	id?: string;
 	type?: TextInputType;
 	maxLength?: number | string;
 	minLength?: number | string;

--- a/src/textinput/TextInput.ts
+++ b/src/textinput/TextInput.ts
@@ -25,6 +25,7 @@ export type TextInputType = 'text' | 'email' | 'number' | 'password' | 'search' 
 
 export interface TextInputProperties extends ThemedProperties, InputProperties, LabeledProperties, PointerEventProperties, KeyEventProperties, InputEventProperties, CustomAriaProperties {
 	controls?: string;
+	id?: string;
 	type?: TextInputType;
 	maxLength?: number | string;
 	minLength?: number | string;
@@ -78,6 +79,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 		const {
 			aria = {},
 			disabled,
+			id = this._uuid,
 			invalid,
 			maxLength,
 			minLength,
@@ -94,7 +96,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 			'aria-invalid': invalid ? 'true' : null,
 			classes: this.theme(css.input),
 			disabled,
-			id: this._uuid,
+			id,
 			key: 'input',
 			maxlength: maxLength ? `${maxLength}` : null,
 			minlength: minLength ? `${minLength}` : null,
@@ -130,6 +132,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 	render(): DNode {
 		const {
 			disabled,
+			id = this._uuid,
 			invalid,
 			label,
 			labelAfter = false,
@@ -147,7 +150,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: this._uuid
+				forId: id
 			}, [ label ]) : null,
 			this.renderInputWrapper()
 		];

--- a/src/textinput/tests/unit/TextInput.ts
+++ b/src/textinput/tests/unit/TextInput.ts
@@ -87,6 +87,7 @@ registerSuite('TextInput', {
 					controls: 'foo',
 					describedBy: 'bar'
 				},
+				id: 'foo',
 				maxLength: 50,
 				minLength: 10,
 				name: 'bar',
@@ -102,6 +103,7 @@ registerSuite('TextInput', {
 			assignProperties(findKey(expectedVdom, 'input')!, {
 				'aria-controls': 'foo',
 				'aria-describedby': 'bar',
+				id: 'foo',
 				maxlength: '50',
 				minlength: '10',
 				name: 'bar',

--- a/src/timepicker/TimePicker.ts
+++ b/src/timepicker/TimePicker.ts
@@ -47,6 +47,7 @@ export interface TimePickerProperties extends ThemedProperties, InputProperties,
 	clearable?: boolean;
 	end?: string;
 	getOptionLabel?(option: TimeUnits): string;
+	id?: string;
 	inputProperties?: TextInputProperties;
 	isOptionDisabled?(result: any): boolean;
 	onBlur?(value: string): void;
@@ -235,6 +236,7 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 			clearable,
 			disabled,
 			extraClasses,
+			id = this._uuid,
 			inputProperties,
 			invalid,
 			isOptionDisabled,
@@ -258,6 +260,7 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 			disabled,
 			extraClasses,
 			getResultLabel: this._getOptionLabel.bind(this),
+			id,
 			inputProperties,
 			invalid,
 			isResultDisabled: isOptionDisabled,
@@ -282,6 +285,7 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 		const {
 			disabled,
 			end,
+			id = this._uuid,
 			inputProperties = {},
 			invalid,
 			name,
@@ -306,10 +310,10 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: this._uuid
+				forId: id
 			}, [ label ]) : null,
 			v('input', {
-				id: this._uuid,
+				id,
 				...formatAriaProperties(aria),
 				'aria-invalid': invalid === true ? 'true' : null,
 				'aria-readonly': readOnly === true ? 'true' : null,

--- a/src/timepicker/TimePicker.ts
+++ b/src/timepicker/TimePicker.ts
@@ -47,7 +47,6 @@ export interface TimePickerProperties extends ThemedProperties, InputProperties,
 	clearable?: boolean;
 	end?: string;
 	getOptionLabel?(option: TimeUnits): string;
-	id?: string;
 	inputProperties?: TextInputProperties;
 	isOptionDisabled?(result: any): boolean;
 	onBlur?(value: string): void;

--- a/src/timepicker/tests/unit/TimePicker.ts
+++ b/src/timepicker/tests/unit/TimePicker.ts
@@ -69,6 +69,7 @@ registerSuite('TimePicker', {
 			picker.setProperties({
 				clearable: true,
 				disabled: false,
+				id: 'foo',
 				invalid: true,
 				label: 'Some Field',
 				openOnFocus: false,
@@ -82,6 +83,7 @@ registerSuite('TimePicker', {
 					clearable: true,
 					disabled: false,
 					getResultLabel: <any> picker.listener,
+					id: 'foo',
 					inputProperties: undefined,
 					invalid: true,
 					isResultDisabled: undefined,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #430, adds an `id` prop to form widgets so anyone wishing to use their own label may do so
