### PR TITLE
Use toolbarTitle instead of title in toolbar

### DIFF
--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -23,10 +23,8 @@ export const enum Direction {
  * Properties that can be set on a SplitPane component
  *
  * @property direction      Orientation of this SplitPane, can be `row` or `column`
- * @property leading        Content to show in the primary pane
  * @property onResize       Called when the divider is dragged; should be used to update `size`
  * @property size           Size of the primary pane
- * @property trailing       Content to show in the secondary pane
  */
 export interface SplitPaneProperties extends ThemedProperties {
 	direction?: Direction;

--- a/src/toolbar/README.md
+++ b/src/toolbar/README.md
@@ -19,10 +19,10 @@ The following CSS classes are used to style the `Toolbar` widget and should be p
 - `action`: Applied to the parent of each action item
 - `actions`: Applied to the parent of the actions container
 - `collapsed`: Applied to the root node if the root width is less than `collapseWidth`
-- `menuTitle`: Applied to the menu trigger
+- `menuButton`: Applied to the menu trigger
 - `root`: Applied to the top-level wrapper node
 - `sticky`: Applied to the root node if `fixed` is `true`
-- `toolbarTitle`: Applied to the node containing the title element
+- `title`: Applied to the node containing the title element
 
 ## Example Usage
 

--- a/src/toolbar/README.md
+++ b/src/toolbar/README.md
@@ -32,7 +32,7 @@ import Toolbar from '@dojo/widgets/toolbar/Toolbar';
 import { w } from '@dojo/widget-core/d';
 
 w(Toolbar, {
-	toolbarTitle: 'My Site',
+	heading: 'My Site',
 	fixed: true,
 	collapseWidth: 720
 }, [

--- a/src/toolbar/README.md
+++ b/src/toolbar/README.md
@@ -19,10 +19,10 @@ The following CSS classes are used to style the `Toolbar` widget and should be p
 - `action`: Applied to the parent of each action item
 - `actions`: Applied to the parent of the actions container
 - `collapsed`: Applied to the root node if the root width is less than `collapseWidth`
-- `menuButton`: Applied to the menu trigger
+- `menuTitle`: Applied to the menu trigger
 - `root`: Applied to the top-level wrapper node
 - `sticky`: Applied to the root node if `fixed` is `true`
-- `title`: Applied to the node containing the title element
+- `toolbarTitle`: Applied to the node containing the title element
 
 ## Example Usage
 
@@ -32,7 +32,7 @@ import Toolbar from '@dojo/widgets/toolbar/Toolbar';
 import { w } from '@dojo/widget-core/d';
 
 w(Toolbar, {
-	title: 'My Site',
+	toolbarTitle: 'My Site',
 	fixed: true,
 	collapseWidth: 720
 }, [

--- a/src/toolbar/example/index.ts
+++ b/src/toolbar/example/index.ts
@@ -22,8 +22,7 @@ export class App extends WidgetBase<WidgetProperties> {
 			],
 			collapseWidth: 700,
 			fixed: true,
-			menuTitle: 'Menu',
-			toolbarTitle: 'Foobar'
+			heading: 'Foobar'
 		}, [
 			v('h2', [ 'Toolbar Examples' ])
 		]);

--- a/src/toolbar/example/index.ts
+++ b/src/toolbar/example/index.ts
@@ -23,7 +23,7 @@ export class App extends WidgetBase<WidgetProperties> {
 			collapseWidth: 700,
 			fixed: true,
 			menuTitle: 'Menu',
-			title: 'Foobar'
+			toolbarTitle: 'Foobar'
 		}, [
 			v('h2', [ 'Toolbar Examples' ])
 		]);

--- a/src/toolbar/index.ts
+++ b/src/toolbar/index.ts
@@ -30,19 +30,17 @@ export const enum Position {
  * @property actions           Action elements to show in the toolbar
  * @property collapseWidth     Width at which to collapse actions into a SlidePane
  * @property fixed             Fixes the toolbar to the top of the viewport
- * @property menuTitle         Title of the SlidePane that holds collapsed action items
  * @property onCollapse        Called when action items change their layout
  * @property position          Determines toolbar position in relation to child contet
- * @property toolbarTitle      Element to show as the toolbar title
+ * @property heading           The toolbar heading
  */
 export interface ToolbarProperties extends ThemedProperties {
 	actions?: DNode[];
 	collapseWidth?: number;
 	fixed?: boolean;
-	menuTitle?: string;
 	onCollapse?(collapsed: boolean): void;
 	position?: Position;
-	toolbarTitle?: DNode;
+	heading?: string;
 }
 
 export const ThemedBase = I18nMixin(ThemedMixin(WidgetBase));
@@ -50,8 +48,8 @@ export const ThemedBase = I18nMixin(ThemedMixin(WidgetBase));
 @theme(css)
 @customElement<ToolbarProperties>({
 	tag: 'dojo-toolbar',
-	properties: [ 'theme', 'extraClasses', 'actions', 'collapseWidth', 'fixed', 'toolbarTitle' ],
-	attributes: [ 'key', 'menuTitle', 'position' ],
+	properties: [ 'theme', 'extraClasses', 'actions', 'collapseWidth', 'fixed' ],
+	attributes: [ 'key', 'heading', 'position' ],
 	events: [
 		'onCollapse'
 	]
@@ -112,7 +110,7 @@ export class ToolbarBase<P extends ToolbarProperties = ToolbarProperties> extend
 		const {
 			actions = [],
 			theme,
-			menuTitle = ''
+			heading
 		} = this.properties;
 
 		const actionsElements = actions.map((action, index) => v('div', {
@@ -126,12 +124,12 @@ export class ToolbarBase<P extends ToolbarProperties = ToolbarProperties> extend
 
 		return this._collapsed ? w(SlidePane, {
 			align: Align.right,
-			closeText: `${messages.close} ${menuTitle}`,
+			closeText: messages.close,
 			key: 'slide-pane-menu',
 			onRequestClose: this._closeMenu,
 			open: this._open,
 			theme,
-			title: menuTitle
+			title: heading
 		}, actionsElements) : v('div', {
 			classes: [ this.theme(css.actions), fixedCss.actionsFixed ],
 			key: 'menu'
@@ -139,26 +137,18 @@ export class ToolbarBase<P extends ToolbarProperties = ToolbarProperties> extend
 	}
 
 	protected renderButton(messages: CommonMessages): DNode {
-		const { menuTitle = '' } = this.properties;
 		return this._collapsed ? v('button', {
 			classes: [ this.theme(css.menuButton), fixedCss.menuButtonFixed ],
 			type: 'button',
 			onclick: this._toggleMenu
 		}, [
-			`${messages.open} ${menuTitle}`,
+			messages.open,
 			w(Icon, { type: 'barsIcon' })
 		]) : null;
 	}
 
-	protected renderTitle(): DNode {
-		const { toolbarTitle } = this.properties;
-
-		return toolbarTitle ? v('div', {
-			classes: [ this.theme(css.title), fixedCss.titleFixed ]
-		}, [ toolbarTitle ]) : null;
-	}
-
 	render(): DNode {
+		const { heading } = this.properties;
 		const classes = this.getRootClasses();
 		const fixedClasses = this.getFixedRootClasses();
 		const messages = this.localizeBundle(commonBundle);
@@ -171,7 +161,9 @@ export class ToolbarBase<P extends ToolbarProperties = ToolbarProperties> extend
 			v('div', {
 				classes: [ this.theme(css.toolbar), fixedCss.toolbarFixed ]
 			}, [
-				this.renderTitle(),
+				heading ? v('div', {
+					classes: [ this.theme(css.title), fixedCss.titleFixed ]
+				}, [ heading ]) : null,
 				this.renderActions(messages),
 				this.renderButton(messages)
 			]),

--- a/src/toolbar/index.ts
+++ b/src/toolbar/index.ts
@@ -33,7 +33,7 @@ export const enum Position {
  * @property menuTitle         Title of the SlidePane that holds collapsed action items
  * @property onCollapse        Called when action items change their layout
  * @property position          Determines toolbar position in relation to child contet
- * @property title             Element to show as the toolbar title
+ * @property toolbarTitle      Element to show as the toolbar title
  */
 export interface ToolbarProperties extends ThemedProperties {
 	actions?: DNode[];
@@ -42,7 +42,7 @@ export interface ToolbarProperties extends ThemedProperties {
 	menuTitle?: string;
 	onCollapse?(collapsed: boolean): void;
 	position?: Position;
-	title?: DNode;
+	toolbarTitle?: DNode;
 }
 
 export const ThemedBase = I18nMixin(ThemedMixin(WidgetBase));
@@ -50,7 +50,7 @@ export const ThemedBase = I18nMixin(ThemedMixin(WidgetBase));
 @theme(css)
 @customElement<ToolbarProperties>({
 	tag: 'dojo-toolbar',
-	properties: [ 'theme', 'extraClasses', 'actions', 'collapseWidth', 'fixed', 'title' ],
+	properties: [ 'theme', 'extraClasses', 'actions', 'collapseWidth', 'fixed', 'toolbarTitle' ],
 	attributes: [ 'key', 'menuTitle', 'position' ],
 	events: [
 		'onCollapse'
@@ -151,11 +151,11 @@ export class ToolbarBase<P extends ToolbarProperties = ToolbarProperties> extend
 	}
 
 	protected renderTitle(): DNode {
-		const { title } = this.properties;
+		const { toolbarTitle } = this.properties;
 
-		return title ? v('div', {
+		return toolbarTitle ? v('div', {
 			classes: [ this.theme(css.title), fixedCss.titleFixed ]
-		}, [ title ]) : null;
+		}, [ toolbarTitle ]) : null;
 	}
 
 	render(): DNode {

--- a/src/toolbar/index.ts
+++ b/src/toolbar/index.ts
@@ -147,7 +147,7 @@ export class ToolbarBase<P extends ToolbarProperties = ToolbarProperties> extend
 		]) : null;
 	}
 
-	render(): DNode {
+	protected render(): DNode {
 		const { heading } = this.properties;
 		const classes = this.getRootClasses();
 		const fixedClasses = this.getFixedRootClasses();

--- a/src/toolbar/tests/unit/Toolbar.ts
+++ b/src/toolbar/tests/unit/Toolbar.ts
@@ -156,7 +156,7 @@ registerSuite('Toolbar', {
 		},
 
 		'custom title rendering'() {
-			const h = harness(() => w(Toolbar, { title: 'test' }));
+			const h = harness(() => w(Toolbar, { toolbarTitle: 'test' }));
 			h.expect(() =>
 				v('div', {
 					classes: [

--- a/src/toolbar/tests/unit/Toolbar.ts
+++ b/src/toolbar/tests/unit/Toolbar.ts
@@ -156,7 +156,7 @@ registerSuite('Toolbar', {
 		},
 
 		'custom title rendering'() {
-			const h = harness(() => w(Toolbar, { toolbarTitle: 'test' }));
+			const h = harness(() => w(Toolbar, { heading: 'test' }));
 			h.expect(() =>
 				v('div', {
 					classes: [
@@ -256,7 +256,7 @@ registerSuite('Toolbar', {
 			const h = harness(() => w(MockMetaMixin(Toolbar, mockMeta), properties));
 			const slidePaneVDom = w(SlidePane, {
 				align: Align.right,
-				closeText: 'close foo',
+				closeText: 'close',
 				key: 'slide-pane-menu',
 				onRequestClose: noop,
 				open: false,
@@ -274,7 +274,7 @@ registerSuite('Toolbar', {
 				type: 'button',
 				onclick: noop
 			}, [
-				'open foo',
+				'open',
 				w(Icon, { type: 'barsIcon' })
 			]);
 
@@ -298,7 +298,11 @@ registerSuite('Toolbar', {
 							css.toolbar,
 							fixedCss.toolbarFixed
 						]
-					}, [ null, null, null]),
+					}, [
+						null,
+						null,
+						null
+					]),
 					v('div', {
 						classes: [
 							css.content,
@@ -307,7 +311,7 @@ registerSuite('Toolbar', {
 					}, [])
 				]));
 
-			properties = { actions: [ 'test' ], menuTitle: 'foo' };
+			properties = { actions: [ 'test' ], heading: 'foo' };
 			h.trigger('@global', (node: any) => {
 				if (isWNode<GlobalEvent>(node) && node.properties.window !== undefined) {
 					return node.properties.window ? node.properties.window.resize : undefined;
@@ -334,7 +338,9 @@ registerSuite('Toolbar', {
 							fixedCss.toolbarFixed
 						]
 					}, [
-						null,
+						v('div', {
+							classes: [ css.title, fixedCss.titleFixed ]
+						}, [ 'foo' ]),
 						slidePaneVDom,
 						buttonVDom
 					]),
@@ -369,7 +375,9 @@ registerSuite('Toolbar', {
 							fixedCss.toolbarFixed
 						]
 					}, [
-						null,
+						v('div', {
+							classes: [ css.title, fixedCss.titleFixed ]
+						}, [ 'foo' ]),
 						slidePaneVDom,
 						buttonVDom
 					]),


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Toolbar takes a `title` property that causes problems when it is used as a custom element.
Changing this to `heading` fixes this and standardises the heading that is shown on both the toolbar and the popup menu when the toolbar is collapsed.

This change means that toolbar no longer takes a `DNode` as it's title / heading, just a string.


