### PR TITLE
Use chrome headless for ci testing

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,6 @@ before_install:
 - if [ ${TRAVIS_BRANCH-""} == "master" ] && [ -n ${encrypted_12c8071d2874_key-""}
   ]; then openssl aes-256-cbc -K $encrypted_12c8071d2874_key -iv $encrypted_12c8071d2874_iv
   -in deploy_key.enc -out deploy_key -d; fi
-- google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 install:
 - travis_retry npm install grunt-cli
 - travis_retry npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,7 +19,7 @@ install:
 - travis_retry npm install
 script:
 - grunt
-- grunt intern:local --test-reporter
+- grunt intern:headless --test-reporter
 - grunt uploadCoverage
 - grunt dist
 - grunt doc

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
 - if [ ${TRAVIS_BRANCH-""} == "master" ] && [ -n ${encrypted_12c8071d2874_key-""}
   ]; then openssl aes-256-cbc -K $encrypted_12c8071d2874_key -iv $encrypted_12c8071d2874_iv
   -in deploy_key.enc -out deploy_key -d; fi
-  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
+- google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 install:
 - travis_retry npm install grunt-cli
 - travis_retry npm install

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 sudo: false
 language: node_js
+addons:
+  chrome: stable
 node_js:
 - '6'
 env:
@@ -12,12 +14,13 @@ before_install:
 - if [ ${TRAVIS_BRANCH-""} == "master" ] && [ -n ${encrypted_12c8071d2874_key-""}
   ]; then openssl aes-256-cbc -K $encrypted_12c8071d2874_key -iv $encrypted_12c8071d2874_iv
   -in deploy_key.enc -out deploy_key -d; fi
+  - google-chrome-stable --headless --disable-gpu --remote-debugging-port=9222 http://localhost &
 install:
 - travis_retry npm install grunt-cli
 - travis_retry npm install
 script:
 - grunt
-- grunt intern:browserstack --test-reporter
+- grunt intern:local --test-reporter
 - grunt uploadCoverage
 - grunt dist
 - grunt doc

--- a/intern.json
+++ b/intern.json
@@ -62,13 +62,30 @@
 			"tunnel": "browserstack",
 
 			"environments+": [
-				{ "browserName": "chrome", "os": "Windows", "os_version": "10" }
+				{ "browserName": "internet explorer", "version": "11" },
+				{ "browserName": "edge" },
+				{ "browserName": "firefox", "os": "Windows", "os_version": "10" },
+				{ "browserName": "chrome", "os": "Windows", "os_version": "10" },
+				{ "browserName": "safari", "version": "9.1", "platform": "MAC" },
+				{ "browserName": "iPhone", "version": "9.1" }
 			],
 
 			"maxConcurrency": 5
 		},
 
 		"local": {
+			"tunnel": "selenium",
+			"tunnelOptions": {
+				"hostname": "localhost",
+				"port": 4444
+			},
+
+			"environments+": [
+				{ "browserName": "chrome" }
+			]
+		},
+
+		"headless": {
 			"tunnel": "selenium",
 			"tunnelOptions": {
 				"hostname": "localhost",
@@ -86,7 +103,12 @@
 
 			"defaultTimeout": 10000,
 			"environments+": [
-				{ "browserName": "chrome", "platform": "Windows 10" }
+				{ "browserName": "internet explorer", "version": [ "11.0" ], "platform": "Windows 7" },
+				{ "browserName": "firefox", "version": "43", "platform": "Windows 10" },
+				{ "browserName": "chrome", "platform": "Windows 10" },
+				{ "browserName": "chrome", "platform": "Windows 10" },
+				{ "browserName": "safari", "version": "9.0", "platform": "OS X 10.11" },
+				{ "browserName": "iphone", "version": "9.3" }
 			],
 			"maxConcurrency": 4
 		}

--- a/intern.json
+++ b/intern.json
@@ -76,7 +76,7 @@
 			},
 
 			"environments+": [
-				{ "browserName": "chrome", "chromeOptions": { "args": ["headless", "disable-gpu"] } }
+				{ "browserName": "chrome", "chromeOptions": { "args": ["headless", "disable-gpu", "no-sandbox"] } }
 			]
 		},
 

--- a/intern.json
+++ b/intern.json
@@ -76,7 +76,7 @@
 			},
 
 			"environments+": [
-				{ "browserName": "chrome" }
+				{ "browserName": "chrome", "chromeOptions": { "args": ["headless", "disable-gpu"] } }
 			]
 		},
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "@types/jsdom": "^2.0.30",
     "@types/sinon": "^1.16.31",
     "grunt": "^1.0.1",
-    "grunt-dojo2": "~0.1.1",
+    "grunt-dojo2": "~0.1.3",
     "intern": "~4.1.0",
     "load-grunt-tasks": "^3.5.2",
     "pkg-dir": "^2.0.0",


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

- Switches the CI to run functional tests in headless chrome, eliminating the need to use browserstack for PR builds. This brings the time down to ~5minutes for a PR builds.
- Re-instates the browserstack / saucelabs configs for future use in a `nightly` build.

Requires: https://github.com/dojo/grunt-dojo2/pull/193 
Related to #488 and #489 