### PR TITLE
A11y testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 /bower_components
 /dist
 /html-report
+/a11y-report
 node_modules
 /typings
 .baseDir.ts

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widgets",
-  "version": "0.4.2",
+  "version": "0.4.3-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -53,6 +53,17 @@
       "requires": {
         "jsdom": "10.1.0",
         "pepjs": "0.4.3"
+      }
+    },
+    "@theintern/a11y": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@theintern/a11y/-/a11y-0.2.0.tgz",
+      "integrity": "sha512-1HrxAHPJqONMvZ/AaeB1FbLM5+k5ep6n/VLRGpnTlllLGCepzLhmU/7gJn5sLZygrXaMIR15wwWLn3OhKiGsSA==",
+      "dev": true,
+      "requires": {
+        "@types/mkdirp": "0.5.2",
+        "axe-core": "2.5.0",
+        "mkdirp": "0.5.1"
       }
     },
     "@theintern/digdug": {
@@ -328,6 +339,15 @@
       "resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
       "integrity": "sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==",
       "dev": true
+    },
+    "@types/mkdirp": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
+      "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "9.3.0"
+      }
     },
     "@types/node": {
       "version": "9.3.0",
@@ -733,6 +753,12 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.6.0.tgz",
       "integrity": "sha1-g+9cqGCysy5KDe7e6MdxudtXRx4=",
+      "dev": true
+    },
+    "axe-core": {
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-2.5.0.tgz",
+      "integrity": "sha512-onOXxjT3lXT3FfIBH5AIDxug+28Xw4q4XY66v+2rTRWg9o8dSiKr58ZWlCveh1cmE2kL5bT1KlO9PsSr7pWClA==",
       "dev": true
     },
     "babel-code-frame": {

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@dojo/loader": "~0.1.1",
     "@dojo/test-extras": "0.4.0",
+    "@theintern/a11y": "~0.2.0",
     "@types/glob": "5.0.*",
     "@types/grunt": "0.4.*",
     "@types/jsdom": "^2.0.30",

--- a/src/accordionpane/tests/functional/AccordionPane.ts
+++ b/src/accordionpane/tests/functional/AccordionPane.ts
@@ -2,6 +2,9 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import { Remote } from 'intern/lib/executors/Node';
+import { services } from '@theintern/a11y';
+
+const axe = services.axe;
 
 function getPage(remote: Remote) {
 	return remote
@@ -28,5 +31,9 @@ registerSuite('AccordionPane', {
 				.then((size: { height: number }) => {
 					assert.isAbove(size.height, 50);
 				});
+	},
+
+	'check accessibility'() {
+		return getPage(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/button/example/index.ts
+++ b/src/button/example/index.ts
@@ -52,7 +52,8 @@ export class App extends WidgetBase<WidgetProperties> {
 					key: 'b3',
 					theme: this._theme,
 					popup: { expanded: false, id: 'fakeId' }
-				}, [ 'Open' ])
+				}, [ 'Open' ]),
+				v('div', { id: 'fakeId' })
 			]),
 			v('div', { id: 'example-4' }, [
 				v('p', [ 'Toggle Button' ]),

--- a/src/button/tests/functional/Button.ts
+++ b/src/button/tests/functional/Button.ts
@@ -3,6 +3,9 @@ const { assert } = intern.getPlugin('chai');
 
 import { Remote } from 'intern/lib/executors/Node';
 import * as css from '../../../theme/button/button.m.css';
+import { services } from '@theintern/a11y';
+
+const axe = services.axe;
 
 function getPage(remote: Remote) {
 	return remote
@@ -66,5 +69,9 @@ registerSuite('Button', {
 					assert.strictEqual(pressed, 'false');
 				})
 			.end();
+	},
+
+	'check accessibility'() {
+		return getPage(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/calendar/tests/functional/Calendar.ts
+++ b/src/calendar/tests/functional/Calendar.ts
@@ -4,6 +4,9 @@ const { assert } = intern.getPlugin('chai');
 import { Remote } from 'intern/lib/executors/Node';
 import keys from '@theintern/leadfoot/keys';
 import * as css from '../../../theme/calendar/calendar.m.css';
+import { services } from '@theintern/a11y';
+
+const axe = services.axe;
 
 const DELAY = 500;
 
@@ -224,5 +227,9 @@ registerSuite('Calendar', {
 				.then((className: string) => {
 					assert.include(className, css.selectedDate, 'Clicked date has selected class');
 				});
+	},
+
+	'check accessibility'() {
+		return openMonthPicker(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/checkbox/Checkbox.ts
+++ b/src/checkbox/Checkbox.ts
@@ -21,6 +21,7 @@ import * as css from '../theme/checkbox/checkbox.m.css';
  */
 export interface CheckboxProperties extends ThemedProperties, InputProperties, LabeledProperties, InputEventProperties, KeyEventProperties, PointerEventProperties, CustomAriaProperties {
 	checked?: boolean;
+	id?: string;
 	mode?: Mode;
 	offLabel?: DNode;
 	onLabel?: DNode;
@@ -114,6 +115,7 @@ export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> ext
 			aria = {},
 			checked = false,
 			disabled,
+			id = this._uuid,
 			invalid,
 			label,
 			labelAfter = true,
@@ -129,7 +131,7 @@ export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> ext
 			v('div', { classes: this.theme(css.inputWrapper) }, [
 				...this.renderToggle(),
 				v('input', {
-					id: this._uuid,
+					id,
 					...formatAriaProperties(aria),
 					classes: this.theme(css.input),
 					checked,
@@ -159,7 +161,7 @@ export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> ext
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: this._uuid,
+				forId: id,
 				secondary: true
 			}, [ label ]) : null
 		];

--- a/src/checkbox/tests/functional/Checkbox.ts
+++ b/src/checkbox/tests/functional/Checkbox.ts
@@ -2,7 +2,10 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import { Remote } from 'intern/lib/executors/Node';
+import { services } from '@theintern/a11y';
 import * as css from '../../../theme/checkbox/checkbox.m.css';
+
+const axe = services.axe;
 
 function getPage(remote: Remote) {
 	return remote
@@ -107,5 +110,9 @@ registerSuite('Checkbox', {
 				assert.isFalse(checked);
 			})
 			.end();
+	},
+
+	'check accessibility'() {
+		return getPage(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/checkbox/tests/unit/Checkbox.ts
+++ b/src/checkbox/tests/unit/Checkbox.ts
@@ -113,6 +113,7 @@ registerSuite('Checkbox', {
 					describedBy: 'foo'
 				},
 				checked: true,
+				id: 'foo',
 				name: 'bar',
 				value: 'baz'
 			});
@@ -121,6 +122,7 @@ registerSuite('Checkbox', {
 			assignChildProperties(expectedVdom, '0,0', {
 				checked: true,
 				'aria-describedby': 'foo',
+				id: 'foo',
 				name: 'bar',
 				value: 'baz'
 			});

--- a/src/combobox/ComboBox.ts
+++ b/src/combobox/ComboBox.ts
@@ -268,6 +268,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 	protected renderInput(results: any[]): DNode {
 		const {
 			disabled,
+			id = this._idBase,
 			inputProperties = {},
 			invalid,
 			readOnly,
@@ -285,6 +286,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 				owns: this._getMenuId()
 			},
 			disabled,
+			id,
 			invalid,
 			onBlur: this._onInputBlur,
 			onFocus: this._onInputFocus,
@@ -424,7 +426,6 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 			'aria-haspopup': 'true',
 			'aria-readonly': readOnly ? 'true' : null,
 			'aria-required': required ? 'true' : null,
-			id,
 			classes: this.theme([
 				css.root,
 				this._open ? css.open : null,

--- a/src/combobox/ComboBox.ts
+++ b/src/combobox/ComboBox.ts
@@ -381,7 +381,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 	render(): DNode {
 		const {
 			clearable = false,
-			id,
+			id = this._idBase,
 			invalid,
 			label,
 			readOnly,

--- a/src/combobox/example/index.ts
+++ b/src/combobox/example/index.ts
@@ -115,6 +115,7 @@ export class App extends WidgetBase<WidgetProperties> {
 			v('h3', ['Clearable']),
 			w(ComboBox, {
 				key: '2',
+				label: 'Combo:',
 				clearable: true,
 				onChange,
 				getResultLabel: (result: any) => result.value,
@@ -129,6 +130,7 @@ export class App extends WidgetBase<WidgetProperties> {
 			v('h3', ['Open on focus']),
 			w(ComboBox, {
 				key: '1',
+				label: 'Combo:',
 				openOnFocus: true,
 				onChange,
 				getResultLabel: (result: any) => result.value,
@@ -143,6 +145,7 @@ export class App extends WidgetBase<WidgetProperties> {
 			v('h3', ['Disabled menu items']),
 			w(ComboBox, {
 				key: '5',
+				label: 'Combo:',
 				onChange,
 				getResultLabel: (result: any) => result.value,
 				onRequestResults,
@@ -157,6 +160,7 @@ export class App extends WidgetBase<WidgetProperties> {
 			v('h3', ['Disabled']),
 			w(ComboBox, {
 				key: '6',
+				label: 'Combo:',
 				disabled: true,
 				inputProperties: {
 					placeholder: 'Enter a value'
@@ -166,6 +170,7 @@ export class App extends WidgetBase<WidgetProperties> {
 			v('h3', ['Read Only']),
 			w(ComboBox, {
 				key: '7',
+				label: 'Combo:',
 				readOnly: true,
 				inputProperties: {
 					placeholder: 'Enter a value'
@@ -186,6 +191,7 @@ export class App extends WidgetBase<WidgetProperties> {
 			v('h3', ['Required and validated']),
 			w(ComboBox, {
 				key: '9',
+				label: 'Combo:',
 				required: true,
 				onChange: (value: string) => {
 					this._value9 = value;

--- a/src/combobox/tests/functional/ComboBox.ts
+++ b/src/combobox/tests/functional/ComboBox.ts
@@ -3,9 +3,11 @@ const { assert } = intern.getPlugin('chai');
 
 import { Remote } from 'intern/lib/executors/Node';
 import keys from '@theintern/leadfoot/keys';
+import { services } from '@theintern/a11y';
 import * as listboxCss from '../../../theme/listbox/listbox.m.css';
 import * as css from '../../../theme/combobox/comboBox.m.css';
 
+const axe = services.axe;
 const DELAY = 300;
 
 function getPage(remote: Remote) {
@@ -164,5 +166,9 @@ registerSuite('ComboBox', {
 				.then(tag => {
 					assert.strictEqual(tag.toLowerCase(), 'input', 'The input should receive focus when the "open" button is activated with the ENTER key.');
 				});
+	},
+
+	'check accessibility'() {
+		return getPage(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -144,7 +144,7 @@ const getExpectedVdom = function(widget: Harness<ComboBox>, useTestProperties = 
 		'aria-readonly': null,
 		'aria-required': null,
 		dir: null,
-		id: useTestProperties ? 'foo' : undefined,
+		id: useTestProperties ? 'foo' : compareId as any,
 		classes: [
 			css.root,
 			open ? css.open : null,
@@ -164,7 +164,7 @@ const getExpectedVdom = function(widget: Harness<ComboBox>, useTestProperties = 
 			invalid: undefined,
 			readOnly: undefined,
 			required: undefined,
-			forId: compareId as any
+			forId: useTestProperties ? 'foo' : compareId as any
 		}, [ 'foo' ]) : null,
 		controlsVdom,
 		menuVdom

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -58,6 +58,7 @@ const getExpectedControls = function(widget: Harness<ComboBox>, useTestPropertie
 				owns: compareId as any
 			},
 			disabled: undefined,
+			id: useTestProperties ? 'foo' : compareId as any,
 			invalid: undefined,
 			readOnly: undefined,
 			required: undefined,
@@ -144,7 +145,6 @@ const getExpectedVdom = function(widget: Harness<ComboBox>, useTestProperties = 
 		'aria-readonly': null,
 		'aria-required': null,
 		dir: null,
-		id: useTestProperties ? 'foo' : compareId as any,
 		classes: [
 			css.root,
 			open ? css.open : null,

--- a/src/common/example/index.html
+++ b/src/common/example/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html lang="en">
 <head>
 	<title>Example</title>
 	<meta name="viewport" content="width=device-width, initial-scale=1">

--- a/src/common/example/index.ts
+++ b/src/common/example/index.ts
@@ -42,6 +42,7 @@ export class App extends WidgetBase<WidgetProperties> {
 			w(Select, {
 				onChange: this.onModuleChange,
 				useNativeElement: true,
+				label: 'Select a module to view',
 				options: modules,
 				getOptionValue: (module: any) => module,
 				getOptionLabel: (module: any) => module

--- a/src/dialog/tests/functional/Dialog.ts
+++ b/src/dialog/tests/functional/Dialog.ts
@@ -3,8 +3,11 @@ const { assert } = intern.getPlugin('chai');
 
 import { Remote } from 'intern/lib/executors/Node';
 import keys from '@theintern/leadfoot/keys';
+import { services } from '@theintern/a11y';
 import * as css from '../../../theme/dialog/dialog.m.css';
 import * as fixedCss from '../../styles/dialog.m.css';
+
+const axe = services.axe;
 
 interface Options {
 	closeable?: boolean;
@@ -167,5 +170,9 @@ registerSuite('Dialog', {
 				.then((children: HTMLElement[]) => {
 					assert.lengthOf(children, 0);
 				});
+	},
+
+	'check accessibility'() {
+		return openDialog(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/label/tests/functional/Label.ts
+++ b/src/label/tests/functional/Label.ts
@@ -2,7 +2,10 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import { Remote } from 'intern/lib/executors/Node';
+import { services } from '@theintern/a11y';
 import * as css from '../../../theme/label/label.m.css';
+
+const axe = services.axe;
 
 function getPage(remote: Remote) {
 	return remote
@@ -56,5 +59,9 @@ registerSuite('Label', {
 					assert.isAtMost(width, 1, 'The label text width should be no more than 1px.');
 				})
 			.end();
+	},
+
+	'check accessibility'() {
+		return getPage(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/listbox/tests/functional/Listbox.ts
+++ b/src/listbox/tests/functional/Listbox.ts
@@ -3,8 +3,10 @@ const { assert } = intern.getPlugin('chai');
 
 import { Remote } from 'intern/lib/executors/Node';
 import keys from '@theintern/leadfoot/keys';
+import { services } from '@theintern/a11y';
 import * as css from '../../../theme/listbox/listbox.m.css';
 
+const axe = services.axe;
 const DELAY = 300;
 
 function getPage(remote: Remote) {
@@ -139,5 +141,9 @@ registerSuite('Listbox', {
 				.then((id: string) => {
 					assert.strictEqual(id, 'listbox2');
 				});
+	},
+
+	'check accessibility'() {
+		return getPage(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/radio/Radio.ts
+++ b/src/radio/Radio.ts
@@ -18,6 +18,7 @@ import * as css from '../theme/radio/radio.m.css';
  */
 export interface RadioProperties extends ThemedProperties, LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties, CustomAriaProperties {
 	checked?: boolean;
+	id?: string;
 	value?: string;
 }
 
@@ -72,6 +73,7 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 			aria = {},
 			checked = false,
 			disabled,
+			id = this._uuid,
 			invalid,
 			label,
 			labelAfter = true,
@@ -86,7 +88,7 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 		const children = [
 			v('div', { classes: this.theme(css.inputWrapper) }, [
 				v('input', {
-					id: this._uuid,
+					id,
 					...formatAriaProperties(aria),
 					classes: this.theme(css.input),
 					checked,
@@ -116,7 +118,7 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: this._uuid,
+				forId: id,
 				secondary: true
 			}, [ label ]) : null
 		];

--- a/src/radio/tests/functional/Radio.ts
+++ b/src/radio/tests/functional/Radio.ts
@@ -2,7 +2,10 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import { Remote } from 'intern/lib/executors/Node';
+import { services } from '@theintern/a11y';
 import * as css from '../../../theme/radio/radio.m.css';
+
+const axe = services.axe;
 
 function getPage(remote: Remote) {
 	return remote
@@ -90,5 +93,9 @@ registerSuite('Radio Button', {
 					assert.isFalse(checked);
 				})
 			.end();
+	},
+
+	'check accessibility'() {
+		return getPage(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/radio/tests/unit/Radio.ts
+++ b/src/radio/tests/unit/Radio.ts
@@ -81,6 +81,7 @@ registerSuite('Radio', {
 			widget.setProperties({
 				aria: { describedBy: 'foo' },
 				checked: true,
+				id: 'foo',
 				name: 'bar',
 				value: 'baz'
 			});
@@ -89,6 +90,7 @@ registerSuite('Radio', {
 			assignChildProperties(expectedVdom, '0,0', {
 				checked: true,
 				'aria-describedby': 'foo',
+				id: 'foo',
 				name: 'bar',
 				value: 'baz'
 			});

--- a/src/select/Select.ts
+++ b/src/select/Select.ts
@@ -34,6 +34,7 @@ export interface SelectProperties extends ThemedProperties, InputProperties, Lab
 	getOptionLabel?(option: any): DNode;
 	getOptionSelected?(option: any, index: number): boolean;
 	getOptionValue?(option: any, index: number): string;
+	id?: string;
 	options?: any[];
 	placeholder?: string;
 	useNativeElement?: boolean;
@@ -188,6 +189,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 			getOptionId,
 			getOptionSelected,
 			getOptionValue,
+			id = this._baseId,
 			invalid,
 			name,
 			options = [],
@@ -210,6 +212,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 				classes: this.theme(css.input),
 				disabled,
 				'aria-invalid': invalid ? 'true' : null,
+				id,
 				name,
 				readOnly,
 				'aria-readonly': readOnly ? 'true' : null,
@@ -229,6 +232,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 			getOptionId,
 			getOptionLabel,
 			getOptionSelected = this._getOptionSelected,
+			id = this._baseId,
 			key,
 			options = [],
 			theme,
@@ -237,8 +241,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 
 		const {
 			_open,
-			_focusedIndex,
-			_baseId
+			_focusedIndex
 		} = this;
 
 		// create dropdown trigger and select box
@@ -255,7 +258,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 				w(Listbox, {
 					key: 'listbox',
 					activeIndex: _focusedIndex,
-					id: _baseId,
+					id,
 					optionData: options,
 					tabIndex: _open ? 0 : -1,
 					getOptionDisabled,
@@ -334,6 +337,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 			labelHidden,
 			labelAfter,
 			disabled,
+			id = this._baseId,
 			invalid,
 			readOnly,
 			required,
@@ -349,7 +353,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: this._baseId
+				forId: id
 			}, [ label ]) : null,
 			useNativeElement ? this.renderNativeSelect() : this.renderCustomSelect()
 		];

--- a/src/select/tests/unit/Select.ts
+++ b/src/select/tests/unit/Select.ts
@@ -47,6 +47,7 @@ const testProperties: Partial<SelectProperties> = {
 	getOptionLabel: (option: any) => option.label,
 	getOptionSelected: (option: any, index: number) => option.value === 'two',
 	getOptionValue: (option: any, index: number) => option.value,
+	id: 'foo',
 	name: 'foo',
 	options: testOptions,
 	value: 'two'
@@ -66,6 +67,7 @@ const expectedNative = function(widget: Harness<Select>, useTestProperties = fal
 			classes: css.input,
 			disabled: useTestProperties ? true : undefined,
 			'aria-invalid': useTestProperties ? 'true' : null,
+			id: useTestProperties ? 'foo' : compareId as any,
 			name: useTestProperties ? 'foo' : undefined,
 			readOnly: useTestProperties ? true : undefined,
 			'aria-readonly': useTestProperties ? 'true' : null,
@@ -144,7 +146,7 @@ const expectedSingle = function(widget: Harness<Select>, useTestProperties = fal
 		}, [
 			w(Listbox, {
 				activeIndex: 0,
-				id: <any> compareId,
+				id: useTestProperties ? 'foo' : compareId as any,
 				key: 'listbox',
 				optionData: useTestProperties ? testOptions : [],
 				tabIndex: open ? 0 : -1,

--- a/src/slidepane/tests/functional/SlidePane.ts
+++ b/src/slidepane/tests/functional/SlidePane.ts
@@ -3,9 +3,11 @@ const { assert } = intern.getPlugin('chai');
 
 import { Remote } from 'intern/lib/executors/Node';
 import Command from '@theintern/leadfoot/Command';
+import { services } from '@theintern/a11y';
 import * as css from '../../../theme/slidepane/slidePane.m.css';
 import * as fixedCss from '../../styles/slidePane.m.css';
 
+const axe = services.axe;
 const DELAY = 400;
 
 function openSlidePane(remote: Remote, alignRight?: boolean) {
@@ -177,5 +179,9 @@ registerSuite('SlidePane', {
 					.then(({ x }) => {
 						assert.strictEqual(x, 0, 'The slidepane should be open.');
 					});
+	},
+
+	'check accessibility'() {
+		return openSlidePane(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -23,6 +23,7 @@ import * as css from '../theme/slider/slider.m.css';
  * @property value           The current value
  */
 export interface SliderProperties extends ThemedProperties, LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties, KeyEventProperties, CustomAriaProperties {
+	id?: string;
 	max?: number;
 	min?: number;
 	output?(value: number): DNode;
@@ -122,6 +123,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 		const {
 			aria = {},
 			disabled,
+			id = this._inputId,
 			invalid,
 			label,
 			labelAfter,
@@ -155,7 +157,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 				...formatAriaProperties(aria),
 				classes: [ this.theme(css.input), fixedCss.nativeInput ],
 				disabled,
-				id: this._inputId,
+				id,
 				'aria-invalid': invalid === true ? 'true' : null,
 				max: `${max}`,
 				min: `${min}`,
@@ -193,7 +195,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: this._inputId
+				forId: id
 			}, [ label ]) : null,
 			slider
 		];

--- a/src/slider/tests/functional/Slider.ts
+++ b/src/slider/tests/functional/Slider.ts
@@ -3,7 +3,10 @@ const { assert } = intern.getPlugin('chai');
 
 import keys from '@theintern/leadfoot/keys';
 import { Remote } from 'intern/lib/executors/Node';
+import { services } from '@theintern/a11y';
 import * as css from '../../../theme/slider/slider.m.css';
+
+const axe = services.axe;
 
 function getPage(test: any) {
 	const { browserName } = test.remote.environmentType;
@@ -273,5 +276,9 @@ registerSuite('Slider', {
 				})
 				.end();
 		}
+	},
+
+	'check accessibility'() {
+		return getPage(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -110,6 +110,7 @@ registerSuite('Slider', {
 		'custom properties'() {
 			widget.setProperties({
 				aria: { describedBy: 'foo' },
+				id: 'foo',
 				max: 60,
 				min: 10,
 				name: 'bar',
@@ -122,6 +123,7 @@ registerSuite('Slider', {
 			const expectedVdom = expected(widget, false, true);
 			assignProperties(findKey(expectedVdom, 'input')!, {
 				'aria-describedby': 'foo',
+				id: 'foo',
 				max: '60',
 				min: '10',
 				name: 'bar',

--- a/src/splitpane/tests/functional/SplitPane.ts
+++ b/src/splitpane/tests/functional/SplitPane.ts
@@ -4,8 +4,10 @@ const { assert } = intern.getPlugin('chai');
 import Command from '@theintern/leadfoot/Command';
 import Element from '@theintern/leadfoot/Element';
 import Test from 'intern/lib/Test';
+import { services } from '@theintern/a11y';
 import * as css from '../../../theme/splitpane/splitPane.m.css';
 
+const axe = services.axe;
 const DELAY = 300;
 
 function getPage(test: Test): Command<void> {
@@ -189,5 +191,9 @@ registerSuite('SplitPane', {
 			[ { x: 10, y: 0 }, { x: (x) => { return x > 10; } , y: 0 }, { x: 10, y: 0 } ]
 		);
 		return command;
+	},
+
+	'check accessibility'() {
+		return getPage(this).then(axe.createChecker());
 	}
 });

--- a/src/tabcontroller/example/index.ts
+++ b/src/tabcontroller/example/index.ts
@@ -81,14 +81,17 @@ export class App extends WidgetBase<WidgetProperties> {
 					onchange: this.themeChange
 				})
 			]),
-			v('select', {
-				styles: { marginBottom: '20px' },
-				onchange: this.onAlignChange
-			}, [
-				v('option', { selected: true, value: 'top' }, [ 'Top' ]),
-				v('option', { value: 'left' }, [ 'Left' ]),
-				v('option', { value: 'right' }, [ 'Right' ]),
-				v('option', { value: 'bottom' }, [ 'Bottom' ])
+			v('label', [
+				'Tab location',
+				v('select', {
+					styles: { marginBottom: '20px' },
+					onchange: this.onAlignChange
+				}, [
+					v('option', { selected: true, value: 'top' }, [ 'Top' ]),
+					v('option', { value: 'left' }, [ 'Left' ]),
+					v('option', { value: 'right' }, [ 'Right' ]),
+					v('option', { value: 'bottom' }, [ 'Bottom' ])
+				])
 			]),
 			w(TabController, {
 				theme: this._theme,

--- a/src/tabcontroller/tests/functional/TabController.ts
+++ b/src/tabcontroller/tests/functional/TabController.ts
@@ -2,7 +2,10 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import { Remote } from 'intern/lib/executors/Node';
+import { services } from '@theintern/a11y';
 import * as css from '../../../theme/tabcontroller/tabController.m.css';
+
+const axe = services.axe;
 
 function getPage(remote: Remote) {
 	return remote
@@ -103,5 +106,9 @@ registerSuite('TabController', {
 					assert.strictEqual(count, childElementCount - 1);
 				})
 			.end();
+	},
+
+	'check accessibility'() {
+		return getPage(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/textarea/Textarea.ts
+++ b/src/textarea/Textarea.ts
@@ -23,6 +23,7 @@ import * as css from '../theme/textarea/textarea.m.css';
  */
 export interface TextareaProperties extends ThemedProperties, InputProperties, LabeledProperties, InputEventProperties, KeyEventProperties, PointerEventProperties, CustomAriaProperties {
 	columns?: number;
+	id?: string;
 	rows?: number;
 	wrapText?: 'hard' | 'soft' | 'off';
 	maxLength?: number | string;
@@ -78,6 +79,7 @@ export class TextareaBase<P extends TextareaProperties = TextareaProperties> ext
 			aria = {},
 			columns,
 			disabled,
+			id = this._uuid,
 			invalid,
 			label,
 			maxLength,
@@ -102,11 +104,11 @@ export class TextareaBase<P extends TextareaProperties = TextareaProperties> ext
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: this._uuid
+				forId: id
 			}, [ label ]) : null,
 			v('div', { classes: this.theme(css.inputWrapper) }, [
 				v('textarea', {
-					id: this._uuid,
+					id,
 					key: 'input',
 					...formatAriaProperties(aria),
 					classes: this.theme(css.input),

--- a/src/textarea/tests/functional/Textarea.ts
+++ b/src/textarea/tests/functional/Textarea.ts
@@ -3,8 +3,11 @@ const { assert } = intern.getPlugin('chai');
 
 import { Remote } from 'intern/lib/executors/Node';
 import keys from '@theintern/leadfoot/keys';
+import { services } from '@theintern/a11y';
 import * as css from '../../../theme/textarea/textarea.m.css';
 import * as baseCss from '../../../common/styles/base.m.css';
+
+const axe = services.axe;
 
 function getPage(remote: Remote) {
 	return remote
@@ -155,5 +158,9 @@ registerSuite('Textarea', {
 					})
 				.end()
 			.end();
+	},
+
+	'check accessibility'() {
+		return getPage(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/textarea/tests/unit/Textarea.ts
+++ b/src/textarea/tests/unit/Textarea.ts
@@ -87,6 +87,7 @@ registerSuite('Textarea', {
 			widget.setProperties({
 				aria: { describedBy: 'foo' },
 				columns: 15,
+				id: 'foo',
 				maxLength: 50,
 				minLength: 10,
 				name: 'bar',
@@ -100,6 +101,7 @@ registerSuite('Textarea', {
 			assignProperties(findKey(expectedVdom, 'input')!, {
 				cols: '15',
 				'aria-describedby': 'foo',
+				id: 'foo',
 				maxlength: '50',
 				minlength: '10',
 				name: 'bar',

--- a/src/textinput/TextInput.ts
+++ b/src/textinput/TextInput.ts
@@ -25,6 +25,7 @@ export type TextInputType = 'text' | 'email' | 'number' | 'password' | 'search' 
 
 export interface TextInputProperties extends ThemedProperties, InputProperties, LabeledProperties, PointerEventProperties, KeyEventProperties, InputEventProperties, CustomAriaProperties {
 	controls?: string;
+	id?: string;
 	type?: TextInputType;
 	maxLength?: number | string;
 	minLength?: number | string;
@@ -78,6 +79,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 		const {
 			aria = {},
 			disabled,
+			id = this._uuid,
 			invalid,
 			maxLength,
 			minLength,
@@ -94,7 +96,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 			'aria-invalid': invalid ? 'true' : null,
 			classes: this.theme(css.input),
 			disabled,
-			id: this._uuid,
+			id,
 			key: 'input',
 			maxlength: maxLength ? `${maxLength}` : null,
 			minlength: minLength ? `${minLength}` : null,
@@ -130,6 +132,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 	render(): DNode {
 		const {
 			disabled,
+			id = this._uuid,
 			invalid,
 			label,
 			labelAfter = false,
@@ -147,7 +150,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: this._uuid
+				forId: id
 			}, [ label ]) : null,
 			this.renderInputWrapper()
 		];

--- a/src/textinput/tests/functional/TextInput.ts
+++ b/src/textinput/tests/functional/TextInput.ts
@@ -2,8 +2,11 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import { Remote } from 'intern/lib/executors/Node';
+import { services } from '@theintern/a11y';
 import * as css from '../../../theme/textinput/textinput.m.css';
 import * as baseCss from '../../../common/styles/base.m.css';
+
+const axe = services.axe;
 
 function getPage(remote: Remote) {
 	return remote
@@ -128,5 +131,9 @@ registerSuite('TextInput', {
 					assert.include(className, css.invalid);
 				})
 			.end();
+	},
+
+	'check accessibility'() {
+		return getPage(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/textinput/tests/unit/TextInput.ts
+++ b/src/textinput/tests/unit/TextInput.ts
@@ -87,6 +87,7 @@ registerSuite('TextInput', {
 					controls: 'foo',
 					describedBy: 'bar'
 				},
+				id: 'foo',
 				maxLength: 50,
 				minLength: 10,
 				name: 'bar',
@@ -102,6 +103,7 @@ registerSuite('TextInput', {
 			assignProperties(findKey(expectedVdom, 'input')!, {
 				'aria-controls': 'foo',
 				'aria-describedby': 'bar',
+				id: 'foo',
 				maxlength: '50',
 				minlength: '10',
 				name: 'bar',

--- a/src/timepicker/TimePicker.ts
+++ b/src/timepicker/TimePicker.ts
@@ -47,6 +47,7 @@ export interface TimePickerProperties extends ThemedProperties, InputProperties,
 	clearable?: boolean;
 	end?: string;
 	getOptionLabel?(option: TimeUnits): string;
+	id?: string;
 	inputProperties?: TextInputProperties;
 	isOptionDisabled?(result: any): boolean;
 	onBlur?(value: string): void;
@@ -235,6 +236,7 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 			clearable,
 			disabled,
 			extraClasses,
+			id = this._uuid,
 			inputProperties,
 			invalid,
 			isOptionDisabled,
@@ -258,6 +260,7 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 			disabled,
 			extraClasses,
 			getResultLabel: this._getOptionLabel.bind(this),
+			id,
 			inputProperties,
 			invalid,
 			isResultDisabled: isOptionDisabled,
@@ -282,6 +285,7 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 		const {
 			disabled,
 			end,
+			id = this._uuid,
 			inputProperties = {},
 			invalid,
 			name,
@@ -306,10 +310,10 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: this._uuid
+				forId: id
 			}, [ label ]) : null,
 			v('input', {
-				id: this._uuid,
+				id,
 				...formatAriaProperties(aria),
 				'aria-invalid': invalid === true ? 'true' : null,
 				'aria-readonly': readOnly === true ? 'true' : null,

--- a/src/timepicker/example/index.ts
+++ b/src/timepicker/example/index.ts
@@ -81,6 +81,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 						}
 						this.invalidate();
 					},
+					label: 'Time: ',
 					options: this._options,
 					step: 1800,
 					theme: this._theme,
@@ -101,6 +102,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 						this._setValue('value2', value);
 					},
 					onRequestOptions: this.onRequestOptions,
+					label: 'Time: ',
 					options: this._options,
 					step: 1800,
 					theme: this._theme,
@@ -125,6 +127,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 						this._setValue('value3', value);
 					},
 					onRequestOptions: this.onRequestOptions,
+					label: 'Time: ',
 					options: this._options,
 					step: 3600,
 					theme: this._theme,
@@ -140,6 +143,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 						placeholder: 'Enter a value'
 					},
 					key: '4',
+					label: 'Time: ',
 					disabled: true,
 					theme: this._theme
 				})
@@ -153,6 +157,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 						placeholder: 'Enter a value'
 					},
 					key: '5',
+					label: 'Time: ',
 					readOnly: true,
 					theme: this._theme
 				})
@@ -196,6 +201,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 						this._setValue('value7', value);
 					},
 					onRequestOptions: this.onRequestOptions,
+					label: 'Time: ',
 					options: this._options,
 					step: 1800,
 					theme: this._theme,
@@ -221,6 +227,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 						this._setValue('value8', value);
 					},
 					onRequestOptions: this.onRequestOptions,
+					label: 'Time: ',
 					start: '12:00:00',
 					step: 1,
 					theme: this._theme,
@@ -249,6 +256,7 @@ export class App extends ThemedMixin(WidgetBase)<ThemedProperties> {
 						this._setValue('value9', value );
 					},
 					onRequestOptions: this.onRequestOptions,
+					label: 'Time: ',
 					options: this._options,
 					step: 1800,
 					theme: this._theme,

--- a/src/timepicker/tests/functional/TimePicker.ts
+++ b/src/timepicker/tests/functional/TimePicker.ts
@@ -5,10 +5,12 @@ import { Remote } from 'intern/lib/executors/Node';
 import Command from '@theintern/leadfoot/Command';
 import Element from '@theintern/leadfoot/Element';
 import keys from '@theintern/leadfoot/keys';
+import { services } from '@theintern/a11y';
 import * as comboBoxCss from '../../../theme/combobox/comboBox.m.css';
 import * as listboxCss from '../../../theme/listbox/listbox.m.css';
 import * as textinputCss from '../../../theme/textinput/textinput.m.css';
 
+const axe = services.axe;
 const DELAY = 300;
 
 function getPage(remote: Remote, exampleId: string) {
@@ -213,5 +215,10 @@ registerSuite('TimePicker', {
 					assert.include(className, textinputCss.invalid);
 				})
 			.end();
+	},
+
+	'check accessibility'() {
+		const exampleId = 'example-filter-on-input';
+		return getPage(this.remote, exampleId).then(axe.createChecker());
 	}
 });

--- a/src/timepicker/tests/unit/TimePicker.ts
+++ b/src/timepicker/tests/unit/TimePicker.ts
@@ -69,6 +69,7 @@ registerSuite('TimePicker', {
 			picker.setProperties({
 				clearable: true,
 				disabled: false,
+				id: 'foo',
 				invalid: true,
 				label: 'Some Field',
 				openOnFocus: false,
@@ -82,6 +83,7 @@ registerSuite('TimePicker', {
 					clearable: true,
 					disabled: false,
 					getResultLabel: <any> picker.listener,
+					id: 'foo',
 					inputProperties: undefined,
 					invalid: true,
 					isResultDisabled: undefined,

--- a/src/titlepane/tests/functional/TitlePane.ts
+++ b/src/titlepane/tests/functional/TitlePane.ts
@@ -2,6 +2,9 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import { Remote } from 'intern/lib/executors/Node';
+import { services } from '@theintern/a11y';
+
+const axe = services.axe;
 
 function getPage(remote: Remote) {
 	return remote
@@ -41,5 +44,9 @@ registerSuite('TitlePane', {
 				.then(marginTop => {
 					assert.closeTo(parseInt(marginTop, 10), -height, 2);
 				});
+	},
+
+	'check accessibility'() {
+		return getPage(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/toolbar/tests/functional/Toolbar.ts
+++ b/src/toolbar/tests/functional/Toolbar.ts
@@ -1,6 +1,9 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import { Remote } from 'intern/lib/executors/Node';
+import { services } from '@theintern/a11y';
+
+const axe = services.axe;
 
 function getPage(remote: Remote) {
 	return remote
@@ -52,5 +55,9 @@ registerSuite('Toolbar', {
 				.then(position => {
 					assert.isAbove(position.x, WIDTH - 50);
 				});
+	},
+
+	'check accessibility'() {
+		return getPage(this.remote).then(axe.createChecker());
 	}
 });

--- a/src/tooltip/example/index.ts
+++ b/src/tooltip/example/index.ts
@@ -66,6 +66,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					theme: this._theme
 				}, [
 					w(TextInput, {
+						label: 'Focus me',
 						theme: this._theme,
 						placeholder: 'Focus me',
 						onFocus: () => { this.onShow('bar'); },

--- a/src/tooltip/tests/functional/Tooltip.ts
+++ b/src/tooltip/tests/functional/Tooltip.ts
@@ -2,6 +2,9 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import { Remote } from 'intern/lib/executors/Node';
+import { services } from '@theintern/a11y';
+
+const axe = services.axe;
 
 function getPage(remote: Remote) {
 	return remote
@@ -25,5 +28,9 @@ registerSuite('Tooltip', {
 					assert.strictEqual(text,
 						'This is a right-oriented tooltip that opens and closes based on child click.');
 				});
+	},
+
+	'check accessibility'() {
+		return getPage(this.remote).then(axe.createChecker());
 	}
 });


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds accessibility testing for widgets using `@theintern/a11y` and axe.

There are still some outstanding issues where `aria-controls`, `aria-owns`, and `aria-activedescendant` are set to IDs of nodes that are not in the DOM which cause axe to fail.

Related to #342 
