### PR TITLE
Remove dom event from widget callbacks

### DIFF
--- a/src/button/Button.ts
+++ b/src/button/Button.ts
@@ -70,15 +70,15 @@ export class ButtonBase<P extends ButtonProperties = ButtonProperties> extends T
 	}
 	private _onKeyDown (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyDown && this.properties.onKeyDown(event.which, event.preventDefault);
+		this.properties.onKeyDown && this.properties.onKeyDown(event.which, () => { event.preventDefault(); });
 	}
 	private _onKeyPress (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyPress && this.properties.onKeyPress(event.which, event.preventDefault);
+		this.properties.onKeyPress && this.properties.onKeyPress(event.which, () => { event.preventDefault(); });
 	}
 	private _onKeyUp (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyUp && this.properties.onKeyUp(event.which, event.preventDefault);
+		this.properties.onKeyUp && this.properties.onKeyUp(event.which, () => { event.preventDefault(); });
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();

--- a/src/button/Button.ts
+++ b/src/button/Button.ts
@@ -30,6 +30,7 @@ export interface ButtonProperties extends ThemedProperties, InputEventProperties
 	pressed?: boolean;
 	type?: ButtonType;
 	value?: string;
+	onClick?(value?: string | number | boolean): void;
 }
 
 export const ThemedBase = ThemedMixin(WidgetBase);
@@ -69,15 +70,15 @@ export class ButtonBase<P extends ButtonProperties = ButtonProperties> extends T
 	}
 	private _onKeyDown (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyDown && this.properties.onKeyDown();
+		this.properties.onKeyDown && this.properties.onKeyDown(event.which, event.preventDefault);
 	}
 	private _onKeyPress (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyPress && this.properties.onKeyPress();
+		this.properties.onKeyPress && this.properties.onKeyPress(event.which, event.preventDefault);
 	}
 	private _onKeyUp (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyUp && this.properties.onKeyUp();
+		this.properties.onKeyUp && this.properties.onKeyUp(event.which, event.preventDefault);
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();

--- a/src/button/Button.ts
+++ b/src/button/Button.ts
@@ -30,7 +30,7 @@ export interface ButtonProperties extends ThemedProperties, InputEventProperties
 	pressed?: boolean;
 	type?: ButtonType;
 	value?: string;
-	onClick?(value?: string | number | boolean): void;
+	onClick?(): void;
 }
 
 export const ThemedBase = ThemedMixin(WidgetBase);

--- a/src/button/Button.ts
+++ b/src/button/Button.ts
@@ -58,46 +58,46 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 })
 export class ButtonBase<P extends ButtonProperties = ButtonProperties> extends ThemedBase<P> {
 	private _onBlur (event: FocusEvent) {
-		this.properties.onBlur && this.properties.onBlur(event);
+		this.properties.onBlur && this.properties.onBlur();
 	}
 	private _onClick (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onClick && this.properties.onClick(event);
+		this.properties.onClick && this.properties.onClick();
 	}
 	private _onFocus (event: FocusEvent) {
-		this.properties.onFocus && this.properties.onFocus(event);
+		this.properties.onFocus && this.properties.onFocus();
 	}
 	private _onKeyDown (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyDown && this.properties.onKeyDown(event);
+		this.properties.onKeyDown && this.properties.onKeyDown();
 	}
 	private _onKeyPress (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyPress && this.properties.onKeyPress(event);
+		this.properties.onKeyPress && this.properties.onKeyPress();
 	}
 	private _onKeyUp (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyUp && this.properties.onKeyUp(event);
+		this.properties.onKeyUp && this.properties.onKeyUp();
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onMouseDown && this.properties.onMouseDown(event);
+		this.properties.onMouseDown && this.properties.onMouseDown();
 	}
 	private _onMouseUp (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onMouseUp && this.properties.onMouseUp(event);
+		this.properties.onMouseUp && this.properties.onMouseUp();
 	}
 	private _onTouchStart (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchStart && this.properties.onTouchStart(event);
+		this.properties.onTouchStart && this.properties.onTouchStart();
 	}
 	private _onTouchEnd (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchEnd && this.properties.onTouchEnd(event);
+		this.properties.onTouchEnd && this.properties.onTouchEnd();
 	}
 	private _onTouchCancel (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchCancel && this.properties.onTouchCancel(event);
+		this.properties.onTouchCancel && this.properties.onTouchCancel();
 	}
 
 	protected getContent(): DNode[] {

--- a/src/calendar/Calendar.ts
+++ b/src/calendar/Calendar.ts
@@ -179,32 +179,31 @@ export class CalendarBase<P extends CalendarProperties = CalendarProperties> ext
 		this._callDateFocus = false;
 	}
 
-	private _onDateKeyDown(event: KeyboardEvent) {
-		event.stopPropagation();
+	private _onDateKeyDown(key: number, preventDefault: () => void) {
 		const { month, year } = this._getMonthYear();
-		switch (event.which) {
+		switch (key) {
 			case Keys.Up:
-				event.preventDefault();
+				preventDefault();
 				this._goToDate(this._focusedDay - 7);
 				break;
 			case Keys.Down:
-				event.preventDefault();
+				preventDefault();
 				this._goToDate(this._focusedDay + 7);
 				break;
 			case Keys.Left:
-				event.preventDefault();
+				preventDefault();
 				this._goToDate(this._focusedDay - 1);
 				break;
 			case Keys.Right:
-				event.preventDefault();
+				preventDefault();
 				this._goToDate(this._focusedDay + 1);
 				break;
 			case Keys.PageUp:
-				event.preventDefault();
+				preventDefault();
 				this._goToDate(1);
 				break;
 			case Keys.PageDown:
-				event.preventDefault();
+				preventDefault();
 				const monthLengh = this._getMonthLength(month, year);
 				this._goToDate(monthLengh);
 				break;

--- a/src/calendar/CalendarCell.ts
+++ b/src/calendar/CalendarCell.ts
@@ -29,7 +29,7 @@ export interface CalendarCellProperties extends ThemedProperties {
 	today?: boolean;
 	onClick?(date: number, disabled: boolean): void;
 	onFocusCalled?(): void;
-	onKeyDown?(): void;
+	onKeyDown?(key: number, preventDefault: () => void): void;
 };
 
 export const ThemedBase = ThemedMixin(WidgetBase);
@@ -45,7 +45,7 @@ export class CalendarCellBase<P extends CalendarCellProperties = CalendarCellPro
 	private _onKeyDown(event: KeyboardEvent) {
 		event.stopPropagation();
 		const { onKeyDown } = this.properties;
-		onKeyDown && onKeyDown();
+		onKeyDown && onKeyDown(event.which, event.preventDefault);
 	}
 
 	protected formatDate(date: number): DNode {

--- a/src/calendar/CalendarCell.ts
+++ b/src/calendar/CalendarCell.ts
@@ -45,7 +45,7 @@ export class CalendarCellBase<P extends CalendarCellProperties = CalendarCellPro
 	private _onKeyDown(event: KeyboardEvent) {
 		event.stopPropagation();
 		const { onKeyDown } = this.properties;
-		onKeyDown && onKeyDown(event.which, event.preventDefault);
+		onKeyDown && onKeyDown(event.which, () => { event.preventDefault(); });
 	}
 
 	protected formatDate(date: number): DNode {

--- a/src/calendar/CalendarCell.ts
+++ b/src/calendar/CalendarCell.ts
@@ -29,7 +29,7 @@ export interface CalendarCellProperties extends ThemedProperties {
 	today?: boolean;
 	onClick?(date: number, disabled: boolean): void;
 	onFocusCalled?(): void;
-	onKeyDown?(event: KeyboardEvent): void;
+	onKeyDown?(): void;
 };
 
 export const ThemedBase = ThemedMixin(WidgetBase);
@@ -45,7 +45,7 @@ export class CalendarCellBase<P extends CalendarCellProperties = CalendarCellPro
 	private _onKeyDown(event: KeyboardEvent) {
 		event.stopPropagation();
 		const { onKeyDown } = this.properties;
-		onKeyDown && onKeyDown(event);
+		onKeyDown && onKeyDown();
 	}
 
 	protected formatDate(date: number): DNode {

--- a/src/calendar/tests/unit/Calendar.ts
+++ b/src/calendar/tests/unit/Calendar.ts
@@ -258,85 +258,37 @@ registerSuite('Calendar', {
 			}));
 
 			// right arrow, then select
-			h.trigger('@date-4', 'onKeyDown', {
-				which: Keys.Right,
-				preventDefault: () => {},
-				...stubEvent
-			});
+			h.trigger('@date-4', 'onKeyDown', Keys.Right, () => {});
 			h.trigger('@date-4', 'onFocusCalled');
-			h.trigger('@date-5', 'onKeyDown', {
-				which: Keys.Enter,
-				preventDefault: () => {},
-				...stubEvent
-			});
+			h.trigger('@date-5', 'onKeyDown', Keys.Enter, () => {});
 			assert.strictEqual(selectedDate.getDate(), 2, 'Right arrow + enter selects second day');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
 
-			h.trigger('@date-5', 'onKeyDown', {
-				which: Keys.Down,
-				preventDefault: () => {},
-				...stubEvent
-			});
-			h.trigger('@date-12', 'onKeyDown', {
-				which: Keys.Enter,
-				preventDefault: () => {},
-				...stubEvent
-			});
+			h.trigger('@date-5', 'onKeyDown', Keys.Down, () => {});
+			h.trigger('@date-12', 'onKeyDown', Keys.Enter, () => {});
 			assert.strictEqual(selectedDate.getDate(), 9, 'Down arrow + enter selects one week down');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
 
-			h.trigger('@date-12', 'onKeyDown', {
-				which: Keys.Left,
-				preventDefault: () => {},
-				...stubEvent
-			});
-			h.trigger('@date-11', 'onKeyDown', {
-				which: Keys.Space,
-				preventDefault: () => {},
-				...stubEvent
-			});
+			h.trigger('@date-12', 'onKeyDown', Keys.Left, () => {});
+			h.trigger('@date-11', 'onKeyDown', Keys.Space, () => {});
 
 			assert.strictEqual(selectedDate.getDate(), 8, 'Left arrow + space selects previous day');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
 
-			h.trigger('@date-11', 'onKeyDown', {
-				which: Keys.Up,
-				preventDefault: () => {},
-				...stubEvent
-			});
-			h.trigger('@date-4', 'onKeyDown', {
-				which: Keys.Space,
-				preventDefault: () => {},
-				...stubEvent
-			});
+			h.trigger('@date-11', 'onKeyDown', Keys.Up, () => {});
+			h.trigger('@date-4', 'onKeyDown', Keys.Space, () => {});
 
 			assert.strictEqual(selectedDate.getDate(), 1, 'Left arrow + space selects previous day');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
 
-			h.trigger('@date-4', 'onKeyDown', {
-				which: Keys.PageDown,
-				preventDefault: () => {},
-				...stubEvent
-			});
-			h.trigger('@date-33', 'onKeyDown', {
-				which: Keys.Space,
-				preventDefault: () => {},
-				...stubEvent
-			});
+			h.trigger('@date-4', 'onKeyDown', Keys.PageDown, () => {});
+			h.trigger('@date-33', 'onKeyDown', Keys.Space, () => {});
 
 			assert.strictEqual(selectedDate.getDate(), 30, 'Page Down + space selects last day');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
 
-			h.trigger('@date-33', 'onKeyDown', {
-				which: Keys.PageUp,
-				preventDefault: () => {},
-				...stubEvent
-			});
-			h.trigger('@date-4', 'onKeyDown', {
-				which: Keys.Space,
-				preventDefault: () => {},
-				...stubEvent
-			});
+			h.trigger('@date-33', 'onKeyDown', Keys.PageUp, () => {});
+			h.trigger('@date-4', 'onKeyDown', Keys.Space, () => {});
 
 			assert.strictEqual(selectedDate.getDate(), 1, 'Page Up + space selects first day');
 			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
@@ -352,23 +304,11 @@ registerSuite('Calendar', {
 				}
 			}));
 
-			h.trigger('@date-4', 'onKeyDown', {
-				which: Keys.Left,
-				preventDefault: () => {},
-				...stubEvent
-			});
+			h.trigger('@date-4', 'onKeyDown', Keys.Left, () => {});
 			assert.strictEqual(currentMonth, testDate.getMonth() - 1, 'Going left from the first day goes to previous month');
 
-			h.trigger('@date-4', 'onKeyDown', {
-				which: Keys.PageDown,
-				preventDefault: () => {},
-				...stubEvent
-			});
-			h.trigger('@date-4', 'onKeyDown', {
-				which: Keys.Right,
-				preventDefault: () => {},
-				...stubEvent
-			});
+			h.trigger('@date-4', 'onKeyDown', Keys.PageDown, () => {});
+			h.trigger('@date-4', 'onKeyDown', Keys.Right, () => {});
 			assert.strictEqual(currentMonth, testDate.getMonth(), 'Going right from the last day goes to next month');
 		},
 
@@ -387,11 +327,7 @@ registerSuite('Calendar', {
 			};
 			const h = harness(() => w(Calendar, properties));
 
-			h.trigger('@date-0', 'onKeyDown', {
-				which: Keys.Up,
-				preventDefault: () => {},
-				...stubEvent
-			});
+			h.trigger('@date-0', 'onKeyDown', Keys.Up, () => {});
 
 			assert.strictEqual(currentMonth, 11, 'Previous month wraps from January to December');
 			assert.strictEqual(currentYear, 2016, 'Year decrements when month wraps');
@@ -407,11 +343,7 @@ registerSuite('Calendar', {
 				}
 			};
 
-			h.trigger('@date-35', 'onKeyDown', {
-				which: Keys.Down,
-				preventDefault: () => {},
-				...stubEvent
-			});
+			h.trigger('@date-35', 'onKeyDown', Keys.Down, () => {});
 
 			assert.strictEqual(currentMonth, 0, 'Next month wraps from December to January');
 			assert.strictEqual(currentYear, 2018, 'Year increments when month wraps');

--- a/src/checkbox/Checkbox.ts
+++ b/src/checkbox/Checkbox.ts
@@ -61,20 +61,20 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 })
 export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> extends ThemedBase<P, null> {
 	private _onBlur (event: FocusEvent) {
-		const checkbox = (event.target as HTMLInputElement);
+		const checkbox = event.target as HTMLInputElement;
 		this.properties.onBlur && this.properties.onBlur(checkbox.value, checkbox.checked);
 	}
 	private _onChange (event: Event) {
-		const checkbox = (event.target as HTMLInputElement);
+		const checkbox = event.target as HTMLInputElement;
 		this.properties.onChange && this.properties.onChange(checkbox.value, checkbox.checked);
 	}
 	private _onClick (event: MouseEvent) {
 		event.stopPropagation();
-		const checkbox = (event.target as HTMLInputElement);
+		const checkbox = event.target as HTMLInputElement;
 		this.properties.onClick && this.properties.onClick(checkbox.value, checkbox.checked);
 	}
 	private _onFocus (event: FocusEvent) {
-		const checkbox = (event.target as HTMLInputElement);
+		const checkbox = event.target as HTMLInputElement;
 		this.properties.onFocus && this.properties.onFocus(checkbox.value, checkbox.checked);
 	}
 	private _onMouseDown (event: MouseEvent) {

--- a/src/checkbox/Checkbox.ts
+++ b/src/checkbox/Checkbox.ts
@@ -62,38 +62,38 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 })
 export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> extends ThemedBase<P, null> {
 	private _onBlur (event: FocusEvent) {
-		this.properties.onBlur && this.properties.onBlur(event);
+		this.properties.onBlur && this.properties.onBlur();
 	}
 	private _onChange (event: Event) {
-		this.properties.onChange && this.properties.onChange(event);
+		this.properties.onChange && this.properties.onChange();
 	}
 	private _onClick (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onClick && this.properties.onClick(event);
+		this.properties.onClick && this.properties.onClick();
 	}
 	private _onFocus (event: FocusEvent) {
-		this.properties.onFocus && this.properties.onFocus(event);
+		this.properties.onFocus && this.properties.onFocus();
 		this.invalidate();
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onMouseDown && this.properties.onMouseDown(event);
+		this.properties.onMouseDown && this.properties.onMouseDown();
 	}
 	private _onMouseUp (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onMouseUp && this.properties.onMouseUp(event);
+		this.properties.onMouseUp && this.properties.onMouseUp();
 	}
 	private _onTouchStart (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchStart && this.properties.onTouchStart(event);
+		this.properties.onTouchStart && this.properties.onTouchStart();
 	}
 	private _onTouchEnd (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchEnd && this.properties.onTouchEnd(event);
+		this.properties.onTouchEnd && this.properties.onTouchEnd();
 	}
 	private _onTouchCancel (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchCancel && this.properties.onTouchCancel(event);
+		this.properties.onTouchCancel && this.properties.onTouchCancel();
 	}
 
 	private _uuid = uuid();

--- a/src/checkbox/Checkbox.ts
+++ b/src/checkbox/Checkbox.ts
@@ -3,7 +3,7 @@ import { DNode } from '@dojo/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import Focus from '@dojo/widget-core/meta/Focus';
 import Label from '../label/Label';
-import { CustomAriaProperties, LabeledProperties, InputProperties, InputEventProperties, KeyEventProperties, PointerEventProperties } from '../common/interfaces';
+import { CustomAriaProperties, LabeledProperties, InputProperties, CheckboxRadioEventProperties, KeyEventProperties, PointerEventProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 import { v, w } from '@dojo/widget-core/d';
 import uuid from '@dojo/core/uuid';
@@ -21,7 +21,7 @@ import { customElement } from '@dojo/widget-core/decorators/customElement';
  * @property onLabel        Label to show in the "on" positin of a toggle
  * @property value           The current value
  */
-export interface CheckboxProperties extends ThemedProperties, InputProperties, LabeledProperties, InputEventProperties, KeyEventProperties, PointerEventProperties, CustomAriaProperties {
+export interface CheckboxProperties extends ThemedProperties, InputProperties, LabeledProperties, KeyEventProperties, PointerEventProperties, CustomAriaProperties, CheckboxRadioEventProperties {
 	checked?: boolean;
 	mode?: Mode;
 	offLabel?: DNode;
@@ -49,7 +49,6 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 		'onChange',
 		'onClick',
 		'onFocus',
-		'onInput',
 		'onKeyDown',
 		'onKeyPress',
 		'onKeyUp',
@@ -62,18 +61,21 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 })
 export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> extends ThemedBase<P, null> {
 	private _onBlur (event: FocusEvent) {
-		this.properties.onBlur && this.properties.onBlur();
+		const checkbox = (event.target as HTMLInputElement);
+		this.properties.onBlur && this.properties.onBlur(checkbox.value, checkbox.checked);
 	}
 	private _onChange (event: Event) {
-		this.properties.onChange && this.properties.onChange();
+		const checkbox = (event.target as HTMLInputElement);
+		this.properties.onChange && this.properties.onChange(checkbox.value, checkbox.checked);
 	}
 	private _onClick (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onClick && this.properties.onClick();
+		const checkbox = (event.target as HTMLInputElement);
+		this.properties.onClick && this.properties.onClick(checkbox.value, checkbox.checked);
 	}
 	private _onFocus (event: FocusEvent) {
-		this.properties.onFocus && this.properties.onFocus();
-		this.invalidate();
+		const checkbox = (event.target as HTMLInputElement);
+		this.properties.onFocus && this.properties.onFocus(checkbox.value, checkbox.checked);
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();

--- a/src/checkbox/example/index.ts
+++ b/src/checkbox/example/index.ts
@@ -13,9 +13,7 @@ export class App extends WidgetBase<WidgetProperties> {
 		c5: true
 	};
 
-	onChange(event: Event) {
-		const value = (event.target as HTMLInputElement).value;
-		const checked = (event.target as HTMLInputElement).checked;
+	onChange(value: string, checked: boolean) {
 		this._checkboxStates[value] = checked;
 		this.invalidate();
 	}

--- a/src/checkbox/tests/unit/Checkbox.ts
+++ b/src/checkbox/tests/unit/Checkbox.ts
@@ -375,13 +375,13 @@ registerSuite('Checkbox', {
 				onTouchCancel
 			}));
 
-			h.trigger('input', 'onblur');
+			h.trigger('input', 'onblur', stubEvent);
 			assert.isTrue(onBlur.called, 'onBlur called');
-			h.trigger('input', 'onchange');
+			h.trigger('input', 'onchange', stubEvent);
 			assert.isTrue(onChange.called, 'onChange called');
 			h.trigger('input', 'onclick', stubEvent);
 			assert.isTrue(onClick.called, 'onClick called');
-			h.trigger('input', 'onfocus');
+			h.trigger('input', 'onfocus', stubEvent);
 			assert.isTrue(onFocus.called, 'onFocus called');
 			h.trigger('input', 'onmousedown', stubEvent);
 			assert.isTrue(onMouseDown.called, 'onMouseDown called');

--- a/src/combobox/ComboBox.ts
+++ b/src/combobox/ComboBox.ts
@@ -158,14 +158,14 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 		onChange && onChange('', key);
 	}
 
-	private _onInput(event: Event) {
+	private _onInput(value: string) {
 		const { key, disabled, readOnly, onChange } = this.properties;
 
-		onChange && onChange((<HTMLInputElement> event.target).value, key);
+		onChange && onChange(value, key);
 		!disabled && !readOnly && this._openMenu();
 	}
 
-	private _onInputBlur(event: FocusEvent) {
+	private _onInputBlur(value: string) {
 		const { key, onBlur } = this.properties;
 
 		if (this._ignoreBlur) {
@@ -173,11 +173,11 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 			return;
 		}
 
-		onBlur && onBlur((<HTMLInputElement> event.target).value, key);
+		onBlur && onBlur(value, key);
 		this._closeMenu();
 	}
 
-	private _onInputFocus(event: FocusEvent) {
+	private _onInputFocus(value: string) {
 		const {
 			key,
 			disabled,
@@ -186,11 +186,11 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 			openOnFocus
 		} = this.properties;
 
-		onFocus && onFocus((<HTMLInputElement> event.target).value, key);
+		onFocus && onFocus(value, key);
 		!disabled && !readOnly && openOnFocus && this._openMenu();
 	}
 
-	private _onInputKeyDown(event: KeyboardEvent) {
+	private _onInputKeyDown(key: number, preventDefault: () => void) {
 		const {
 			disabled,
 			isResultDisabled = () => false,
@@ -199,13 +199,13 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 		} = this.properties;
 		this._menuHasVisualFocus = true;
 
-		switch (event.which) {
+		switch (key) {
 			case Keys.Up:
-				event.preventDefault();
+				preventDefault();
 				this._moveActiveIndex(Operation.decrease);
 				break;
 			case Keys.Down:
-				event.preventDefault();
+				preventDefault();
 				if (!this._open && !disabled && !readOnly) {
 					this._openMenu();
 				}

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -228,7 +228,7 @@ registerSuite('ComboBox', {
 				onMenuChange
 			}));
 
-			h.trigger('@textinput', 'onInput', { target: { value: 'foo' } });
+			h.trigger('@textinput', 'onInput', 'foo');
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true));
 
 			assert.isTrue(onChange.calledWith('foo'), 'onChange callback called with input value');
@@ -248,7 +248,7 @@ registerSuite('ComboBox', {
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true));
 
-			h.trigger('@textinput', 'onBlur', { target: { value: 'foo' } });
+			h.trigger('@textinput', 'onBlur', 'foo');
 			h.expect(() => getExpectedVdom(true, false, true));
 			assert.isTrue(onBlur.calledWith('foo'), 'onBlur callback called with input value');
 			assert.isTrue(onMenuChange.calledTwice, 'onMenuChange called twice');
@@ -266,7 +266,7 @@ registerSuite('ComboBox', {
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true));
 
 			h.trigger('@dropdown', 'onmousedown', stubEvent);
-			h.trigger('@textinput', 'onBlur', { target: { value: 'foo' } });
+			h.trigger('@textinput', 'onBlur', 'foo');
 
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true));
 			assert.isFalse(onBlur.called, 'onBlur not called for dropdown click');
@@ -294,12 +294,12 @@ registerSuite('ComboBox', {
 				onRequestResults
 			}));
 
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Down, preventDefault, ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.Down, preventDefault);
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true, { visualFocus: true }));
 			assert.isTrue(onRequestResults.calledOnce, 'onRequestResults called when menu is opened');
 			assert.isTrue(preventDefault.calledOnce, 'down key press prevents default page scroll');
 
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Escape, ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.Escape, preventDefault);
 			h.expect(() => getExpectedVdom(true, false, true));
 		},
 
@@ -314,17 +314,17 @@ registerSuite('ComboBox', {
 			const preventDefault = sinon.stub();
 			const h = harness(() => w(ComboBox, testProperties ));
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Down, preventDefault, ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.Down, preventDefault);
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true, { visualFocus: true, activeIndex: 1 }));
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Up, preventDefault, ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.Up, preventDefault);
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true, { visualFocus: true, activeIndex: 0 }));
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Up, preventDefault, ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.Up, preventDefault);
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true, { visualFocus: true, activeIndex: 2 }));
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Down, preventDefault, ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.Down, preventDefault);
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true, { visualFocus: true, activeIndex: 0 }));
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.End, preventDefault, ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.End, preventDefault);
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true, { visualFocus: true, activeIndex: 2 }));
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Home, preventDefault, ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.Home, preventDefault);
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true, { visualFocus: true, activeIndex: 0 }));
 			assert.strictEqual(preventDefault.callCount, 4, 'preventDefault called four times for up and down keys');
 		},
@@ -336,17 +336,17 @@ registerSuite('ComboBox', {
 				onChange
 			}));
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Enter, ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.Enter, () => {});
 
 			assert.isTrue(onChange.calledWith('One'), 'enter triggers onChange callback called with label of first option');
 			h.expect(() => getExpectedVdom(true, false, true, {}, true));
 
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Enter, ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.Enter, () => {});
 			assert.isFalse(onChange.calledTwice, 'enter does not trigger onChange when menu is closed');
 			onChange.reset();
 
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Space, ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.Space, () => {});
 			assert.isTrue(onChange.calledWith('One'), 'space triggers onChange callback called with label of first option');
 			h.expect(() => getExpectedVdom(true, false, true, {}, true));
 		},
@@ -360,8 +360,8 @@ registerSuite('ComboBox', {
 				onChange
 			}));
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Up, preventDefault, ...stubEvent });
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Enter, preventDefault, ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.Up, preventDefault);
+			h.trigger('@textinput', 'onKeyDown', Keys.Enter, preventDefault);
 
 			assert.isFalse(onChange.called, 'onChange not called for disabled option');
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true, {
@@ -378,8 +378,8 @@ registerSuite('ComboBox', {
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
 			h.expect(() => getExpectedVdom(false, true, false, {}, true));
 
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Down, preventDefault, ...stubEvent });
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Enter, preventDefault, ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.Down, preventDefault);
+			h.trigger('@textinput', 'onKeyDown', Keys.Enter, preventDefault);
 
 			assert.isFalse(onChange.called, 'onChange not called for no results');
 		},
@@ -431,7 +431,7 @@ registerSuite('ComboBox', {
 				openOnFocus: true,
 				onFocus
 			}));
-			h.trigger('@textinput', 'onFocus', { target: { value: 'foo' } });
+			h.trigger('@textinput', 'onFocus', 'foo');
 
 			assert.isTrue(onFocus.calledWith('foo'), 'onFocus handler called with input value');
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true));
@@ -559,7 +559,7 @@ registerSuite('ComboBox', {
 
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
 			h.expect(() => getExpectedVdom(true, false, true, { disabled: true }));
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Down, preventDefault: sinon.stub(), ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.Down, () => {});
 			h.expect(() => getExpectedVdom(true, false, true, { disabled: true }));
 			assert.isFalse(onMenuChange.called, 'onMenuChange never called');
 			assert.isFalse(onRequestResults.called, 'onRequestResults never called');
@@ -577,7 +577,7 @@ registerSuite('ComboBox', {
 
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
 			h.expect(() => getExpectedVdom(true, false, true, { readOnly: true }));
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Down, preventDefault: sinon.stub(), ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.Down, () => {});
 			h.expect(() => getExpectedVdom(true, false, true, { readOnly: true }));
 
 			assert.isFalse(onMenuChange.called, 'onMenuChange never called');
@@ -589,8 +589,8 @@ registerSuite('ComboBox', {
 			const h = harness(() => w(ComboBox, { ...testProperties }));
 			h.expect(() =>  getExpectedVdom(true, false, true));
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Up, preventDefault, ...stubEvent });
-			h.trigger('@textinput', 'onKeyDown', { which: Keys.Down, preventDefault, ...stubEvent });
+			h.trigger('@textinput', 'onKeyDown', Keys.Up, preventDefault);
+			h.trigger('@textinput', 'onKeyDown', Keys.Down, preventDefault);
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true, { visualFocus: true }));
 			h.trigger('@dropdown', 'onmouseover', stubEvent);
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true));

--- a/src/common/interfaces.d.ts
+++ b/src/common/interfaces.d.ts
@@ -39,10 +39,17 @@ export interface InputProperties {
  * @property onInput        Called when the 'input' event is fired
  */
 export interface InputEventProperties {
-	onBlur?(): void;
-	onChange?(): void;
-	onFocus?(): void;
-	onInput?(): void;
+	onBlur?(value?: string | number | boolean): void;
+	onChange?(value?: string | number | boolean): void;
+	onFocus?(value?: string | number | boolean): void;
+	onInput?(value?: string | number | boolean): void;
+}
+
+export interface CheckboxRadioEventProperties {
+	onBlur?(value: string, checked: boolean): void;
+	onChange?(value: string, checked: boolean): void;
+	onFocus?(value: string, checked: boolean): void;
+	onClick?(value: string, checked: boolean): void;
 }
 
 /**
@@ -52,9 +59,9 @@ export interface InputEventProperties {
  * @property onKeyUp        Called on the input's keyup event
  */
 export interface KeyEventProperties {
-	onKeyDown?(): void;
-	onKeyPress?(): void;
-	onKeyUp?(): void;
+	onKeyDown?(key: number, preventDefault: () => void): void;
+	onKeyPress?(key: number, preventDefault: () => void): void;
+	onKeyUp?(key: number, preventDefault: () => void): void;
 }
 
 /**
@@ -71,7 +78,6 @@ export interface LabeledProperties {
 
 /**
  * @type PointerEventProperties
- * @property onClick        Called when the input is clicked
  * @property onMouseDown    Called on the input's mousedown event
  * @property onMouseUp      Called on the input's mouseup event
  * @property onTouchStart   Called on the input's touchstart event
@@ -79,7 +85,6 @@ export interface LabeledProperties {
  * @property onTouchCancel  Called on the input's touchcancel event
  */
 export interface PointerEventProperties {
-	onClick?(): void;
 	onMouseDown?(): void;
 	onMouseUp?(): void;
 	onTouchStart?(): void;

--- a/src/common/interfaces.d.ts
+++ b/src/common/interfaces.d.ts
@@ -39,10 +39,10 @@ export interface InputProperties {
  * @property onInput        Called when the 'input' event is fired
  */
 export interface InputEventProperties {
-	onBlur?(event: FocusEvent): void;
-	onChange?(event: Event): void;
-	onFocus?(event: FocusEvent): void;
-	onInput?(event: Event): void;
+	onBlur?(): void;
+	onChange?(): void;
+	onFocus?(): void;
+	onInput?(): void;
 }
 
 /**
@@ -52,9 +52,9 @@ export interface InputEventProperties {
  * @property onKeyUp        Called on the input's keyup event
  */
 export interface KeyEventProperties {
-	onKeyDown?(event: KeyboardEvent): void;
-	onKeyPress?(event: KeyboardEvent): void;
-	onKeyUp?(event: KeyboardEvent): void;
+	onKeyDown?(): void;
+	onKeyPress?(): void;
+	onKeyUp?(): void;
 }
 
 /**
@@ -79,10 +79,10 @@ export interface LabeledProperties {
  * @property onTouchCancel  Called on the input's touchcancel event
  */
 export interface PointerEventProperties {
-	onClick?(event: MouseEvent): void;
-	onMouseDown?(event: MouseEvent): void;
-	onMouseUp?(event: MouseEvent): void;
-	onTouchStart?(event: TouchEvent): void;
-	onTouchEnd?(event: TouchEvent): void;
-	onTouchCancel?(event: TouchEvent): void;
+	onClick?(): void;
+	onMouseDown?(): void;
+	onMouseUp?(): void;
+	onTouchStart?(): void;
+	onTouchEnd?(): void;
+	onTouchCancel?(): void;
 }

--- a/src/common/tests/support/test-helpers.ts
+++ b/src/common/tests/support/test-helpers.ts
@@ -6,7 +6,9 @@ import { WidgetBase } from '@dojo/widget-core/WidgetBase';
 export const noop: any = () => {};
 
 export const stubEvent = {
-	stopPropagation: noop
+	stopPropagation: noop,
+	preventDefault: noop,
+	target: {}
 };
 
 export const isStringComparator = (value: any) => typeof value === 'string';

--- a/src/enhancedtextinput/example/index.ts
+++ b/src/enhancedtextinput/example/index.ts
@@ -25,8 +25,8 @@ export class App extends WidgetBase<WidgetProperties> {
 					type: 'text',
 					placeholder: 'username',
 					value: this._value1,
-					onChange: (event: Event) => {
-						this._value1 = (event.target as HTMLInputElement).value;
+					onChange: (value: string) => {
+						this._value1 = value;
 						this.invalidate();
 					}
 				}),
@@ -41,8 +41,8 @@ export class App extends WidgetBase<WidgetProperties> {
 					label: 'Price, rounded to the nearest dollar',
 					type: 'number',
 					value: this._value2,
-					onChange: (event: Event) => {
-						this._value2 = (event.target as HTMLInputElement).value;
+					onChange: (value: string) => {
+						this._value2 = value;
 						this.invalidate();
 					}
 				})

--- a/src/enhancedtextinput/tests/unit/EnhancedTextInput.ts
+++ b/src/enhancedtextinput/tests/unit/EnhancedTextInput.ts
@@ -247,15 +247,15 @@ registerSuite('EnhancedTextInput', {
 					onTouchCancel
 				}));
 
-				h.trigger('@input', 'onblur');
+				h.trigger('@input', 'onblur', stubEvent);
 				assert.isTrue(onBlur.called, 'onBlur called');
-				h.trigger('@input', 'onchange');
+				h.trigger('@input', 'onchange', stubEvent);
 				assert.isTrue(onChange.called, 'onChange called');
 				h.trigger('@input', 'onclick', stubEvent);
 				assert.isTrue(onClick.called, 'onClick called');
-				h.trigger('@input', 'onfocus');
+				h.trigger('@input', 'onfocus', stubEvent);
 				assert.isTrue(onFocus.called, 'onFocus called');
-				h.trigger('@input', 'oninput');
+				h.trigger('@input', 'oninput', stubEvent);
 				assert.isTrue(onInput.called, 'onInput called');
 				h.trigger('@input', 'onkeydown', stubEvent);
 				assert.isTrue(onKeyDown.called, 'onKeyDown called');

--- a/src/radio/Radio.ts
+++ b/src/radio/Radio.ts
@@ -3,7 +3,7 @@ import { DNode } from '@dojo/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/widget-core/mixins/Themed';
 import Focus from '@dojo/widget-core/meta/Focus';
 import Label from '../label/Label';
-import { CustomAriaProperties, LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties } from '../common/interfaces';
+import { CustomAriaProperties, LabeledProperties, InputProperties, CheckboxRadioEventProperties, PointerEventProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 import { v, w } from '@dojo/widget-core/d';
 import uuid from '@dojo/core/uuid';
@@ -18,7 +18,7 @@ import { customElement } from '@dojo/widget-core/decorators/customElement';
  * @property checked          Checked/unchecked property of the radio
  * @property value           The current value
  */
-export interface RadioProperties extends ThemedProperties, LabeledProperties, InputProperties, InputEventProperties, PointerEventProperties, CustomAriaProperties {
+export interface RadioProperties extends ThemedProperties, LabeledProperties, InputProperties, PointerEventProperties, CustomAriaProperties, CheckboxRadioEventProperties {
 	checked?: boolean;
 	value?: string;
 }
@@ -35,7 +35,6 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 		'onChange',
 		'onClick',
 		'onFocus',
-		'onInput',
 		'onMouseDown',
 		'onMouseUp',
 		'onTouchCancel',
@@ -47,18 +46,21 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 	private _uuid = uuid();
 
 	private _onBlur (event: FocusEvent) {
-		this.properties.onBlur && this.properties.onBlur();
+		const radio = (event.target as HTMLInputElement);
+		this.properties.onBlur && this.properties.onBlur(radio.value, radio.checked);
 	}
 	private _onChange (event: Event) {
-		this.properties.onChange && this.properties.onChange();
+		const radio = (event.target as HTMLInputElement);
+		this.properties.onChange && this.properties.onChange(radio.value, radio.checked);
 	}
 	private _onClick (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onClick && this.properties.onClick();
+		const radio = (event.target as HTMLInputElement);
+		this.properties.onClick && this.properties.onClick(radio.value, radio.checked);
 	}
 	private _onFocus (event: FocusEvent) {
-		this.properties.onFocus && this.properties.onFocus();
-		this.invalidate();
+		const radio = (event.target as HTMLInputElement);
+		this.properties.onFocus && this.properties.onFocus(radio.value, radio.checked);
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();

--- a/src/radio/Radio.ts
+++ b/src/radio/Radio.ts
@@ -47,38 +47,38 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 	private _uuid = uuid();
 
 	private _onBlur (event: FocusEvent) {
-		this.properties.onBlur && this.properties.onBlur(event);
+		this.properties.onBlur && this.properties.onBlur();
 	}
 	private _onChange (event: Event) {
-		this.properties.onChange && this.properties.onChange(event);
+		this.properties.onChange && this.properties.onChange();
 	}
 	private _onClick (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onClick && this.properties.onClick(event);
+		this.properties.onClick && this.properties.onClick();
 	}
 	private _onFocus (event: FocusEvent) {
-		this.properties.onFocus && this.properties.onFocus(event);
+		this.properties.onFocus && this.properties.onFocus();
 		this.invalidate();
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onMouseDown && this.properties.onMouseDown(event);
+		this.properties.onMouseDown && this.properties.onMouseDown();
 	}
 	private _onMouseUp (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onMouseUp && this.properties.onMouseUp(event);
+		this.properties.onMouseUp && this.properties.onMouseUp();
 	}
 	private _onTouchStart (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchStart && this.properties.onTouchStart(event);
+		this.properties.onTouchStart && this.properties.onTouchStart();
 	}
 	private _onTouchEnd (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchEnd && this.properties.onTouchEnd(event);
+		this.properties.onTouchEnd && this.properties.onTouchEnd();
 	}
 	private _onTouchCancel (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchCancel && this.properties.onTouchCancel(event);
+		this.properties.onTouchCancel && this.properties.onTouchCancel();
 	}
 
 	protected getRootClasses(): (string | null)[] {

--- a/src/radio/Radio.ts
+++ b/src/radio/Radio.ts
@@ -46,20 +46,20 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 	private _uuid = uuid();
 
 	private _onBlur (event: FocusEvent) {
-		const radio = (event.target as HTMLInputElement);
+		const radio = event.target as HTMLInputElement;
 		this.properties.onBlur && this.properties.onBlur(radio.value, radio.checked);
 	}
 	private _onChange (event: Event) {
-		const radio = (event.target as HTMLInputElement);
+		const radio = event.target as HTMLInputElement;
 		this.properties.onChange && this.properties.onChange(radio.value, radio.checked);
 	}
 	private _onClick (event: MouseEvent) {
 		event.stopPropagation();
-		const radio = (event.target as HTMLInputElement);
+		const radio = event.target as HTMLInputElement;
 		this.properties.onClick && this.properties.onClick(radio.value, radio.checked);
 	}
 	private _onFocus (event: FocusEvent) {
-		const radio = (event.target as HTMLInputElement);
+		const radio = event.target as HTMLInputElement;
 		this.properties.onFocus && this.properties.onFocus(radio.value, radio.checked);
 	}
 	private _onMouseDown (event: MouseEvent) {

--- a/src/radio/example/index.ts
+++ b/src/radio/example/index.ts
@@ -7,8 +7,7 @@ import Radio from '../../radio/Radio';
 export class App extends WidgetBase<WidgetProperties> {
 	private _inputValue: string;
 
-	onChange(event: Event) {
-		const value = (event.target as HTMLInputElement).value;
+	onChange(value: string) {
 		this._inputValue = value;
 		this.invalidate();
 	}

--- a/src/radio/tests/unit/Radio.ts
+++ b/src/radio/tests/unit/Radio.ts
@@ -185,13 +185,13 @@ registerSuite('Radio', {
 				onTouchEnd,
 				onTouchCancel
 			}));
-			h.trigger('input', 'onblur');
+			h.trigger('input', 'onblur', stubEvent);
 			assert.isTrue(onBlur.called, 'onBlur called');
-			h.trigger('input', 'onchange');
+			h.trigger('input', 'onchange', stubEvent);
 			assert.isTrue(onChange.called, 'onChange called');
 			h.trigger('input', 'onclick', stubEvent);
 			assert.isTrue(onClick.called, 'onClick called');
-			h.trigger('input', 'onfocus');
+			h.trigger('input', 'onfocus', stubEvent);
 			assert.isTrue(onFocus.called, 'onFocus called');
 			h.trigger('input', 'onmousedown', stubEvent);
 			assert.isTrue(onMouseDown.called, 'onMouseDown called');

--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -77,52 +77,52 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 	private _inputId = uuid();
 
 	private _onBlur (event: FocusEvent) {
-		this.properties.onBlur && this.properties.onBlur(event);
+		this.properties.onBlur && this.properties.onBlur();
 	}
 	private _onChange (event: Event) {
-		this.properties.onChange && this.properties.onChange(event);
+		this.properties.onChange && this.properties.onChange();
 	}
 	private _onClick (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onClick && this.properties.onClick(event);
+		this.properties.onClick && this.properties.onClick();
 	}
 	private _onFocus (event: FocusEvent) {
-		this.properties.onFocus && this.properties.onFocus(event);
+		this.properties.onFocus && this.properties.onFocus();
 	}
 	private _onInput (event: Event) {
-		this.properties.onInput && this.properties.onInput(event);
+		this.properties.onInput && this.properties.onInput();
 	}
 	private _onKeyDown (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyDown && this.properties.onKeyDown(event);
+		this.properties.onKeyDown && this.properties.onKeyDown();
 	}
 	private _onKeyPress (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyPress && this.properties.onKeyPress(event);
+		this.properties.onKeyPress && this.properties.onKeyPress();
 	}
 	private _onKeyUp (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyUp && this.properties.onKeyUp(event);
+		this.properties.onKeyUp && this.properties.onKeyUp();
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onMouseDown && this.properties.onMouseDown(event);
+		this.properties.onMouseDown && this.properties.onMouseDown();
 	}
 	private _onMouseUp (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onMouseUp && this.properties.onMouseUp(event);
+		this.properties.onMouseUp && this.properties.onMouseUp();
 	}
 	private _onTouchStart (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchStart && this.properties.onTouchStart(event);
+		this.properties.onTouchStart && this.properties.onTouchStart();
 	}
 	private _onTouchEnd (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchEnd && this.properties.onTouchEnd(event);
+		this.properties.onTouchEnd && this.properties.onTouchEnd();
 	}
 	private _onTouchCancel (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchCancel && this.properties.onTouchCancel(event);
+		this.properties.onTouchCancel && this.properties.onTouchCancel();
 	}
 
 	protected getRootClasses(): (string | null)[] {

--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -33,9 +33,15 @@ export interface SliderProperties extends ThemedProperties, LabeledProperties, I
 	vertical?: boolean;
 	verticalHeight?: string;
 	value?: number;
+	onClick?(value: number): void;
 }
 
 export const ThemedBase = ThemedMixin(WidgetBase);
+
+function extractValue(event: Event): number {
+	const value = (event.target as HTMLInputElement).value;
+	return parseFloat(value);
+}
 
 @theme(css)
 @customElement<SliderProperties>({
@@ -77,32 +83,32 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 	private _inputId = uuid();
 
 	private _onBlur (event: FocusEvent) {
-		this.properties.onBlur && this.properties.onBlur();
+		this.properties.onBlur && this.properties.onBlur(extractValue(event));
 	}
 	private _onChange (event: Event) {
-		this.properties.onChange && this.properties.onChange();
+		this.properties.onChange && this.properties.onChange(extractValue(event));
 	}
 	private _onClick (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onClick && this.properties.onClick();
+		this.properties.onClick && this.properties.onClick(extractValue(event));
 	}
 	private _onFocus (event: FocusEvent) {
-		this.properties.onFocus && this.properties.onFocus();
+		this.properties.onFocus && this.properties.onFocus(extractValue(event));
 	}
 	private _onInput (event: Event) {
-		this.properties.onInput && this.properties.onInput();
+		this.properties.onInput && this.properties.onInput(extractValue(event));
 	}
 	private _onKeyDown (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyDown && this.properties.onKeyDown();
+		this.properties.onKeyDown && this.properties.onKeyDown(event.which, event.preventDefault);
 	}
 	private _onKeyPress (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyPress && this.properties.onKeyPress();
+		this.properties.onKeyPress && this.properties.onKeyPress(event.which, event.preventDefault);
 	}
 	private _onKeyUp (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyUp && this.properties.onKeyUp();
+		this.properties.onKeyUp && this.properties.onKeyUp(event.which, event.preventDefault);
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();

--- a/src/slider/Slider.ts
+++ b/src/slider/Slider.ts
@@ -100,15 +100,15 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 	}
 	private _onKeyDown (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyDown && this.properties.onKeyDown(event.which, event.preventDefault);
+		this.properties.onKeyDown && this.properties.onKeyDown(event.which, () => { event.preventDefault(); });
 	}
 	private _onKeyPress (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyPress && this.properties.onKeyPress(event.which, event.preventDefault);
+		this.properties.onKeyPress && this.properties.onKeyPress(event.which, () => { event.preventDefault(); });
 	}
 	private _onKeyUp (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyUp && this.properties.onKeyUp(event.which, event.preventDefault);
+		this.properties.onKeyUp && this.properties.onKeyUp(event.which, () => { event.preventDefault(); });
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();

--- a/src/slider/example/index.ts
+++ b/src/slider/example/index.ts
@@ -9,14 +9,12 @@ export class App extends WidgetBase<WidgetProperties> {
 	private _verticalValue: number;
 	private _verticalInvalid: boolean;
 
-	onTribbleInput(event: Event) {
-		const value = (event.target as HTMLInputElement).value;
-		this._tribbleValue = parseFloat(value);
+	onTribbleInput(value: number) {
+		this._tribbleValue = value;
 		this.invalidate();
 	}
 
-	onVerticalInput(event: Event) {
-		const value = parseFloat((event.target as HTMLInputElement).value);
+	onVerticalInput(value: number) {
 		this._verticalValue = value;
 		this._verticalInvalid = value > 50;
 		this.invalidate();

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -604,19 +604,19 @@ registerSuite('Slider', {
 				onTouchCancel
 			}));
 
-			h.trigger('@input', 'onblur');
+			h.trigger('@input', 'onblur', stubEvent);
 			assert.isTrue(onBlur.called, 'onBlur called');
 
-			h.trigger('@input', 'onchange');
+			h.trigger('@input', 'onchange', stubEvent);
 			assert.isTrue(onChange.called, 'onChange called');
 
 			h.trigger('@input', 'onclick', stubEvent);
 			assert.isTrue(onClick.called, 'onClick called');
 
-			h.trigger('@input', 'onfocus');
+			h.trigger('@input', 'onfocus', stubEvent);
 			assert.isTrue(onFocus.called, 'onFocus called');
 
-			h.trigger('@input', 'oninput');
+			h.trigger('@input', 'oninput', stubEvent);
 			assert.isTrue(onInput.called, 'onInput called');
 
 			h.trigger('@input', 'onkeydown', stubEvent);

--- a/src/textarea/Textarea.ts
+++ b/src/textarea/Textarea.ts
@@ -31,6 +31,7 @@ export interface TextareaProperties extends ThemedProperties, InputProperties, L
 	minLength?: number | string;
 	placeholder?: string;
 	value?: string;
+	onClick?(value: string): void;
 }
 
 export const ThemedBase = ThemedMixin(WidgetBase);
@@ -58,32 +59,32 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 })
 export class TextareaBase<P extends TextareaProperties = TextareaProperties> extends ThemedBase<P, null> {
 	private _onBlur (event: FocusEvent) {
-		this.properties.onBlur && this.properties.onBlur();
+		this.properties.onBlur && this.properties.onBlur((event.target as HTMLInputElement).value);
 	}
 	private _onChange (event: Event) {
-		this.properties.onChange && this.properties.onChange();
+		this.properties.onChange && this.properties.onChange((event.target as HTMLInputElement).value);
 	}
 	private _onClick (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onClick && this.properties.onClick();
+		this.properties.onClick && this.properties.onClick((event.target as HTMLInputElement).value);
 	}
 	private _onFocus (event: FocusEvent) {
-		this.properties.onFocus && this.properties.onFocus();
+		this.properties.onFocus && this.properties.onFocus((event.target as HTMLInputElement).value);
 	}
 	private _onInput (event: Event) {
-		this.properties.onInput && this.properties.onInput();
+		this.properties.onInput && this.properties.onInput((event.target as HTMLInputElement).value);
 	}
 	private _onKeyDown (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyDown && this.properties.onKeyDown();
+		this.properties.onKeyDown && this.properties.onKeyDown(event.which, event.preventDefault);
 	}
 	private _onKeyPress (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyPress && this.properties.onKeyPress();
+		this.properties.onKeyPress && this.properties.onKeyPress(event.which, event.preventDefault);
 	}
 	private _onKeyUp (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyUp && this.properties.onKeyUp();
+		this.properties.onKeyUp && this.properties.onKeyUp(event.which, event.preventDefault);
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();

--- a/src/textarea/Textarea.ts
+++ b/src/textarea/Textarea.ts
@@ -58,52 +58,52 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 })
 export class TextareaBase<P extends TextareaProperties = TextareaProperties> extends ThemedBase<P, null> {
 	private _onBlur (event: FocusEvent) {
-		this.properties.onBlur && this.properties.onBlur(event);
+		this.properties.onBlur && this.properties.onBlur();
 	}
 	private _onChange (event: Event) {
-		this.properties.onChange && this.properties.onChange(event);
+		this.properties.onChange && this.properties.onChange();
 	}
 	private _onClick (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onClick && this.properties.onClick(event);
+		this.properties.onClick && this.properties.onClick();
 	}
 	private _onFocus (event: FocusEvent) {
-		this.properties.onFocus && this.properties.onFocus(event);
+		this.properties.onFocus && this.properties.onFocus();
 	}
 	private _onInput (event: Event) {
-		this.properties.onInput && this.properties.onInput(event);
+		this.properties.onInput && this.properties.onInput();
 	}
 	private _onKeyDown (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyDown && this.properties.onKeyDown(event);
+		this.properties.onKeyDown && this.properties.onKeyDown();
 	}
 	private _onKeyPress (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyPress && this.properties.onKeyPress(event);
+		this.properties.onKeyPress && this.properties.onKeyPress();
 	}
 	private _onKeyUp (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyUp && this.properties.onKeyUp(event);
+		this.properties.onKeyUp && this.properties.onKeyUp();
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onMouseDown && this.properties.onMouseDown(event);
+		this.properties.onMouseDown && this.properties.onMouseDown();
 	}
 	private _onMouseUp (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onMouseUp && this.properties.onMouseUp(event);
+		this.properties.onMouseUp && this.properties.onMouseUp();
 	}
 	private _onTouchStart (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchStart && this.properties.onTouchStart(event);
+		this.properties.onTouchStart && this.properties.onTouchStart();
 	}
 	private _onTouchEnd (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchEnd && this.properties.onTouchEnd(event);
+		this.properties.onTouchEnd && this.properties.onTouchEnd();
 	}
 	private _onTouchCancel (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchCancel && this.properties.onTouchCancel(event);
+		this.properties.onTouchCancel && this.properties.onTouchCancel();
 	}
 
 	private _uuid: string;

--- a/src/textarea/Textarea.ts
+++ b/src/textarea/Textarea.ts
@@ -76,15 +76,15 @@ export class TextareaBase<P extends TextareaProperties = TextareaProperties> ext
 	}
 	private _onKeyDown (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyDown && this.properties.onKeyDown(event.which, event.preventDefault);
+		this.properties.onKeyDown && this.properties.onKeyDown(event.which, () => { event.preventDefault(); });
 	}
 	private _onKeyPress (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyPress && this.properties.onKeyPress(event.which, event.preventDefault);
+		this.properties.onKeyPress && this.properties.onKeyPress(event.which, () => { event.preventDefault(); });
 	}
 	private _onKeyUp (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyUp && this.properties.onKeyUp(event.which, event.preventDefault);
+		this.properties.onKeyUp && this.properties.onKeyUp(event.which, () => { event.preventDefault(); });
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();

--- a/src/textarea/example/index.ts
+++ b/src/textarea/example/index.ts
@@ -20,8 +20,8 @@ export class App extends WidgetBase<WidgetProperties> {
 					placeholder: 'Hello, World',
 					label: 'Type Something',
 					value: this._value1,
-					onInput: (event: Event) => {
-						this._value1 = (event.target as HTMLInputElement).value;
+					onInput: (value: string) => {
+						this._value1 = value;
 						this.invalidate();
 					}
 				})
@@ -47,8 +47,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					required: true,
 					value: this._value2,
 					invalid: this._invalid,
-					onChange: (event: Event) => {
-						const value = (event.target as HTMLInputElement).value;
+					onChange: (value: string) => {
 						this._value2 = value;
 						this._invalid = value.trim().length === 0;
 						this.invalidate();

--- a/src/textarea/tests/unit/Textarea.ts
+++ b/src/textarea/tests/unit/Textarea.ts
@@ -181,15 +181,15 @@ registerSuite('Textarea', {
 				onTouchCancel
 			}));
 
-			h.trigger('@input', 'onblur');
+			h.trigger('@input', 'onblur', stubEvent);
 			assert.isTrue(onBlur.called, 'onBlur called');
-			h.trigger('@input', 'onchange');
+			h.trigger('@input', 'onchange', stubEvent);
 			assert.isTrue(onChange.called, 'onChange called');
 			h.trigger('@input', 'onclick', stubEvent);
 			assert.isTrue(onClick.called, 'onClick called');
-			h.trigger('@input', 'onfocus');
+			h.trigger('@input', 'onfocus', stubEvent);
 			assert.isTrue(onFocus.called, 'onFocus called');
-			h.trigger('@input', 'oninput');
+			h.trigger('@input', 'oninput', stubEvent);
 			assert.isTrue(onInput.called, 'onInput called');
 			h.trigger('@input', 'onkeydown', stubEvent);
 			assert.isTrue(onKeyDown.called, 'onKeyDown called');

--- a/src/textinput/TextInput.ts
+++ b/src/textinput/TextInput.ts
@@ -69,52 +69,52 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 })
 export class TextInputBase<P extends TextInputProperties = TextInputProperties> extends ThemedBase<P, null> {
 	private _onBlur (event: FocusEvent) {
-		this.properties.onBlur && this.properties.onBlur(event);
+		this.properties.onBlur && this.properties.onBlur();
 	}
 	private _onChange (event: Event) {
-		this.properties.onChange && this.properties.onChange(event);
+		this.properties.onChange && this.properties.onChange();
 	}
 	private _onClick (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onClick && this.properties.onClick(event);
+		this.properties.onClick && this.properties.onClick();
 	}
 	private _onFocus (event: FocusEvent) {
-		this.properties.onFocus && this.properties.onFocus(event);
+		this.properties.onFocus && this.properties.onFocus();
 	}
 	private _onInput (event: Event) {
-		this.properties.onInput && this.properties.onInput(event);
+		this.properties.onInput && this.properties.onInput();
 	}
 	private _onKeyDown (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyDown && this.properties.onKeyDown(event);
+		this.properties.onKeyDown && this.properties.onKeyDown();
 	}
 	private _onKeyPress (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyPress && this.properties.onKeyPress(event);
+		this.properties.onKeyPress && this.properties.onKeyPress();
 	}
 	private _onKeyUp (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyUp && this.properties.onKeyUp(event);
+		this.properties.onKeyUp && this.properties.onKeyUp();
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onMouseDown && this.properties.onMouseDown(event);
+		this.properties.onMouseDown && this.properties.onMouseDown();
 	}
 	private _onMouseUp (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onMouseUp && this.properties.onMouseUp(event);
+		this.properties.onMouseUp && this.properties.onMouseUp();
 	}
 	private _onTouchStart (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchStart && this.properties.onTouchStart(event);
+		this.properties.onTouchStart && this.properties.onTouchStart();
 	}
 	private _onTouchEnd (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchEnd && this.properties.onTouchEnd(event);
+		this.properties.onTouchEnd && this.properties.onTouchEnd();
 	}
 	private _onTouchCancel (event: TouchEvent) {
 		event.stopPropagation();
-		this.properties.onTouchCancel && this.properties.onTouchCancel(event);
+		this.properties.onTouchCancel && this.properties.onTouchCancel();
 	}
 
 	private _uuid: string;

--- a/src/textinput/TextInput.ts
+++ b/src/textinput/TextInput.ts
@@ -33,6 +33,7 @@ export interface TextInputProperties extends ThemedProperties, InputProperties, 
 	placeholder?: string;
 	value?: string;
 	focus?: boolean;
+	onClick?(value: string): void;
 }
 
 export const ThemedBase = ThemedMixin(WidgetBase);
@@ -69,32 +70,32 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 })
 export class TextInputBase<P extends TextInputProperties = TextInputProperties> extends ThemedBase<P, null> {
 	private _onBlur (event: FocusEvent) {
-		this.properties.onBlur && this.properties.onBlur();
+		this.properties.onBlur && this.properties.onBlur((event.target as HTMLInputElement).value);
 	}
 	private _onChange (event: Event) {
-		this.properties.onChange && this.properties.onChange();
+		this.properties.onChange && this.properties.onChange((event.target as HTMLInputElement).value);
 	}
 	private _onClick (event: MouseEvent) {
 		event.stopPropagation();
-		this.properties.onClick && this.properties.onClick();
+		this.properties.onClick && this.properties.onClick((event.target as HTMLInputElement).value);
 	}
 	private _onFocus (event: FocusEvent) {
-		this.properties.onFocus && this.properties.onFocus();
+		this.properties.onFocus && this.properties.onFocus((event.target as HTMLInputElement).value);
 	}
 	private _onInput (event: Event) {
-		this.properties.onInput && this.properties.onInput();
+		this.properties.onInput && this.properties.onInput((event.target as HTMLInputElement).value);
 	}
 	private _onKeyDown (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyDown && this.properties.onKeyDown();
+		this.properties.onKeyDown && this.properties.onKeyDown(event.which, event.preventDefault);
 	}
 	private _onKeyPress (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyPress && this.properties.onKeyPress();
+		this.properties.onKeyPress && this.properties.onKeyPress(event.which, event.preventDefault);
 	}
 	private _onKeyUp (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyUp && this.properties.onKeyUp();
+		this.properties.onKeyUp && this.properties.onKeyUp(event.which, event.preventDefault);
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();

--- a/src/textinput/TextInput.ts
+++ b/src/textinput/TextInput.ts
@@ -87,15 +87,15 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 	}
 	private _onKeyDown (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyDown && this.properties.onKeyDown(event.which, event.preventDefault);
+		this.properties.onKeyDown && this.properties.onKeyDown(event.which, () => { event.preventDefault(); });
 	}
 	private _onKeyPress (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyPress && this.properties.onKeyPress(event.which, event.preventDefault);
+		this.properties.onKeyPress && this.properties.onKeyPress(event.which, () => { event.preventDefault(); });
 	}
 	private _onKeyUp (event: KeyboardEvent) {
 		event.stopPropagation();
-		this.properties.onKeyUp && this.properties.onKeyUp(event.which, event.preventDefault);
+		this.properties.onKeyUp && this.properties.onKeyUp(event.which, () => { event.preventDefault(); });
 	}
 	private _onMouseDown (event: MouseEvent) {
 		event.stopPropagation();

--- a/src/textinput/example/index.ts
+++ b/src/textinput/example/index.ts
@@ -24,8 +24,8 @@ export class App extends WidgetBase<WidgetProperties> {
 					type: 'text',
 					placeholder: 'Hello, World',
 					value: this._value1,
-					onChange: (event: Event) => {
-						this._value1 = (event.target as HTMLInputElement).value;
+					onChange: (value: string) => {
+						this._value1 = value;
 						this.invalidate();
 					}
 				})
@@ -38,8 +38,8 @@ export class App extends WidgetBase<WidgetProperties> {
 					label: 'Email (required)',
 					required: true,
 					value: this._value2,
-					onChange: (event: Event) => {
-						this._value2 = (event.target as HTMLInputElement).value;
+					onChange: (value: string) => {
+						this._value2 = value;
 						this.invalidate();
 					}
 				})
@@ -54,8 +54,8 @@ export class App extends WidgetBase<WidgetProperties> {
 					labelAfter: true,
 					labelHidden: true,
 					value: this._value3,
-					onChange: (event: Event) => {
-						this._value3 = (event.target as HTMLInputElement).value;
+					onChange: (value: string) => {
+						this._value3 = value;
 						this.invalidate();
 					}
 				})
@@ -79,9 +79,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					label: 'Type "foo" or "bar"',
 					value: this._value4,
 					invalid: this._invalid,
-					onInput: (event: Event) => {
-						const target = event.target as HTMLInputElement;
-						const value = target.value;
+					onInput: (value: string) => {
 						this._value4 = value;
 						this._invalid = value.toLowerCase() !== 'foo' && value.toLowerCase() !== 'bar';
 						this.invalidate();

--- a/src/textinput/tests/unit/TextInput.ts
+++ b/src/textinput/tests/unit/TextInput.ts
@@ -178,15 +178,15 @@ registerSuite('TextInput', {
 				onTouchCancel
 			}));
 
-			h.trigger('@input', 'onblur');
+			h.trigger('@input', 'onblur', stubEvent);
 			assert.isTrue(onBlur.called, 'onBlur called');
-			h.trigger('@input', 'onchange');
+			h.trigger('@input', 'onchange', stubEvent);
 			assert.isTrue(onChange.called, 'onChange called');
 			h.trigger('@input', 'onclick', stubEvent);
 			assert.isTrue(onClick.called, 'onClick called');
-			h.trigger('@input', 'onfocus');
+			h.trigger('@input', 'onfocus', stubEvent);
 			assert.isTrue(onFocus.called, 'onFocus called');
-			h.trigger('@input', 'oninput');
+			h.trigger('@input', 'oninput', stubEvent);
 			assert.isTrue(onInput.called, 'onInput called');
 			h.trigger('@input', 'onkeydown', stubEvent);
 			assert.isTrue(onKeyDown.called, 'onKeyDown called');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Removes the dom events from widget callbacks.
Widgets not callback with data more appropriate to the widget type. ie. 

- inputs return `value:string`
- checkbox returns `value: string` and `checked: boolean`.

Resolves #302 
