### PR TITLE
Fix auto width on split-pane

### DIFF
--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -136,9 +136,9 @@ export class SplitPaneBase<P extends SplitPaneProperties = SplitPaneProperties> 
 
 		const styles: {[key: string]: string} = {};
 
-		let computedSize: string | number = this._collapsed ? 'auto' : size;
+		let computedSize = this._collapsed ? 'auto' : `${size}px`;
 
-		styles[direction === Direction.column ? 'width' : 'height'] = `${computedSize}px`;
+		styles[direction === Direction.column ? 'width' : 'height'] = computedSize;
 
 		return styles;
 	}

--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -124,8 +124,8 @@ export class SplitPaneBase<P extends SplitPaneProperties = SplitPaneProperties> 
 		this._lastSize = undefined;
 	}
 
-	protected getPaneContent(content: DNode): DNode[] {
-		return [ content ];
+	protected getPaneContent(content: DNode | undefined): DNode[] {
+		return content ? [ content ] : [];
 	}
 
 	protected getPaneStyles(): {[key: string]: string} {

--- a/src/split-pane/tests/unit/SplitPane.ts
+++ b/src/split-pane/tests/unit/SplitPane.ts
@@ -43,7 +43,7 @@ registerSuite('SplitPane', {
 					classes: [ css.leading, fixedCss.leadingFixed ],
 					key: 'leading',
 					styles: { width: '100px' }
-				}, [ null ]),
+				}, []),
 				v('div', {
 					classes: [ css.divider, fixedCss.dividerFixed ],
 					key: 'divider',
@@ -54,7 +54,7 @@ registerSuite('SplitPane', {
 				v('div', {
 					classes: [ css.trailing, fixedCss.trailingFixed ],
 					key: 'trailing'
-				}, [ null ])
+				}, [])
 			]));
 		},
 
@@ -228,6 +228,15 @@ registerSuite('SplitPane', {
 			h.trigger('@global', createVNodeSelector('window', 'resize'), stubEvent);
 			assert.isTrue(onCollapse.calledOnce);
 			assert.isTrue(onCollapse.calledWith(true));
+
+			h.expectPartial('@leading', () => v('div', {
+				classes: [
+					css.leading,
+					fixedCss.leadingFixed
+				],
+				key: 'leading',
+				styles: { width: 'auto' }
+			}, []));
 		},
 
 		'collapse is ignored when using Direction.Row configuration'() {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixes an issue where `autopx` was being set as width instead of `auto` when collapsing the split pane.
