### PR TITLE
Explicitly disabling focus from output tag for Edge

### DIFF
--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -152,7 +152,8 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 		return v('output', {
 			classes: [ this.theme(css.output), outputIsTooltip ? fixedCss.outputTooltip : null ],
 			for: this._inputId,
-			styles: outputStyles
+			styles: outputStyles,
+			tabIndex: -1
 		}, [ outputNode ]);
 	}
 

--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -153,7 +153,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 			classes: [ this.theme(css.output), outputIsTooltip ? fixedCss.outputTooltip : null ],
 			for: this._inputId,
 			styles: outputStyles,
-			tabIndex: -1
+			tabIndex: -1 /* needed so Edge doesn't select the element while tabbing through */
 		}, [ outputNode ]);
 	}
 

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -81,6 +81,7 @@ const expected = function(label = false, tooltip = false, overrides = {}, child 
 			v('output', {
 				classes: [ css.output, tooltip ? fixedCss.outputTooltip : null ],
 				for: '',
+				tabIndex: -1,
 				styles: progress !== '0%' ? { left: progress } : {}
 			}, [ child ])
 		])
@@ -200,7 +201,8 @@ registerSuite('Slider', {
 						v('output', {
 							classes: [ css.output, null ],
 							for: '',
-							styles: {}
+							styles: {},
+							tabIndex: -1
 						}, [ '0' ])
 					])
 				]));
@@ -276,7 +278,8 @@ registerSuite('Slider', {
 						v('output', {
 							classes: [ css.output, fixedCss.outputTooltip ],
 							for: '',
-							styles: { top: '80%' }
+							styles: { top: '80%' },
+							tabIndex: -1
 						}, [ '6' ])
 					])
 				]));
@@ -345,7 +348,8 @@ registerSuite('Slider', {
 					v('output', {
 						classes: [ css.output, null ],
 						for: '',
-						styles: {}
+						styles: {},
+						tabIndex: -1
 					}, [ '40' ])
 				])
 			]));
@@ -413,7 +417,8 @@ registerSuite('Slider', {
 					v('output', {
 						classes: [ css.output, null ],
 						for: '',
-						styles: {}
+						styles: {},
+						tabIndex: -1
 					}, [ '30' ])
 				])
 			]));
@@ -492,7 +497,8 @@ registerSuite('Slider', {
 					v('output', {
 						classes: [ css.output, null ],
 						for: '',
-						styles: {}
+						styles: {},
+						tabIndex: -1
 					}, [ '0' ])
 				])
 			]));
@@ -560,7 +566,8 @@ registerSuite('Slider', {
 					v('output', {
 						classes: [ css.output, null ],
 						for: '',
-						styles: {}
+						styles: {},
+						tabIndex: -1
 					}, [ '0' ])
 				])
 			]));


### PR DESCRIPTION
Massive change to disable focus from `<output>` tag so Edge doesn't jump to it when navigating with Tab.

Issue #402 