### PR TITLE
Update widgets to use Focus meta

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -149,16 +149,17 @@
       "dev": true,
       "requires": {
         "@types/body-parser": "1.16.8",
-        "@types/express-serve-static-core": "4.11.0",
+        "@types/express-serve-static-core": "4.11.1",
         "@types/serve-static": "1.13.1"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.0.tgz",
-      "integrity": "sha512-hOi1QNb+4G+UjDt6CEJ6MjXHy+XceY7AxIa28U9HgJ80C+3gIbj7h5dJNxOI7PU3DO1LIhGP5Bs47Dbf5l8+MA==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.1.tgz",
+      "integrity": "sha512-EehCl3tpuqiM8RUb+0255M8PhhSwTtLfmO7zBBdv0ay/VTd/zmrqDfQdZFsa5z/PVMbH2yCMZPXsnrImpATyIw==",
       "dev": true,
       "requires": {
+        "@types/events": "1.1.0",
         "@types/node": "9.3.0"
       }
     },
@@ -300,9 +301,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.92",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.92.tgz",
-      "integrity": "sha512-cdvY1fyUGYgG7/i07a/sR5PnD6+Z+ljUrD0CNVf0qj645VvEdLNtZPjvCp4siPy3rQ/KRXMfUATIqi3+9x57Sw==",
+      "version": "4.14.93",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.93.tgz",
+      "integrity": "sha512-xI9Il9Fqxse5hSh6bVwowEC5RXyEVJ2hssRJXANU70H/+NlirvsNi87JjvGMxtn6yTemyUPkkzSl9SCKFW4U3g==",
       "dev": true
     },
     "@types/marked": {
@@ -356,7 +357,7 @@
       "integrity": "sha512-jDMH+3BQPtvqZVIcsH700Dfi8Q3MIcEx16g/VdxjoqiGR/NntekB10xdBpirMKnPe9z2C5cBmL0vte0YttOr3Q==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.11.0",
+        "@types/express-serve-static-core": "4.11.1",
         "@types/mime": "2.0.0"
       }
     },
@@ -1148,7 +1149,7 @@
         "deep-eql": "3.0.1",
         "get-func-name": "2.0.0",
         "pathval": "1.1.0",
-        "type-detect": "4.0.6"
+        "type-detect": "4.0.7"
       }
     },
     "chalk": {
@@ -2030,7 +2031,7 @@
       "integrity": "sha512-+QeIQyN5ZuO+3Uk5DYh6/1eKO0m0YmJFGNmFHGACpf1ClL1nmlV/p4gNgbl2pJGxgXb4faqo6UE+M5ACEMyVcw==",
       "dev": true,
       "requires": {
-        "type-detect": "4.0.6"
+        "type-detect": "4.0.7"
       }
     },
     "deep-equal": {
@@ -2175,9 +2176,9 @@
       "dev": true
     },
     "encodeurl": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.1.tgz",
-      "integrity": "sha1-eePVhlU0aQn+bw9Fpd5oEDspTSA=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
+      "integrity": "sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=",
       "dev": true
     },
     "end-of-stream": {
@@ -2311,7 +2312,7 @@
         "cookie-signature": "1.0.6",
         "debug": "2.6.9",
         "depd": "1.1.2",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
         "finalhandler": "1.0.6",
@@ -2472,7 +2473,7 @@
       "dev": true,
       "requires": {
         "debug": "2.6.9",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "on-finished": "2.3.0",
         "parseurl": "1.3.2",
@@ -2969,7 +2970,7 @@
         "postcss-cssnext": "2.11.0",
         "postcss-import": "9.1.0",
         "postcss-modules": "0.6.4",
-        "remap-istanbul": "0.10.0",
+        "remap-istanbul": "0.10.1",
         "resolve-from": "2.0.0",
         "shelljs": "0.7.8",
         "tslint": "4.5.1",
@@ -3417,7 +3418,7 @@
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.1",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.92",
+        "@types/lodash": "4.14.93",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -6714,17 +6715,25 @@
       }
     },
     "remap-istanbul": {
-      "version": "0.10.0",
-      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.10.0.tgz",
-      "integrity": "sha512-C3vinclZ2p8na07f/f+JWLchmiofgqroyxBrkKPA4kkbjsHHa94HFd5ZYkYrMEs9cbsufh53t5DFJyTK8UDVjg==",
+      "version": "0.10.1",
+      "resolved": "https://registry.npmjs.org/remap-istanbul/-/remap-istanbul-0.10.1.tgz",
+      "integrity": "sha512-gsNQXs5kJLhErICSyYhzVZ++C8LBW8dgwr874Y2QvzAUS75zBlD/juZgXs39nbYJ09fZDlX2AVLVJAY2jbFJoQ==",
       "dev": true,
       "requires": {
         "amdefine": "1.0.1",
         "istanbul": "0.4.5",
         "minimatch": "3.0.4",
         "plugin-error": "0.1.2",
-        "source-map": "0.5.7",
+        "source-map": "0.6.1",
         "through2": "2.0.1"
+      },
+      "dependencies": {
+        "source-map": {
+          "version": "0.6.1",
+          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+          "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+          "dev": true
+        }
       }
     },
     "remove-trailing-separator": {
@@ -6925,7 +6934,7 @@
         "debug": "2.6.9",
         "depd": "1.1.2",
         "destroy": "1.0.4",
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "etag": "1.8.1",
         "fresh": "0.5.2",
@@ -6992,7 +7001,7 @@
       "integrity": "sha1-uXN3P2NEmTTaVOW+ul4x2fQhFXc=",
       "dev": true,
       "requires": {
-        "encodeurl": "1.0.1",
+        "encodeurl": "1.0.2",
         "escape-html": "1.0.3",
         "parseurl": "1.3.2",
         "send": "0.15.6"
@@ -7754,9 +7763,9 @@
       }
     },
     "type-detect": {
-      "version": "4.0.6",
-      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.6.tgz",
-      "integrity": "sha512-qZ3bAurt2IXGPR3c57PyaSYEnQiLRwPeS60G9TahElBZsdOABo+iKYch/PhRjSTZJ5/DF08x43XMt9qec2g3ig==",
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.7.tgz",
+      "integrity": "sha512-4Rh17pAMVdMWzktddFhISRnUnFIStObtUMNGzDwlA6w/77bmGv3aBbRdCmQR6IjzfkTo9otnW+2K/cDRhKSxDA==",
       "dev": true
     },
     "type-is": {
@@ -8955,7 +8964,7 @@
         "@types/fs-extra": "0.0.33",
         "@types/handlebars": "4.0.36",
         "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.92",
+        "@types/lodash": "4.14.93",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@dojo/has": "~0.1.1",
     "@dojo/i18n": "~0.4.0",
     "@dojo/shim": "~0.2.3",
-    "@dojo/widget-core": "~0.6.1"
+    "@dojo/widget-core": "~0.6.2"
   },
   "devDependencies": {
     "@dojo/loader": "~0.1.1",

--- a/src/calendar/CalendarCell.ts
+++ b/src/calendar/CalendarCell.ts
@@ -1,5 +1,6 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
+import Focus from '@dojo/widget-core/meta/Focus';
 import { v } from '@dojo/widget-core/d';
 import { DNode } from '@dojo/widget-core/interfaces';
 import * as css from '../theme/calendar/calendar.m.css';
@@ -35,22 +36,6 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 
 @theme(css)
 export class CalendarCellBase<P extends CalendarCellProperties = CalendarCellProperties> extends ThemedBase<P, null> {
-	protected onElementCreated(element: HTMLElement, key: string) {
-		this._callFocus(element);
-	}
-
-	protected onElementUpdated(element: HTMLElement, key: string) {
-		this._callFocus(element);
-	}
-
-	private _callFocus(element: HTMLElement) {
-		const { callFocus, onFocusCalled } = this.properties;
-		if (callFocus) {
-			element.focus();
-			onFocusCalled && onFocusCalled();
-		}
-	}
-
 	private _onClick(event: MouseEvent) {
 		const { date, disabled = false, onClick } = this.properties;
 		onClick && onClick(date, disabled);
@@ -81,10 +66,17 @@ export class CalendarCellBase<P extends CalendarCellProperties = CalendarCellPro
 
 	protected render(): DNode {
 		const {
+			callFocus,
 			date,
 			focusable = false,
-			selected = false
+			selected = false,
+			onFocusCalled
 		} = this.properties;
+
+		if (callFocus) {
+			this.meta(Focus).set('root');
+			onFocusCalled && onFocusCalled();
+		}
 
 		return v('td', {
 			key: 'root',

--- a/src/calendar/DatePicker.ts
+++ b/src/calendar/DatePicker.ts
@@ -1,5 +1,6 @@
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
+import Focus from '@dojo/widget-core/meta/Focus';
 import { v } from '@dojo/widget-core/d';
 import uuid from '@dojo/core/uuid';
 import { DNode } from '@dojo/widget-core/interfaces';
@@ -62,10 +63,6 @@ const BASE_YEAR = 2000;
 @theme(css)
 @theme(iconCss)
 export class DatePickerBase<P extends DatePickerProperties = DatePickerProperties> extends ThemedBase<P, null> {
-	private _callMonthTriggerFocus = false;
-	private _callYearTriggerFocus = false;
-	private _callMonthPopupFocus = false;
-	private _callYearPopupFocus = false;
 	private _idBase = uuid();
 	private _monthPopupOpen = false;
 	private _yearPopupOpen = false;
@@ -74,7 +71,7 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 	private _closeMonthPopup() {
 		const { onPopupChange } = this.properties;
 		this._monthPopupOpen = false;
-		this._callMonthTriggerFocus = true;
+		this.meta(Focus).set('month-button');
 		this.invalidate();
 		onPopupChange && onPopupChange(this._getPopupState());
 	}
@@ -82,7 +79,7 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 	private _closeYearPopup() {
 		const { onPopupChange } = this.properties;
 		this._yearPopupOpen = false;
-		this._callYearTriggerFocus = true;
+		this.meta(Focus).set('year-button');
 		this.invalidate();
 		onPopupChange && onPopupChange(this._getPopupState());
 	}
@@ -103,36 +100,6 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 		}
 	}
 
-	// move focus when opening/closing the popup
-	protected onElementUpdated(element: HTMLElement, key: string) {
-		if (key === 'month-button') {
-			if (!this._monthPopupOpen && this._callMonthTriggerFocus) {
-				element.focus();
-				this._callMonthTriggerFocus = false;
-			}
-		}
-		if (key === 'year-button') {
-			if (!this._yearPopupOpen && this._callYearTriggerFocus) {
-				element.focus();
-				this._callYearTriggerFocus = false;
-			}
-		}
-		if (this._callMonthPopupFocus && key.indexOf(`${this._idBase}_month_radios`) > -1) {
-			const month = key.split('_')[3];
-			if (this._monthPopupOpen && month === `${this.properties.month}`) {
-				(<HTMLInputElement> element.children[0]).focus();
-				this._callMonthPopupFocus = false;
-			}
-		}
-		if (this._callYearPopupFocus && key.indexOf(`${this._idBase}_year_radios`) > -1) {
-			const year = key.split('_')[3];
-			if (this._yearPopupOpen && year === `${this.properties.year}`) {
-				(<HTMLInputElement> element.children[0]).focus();
-				this._callYearPopupFocus = false;
-			}
-		}
-	}
-
 	private _onMonthButtonClick() {
 		this._monthPopupOpen ? this._closeMonthPopup() : this._openMonthPopup();
 	}
@@ -149,8 +116,8 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 			event.which === Keys.Enter ||
 			event.which === Keys.Space
 		) {
-			this._closeMonthPopup();
-			this._closeYearPopup();
+			this._monthPopupOpen && this._closeMonthPopup();
+			this._yearPopupOpen && this._closeYearPopup();
 		}
 	}
 
@@ -175,18 +142,18 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 	}
 
 	private _openMonthPopup() {
-		const { onPopupChange } = this.properties;
+		const { month, onPopupChange } = this.properties;
 		this._monthPopupOpen = true;
-		this._callMonthPopupFocus = true;
+		this.meta(Focus).set(`${this._idBase}_month_input_${month}`);
 		this._yearPopupOpen = false;
 		this.invalidate();
 		onPopupChange && onPopupChange(this._getPopupState());
 	}
 
 	private _openYearPopup() {
-		const { onPopupChange } = this.properties;
+		const { year, onPopupChange } = this.properties;
 		this._yearPopupOpen = true;
-		this._callYearPopupFocus = true;
+		this.meta(Focus).set(`${this._idBase}_year_input_${year}`);
 		this._monthPopupOpen = false;
 		this.invalidate();
 		onPopupChange && onPopupChange(this._getPopupState());
@@ -233,6 +200,7 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 			v('input', {
 				checked: i === month,
 				classes: this.theme(css.monthRadioInput),
+				key: `${this._idBase}_month_input_${i}`,
 				name: `${this._idBase}_month_radios`,
 				tabIndex: this._monthPopupOpen ? 0 : -1,
 				type: 'radio',
@@ -273,6 +241,7 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 				v('input', {
 					checked: i === year,
 					classes: this.theme(css.yearRadioInput),
+					key: `${this._idBase}_year_input_${i}`,
 					name: `${this._idBase}_year_radios`,
 					tabIndex: this._yearPopupOpen ? 0 : -1,
 					type: 'radio',

--- a/src/calendar/DatePicker.ts
+++ b/src/calendar/DatePicker.ts
@@ -84,8 +84,16 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 		onPopupChange && onPopupChange(this._getPopupState());
 	}
 
+	private _getMonthInputKey(month: number): string {
+		return `${this._idBase}_month_input_${month}`;
+	}
+
 	private _getPopupState() {
 		return this._monthPopupOpen || this._yearPopupOpen;
+	}
+
+	private _getYearInputKey(year: number): string {
+		return `${this._idBase}_year_input_${year}`;
 	}
 
 	private _getYearRange() {
@@ -144,7 +152,7 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 	private _openMonthPopup() {
 		const { month, onPopupChange } = this.properties;
 		this._monthPopupOpen = true;
-		this.meta(Focus).set(`${this._idBase}_month_input_${month}`);
+		this.meta(Focus).set(this._getMonthInputKey(month));
 		this._yearPopupOpen = false;
 		this.invalidate();
 		onPopupChange && onPopupChange(this._getPopupState());
@@ -153,7 +161,7 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 	private _openYearPopup() {
 		const { year, onPopupChange } = this.properties;
 		this._yearPopupOpen = true;
-		this.meta(Focus).set(`${this._idBase}_year_input_${year}`);
+		this.meta(Focus).set(this._getYearInputKey(year));
 		this._monthPopupOpen = false;
 		this.invalidate();
 		onPopupChange && onPopupChange(this._getPopupState());
@@ -200,7 +208,7 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 			v('input', {
 				checked: i === month,
 				classes: this.theme(css.monthRadioInput),
-				key: `${this._idBase}_month_input_${i}`,
+				key: this._getMonthInputKey(i),
 				name: `${this._idBase}_month_radios`,
 				tabIndex: this._monthPopupOpen ? 0 : -1,
 				type: 'radio',
@@ -241,7 +249,7 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 				v('input', {
 					checked: i === year,
 					classes: this.theme(css.yearRadioInput),
-					key: `${this._idBase}_year_input_${i}`,
+					key: this._getYearInputKey(i),
 					name: `${this._idBase}_year_radios`,
 					tabIndex: this._yearPopupOpen ? 0 : -1,
 					type: 'radio',

--- a/src/calendar/tests/unit/DatePicker.ts
+++ b/src/calendar/tests/unit/DatePicker.ts
@@ -34,7 +34,8 @@ const monthRadios = function(widget: Harness<DatePicker>, open?: boolean) {
 		v('input', {
 			checked: i === 5,
 			classes: css.monthRadioInput,
-			name: <any> compareId,
+			key: compareId as any,
+			name: compareId as any,
 			tabIndex: open ? 0 : -1,
 			type: 'radio',
 			value: `${i}`,
@@ -58,7 +59,8 @@ const yearRadios = function(widget: Harness<DatePicker>, open?: boolean, yearSta
 			v('input', {
 				checked: i === 2017,
 				classes: css.yearRadioInput,
-				name: <any> compareId,
+				key: compareId as any,
+				name: compareId as any,
 				tabIndex: open ? 0 : -1,
 				type: 'radio',
 				value: `${ i }`,

--- a/src/dialog/Dialog.ts
+++ b/src/dialog/Dialog.ts
@@ -81,6 +81,13 @@ export class DialogBase<P extends DialogProperties = DialogProperties> extends T
 		document.addEventListener('keyup', this._onKeyUp);
 	}
 
+	protected onElementCreated(element: HTMLElement, key: string) {
+		if (key === 'main') {
+			const { open = false } = this.properties;
+			open && element.focus();
+		}
+	}
+
 	protected onDetach(): void {
 		document.removeEventListener('keyup', this._onKeyUp);
 	}
@@ -114,7 +121,7 @@ export class DialogBase<P extends DialogProperties = DialogProperties> extends T
 		});
 	}
 
-	render(): DNode {
+	protected render(): DNode {
 		let {
 			aria = {},
 			closeable = true,
@@ -128,13 +135,12 @@ export class DialogBase<P extends DialogProperties = DialogProperties> extends T
 		} = this.properties;
 
 		open && !this._wasOpen && onOpen && onOpen();
+		this._wasOpen = open;
 
 		if (!closeText) {
 			const messages = this.localizeBundle(commonBundle);
 			closeText = `${messages.close} ${title}`;
 		}
-
-		this._wasOpen = open;
 
 		return v('div', {
 			classes: this.theme(css.root)
@@ -147,7 +153,8 @@ export class DialogBase<P extends DialogProperties = DialogProperties> extends T
 				enterAnimation,
 				exitAnimation,
 				key: 'main',
-				role
+				role,
+				tabIndex: -1
 			}, [
 				v('div', {
 					classes: this.theme(css.title),

--- a/src/dialog/example/index.ts
+++ b/src/dialog/example/index.ts
@@ -3,6 +3,7 @@ import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import { WidgetProperties } from '@dojo/widget-core/interfaces';
 import { ProjectorMixin } from '@dojo/widget-core/mixins/Projector';
 import { v, w } from '@dojo/widget-core/d';
+import Focus from '@dojo/widget-core/meta/Focus';
 import Dialog from '../../dialog/Dialog';
 import dojoTheme from '../../themes/dojo/theme';
 
@@ -43,6 +44,7 @@ export class App extends WidgetBase<WidgetProperties> {
 		return v('div', [
 			v('button', {
 				id: 'button',
+				key: 'button',
 				innerHTML: 'open dialog',
 				onclick: this.openDialog
 			}),
@@ -55,6 +57,7 @@ export class App extends WidgetBase<WidgetProperties> {
 				closeable: this._closeable,
 				onRequestClose: () => {
 					this._open = false;
+					this.meta(Focus).set('button');
 					this.invalidate();
 				},
 				theme: this._theme

--- a/src/dialog/tests/unit/Dialog.ts
+++ b/src/dialog/tests/unit/Dialog.ts
@@ -51,7 +51,8 @@ const expected = function(widget: Harness<Dialog>, open = false, closeable = fal
 			enterAnimation: animations.fadeIn,
 			exitAnimation: animations.fadeOut,
 			key: 'main',
-			role: 'dialog'
+			role: 'dialog',
+			tabIndex: -1
 		}, [
 			v('div', {
 				classes: css.title,

--- a/src/select/Select.ts
+++ b/src/select/Select.ts
@@ -3,6 +3,7 @@ import { diffProperty } from '@dojo/widget-core/decorators/diffProperty';
 import { reference } from '@dojo/widget-core/diff';
 import { DNode } from '@dojo/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
+import Focus from '@dojo/widget-core/meta/Focus';
 import { v, w } from '@dojo/widget-core/d';
 import uuid from '@dojo/core/uuid';
 import { find } from '@dojo/shim/array';
@@ -49,7 +50,6 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 @theme(iconCss)
 @diffProperty('options', reference)
 export class SelectBase<P extends SelectProperties = SelectProperties> extends ThemedBase<P, null> {
-	private _callTriggerFocus = false;
 	private _callListboxFocus = false;
 	private _focusedIndex = 0;
 	private _ignoreBlur = false;
@@ -100,7 +100,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 
 	private _onDropdownKeyDown(event: KeyboardEvent) {
 		if (event.which === Keys.Escape) {
-			this._callTriggerFocus = true;
+			this.meta(Focus).set('trigger');
 			this._closeSelect();
 		}
 	}
@@ -164,11 +164,6 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 			this._callListboxFocus = false;
 			const listbox = <HTMLElement> element.querySelector('[role="listbox"]');
 			listbox && listbox.focus();
-		}
-
-		if (key === 'trigger' && this._callTriggerFocus) {
-			this._callTriggerFocus = false;
-			element.focus();
 		}
 	}
 
@@ -269,7 +264,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 					},
 					onOptionSelect: (option: any) => {
 						onChange && onChange(option, key);
-						this._callTriggerFocus = true;
+						this.meta(Focus).set('trigger');
 						this._closeSelect();
 					}
 				})

--- a/src/tabcontroller/TabButton.ts
+++ b/src/tabcontroller/TabButton.ts
@@ -1,6 +1,7 @@
 import { DNode } from '@dojo/widget-core/interfaces';
 import { I18nMixin } from '@dojo/widget-core/mixins/I18n';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
+import Focus from '@dojo/widget-core/meta/Focus';
 import { v } from '@dojo/widget-core/d';
 import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 import commonBundle from '../common/nls/common';
@@ -125,14 +126,6 @@ export class TabButtonBase<P extends TabButtonProperties = TabButtonProperties> 
 		}
 	}
 
-	private _callFocus(element: HTMLElement) {
-		const { callFocus, onFocusCalled } = this.properties;
-		if (callFocus) {
-			element.focus();
-			onFocusCalled && onFocusCalled();
-		}
-	}
-
 	protected getContent(messages: CommonMessages): DNode[] {
 		const { active, closeable } = this.properties;
 
@@ -157,22 +150,21 @@ export class TabButtonBase<P extends TabButtonProperties = TabButtonProperties> 
 		];
 	}
 
-	protected onElementCreated(element: HTMLElement, key: string) {
-		key === 'tab-button' && this._callFocus(element);
-	}
-
-	protected onElementUpdated(element: HTMLElement, key: string) {
-		key === 'tab-button' && this._callFocus(element);
-	}
-
 	render(): DNode {
 		const {
 			active,
+			callFocus,
 			controls,
 			disabled,
-			id
+			id,
+			onFocusCalled
 		} = this.properties;
 		const messages = this.localizeBundle(commonBundle);
+
+		if (callFocus) {
+			this.meta(Focus).set('tab-button');
+			onFocusCalled && onFocusCalled();
+		}
 
 		return v('div', {
 			'aria-controls': controls,

--- a/src/tabcontroller/tests/unit/TabButton.ts
+++ b/src/tabcontroller/tests/unit/TabButton.ts
@@ -228,14 +228,15 @@ registerSuite('TabButton', {
 				onFocusCalled
 			}));
 			widget.getRender();
-			assert.isTrue(onFocusCalled.calledOnce, 'onFocusCalled called on render if callFocus is true');
+			assert.isTrue(onFocusCalled.called, 'onFocusCalled called on render if callFocus is true');
 
+			onFocusCalled.reset();
 			widget.setProperties(props({
 				callFocus: false,
 				onFocusCalled
 			}));
 			widget.getRender();
-			assert.isTrue(onFocusCalled.calledOnce, 'onFocusCalled not called if callFocus is false');
+			assert.isFalse(onFocusCalled.called, 'onFocusCalled not called if callFocus is false');
 		}
 	}
 });

--- a/src/theme/dialog/dialog.m.css
+++ b/src/theme/dialog/dialog.m.css
@@ -10,6 +10,7 @@
 	background: var(--component-background);
 	width: 450px;
 	overflow: hidden;
+	outline: none;
 	max-width: calc(100% - 30px);
 	z-index: calc(var(--zindex-dialog) + 1);
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Removes directly accessing elements in `onElementUpdated`/`onElementCreated` where possible in favor of the Focus meta. It is still necessary to use the old method for reaching into child widgets and focusing on VNode creation.
