### PR TITLE
Add missing text attributes to checkbox and radio

### DIFF
--- a/src/checkbox/index.ts
+++ b/src/checkbox/index.ts
@@ -53,11 +53,10 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 		'labelAfter',
 		'labelHidden',
 		'checked',
-		'mode',
 		'offLabel',
 		'onLabel'
 	],
-	attributes: [ 'label', 'value' ],
+	attributes: [ 'label', 'value', 'mode' ],
 	events: [
 		'onBlur',
 		'onChange',

--- a/src/radio/index.ts
+++ b/src/radio/index.ts
@@ -29,7 +29,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 @customElement<RadioProperties>({
 	tag: 'dojo-radio',
 	properties: [ 'theme', 'aria', 'extraClasses', 'checked' ],
-	attributes: [ 'label', 'value' ],
+	attributes: [ 'label', 'value', 'name' ],
 	events: [
 		'onBlur',
 		'onChange',


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

- `mode` is now a string, so should be set as an attribute on checkbox.
- `name` was missing from radio.
