### PR TITLE
Run CI functional tests on chrome only

### DIFF
--- a/intern.json
+++ b/intern.json
@@ -62,12 +62,7 @@
 			"tunnel": "browserstack",
 
 			"environments+": [
-				{ "browserName": "internet explorer", "version": "11" },
-				{ "browserName": "edge" },
-				{ "browserName": "firefox", "os": "Windows", "os_version": "10" },
-				{ "browserName": "chrome", "os": "Windows", "os_version": "10" },
-				{ "browserName": "safari", "version": "9.1", "platform": "MAC" },
-				{ "browserName": "iPhone", "version": "9.1" }
+				{ "browserName": "chrome", "os": "Windows", "os_version": "10" }
 			],
 
 			"maxConcurrency": 5
@@ -91,12 +86,7 @@
 
 			"defaultTimeout": 10000,
 			"environments+": [
-				{ "browserName": "internet explorer", "version": [ "11.0" ], "platform": "Windows 7" },
-				{ "browserName": "firefox", "version": "43", "platform": "Windows 10" },
-				{ "browserName": "chrome", "platform": "Windows 10" },
-				{ "browserName": "chrome", "platform": "Windows 10" },
-				{ "browserName": "safari", "version": "9.0", "platform": "OS X 10.11" },
-				{ "browserName": "iphone", "version": "9.3" }
+				{ "browserName": "chrome", "platform": "Windows 10" }
 			],
 			"maxConcurrency": 4
 		}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Limit functional test running to chrome only via browserstack

Resolves #487 
