### PR TITLE
Add icon custom-element to dojorc

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -8,6 +8,7 @@
 			"src/combobox",
 			"src/dialog",
 			"src/enhanced-text-input",
+			"src/icon",
 			"src/label",
 			"src/listbox",
 			"src/progress",


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds missing icon widget to dojorc so it can be used as a custom-element
