### PR TITLE
Rename widget id properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widgets",
-  "version": "0.7.0",
+  "version": "0.7.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/button/index.ts
+++ b/src/button/index.ts
@@ -17,7 +17,7 @@ export type ButtonType = 'submit' | 'reset' | 'button' | 'menu';
  * Properties that can be set on a Button component
  *
  * @property disabled       Whether the button is disabled or clickable
- * @property rootId         DOM id set on the root button node
+ * @property widgetId       DOM id set on the root button node
  * @property popup       		Controls aria-haspopup, aria-expanded, and aria-controls for popup buttons
  * @property name           The button's name attribute
  * @property pressed        Indicates status of a toggle button
@@ -26,7 +26,7 @@ export type ButtonType = 'submit' | 'reset' | 'button' | 'menu';
  */
 export interface ButtonProperties extends ThemedProperties, InputEventProperties, PointerEventProperties, KeyEventProperties, CustomAriaProperties {
 	disabled?: boolean;
-	rootId?: string;
+	widgetId?: string;
 	popup?: { expanded?: boolean; id?: string; } | boolean;
 	name?: string;
 	pressed?: boolean;
@@ -42,7 +42,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 	tag: 'dojo-button',
 	childType: CustomElementChildType.TEXT,
 	properties: [ 'disabled', 'pressed', 'popup', 'theme', 'aria', 'extraClasses' ],
-	attributes: [ 'rootId', 'name', 'value' ],
+	attributes: [ 'widgetId', 'name', 'value' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -125,7 +125,7 @@ export class ButtonBase<P extends ButtonProperties = ButtonProperties> extends T
 		let {
 			aria = {},
 			disabled,
-			rootId,
+			widgetId,
 			popup = false,
 			name,
 			pressed,
@@ -141,7 +141,7 @@ export class ButtonBase<P extends ButtonProperties = ButtonProperties> extends T
 		return v('button', {
 			classes: this.theme([ css.root, ...this.getModifierClasses() ]),
 			disabled,
-			id: rootId,
+			id: widgetId,
 			name,
 			type,
 			value,

--- a/src/button/index.ts
+++ b/src/button/index.ts
@@ -17,6 +17,7 @@ export type ButtonType = 'submit' | 'reset' | 'button' | 'menu';
  * Properties that can be set on a Button component
  *
  * @property disabled       Whether the button is disabled or clickable
+ * @property rootId         DOM id set on the root button node
  * @property popup       		Controls aria-haspopup, aria-expanded, and aria-controls for popup buttons
  * @property name           The button's name attribute
  * @property pressed        Indicates status of a toggle button
@@ -25,7 +26,7 @@ export type ButtonType = 'submit' | 'reset' | 'button' | 'menu';
  */
 export interface ButtonProperties extends ThemedProperties, InputEventProperties, PointerEventProperties, KeyEventProperties, CustomAriaProperties {
 	disabled?: boolean;
-	id?: string;
+	rootId?: string;
 	popup?: { expanded?: boolean; id?: string; } | boolean;
 	name?: string;
 	pressed?: boolean;
@@ -41,7 +42,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 	tag: 'dojo-button',
 	childType: CustomElementChildType.TEXT,
 	properties: [ 'disabled', 'pressed', 'popup', 'theme', 'aria', 'extraClasses' ],
-	attributes: [ 'id', 'name', 'value' ],
+	attributes: [ 'rootId', 'name', 'value' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -124,7 +125,7 @@ export class ButtonBase<P extends ButtonProperties = ButtonProperties> extends T
 		let {
 			aria = {},
 			disabled,
-			id,
+			rootId,
 			popup = false,
 			name,
 			pressed,
@@ -140,7 +141,7 @@ export class ButtonBase<P extends ButtonProperties = ButtonProperties> extends T
 		return v('button', {
 			classes: this.theme([ css.root, ...this.getModifierClasses() ]),
 			disabled,
-			id,
+			id: rootId,
 			name,
 			type,
 			value,

--- a/src/button/tests/unit/Button.ts
+++ b/src/button/tests/unit/Button.ts
@@ -42,7 +42,7 @@ registerSuite('Button', {
 			const h = harness(() => w(Button, {
 				type: 'submit',
 				name: 'bar',
-				rootId: 'qux',
+				widgetId: 'qux',
 				aria: {
 					describedBy: 'baz'
 				},

--- a/src/button/tests/unit/Button.ts
+++ b/src/button/tests/unit/Button.ts
@@ -42,7 +42,7 @@ registerSuite('Button', {
 			const h = harness(() => w(Button, {
 				type: 'submit',
 				name: 'bar',
-				id: 'qux',
+				rootId: 'qux',
 				aria: {
 					describedBy: 'baz'
 				},

--- a/src/checkbox/index.ts
+++ b/src/checkbox/index.ts
@@ -54,7 +54,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 		'labelHidden',
 		'checked'
 	],
-	attributes: [ 'label', 'value', 'mode', 'offLabel', 'onLabel' ],
+	attributes: [ 'inputId', 'label', 'value', 'mode', 'offLabel', 'onLabel' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -167,7 +167,7 @@ export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> ext
 			aria = {},
 			checked = false,
 			disabled,
-			id = this._uuid,
+			inputId = this._uuid,
 			invalid,
 			label,
 			labelAfter = true,
@@ -184,7 +184,7 @@ export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> ext
 			v('div', { classes: this.theme(css.inputWrapper) }, [
 				...this.renderToggle(),
 				v('input', {
-					id,
+					id: inputId,
 					...formatAriaProperties(aria),
 					classes: this.theme(css.input),
 					checked,
@@ -216,7 +216,7 @@ export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> ext
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: id,
+				forId: inputId,
 				secondary: true
 			}, [ label ]) : null
 		];

--- a/src/checkbox/index.ts
+++ b/src/checkbox/index.ts
@@ -54,7 +54,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 		'labelHidden',
 		'checked'
 	],
-	attributes: [ 'inputId', 'label', 'value', 'mode', 'offLabel', 'onLabel' ],
+	attributes: [ 'widgetId', 'label', 'value', 'mode', 'offLabel', 'onLabel' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -167,7 +167,7 @@ export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> ext
 			aria = {},
 			checked = false,
 			disabled,
-			inputId = this._uuid,
+			widgetId = this._uuid,
 			invalid,
 			label,
 			labelAfter = true,
@@ -184,7 +184,7 @@ export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> ext
 			v('div', { classes: this.theme(css.inputWrapper) }, [
 				...this.renderToggle(),
 				v('input', {
-					id: inputId,
+					id: widgetId,
 					...formatAriaProperties(aria),
 					classes: this.theme(css.input),
 					checked,
@@ -216,7 +216,7 @@ export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> ext
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: inputId,
+				forId: widgetId,
 				secondary: true
 			}, [ label ]) : null
 		];

--- a/src/checkbox/tests/unit/Checkbox.ts
+++ b/src/checkbox/tests/unit/Checkbox.ts
@@ -102,7 +102,7 @@ registerSuite('Checkbox', {
 					describedBy: 'foo'
 				},
 				checked: true,
-				inputId: 'foo',
+				widgetId: 'foo',
 				name: 'bar',
 				value: 'baz'
 			}), [ compareId ]);

--- a/src/checkbox/tests/unit/Checkbox.ts
+++ b/src/checkbox/tests/unit/Checkbox.ts
@@ -102,7 +102,7 @@ registerSuite('Checkbox', {
 					describedBy: 'foo'
 				},
 				checked: true,
-				id: 'foo',
+				inputId: 'foo',
 				name: 'bar',
 				value: 'baz'
 			}), [ compareId ]);

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -28,7 +28,7 @@ import { customElement } from '@dojo/widget-core/decorators/customElement';
  * @property disabled           Prevents user interaction and styles content accordingly
  * @property getResultLabel     Can be used to get the text label of a result based on the underlying result object
  * @property getResultSelected  Can be used to highlight the selected result. Defaults to checking the result label.
- * @property inputId            Optional id string for the combobox, set on the text input
+ * @property widgetId            Optional id string for the combobox, set on the text input
  * @property inputProperties    TextInput properties to set on the underlying input
  * @property invalid            Determines if this input is valid
  * @property isResultDisabled   Used to determine if an item should be disabled
@@ -49,7 +49,7 @@ export interface ComboBoxProperties extends ThemedProperties, LabeledProperties 
 	disabled?: boolean;
 	getResultLabel?(result: any): string;
 	getResultSelected?(result: any): boolean;
-	inputId?: string;
+	widgetId?: string;
 	inputProperties?: TextInputProperties;
 	invalid?: boolean;
 	isResultDisabled?(result: any): boolean;
@@ -92,7 +92,7 @@ export const ThemedBase = I18nMixin(ThemedMixin(WidgetBase));
 		'required',
 		'results'
 	],
-	attributes: [ 'inputId', 'label', 'value' ],
+	attributes: [ 'widgetId', 'label', 'value' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -317,7 +317,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 	protected renderInput(results: any[]): DNode {
 		const {
 			disabled,
-			inputId = this._idBase,
+			widgetId = this._idBase,
 			inputProperties = {},
 			invalid,
 			readOnly,
@@ -341,7 +341,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 				owns: this._getMenuId()
 			},
 			disabled,
-			inputId,
+			widgetId,
 			invalid,
 			shouldFocus: focusInput,
 			onBlur: this._onInputBlur,
@@ -413,7 +413,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 			w(Listbox, {
 				key: 'listbox',
 				activeIndex: this._activeIndex,
-				rootId: this._getMenuId(),
+				widgetId: this._getMenuId(),
 				visualFocus: this._menuHasVisualFocus,
 				optionData: results,
 				tabIndex: -1,
@@ -436,7 +436,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 	render(): DNode {
 		const {
 			clearable = false,
-			inputId = this._idBase,
+			widgetId = this._idBase,
 			invalid,
 			label,
 			readOnly,
@@ -464,7 +464,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: inputId
+				forId: widgetId
 			}, [ label ]) : null,
 			v('div', {
 				classes: this.theme(css.controls)

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -28,7 +28,7 @@ import { customElement } from '@dojo/widget-core/decorators/customElement';
  * @property disabled           Prevents user interaction and styles content accordingly
  * @property getResultLabel     Can be used to get the text label of a result based on the underlying result object
  * @property getResultSelected  Can be used to highlight the selected result. Defaults to checking the result label.
- * @property id                 Optional id string for the combobox
+ * @property inputId            Optional id string for the combobox, set on the text input
  * @property inputProperties    TextInput properties to set on the underlying input
  * @property invalid            Determines if this input is valid
  * @property isResultDisabled   Used to determine if an item should be disabled
@@ -49,7 +49,7 @@ export interface ComboBoxProperties extends ThemedProperties, LabeledProperties 
 	disabled?: boolean;
 	getResultLabel?(result: any): string;
 	getResultSelected?(result: any): boolean;
-	id?: string;
+	inputId?: string;
 	inputProperties?: TextInputProperties;
 	invalid?: boolean;
 	isResultDisabled?(result: any): boolean;
@@ -92,7 +92,7 @@ export const ThemedBase = I18nMixin(ThemedMixin(WidgetBase));
 		'required',
 		'results'
 	],
-	attributes: [ 'id', 'label', 'value' ],
+	attributes: [ 'inputId', 'label', 'value' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -317,7 +317,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 	protected renderInput(results: any[]): DNode {
 		const {
 			disabled,
-			id = this._idBase,
+			inputId = this._idBase,
 			inputProperties = {},
 			invalid,
 			readOnly,
@@ -341,7 +341,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 				owns: this._getMenuId()
 			},
 			disabled,
-			id,
+			inputId,
 			invalid,
 			shouldFocus: focusInput,
 			onBlur: this._onInputBlur,
@@ -413,7 +413,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 			w(Listbox, {
 				key: 'listbox',
 				activeIndex: this._activeIndex,
-				id: this._getMenuId(),
+				rootId: this._getMenuId(),
 				visualFocus: this._menuHasVisualFocus,
 				optionData: results,
 				tabIndex: -1,
@@ -436,7 +436,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 	render(): DNode {
 		const {
 			clearable = false,
-			id = this._idBase,
+			inputId = this._idBase,
 			invalid,
 			label,
 			readOnly,
@@ -464,7 +464,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: id
+				forId: inputId
 			}, [ label ]) : null,
 			v('div', {
 				classes: this.theme(css.controls)

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -15,8 +15,7 @@ import * as css from '../../../theme/combobox.m.css';
 import {
 	createHarness,
 	compareId,
-	compareInputId,
-	compareRootId,
+	comparewidgetId,
 	compareAria,
 	compareAriaControls,
 	noop,
@@ -24,7 +23,7 @@ import {
 	stubEvent
 } from '../../../common/tests/support/test-helpers';
 
-const harness = createHarness([ compareId, compareInputId, compareRootId, compareAria, compareAriaControls ]);
+const harness = createHarness([ compareId, comparewidgetId, compareAria, compareAriaControls ]);
 
 const testOptions: any[] = [
 	{
@@ -45,7 +44,7 @@ const testOptions: any[] = [
 const testProperties = {
 	clearable: true,
 	getResultLabel: (result: any) => result.label,
-	inputId: 'foo',
+	widgetId: 'foo',
 	label: 'foo',
 	results: testOptions,
 	value: 'one',
@@ -73,7 +72,7 @@ const getExpectedControls = function(useTestProperties: boolean, label: boolean,
 			},
 			disabled,
 			shouldFocus: callFocus,
-			inputId: useTestProperties ? 'foo' : '',
+			widgetId: useTestProperties ? 'foo' : '',
 			invalid,
 			readOnly,
 			required,
@@ -124,7 +123,7 @@ const getExpectedMenu = function(useTestProperties: boolean, open: boolean, over
 	}, [
 		w(Listbox, {
 			activeIndex: 0,
-			rootId: '',
+			widgetId: '',
 			key: 'listbox',
 			visualFocus: false,
 			optionData: testOptions,
@@ -407,7 +406,7 @@ registerSuite('ComboBox', {
 				placeholder: 'foo',
 				shouldFocus: false,
 				disabled: undefined,
-				inputId: '',
+				widgetId: '',
 				invalid: undefined,
 				readOnly: undefined,
 				required: undefined,
@@ -450,7 +449,7 @@ registerSuite('ComboBox', {
 					controls: '',
 					owns: ''
 				},
-				inputId: 'foo',
+				widgetId: 'foo',
 				shouldFocus: false,
 				disabled: true,
 				invalid: true,
@@ -509,7 +508,7 @@ registerSuite('ComboBox', {
 					controls: '',
 					owns: ''
 				},
-				inputId: 'foo',
+				widgetId: 'foo',
 				shouldFocus: false,
 				disabled: true,
 				invalid: false,

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -15,6 +15,8 @@ import * as css from '../../../theme/combobox.m.css';
 import {
 	createHarness,
 	compareId,
+	compareInputId,
+	compareRootId,
 	compareAria,
 	compareAriaControls,
 	noop,
@@ -22,7 +24,7 @@ import {
 	stubEvent
 } from '../../../common/tests/support/test-helpers';
 
-const harness = createHarness([ compareId, compareAria, compareAriaControls ]);
+const harness = createHarness([ compareId, compareInputId, compareRootId, compareAria, compareAriaControls ]);
 
 const testOptions: any[] = [
 	{
@@ -43,7 +45,7 @@ const testOptions: any[] = [
 const testProperties = {
 	clearable: true,
 	getResultLabel: (result: any) => result.label,
-	id: 'foo',
+	inputId: 'foo',
 	label: 'foo',
 	results: testOptions,
 	value: 'one',
@@ -71,7 +73,7 @@ const getExpectedControls = function(useTestProperties: boolean, label: boolean,
 			},
 			disabled,
 			shouldFocus: callFocus,
-			id: useTestProperties ? 'foo' : '',
+			inputId: useTestProperties ? 'foo' : '',
 			invalid,
 			readOnly,
 			required,
@@ -122,7 +124,7 @@ const getExpectedMenu = function(useTestProperties: boolean, open: boolean, over
 	}, [
 		w(Listbox, {
 			activeIndex: 0,
-			id: '',
+			rootId: '',
 			key: 'listbox',
 			visualFocus: false,
 			optionData: testOptions,
@@ -405,7 +407,7 @@ registerSuite('ComboBox', {
 				placeholder: 'foo',
 				shouldFocus: false,
 				disabled: undefined,
-				id: '',
+				inputId: '',
 				invalid: undefined,
 				readOnly: undefined,
 				required: undefined,
@@ -448,7 +450,7 @@ registerSuite('ComboBox', {
 					controls: '',
 					owns: ''
 				},
-				id: 'foo',
+				inputId: 'foo',
 				shouldFocus: false,
 				disabled: true,
 				invalid: true,
@@ -507,7 +509,7 @@ registerSuite('ComboBox', {
 					controls: '',
 					owns: ''
 				},
-				id: 'foo',
+				inputId: 'foo',
 				shouldFocus: false,
 				disabled: true,
 				invalid: false,

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -15,7 +15,7 @@ import * as css from '../../../theme/combobox.m.css';
 import {
 	createHarness,
 	compareId,
-	comparewidgetId,
+	compareWidgetId,
 	compareAria,
 	compareAriaControls,
 	noop,
@@ -23,7 +23,7 @@ import {
 	stubEvent
 } from '../../../common/tests/support/test-helpers';
 
-const harness = createHarness([ compareId, comparewidgetId, compareAria, compareAriaControls ]);
+const harness = createHarness([ compareId, compareWidgetId, compareAria, compareAriaControls ]);
 
 const testOptions: any[] = [
 	{

--- a/src/common/interfaces.d.ts
+++ b/src/common/interfaces.d.ts
@@ -16,7 +16,7 @@ export interface CustomAriaProperties {
  * Properties that can be set on a input component
  *
  * @property disabled       Prevents the user from interacting with the form field
- * @property inputId        Adds an id property to the input node so custom labels are possible
+ * @property widgetId        Adds an id property to the input node so custom labels are possible
  * @property invalid        Indicates the value entered in the form field is invalid
  * @property name           The form widget's name
  * @property readOnly       Allows or prevents user interaction
@@ -24,7 +24,7 @@ export interface CustomAriaProperties {
  */
 export interface InputProperties {
 	disabled?: boolean;
-	inputId?: string;
+	widgetId?: string;
 	invalid?: boolean;
 	name?: string;
 	readOnly?: boolean;

--- a/src/common/interfaces.d.ts
+++ b/src/common/interfaces.d.ts
@@ -16,7 +16,7 @@ export interface CustomAriaProperties {
  * Properties that can be set on a input component
  *
  * @property disabled       Prevents the user from interacting with the form field
- * @property id             Adds an id property to the input node so custom labels are possible
+ * @property inputId        Adds an id property to the input node so custom labels are possible
  * @property invalid        Indicates the value entered in the form field is invalid
  * @property name           The form widget's name
  * @property readOnly       Allows or prevents user interaction
@@ -24,7 +24,7 @@ export interface CustomAriaProperties {
  */
 export interface InputProperties {
 	disabled?: boolean;
-	id?: string;
+	inputId?: string;
 	invalid?: boolean;
 	name?: string;
 	readOnly?: boolean;

--- a/src/common/tests/support/test-helpers.ts
+++ b/src/common/tests/support/test-helpers.ts
@@ -20,15 +20,9 @@ export const compareId = {
 	comparator: isStringComparator
 };
 
-export const compareInputId = {
+export const comparewidgetId = {
 	selector: '*',
-	property: 'inputId',
-	comparator: isStringComparator
-};
-
-export const compareRootId = {
-	selector: '*',
-	property: 'rootId',
+	property: 'widgetId',
 	comparator: isStringComparator
 };
 

--- a/src/common/tests/support/test-helpers.ts
+++ b/src/common/tests/support/test-helpers.ts
@@ -20,7 +20,7 @@ export const compareId = {
 	comparator: isStringComparator
 };
 
-export const comparewidgetId = {
+export const compareWidgetId = {
 	selector: '*',
 	property: 'widgetId',
 	comparator: isStringComparator

--- a/src/common/tests/support/test-helpers.ts
+++ b/src/common/tests/support/test-helpers.ts
@@ -20,6 +20,18 @@ export const compareId = {
 	comparator: isStringComparator
 };
 
+export const compareInputId = {
+	selector: '*',
+	property: 'inputId',
+	comparator: isStringComparator
+};
+
+export const compareRootId = {
+	selector: '*',
+	property: 'rootId',
+	comparator: isStringComparator
+};
+
 export const compareForId = {
 	selector: '*',
 	property: 'forId',

--- a/src/enhanced-text-input/index.ts
+++ b/src/enhanced-text-input/index.ts
@@ -26,7 +26,7 @@ export interface EnhancedTextInputProperties extends TextInputProperties {
 		'invalid',
 		'readOnly'
 	],
-	attributes: [ 'placeholder', 'controls', 'type', 'minLength', 'maxLength', 'value', 'name' ],
+	attributes: [ 'inputId', 'label', 'placeholder', 'controls', 'type', 'minLength', 'maxLength', 'value', 'name' ],
 	events: [
 		'onBlur',
 		'onChange',

--- a/src/enhanced-text-input/index.ts
+++ b/src/enhanced-text-input/index.ts
@@ -26,7 +26,7 @@ export interface EnhancedTextInputProperties extends TextInputProperties {
 		'invalid',
 		'readOnly'
 	],
-	attributes: [ 'inputId', 'label', 'placeholder', 'controls', 'type', 'minLength', 'maxLength', 'value', 'name' ],
+	attributes: [ 'widgetId', 'label', 'placeholder', 'controls', 'type', 'minLength', 'maxLength', 'value', 'name' ],
 	events: [
 		'onBlur',
 		'onChange',

--- a/src/enhanced-text-input/tests/unit/EnhancedTextInput.ts
+++ b/src/enhanced-text-input/tests/unit/EnhancedTextInput.ts
@@ -143,6 +143,7 @@ registerSuite('EnhancedTextInput', {
 						controls: 'foo',
 						describedBy: 'bar'
 					},
+					inputId: 'textInputId',
 					maxLength: 50,
 					minLength: 10,
 					name: 'baz',
@@ -155,6 +156,7 @@ registerSuite('EnhancedTextInput', {
 					inputOverrides: {
 						'aria-controls': 'foo',
 						'aria-describedby': 'bar',
+						id: 'textInputId',
 						maxlength: '50',
 						minlength: '10',
 						name: 'baz',

--- a/src/enhanced-text-input/tests/unit/EnhancedTextInput.ts
+++ b/src/enhanced-text-input/tests/unit/EnhancedTextInput.ts
@@ -143,7 +143,7 @@ registerSuite('EnhancedTextInput', {
 						controls: 'foo',
 						describedBy: 'bar'
 					},
-					inputId: 'textInputId',
+					widgetId: 'textwidgetId',
 					maxLength: 50,
 					minLength: 10,
 					name: 'baz',
@@ -156,7 +156,7 @@ registerSuite('EnhancedTextInput', {
 					inputOverrides: {
 						'aria-controls': 'foo',
 						'aria-describedby': 'bar',
-						id: 'textInputId',
+						id: 'textwidgetId',
 						maxlength: '50',
 						minlength: '10',
 						name: 'baz',

--- a/src/enhanced-text-input/tests/unit/EnhancedTextInput.ts
+++ b/src/enhanced-text-input/tests/unit/EnhancedTextInput.ts
@@ -143,7 +143,7 @@ registerSuite('EnhancedTextInput', {
 						controls: 'foo',
 						describedBy: 'bar'
 					},
-					widgetId: 'textwidgetId',
+					widgetId: 'textinputId',
 					maxLength: 50,
 					minLength: 10,
 					name: 'baz',
@@ -156,7 +156,7 @@ registerSuite('EnhancedTextInput', {
 					inputOverrides: {
 						'aria-controls': 'foo',
 						'aria-describedby': 'bar',
-						id: 'textwidgetId',
+						id: 'textinputId',
 						maxlength: '50',
 						minlength: '10',
 						name: 'baz',

--- a/src/listbox/example/index.ts
+++ b/src/listbox/example/index.ts
@@ -94,7 +94,7 @@ export class App extends WidgetBase<WidgetProperties> {
 			w(Listbox, {
 				key: 'listbox1',
 				activeIndex: this._listbox1Index,
-				rootId: 'listbox1',
+				widgetId: 'listbox1',
 				optionData: this._options,
 				getOptionLabel: (option: CustomOption) => option.value,
 				getOptionDisabled: (option: CustomOption) => !!option.disabled,
@@ -114,7 +114,7 @@ export class App extends WidgetBase<WidgetProperties> {
 			w(Listbox, {
 				key: 'listbox2',
 				activeIndex: this._listbox2Index,
-				rootId: 'listbox2',
+				widgetId: 'listbox2',
 				optionData: this._moreOptions,
 				getOptionLabel: (option: CustomOption) => option.label,
 				getOptionDisabled: (option: CustomOption) => !!option.disabled,

--- a/src/listbox/example/index.ts
+++ b/src/listbox/example/index.ts
@@ -94,7 +94,7 @@ export class App extends WidgetBase<WidgetProperties> {
 			w(Listbox, {
 				key: 'listbox1',
 				activeIndex: this._listbox1Index,
-				id: 'listbox1',
+				rootId: 'listbox1',
 				optionData: this._options,
 				getOptionLabel: (option: CustomOption) => option.value,
 				getOptionDisabled: (option: CustomOption) => !!option.disabled,
@@ -114,7 +114,7 @@ export class App extends WidgetBase<WidgetProperties> {
 			w(Listbox, {
 				key: 'listbox2',
 				activeIndex: this._listbox2Index,
-				id: 'listbox2',
+				rootId: 'listbox2',
 				optionData: this._moreOptions,
 				getOptionLabel: (option: CustomOption) => option.label,
 				getOptionDisabled: (option: CustomOption) => !!option.disabled,

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -35,7 +35,7 @@ export class ScrollMeta extends MetaBase {
  * @property getOptionDisabled    Function that accepts option data and returns a boolean for disabled/not disabled
  * @property getOptionId          Function that accepts option data and returns a string ID
  * @property getOptionSelected    Function that accepts option data and returns a boolean for selected/unselected
- * @property rootId               Optional custom id for the root node of the listbox
+ * @property widgetId               Optional custom id for the root node of the listbox
  * @property focus                Indicates if the listbox needs focusing
  * @property multiselect          Adds currect semantics for a multiselect listbox
  * @property optionData           Array of data for listbox options
@@ -51,7 +51,7 @@ export interface ListboxProperties extends ThemedProperties, CustomAriaPropertie
 	getOptionId?(option: any, index: number): string;
 	getOptionLabel?(option: any, index: number): DNode;
 	getOptionSelected?(option: any, index: number): boolean;
-	rootId?: string;
+	widgetId?: string;
 	focus?: boolean;
 	multiselect?: boolean;
 	optionData?: any[];
@@ -81,7 +81,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 		'getOptionSelected'
 	],
 	attributes: [
-		'rootId'
+		'widgetId'
 	],
 	events: [
 		'onActiveIndexChange',
@@ -235,7 +235,7 @@ export class ListboxBase<P extends ListboxProperties = ListboxProperties> extend
 		const {
 			activeIndex = 0,
 			aria = {},
-			rootId,
+			widgetId,
 			multiselect = false,
 			focus,
 			tabIndex = 0
@@ -252,7 +252,7 @@ export class ListboxBase<P extends ListboxProperties = ListboxProperties> extend
 				'aria-activedescendant': this._getOptionId(activeIndex),
 				'aria-multiselectable': multiselect ? 'true' : null,
 				classes: this.theme([ css.root, ...themeClasses ]),
-				id: rootId,
+				id: widgetId,
 				key: 'root',
 				role: 'listbox',
 				tabIndex,

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -35,7 +35,7 @@ export class ScrollMeta extends MetaBase {
  * @property getOptionDisabled    Function that accepts option data and returns a boolean for disabled/not disabled
  * @property getOptionId          Function that accepts option data and returns a string ID
  * @property getOptionSelected    Function that accepts option data and returns a boolean for selected/unselected
- * @property id                   Optional custom id for the listbox
+ * @property rootId               Optional custom id for the root node of the listbox
  * @property focus                Indicates if the listbox needs focusing
  * @property multiselect          Adds currect semantics for a multiselect listbox
  * @property optionData           Array of data for listbox options
@@ -51,7 +51,7 @@ export interface ListboxProperties extends ThemedProperties, CustomAriaPropertie
 	getOptionId?(option: any, index: number): string;
 	getOptionLabel?(option: any, index: number): DNode;
 	getOptionSelected?(option: any, index: number): boolean;
-	id?: string;
+	rootId?: string;
 	focus?: boolean;
 	multiselect?: boolean;
 	optionData?: any[];
@@ -81,7 +81,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 		'getOptionSelected'
 	],
 	attributes: [
-		'id'
+		'rootId'
 	],
 	events: [
 		'onActiveIndexChange',
@@ -235,7 +235,7 @@ export class ListboxBase<P extends ListboxProperties = ListboxProperties> extend
 		const {
 			activeIndex = 0,
 			aria = {},
-			id,
+			rootId,
 			multiselect = false,
 			focus,
 			tabIndex = 0
@@ -252,7 +252,7 @@ export class ListboxBase<P extends ListboxProperties = ListboxProperties> extend
 				'aria-activedescendant': this._getOptionId(activeIndex),
 				'aria-multiselectable': multiselect ? 'true' : null,
 				classes: this.theme([ css.root, ...themeClasses ]),
-				id,
+				id: rootId,
 				key: 'root',
 				role: 'listbox',
 				tabIndex,

--- a/src/listbox/tests/unit/Listbox.ts
+++ b/src/listbox/tests/unit/Listbox.ts
@@ -135,7 +135,7 @@ registerSuite('Listbox', {
 				activeIndex: 0,
 				aria: { describedBy: 'foo' },
 				visualFocus: true,
-				rootId: 'bar',
+				widgetId: 'bar',
 				multiselect: true,
 				optionData: testOptions,
 				tabIndex: -1,

--- a/src/listbox/tests/unit/Listbox.ts
+++ b/src/listbox/tests/unit/Listbox.ts
@@ -135,7 +135,7 @@ registerSuite('Listbox', {
 				activeIndex: 0,
 				aria: { describedBy: 'foo' },
 				visualFocus: true,
-				id: 'bar',
+				rootId: 'bar',
 				multiselect: true,
 				optionData: testOptions,
 				tabIndex: -1,

--- a/src/progress/example/index.ts
+++ b/src/progress/example/index.ts
@@ -19,7 +19,7 @@ export class App extends WidgetBase<WidgetProperties> {
 			]),
 			v('h3', {}, ['Progress with an id']),
 			v('div', { id: 'example-2'}, [
-				w(Progress, { value: 80, id: 'progress-2' })
+				w(Progress, { value: 80, barId: 'progress-2' })
 			]),
 			v('h3', {}, ['Progress with max']),
 			v('div', { id: 'example-3'}, [

--- a/src/progress/example/index.ts
+++ b/src/progress/example/index.ts
@@ -19,7 +19,7 @@ export class App extends WidgetBase<WidgetProperties> {
 			]),
 			v('h3', {}, ['Progress with an id']),
 			v('div', { id: 'example-2'}, [
-				w(Progress, { value: 80, barId: 'progress-2' })
+				w(Progress, { value: 80, widgetId: 'progress-2' })
 			]),
 			v('h3', {}, ['Progress with max']),
 			v('div', { id: 'example-3'}, [

--- a/src/progress/index.ts
+++ b/src/progress/index.ts
@@ -17,7 +17,7 @@ import { customElement } from '@dojo/widget-core/decorators/customElement';
  * @property showOutput     Toggles visibility of progess bar output
  * @property max            Value used to calculate percent width
  * @property min            Value used to calculate percent width
- * @property id             Value used to supply a dom id
+ * @property barId          Value used to supply a dom id to the element with role="progressbar"
  */
 export interface ProgressProperties extends ThemedProperties, CustomAriaProperties {
 	value: number;
@@ -25,7 +25,7 @@ export interface ProgressProperties extends ThemedProperties, CustomAriaProperti
 	showOutput?: boolean;
 	max?: number;
 	min?: number;
-	id?: string;
+	barId?: string;
 }
 
 export const ThemedBase = ThemedMixin(WidgetBase);
@@ -34,7 +34,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 @customElement<ProgressProperties>({
 	tag: 'dojo-progress',
 	properties: [ 'theme', 'aria', 'extraClasses', 'output', 'showOutput', 'max', 'min', 'value' ],
-	attributes: [ 'id' ],
+	attributes: [ 'barId' ],
 	events: [ ]
 })
 export class ProgressBase<P extends ProgressProperties = ProgressProperties> extends ThemedBase<P, null> {
@@ -61,7 +61,7 @@ export class ProgressBase<P extends ProgressProperties = ProgressProperties> ext
 			showOutput = true,
 			max = 100,
 			min = 0,
-			id
+			barId
 		} = this.properties;
 
 		const percent = Math.round(((value - min) / (max - min)) * 100);
@@ -76,7 +76,7 @@ export class ProgressBase<P extends ProgressProperties = ProgressProperties> ext
 				'aria-valuemax': `${max}`,
 				'aria-valuenow': `${value}`,
 				'aria-valuetext': output,
-				id
+				id: barId
 			}, this.renderProgress(percent)),
 			showOutput ? v('span', { classes: this.theme(css.output) }, [ output ]) : null
 		]);

--- a/src/progress/index.ts
+++ b/src/progress/index.ts
@@ -17,7 +17,7 @@ import { customElement } from '@dojo/widget-core/decorators/customElement';
  * @property showOutput     Toggles visibility of progess bar output
  * @property max            Value used to calculate percent width
  * @property min            Value used to calculate percent width
- * @property barId          Value used to supply a dom id to the element with role="progressbar"
+ * @property widgetId       Value used to supply a dom id to the element with role="progressbar"
  */
 export interface ProgressProperties extends ThemedProperties, CustomAriaProperties {
 	value: number;
@@ -25,7 +25,7 @@ export interface ProgressProperties extends ThemedProperties, CustomAriaProperti
 	showOutput?: boolean;
 	max?: number;
 	min?: number;
-	barId?: string;
+	widgetId?: string;
 }
 
 export const ThemedBase = ThemedMixin(WidgetBase);
@@ -34,7 +34,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 @customElement<ProgressProperties>({
 	tag: 'dojo-progress',
 	properties: [ 'theme', 'aria', 'extraClasses', 'output', 'showOutput', 'max', 'min', 'value' ],
-	attributes: [ 'barId' ],
+	attributes: [ 'widgetId' ],
 	events: [ ]
 })
 export class ProgressBase<P extends ProgressProperties = ProgressProperties> extends ThemedBase<P, null> {
@@ -61,7 +61,7 @@ export class ProgressBase<P extends ProgressProperties = ProgressProperties> ext
 			showOutput = true,
 			max = 100,
 			min = 0,
-			barId
+			widgetId
 		} = this.properties;
 
 		const percent = Math.round(((value - min) / (max - min)) * 100);
@@ -76,7 +76,7 @@ export class ProgressBase<P extends ProgressProperties = ProgressProperties> ext
 				'aria-valuemax': `${max}`,
 				'aria-valuenow': `${value}`,
 				'aria-valuetext': output,
-				id: barId
+				id: widgetId
 			}, this.renderProgress(percent)),
 			showOutput ? v('span', { classes: this.theme(css.output) }, [ output ]) : null
 		]);

--- a/src/progress/tests/unit/Progress.ts
+++ b/src/progress/tests/unit/Progress.ts
@@ -95,7 +95,7 @@ describe('Progress', () => {
 	it('can accept an id', () => {
 		const h = harness(() => w(Progress, {
 			value: 50,
-			id: 'my-id'
+			barId: 'my-id'
 		}));
 
 		h.expect(() => expectedVDom({ width: 50, output: '50%', value: 50, id: 'my-id' }));

--- a/src/progress/tests/unit/Progress.ts
+++ b/src/progress/tests/unit/Progress.ts
@@ -95,7 +95,7 @@ describe('Progress', () => {
 	it('can accept an id', () => {
 		const h = harness(() => w(Progress, {
 			value: 50,
-			barId: 'my-id'
+			widgetId: 'my-id'
 		}));
 
 		h.expect(() => expectedVDom({ width: 50, output: '50%', value: 50, id: 'my-id' }));

--- a/src/radio/index.ts
+++ b/src/radio/index.ts
@@ -29,7 +29,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 @customElement<RadioProperties>({
 	tag: 'dojo-radio',
 	properties: [ 'theme', 'aria', 'extraClasses', 'checked' ],
-	attributes: [ 'label', 'value', 'name' ],
+	attributes: [ 'inputId', 'label', 'value', 'name' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -111,7 +111,7 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 			aria = {},
 			checked = false,
 			disabled,
-			id = this._uuid,
+			inputId = this._uuid,
 			invalid,
 			label,
 			labelAfter = true,
@@ -127,7 +127,7 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 		const children = [
 			v('div', { classes: this.theme(css.inputWrapper) }, [
 				v('input', {
-					id,
+					id: inputId,
 					...formatAriaProperties(aria),
 					classes: this.theme(css.input),
 					checked,
@@ -158,7 +158,7 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: id,
+				forId: inputId,
 				secondary: true
 			}, [ label ]) : null
 		];

--- a/src/radio/index.ts
+++ b/src/radio/index.ts
@@ -29,7 +29,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 @customElement<RadioProperties>({
 	tag: 'dojo-radio',
 	properties: [ 'theme', 'aria', 'extraClasses', 'checked' ],
-	attributes: [ 'inputId', 'label', 'value', 'name' ],
+	attributes: [ 'widgetId', 'label', 'value', 'name' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -111,7 +111,7 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 			aria = {},
 			checked = false,
 			disabled,
-			inputId = this._uuid,
+			widgetId = this._uuid,
 			invalid,
 			label,
 			labelAfter = true,
@@ -127,7 +127,7 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 		const children = [
 			v('div', { classes: this.theme(css.inputWrapper) }, [
 				v('input', {
-					id: inputId,
+					id: widgetId,
 					...formatAriaProperties(aria),
 					classes: this.theme(css.input),
 					checked,
@@ -158,7 +158,7 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: inputId,
+				forId: widgetId,
 				secondary: true
 			}, [ label ]) : null
 		];

--- a/src/radio/tests/unit/Radio.ts
+++ b/src/radio/tests/unit/Radio.ts
@@ -88,7 +88,7 @@ registerSuite('Radio', {
 			const h = harness(() => w(Radio, {
 				aria: { describedBy: 'foo' },
 				checked: true,
-				inputId: 'foo',
+				widgetId: 'foo',
 				name: 'bar',
 				value: 'baz'
 			}));

--- a/src/radio/tests/unit/Radio.ts
+++ b/src/radio/tests/unit/Radio.ts
@@ -88,7 +88,7 @@ registerSuite('Radio', {
 			const h = harness(() => w(Radio, {
 				aria: { describedBy: 'foo' },
 				checked: true,
-				id: 'foo',
+				inputId: 'foo',
 				name: 'bar',
 				value: 'baz'
 			}));

--- a/src/select/index.ts
+++ b/src/select/index.ts
@@ -69,7 +69,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 		'labelAfter',
 		'labelHidden'
 	],
-	attributes: [ 'placeholder', 'label', 'value' ],
+	attributes: [ 'inputId', 'placeholder', 'label', 'value' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -207,7 +207,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 			getOptionId,
 			getOptionSelected,
 			getOptionValue,
-			id = this._baseId,
+			inputId = this._baseId,
 			invalid,
 			name,
 			options = [],
@@ -230,7 +230,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 				classes: this.theme(css.input),
 				disabled,
 				'aria-invalid': invalid ? 'true' : null,
-				id,
+				id: inputId,
 				name,
 				readOnly,
 				'aria-readonly': readOnly ? 'true' : null,
@@ -250,7 +250,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 			getOptionId,
 			getOptionLabel,
 			getOptionSelected = this._getOptionSelected,
-			id = this._baseId,
+			inputId = this._baseId,
 			key,
 			options = [],
 			theme,
@@ -282,7 +282,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 				w(Listbox, {
 					key: 'listbox',
 					activeIndex: _focusedIndex,
-					id,
+					rootId: inputId,
 					focus: focusListbox,
 					optionData: options,
 					tabIndex: _open ? 0 : -1,
@@ -362,7 +362,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 			labelHidden,
 			labelAfter,
 			disabled,
-			id = this._baseId,
+			inputId = this._baseId,
 			invalid,
 			readOnly,
 			required,
@@ -380,7 +380,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: id
+				forId: inputId
 			}, [ label ]) : null,
 			useNativeElement ? this.renderNativeSelect() : this.renderCustomSelect()
 		];

--- a/src/select/index.ts
+++ b/src/select/index.ts
@@ -69,7 +69,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 		'labelAfter',
 		'labelHidden'
 	],
-	attributes: [ 'inputId', 'placeholder', 'label', 'value' ],
+	attributes: [ 'widgetId', 'placeholder', 'label', 'value' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -207,7 +207,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 			getOptionId,
 			getOptionSelected,
 			getOptionValue,
-			inputId = this._baseId,
+			widgetId = this._baseId,
 			invalid,
 			name,
 			options = [],
@@ -230,7 +230,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 				classes: this.theme(css.input),
 				disabled,
 				'aria-invalid': invalid ? 'true' : null,
-				id: inputId,
+				id: widgetId,
 				name,
 				readOnly,
 				'aria-readonly': readOnly ? 'true' : null,
@@ -250,7 +250,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 			getOptionId,
 			getOptionLabel,
 			getOptionSelected = this._getOptionSelected,
-			inputId = this._baseId,
+			widgetId = this._baseId,
 			key,
 			options = [],
 			theme,
@@ -282,7 +282,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 				w(Listbox, {
 					key: 'listbox',
 					activeIndex: _focusedIndex,
-					rootId: inputId,
+					widgetId: widgetId,
 					focus: focusListbox,
 					optionData: options,
 					tabIndex: _open ? 0 : -1,
@@ -362,7 +362,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 			labelHidden,
 			labelAfter,
 			disabled,
-			inputId = this._baseId,
+			widgetId = this._baseId,
 			invalid,
 			readOnly,
 			required,
@@ -380,7 +380,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: inputId
+				forId: widgetId
 			}, [ label ]) : null,
 			useNativeElement ? this.renderNativeSelect() : this.renderCustomSelect()
 		];

--- a/src/select/tests/unit/Select.ts
+++ b/src/select/tests/unit/Select.ts
@@ -15,13 +15,15 @@ import * as css from '../../../theme/select.m.css';
 import {
 	createHarness,
 	compareId,
+	compareInputId,
+	compareRootId,
 	MockMetaMixin,
 	noop,
 	compareAriaControls,
 	stubEvent
 } from '../../../common/tests/support/test-helpers';
 
-const harness = createHarness([ compareId, compareAriaControls ]);
+const harness = createHarness([ compareId, compareInputId, compareRootId, compareAriaControls ]);
 
 interface TestEventInit extends EventInit {
 	which: number;
@@ -66,7 +68,7 @@ const testProperties: Partial<SelectProperties> = {
 	getOptionLabel: (option: any) => option.label,
 	getOptionSelected: (option: any, index: number) => option.value === 'two',
 	getOptionValue: (option: any, index: number) => option.value,
-	id: 'foo',
+	inputId: 'foo',
 	name: 'foo',
 	options: testOptions,
 	value: 'two'
@@ -160,7 +162,7 @@ const expectedSingle = function(useTestProperties = false, withStates = false, o
 			w(Listbox, {
 				activeIndex,
 				focus,
-				id: useTestProperties ? 'foo' : '',
+				rootId: useTestProperties ? 'foo' : '',
 				key: 'listbox',
 				optionData: useTestProperties ? testOptions : [],
 				tabIndex: open ? 0 : -1,
@@ -396,7 +398,7 @@ registerSuite('Select', {
 						}, [
 							w(Listbox, {
 								activeIndex: 0,
-								id: '',
+								rootId: '',
 								focus: false,
 								key: 'listbox',
 								optionData: simpleOptions,

--- a/src/select/tests/unit/Select.ts
+++ b/src/select/tests/unit/Select.ts
@@ -15,15 +15,14 @@ import * as css from '../../../theme/select.m.css';
 import {
 	createHarness,
 	compareId,
-	compareInputId,
-	compareRootId,
+	comparewidgetId,
 	MockMetaMixin,
 	noop,
 	compareAriaControls,
 	stubEvent
 } from '../../../common/tests/support/test-helpers';
 
-const harness = createHarness([ compareId, compareInputId, compareRootId, compareAriaControls ]);
+const harness = createHarness([ compareId, comparewidgetId, compareAriaControls ]);
 
 interface TestEventInit extends EventInit {
 	which: number;
@@ -68,7 +67,7 @@ const testProperties: Partial<SelectProperties> = {
 	getOptionLabel: (option: any) => option.label,
 	getOptionSelected: (option: any, index: number) => option.value === 'two',
 	getOptionValue: (option: any, index: number) => option.value,
-	inputId: 'foo',
+	widgetId: 'foo',
 	name: 'foo',
 	options: testOptions,
 	value: 'two'
@@ -162,7 +161,7 @@ const expectedSingle = function(useTestProperties = false, withStates = false, o
 			w(Listbox, {
 				activeIndex,
 				focus,
-				rootId: useTestProperties ? 'foo' : '',
+				widgetId: useTestProperties ? 'foo' : '',
 				key: 'listbox',
 				optionData: useTestProperties ? testOptions : [],
 				tabIndex: open ? 0 : -1,
@@ -398,7 +397,7 @@ registerSuite('Select', {
 						}, [
 							w(Listbox, {
 								activeIndex: 0,
-								rootId: '',
+								widgetId: '',
 								focus: false,
 								key: 'listbox',
 								optionData: simpleOptions,

--- a/src/select/tests/unit/Select.ts
+++ b/src/select/tests/unit/Select.ts
@@ -15,14 +15,14 @@ import * as css from '../../../theme/select.m.css';
 import {
 	createHarness,
 	compareId,
-	comparewidgetId,
+	compareWidgetId,
 	MockMetaMixin,
 	noop,
 	compareAriaControls,
 	stubEvent
 } from '../../../common/tests/support/test-helpers';
 
-const harness = createHarness([ compareId, comparewidgetId, compareAriaControls ]);
+const harness = createHarness([ compareId, compareWidgetId, compareAriaControls ]);
 
 interface TestEventInit extends EventInit {
 	which: number;

--- a/src/slider/index.ts
+++ b/src/slider/index.ts
@@ -62,7 +62,7 @@ function extractValue(event: Event): number {
 		'vertical',
 		'value'
 	],
-	attributes: [ 'verticalHeight' ],
+	attributes: [ 'inputId', 'verticalHeight' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -205,7 +205,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 		const {
 			aria = {},
 			disabled,
-			id = this._inputId,
+			inputId = this._inputId,
 			invalid,
 			label,
 			labelAfter,
@@ -240,7 +240,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 				...formatAriaProperties(aria),
 				classes: [ this.theme(css.input), fixedCss.nativeInput ],
 				disabled,
-				id,
+				id: inputId,
 				'aria-invalid': invalid === true ? 'true' : null,
 				max: `${max}`,
 				min: `${min}`,
@@ -279,7 +279,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: id
+				forId: inputId
 			}, [ label ]) : null,
 			slider
 		];

--- a/src/slider/index.ts
+++ b/src/slider/index.ts
@@ -62,7 +62,7 @@ function extractValue(event: Event): number {
 		'vertical',
 		'value'
 	],
-	attributes: [ 'inputId', 'verticalHeight' ],
+	attributes: [ 'widgetId', 'verticalHeight' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -81,7 +81,7 @@ function extractValue(event: Event): number {
 })
 export class SliderBase<P extends SliderProperties = SliderProperties> extends ThemedBase<P, null> {
 	// id used to associate input with output
-	private _inputId = uuid();
+	private _widgetId = uuid();
 
 	private _onBlur (event: FocusEvent) {
 		this.properties.onBlur && this.properties.onBlur(extractValue(event));
@@ -195,7 +195,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 
 		return v('output', {
 			classes: [ this.theme(css.output), outputIsTooltip ? fixedCss.outputTooltip : null ],
-			for: this._inputId,
+			for: this._widgetId,
 			styles: outputStyles,
 			tabIndex: -1 /* needed so Edge doesn't select the element while tabbing through */
 		}, [ outputNode ]);
@@ -205,7 +205,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 		const {
 			aria = {},
 			disabled,
-			inputId = this._inputId,
+			widgetId = this._widgetId,
 			invalid,
 			label,
 			labelAfter,
@@ -240,7 +240,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 				...formatAriaProperties(aria),
 				classes: [ this.theme(css.input), fixedCss.nativeInput ],
 				disabled,
-				id: inputId,
+				id: widgetId,
 				'aria-invalid': invalid === true ? 'true' : null,
 				max: `${max}`,
 				min: `${min}`,
@@ -279,7 +279,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: inputId
+				forId: widgetId
 			}, [ label ]) : null,
 			slider
 		];

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -99,7 +99,7 @@ registerSuite('Slider', {
 		'custom properties'() {
 			const h = harness(() => w(Slider, {
 				aria: { describedBy: 'foo' },
-				inputId: 'foo',
+				widgetId: 'foo',
 				max: 60,
 				min: 10,
 				name: 'bar',

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -99,7 +99,7 @@ registerSuite('Slider', {
 		'custom properties'() {
 			const h = harness(() => w(Slider, {
 				aria: { describedBy: 'foo' },
-				id: 'foo',
+				inputId: 'foo',
 				max: 60,
 				min: 10,
 				name: 'bar',

--- a/src/tab-controller/index.ts
+++ b/src/tab-controller/index.ts
@@ -161,7 +161,7 @@ export class TabControllerBase<P extends TabControllerProperties = TabController
 		return this._tabs
 			.map((tab, i) => {
 				assign(tab.properties, {
-					id: `${ this._id }-tab-${i}`,
+					rootId: `${ this._id }-tab-${i}`,
 					labelledBy: `${ this._id }-tabbutton-${i}`,
 					show: i === activeIndex
 				});

--- a/src/tab-controller/index.ts
+++ b/src/tab-controller/index.ts
@@ -161,7 +161,7 @@ export class TabControllerBase<P extends TabControllerProperties = TabController
 		return this._tabs
 			.map((tab, i) => {
 				assign(tab.properties, {
-					rootId: `${ this._id }-tab-${i}`,
+					widgetId: `${ this._id }-tab-${i}`,
 					labelledBy: `${ this._id }-tabbutton-${i}`,
 					show: i === activeIndex
 				});

--- a/src/tab-controller/tests/unit/TabController.ts
+++ b/src/tab-controller/tests/unit/TabController.ts
@@ -13,13 +13,14 @@ import * as css from '../../../theme/tab-controller.m.css';
 import {
 	createHarness,
 	compareId,
+	compareRootId,
 	isStringComparator,
 	noop
 } from '../../../common/tests/support/test-helpers';
 
 const compareLabelledBy = { selector: '*', property: 'labelledBy', comparator: isStringComparator };
 const compareControls = { selector: '*', property: 'controls', comparator: isStringComparator };
-const harness = createHarness([ compareId, compareControls, compareLabelledBy ]);
+const harness = createHarness([ compareId, compareRootId, compareControls, compareLabelledBy ]);
 
 const tabChildren = function(tabs = 2) {
 	const children = [
@@ -108,7 +109,7 @@ const expectedTabContent = function(index = 0): DNode {
 	const tabs = [
 		w(Tab, {
 			key: '0',
-			id: '',
+			rootId: '',
 			labelledBy: '',
 			show: index === 0
 		}, [ 'tab content 1' ]),
@@ -117,7 +118,7 @@ const expectedTabContent = function(index = 0): DNode {
 			disabled: true,
 			key: '1',
 			label: 'foo',
-			id: '',
+			rootId: '',
 			show: index === 1,
 			labelledBy: ''
 		}, [ 'tab content 2' ])
@@ -388,13 +389,13 @@ registerSuite('TabController', {
 				classes: css.tabs
 			}, [
 				w(Tab, {
-					id: '',
+					rootId: '',
 					key: '0',
 					labelledBy: '',
 					show: false
 				}, [ 'tab content 1' ]),
 				w(Tab, {
-					id: '',
+					rootId: '',
 					labelledBy: '',
 					closeable: true,
 					key: '1',
@@ -415,13 +416,13 @@ registerSuite('TabController', {
 				classes: css.tabs
 			}, [
 				w(Tab, {
-					id: '',
+					rootId: '',
 					labelledBy: '',
 					show: true,
 					key: '0'
 				}, [ 'tab content 1' ]),
 				w(Tab, {
-					id: '',
+					rootId: '',
 					labelledBy: '',
 					closeable: true,
 					key: '1',
@@ -483,13 +484,13 @@ registerSuite('TabController', {
 				classes: css.tabs
 			}, [
 				w(Tab, {
-					id: '',
+					rootId: '',
 					labelledBy: '',
 					key: '0',
 					show: true
 				}, [ 'tab content 1' ]),
 				w(Tab, {
-					id: '',
+					rootId: '',
 					labelledBy: '',
 					closeable: true,
 					key: '1',

--- a/src/tab-controller/tests/unit/TabController.ts
+++ b/src/tab-controller/tests/unit/TabController.ts
@@ -13,14 +13,14 @@ import * as css from '../../../theme/tab-controller.m.css';
 import {
 	createHarness,
 	compareId,
-	comparewidgetId,
+	compareWidgetId,
 	isStringComparator,
 	noop
 } from '../../../common/tests/support/test-helpers';
 
 const compareLabelledBy = { selector: '*', property: 'labelledBy', comparator: isStringComparator };
 const compareControls = { selector: '*', property: 'controls', comparator: isStringComparator };
-const harness = createHarness([ compareId, comparewidgetId, compareControls, compareLabelledBy ]);
+const harness = createHarness([ compareId, compareWidgetId, compareControls, compareLabelledBy ]);
 
 const tabChildren = function(tabs = 2) {
 	const children = [

--- a/src/tab-controller/tests/unit/TabController.ts
+++ b/src/tab-controller/tests/unit/TabController.ts
@@ -13,14 +13,14 @@ import * as css from '../../../theme/tab-controller.m.css';
 import {
 	createHarness,
 	compareId,
-	compareRootId,
+	comparewidgetId,
 	isStringComparator,
 	noop
 } from '../../../common/tests/support/test-helpers';
 
 const compareLabelledBy = { selector: '*', property: 'labelledBy', comparator: isStringComparator };
 const compareControls = { selector: '*', property: 'controls', comparator: isStringComparator };
-const harness = createHarness([ compareId, compareRootId, compareControls, compareLabelledBy ]);
+const harness = createHarness([ compareId, comparewidgetId, compareControls, compareLabelledBy ]);
 
 const tabChildren = function(tabs = 2) {
 	const children = [
@@ -109,7 +109,7 @@ const expectedTabContent = function(index = 0): DNode {
 	const tabs = [
 		w(Tab, {
 			key: '0',
-			rootId: '',
+			widgetId: '',
 			labelledBy: '',
 			show: index === 0
 		}, [ 'tab content 1' ]),
@@ -118,7 +118,7 @@ const expectedTabContent = function(index = 0): DNode {
 			disabled: true,
 			key: '1',
 			label: 'foo',
-			rootId: '',
+			widgetId: '',
 			show: index === 1,
 			labelledBy: ''
 		}, [ 'tab content 2' ])
@@ -389,13 +389,13 @@ registerSuite('TabController', {
 				classes: css.tabs
 			}, [
 				w(Tab, {
-					rootId: '',
+					widgetId: '',
 					key: '0',
 					labelledBy: '',
 					show: false
 				}, [ 'tab content 1' ]),
 				w(Tab, {
-					rootId: '',
+					widgetId: '',
 					labelledBy: '',
 					closeable: true,
 					key: '1',
@@ -416,13 +416,13 @@ registerSuite('TabController', {
 				classes: css.tabs
 			}, [
 				w(Tab, {
-					rootId: '',
+					widgetId: '',
 					labelledBy: '',
 					show: true,
 					key: '0'
 				}, [ 'tab content 1' ]),
 				w(Tab, {
-					rootId: '',
+					widgetId: '',
 					labelledBy: '',
 					closeable: true,
 					key: '1',
@@ -484,13 +484,13 @@ registerSuite('TabController', {
 				classes: css.tabs
 			}, [
 				w(Tab, {
-					rootId: '',
+					widgetId: '',
 					labelledBy: '',
 					key: '0',
 					show: true
 				}, [ 'tab content 1' ]),
 				w(Tab, {
-					rootId: '',
+					widgetId: '',
 					labelledBy: '',
 					closeable: true,
 					key: '1',

--- a/src/tab/index.ts
+++ b/src/tab/index.ts
@@ -16,7 +16,7 @@ import { CustomElementChildType } from '@dojo/widget-core/registerCustomElement'
  *
  * @property closeable    Determines whether this tab can be closed
  * @property disabled     Determines whether this tab can become active
- * @property id           ID of this underlying DOM element
+ * @property rootId       ID of this underlying DOM element
  * @property key          A unique identifier for this Tab within the TabController
  * @property label        Content to show in the TabController control bar for this tab
  * @property labelledBy   ID of DOM element that serves as a label for this tab
@@ -24,7 +24,7 @@ import { CustomElementChildType } from '@dojo/widget-core/registerCustomElement'
 export interface TabProperties extends ThemedProperties, CustomAriaProperties {
 	closeable?: boolean;
 	disabled?: boolean;
-	id?: string;
+	rootId?: string;
 	key: string;
 	label?: DNode;
 	show?: boolean;
@@ -38,14 +38,14 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 	tag: 'dojo-tab',
 	childType: CustomElementChildType.NODE,
 	properties: [ 'theme', 'aria', 'extraClasses', 'closeable', 'disabled', 'label', 'show' ],
-	attributes: [ 'key', 'labelledBy', 'id', 'label' ],
+	attributes: [ 'key', 'labelledBy', 'rootId', 'label' ],
 	events: [ ]
 })
 export class TabBase<P extends TabProperties = TabProperties> extends ThemedBase<P> {
 	render(): DNode {
 		const {
 			aria = {},
-			id,
+			rootId,
 			labelledBy,
 			show = false
 		} = this.properties;
@@ -54,7 +54,7 @@ export class TabBase<P extends TabProperties = TabProperties> extends ThemedBase
 			...formatAriaProperties(aria),
 			'aria-labelledby': labelledBy,
 			classes: this.theme([css.tab, !show ? css.hidden : null]),
-			id,
+			id: rootId,
 			role: 'tabpanel'
 		}, this.children);
 	}

--- a/src/tab/index.ts
+++ b/src/tab/index.ts
@@ -16,7 +16,7 @@ import { CustomElementChildType } from '@dojo/widget-core/registerCustomElement'
  *
  * @property closeable    Determines whether this tab can be closed
  * @property disabled     Determines whether this tab can become active
- * @property rootId       ID of this underlying DOM element
+ * @property widgetId       ID of this underlying DOM element
  * @property key          A unique identifier for this Tab within the TabController
  * @property label        Content to show in the TabController control bar for this tab
  * @property labelledBy   ID of DOM element that serves as a label for this tab
@@ -24,7 +24,7 @@ import { CustomElementChildType } from '@dojo/widget-core/registerCustomElement'
 export interface TabProperties extends ThemedProperties, CustomAriaProperties {
 	closeable?: boolean;
 	disabled?: boolean;
-	rootId?: string;
+	widgetId?: string;
 	key: string;
 	label?: DNode;
 	show?: boolean;
@@ -38,14 +38,14 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 	tag: 'dojo-tab',
 	childType: CustomElementChildType.NODE,
 	properties: [ 'theme', 'aria', 'extraClasses', 'closeable', 'disabled', 'label', 'show' ],
-	attributes: [ 'key', 'labelledBy', 'rootId', 'label' ],
+	attributes: [ 'key', 'labelledBy', 'widgetId', 'label' ],
 	events: [ ]
 })
 export class TabBase<P extends TabProperties = TabProperties> extends ThemedBase<P> {
 	render(): DNode {
 		const {
 			aria = {},
-			rootId,
+			widgetId,
 			labelledBy,
 			show = false
 		} = this.properties;
@@ -54,7 +54,7 @@ export class TabBase<P extends TabProperties = TabProperties> extends ThemedBase
 			...formatAriaProperties(aria),
 			'aria-labelledby': labelledBy,
 			classes: this.theme([css.tab, !show ? css.hidden : null]),
-			id: rootId,
+			id: widgetId,
 			role: 'tabpanel'
 		}, this.children);
 	}

--- a/src/tab/tests/unit/Tab.ts
+++ b/src/tab/tests/unit/Tab.ts
@@ -29,7 +29,7 @@ registerSuite('Tab', {
 				closeable: true,
 				disabled: true,
 				show: true,
-				rootId: 'foo',
+				widgetId: 'foo',
 				key: 'bar',
 				label: 'baz',
 				labelledBy: 'id'

--- a/src/tab/tests/unit/Tab.ts
+++ b/src/tab/tests/unit/Tab.ts
@@ -29,7 +29,7 @@ registerSuite('Tab', {
 				closeable: true,
 				disabled: true,
 				show: true,
-				id: 'foo',
+				rootId: 'foo',
 				key: 'bar',
 				label: 'baz',
 				labelledBy: 'id'

--- a/src/text-area/index.ts
+++ b/src/text-area/index.ts
@@ -40,7 +40,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 @customElement<TextareaProperties>({
 	tag: 'dojo-text-area',
 	properties: [ 'theme', 'aria', 'extraClasses', 'columns', 'rows', 'columns', 'required', 'readOnly', 'disabled', 'invalid' ],
-	attributes: [ 'minLength', 'maxLength', 'placeholder', 'value' ],
+	attributes: [ 'inputId', 'minLength', 'maxLength', 'placeholder', 'value' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -140,7 +140,7 @@ export class TextareaBase<P extends TextareaProperties = TextareaProperties> ext
 			aria = {},
 			columns,
 			disabled,
-			id = this._uuid,
+			inputId = this._uuid,
 			invalid,
 			label,
 			maxLength,
@@ -167,11 +167,11 @@ export class TextareaBase<P extends TextareaProperties = TextareaProperties> ext
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: id
+				forId: inputId
 			}, [ label ]) : null,
 			v('div', { classes: this.theme(css.inputWrapper) }, [
 				v('textarea', {
-					id,
+					id: inputId,
 					key: 'input',
 					...formatAriaProperties(aria),
 					classes: this.theme(css.input),

--- a/src/text-area/index.ts
+++ b/src/text-area/index.ts
@@ -40,7 +40,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 @customElement<TextareaProperties>({
 	tag: 'dojo-text-area',
 	properties: [ 'theme', 'aria', 'extraClasses', 'columns', 'rows', 'columns', 'required', 'readOnly', 'disabled', 'invalid' ],
-	attributes: [ 'inputId', 'minLength', 'maxLength', 'placeholder', 'value' ],
+	attributes: [ 'widgetId', 'minLength', 'maxLength', 'placeholder', 'value' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -140,7 +140,7 @@ export class TextareaBase<P extends TextareaProperties = TextareaProperties> ext
 			aria = {},
 			columns,
 			disabled,
-			inputId = this._uuid,
+			widgetId = this._uuid,
 			invalid,
 			label,
 			maxLength,
@@ -167,11 +167,11 @@ export class TextareaBase<P extends TextareaProperties = TextareaProperties> ext
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: inputId
+				forId: widgetId
 			}, [ label ]) : null,
 			v('div', { classes: this.theme(css.inputWrapper) }, [
 				v('textarea', {
-					id: inputId,
+					id: widgetId,
 					key: 'input',
 					...formatAriaProperties(aria),
 					classes: this.theme(css.input),

--- a/src/text-area/tests/unit/Textarea.ts
+++ b/src/text-area/tests/unit/Textarea.ts
@@ -84,7 +84,7 @@ registerSuite('Textarea', {
 			const h = harness(() => w(Textarea, {
 				aria: { describedBy: 'foo' },
 				columns: 15,
-				id: 'foo',
+				inputId: 'foo',
 				maxLength: 50,
 				minLength: 10,
 				name: 'bar',

--- a/src/text-area/tests/unit/Textarea.ts
+++ b/src/text-area/tests/unit/Textarea.ts
@@ -84,7 +84,7 @@ registerSuite('Textarea', {
 			const h = harness(() => w(Textarea, {
 				aria: { describedBy: 'foo' },
 				columns: 15,
-				inputId: 'foo',
+				widgetId: 'foo',
 				maxLength: 50,
 				minLength: 10,
 				name: 'bar',

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -51,7 +51,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 		'invalid',
 		'readOnly'
 	],
-	attributes: [ 'label', 'placeholder', 'controls', 'type', 'minLength', 'maxLength', 'value', 'name' ],
+	attributes: [ 'inputId', 'label', 'placeholder', 'controls', 'type', 'minLength', 'maxLength', 'value', 'name' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -150,7 +150,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 		const {
 			aria = {},
 			disabled,
-			id = this._uuid,
+			inputId = this._uuid,
 			invalid,
 			maxLength,
 			minLength,
@@ -172,7 +172,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 			'aria-invalid': invalid ? 'true' : null,
 			classes: this.theme(css.input),
 			disabled,
-			id,
+			id: inputId,
 			key: 'input',
 			maxlength: maxLength ? `${maxLength}` : null,
 			minlength: minLength ? `${minLength}` : null,
@@ -208,7 +208,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 	protected render(): DNode {
 		const {
 			disabled,
-			id = this._uuid,
+			inputId = this._uuid,
 			invalid,
 			label,
 			labelAfter = false,
@@ -228,7 +228,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: id
+				forId: inputId
 			}, [ label ]) : null,
 			this.renderInputWrapper()
 		];

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -51,7 +51,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 		'invalid',
 		'readOnly'
 	],
-	attributes: [ 'inputId', 'label', 'placeholder', 'controls', 'type', 'minLength', 'maxLength', 'value', 'name' ],
+	attributes: [ 'widgetId', 'label', 'placeholder', 'controls', 'type', 'minLength', 'maxLength', 'value', 'name' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -150,7 +150,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 		const {
 			aria = {},
 			disabled,
-			inputId = this._uuid,
+			widgetId = this._uuid,
 			invalid,
 			maxLength,
 			minLength,
@@ -172,7 +172,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 			'aria-invalid': invalid ? 'true' : null,
 			classes: this.theme(css.input),
 			disabled,
-			id: inputId,
+			id: widgetId,
 			key: 'input',
 			maxlength: maxLength ? `${maxLength}` : null,
 			minlength: minLength ? `${minLength}` : null,
@@ -208,7 +208,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 	protected render(): DNode {
 		const {
 			disabled,
-			inputId = this._uuid,
+			widgetId = this._uuid,
 			invalid,
 			label,
 			labelAfter = false,
@@ -228,7 +228,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: inputId
+				forId: widgetId
 			}, [ label ]) : null,
 			this.renderInputWrapper()
 		];

--- a/src/text-input/tests/unit/TextInput.ts
+++ b/src/text-input/tests/unit/TextInput.ts
@@ -85,7 +85,7 @@ registerSuite('TextInput', {
 					controls: 'foo',
 					describedBy: 'bar'
 				},
-				inputId: 'foo',
+				widgetId: 'foo',
 				maxLength: 50,
 				minLength: 10,
 				name: 'bar',

--- a/src/text-input/tests/unit/TextInput.ts
+++ b/src/text-input/tests/unit/TextInput.ts
@@ -85,7 +85,7 @@ registerSuite('TextInput', {
 					controls: 'foo',
 					describedBy: 'bar'
 				},
-				id: 'foo',
+				inputId: 'foo',
 				maxLength: 50,
 				minLength: 10,
 				name: 'bar',

--- a/src/time-picker/index.ts
+++ b/src/time-picker/index.ts
@@ -173,7 +173,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 		'useNativeElement',
 		'step'
 	],
-	attributes: [ 'inputId', 'value', 'start', 'end' ],
+	attributes: [ 'widgetId', 'value', 'start', 'end' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -287,7 +287,7 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 			clearable,
 			disabled,
 			extraClasses,
-			inputId = this._uuid,
+			widgetId = this._uuid,
 			inputProperties,
 			invalid,
 			isOptionDisabled,
@@ -308,7 +308,7 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 			disabled,
 			extraClasses,
 			getResultLabel: this._getOptionLabel.bind(this),
-			inputId,
+			widgetId,
 			inputProperties,
 			invalid,
 			isResultDisabled: isOptionDisabled,
@@ -333,7 +333,7 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 		const {
 			disabled,
 			end,
-			inputId = this._uuid,
+			widgetId = this._uuid,
 			inputProperties = {},
 			invalid,
 			name,
@@ -360,10 +360,10 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: inputId
+				forId: widgetId
 			}, [ label ]) : null,
 			v('input', {
-				id: inputId,
+				id: widgetId,
 				...formatAriaProperties(aria),
 				'aria-invalid': invalid === true ? 'true' : null,
 				'aria-readonly': readOnly === true ? 'true' : null,

--- a/src/time-picker/index.ts
+++ b/src/time-picker/index.ts
@@ -173,7 +173,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 		'useNativeElement',
 		'step'
 	],
-	attributes: [ 'value', 'start', 'end' ],
+	attributes: [ 'inputId', 'value', 'start', 'end' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -287,7 +287,7 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 			clearable,
 			disabled,
 			extraClasses,
-			id = this._uuid,
+			inputId = this._uuid,
 			inputProperties,
 			invalid,
 			isOptionDisabled,
@@ -308,7 +308,7 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 			disabled,
 			extraClasses,
 			getResultLabel: this._getOptionLabel.bind(this),
-			id,
+			inputId,
 			inputProperties,
 			invalid,
 			isResultDisabled: isOptionDisabled,
@@ -333,7 +333,7 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 		const {
 			disabled,
 			end,
-			id = this._uuid,
+			inputId = this._uuid,
 			inputProperties = {},
 			invalid,
 			name,
@@ -360,10 +360,10 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 				readOnly,
 				required,
 				hidden: labelHidden,
-				forId: id
+				forId: inputId
 			}, [ label ]) : null,
 			v('input', {
-				id,
+				id: inputId,
 				...formatAriaProperties(aria),
 				'aria-invalid': invalid === true ? 'true' : null,
 				'aria-readonly': readOnly === true ? 'true' : null,

--- a/src/time-picker/tests/unit/TimePicker.ts
+++ b/src/time-picker/tests/unit/TimePicker.ts
@@ -9,12 +9,12 @@ import TimePicker, { getOptions, parseUnits } from '../../index';
 import * as css from '../../../theme/time-picker.m.css';
 import ComboBox from '../../../combobox/index';
 import Label from '../../../label/index';
-import { noop, compareId, compareInputId, compareForId, MockMetaMixin } from '../../../common/tests/support/test-helpers';
+import { noop, compareId, comparewidgetId, compareForId, MockMetaMixin } from '../../../common/tests/support/test-helpers';
 
 const testProperties = {
 	clearable: true,
 	disabled: false,
-	inputId: 'foo',
+	widgetId: 'foo',
 	invalid: true,
 	label: 'Some Field',
 	openOnFocus: false,
@@ -30,7 +30,7 @@ const getExpectedCombobox = function(useTestProperties = false, results?: any[])
 		clearable: useTestProperties ? true : undefined,
 		disabled: useTestProperties ? false : undefined,
 		getResultLabel: noop,
-		inputId: useTestProperties ? 'foo' : '',
+		widgetId: useTestProperties ? 'foo' : '',
 		inputProperties: undefined,
 		invalid: useTestProperties ? true : undefined,
 		isResultDisabled: undefined,
@@ -129,14 +129,14 @@ registerSuite('TimePicker', {
 		},
 
 		'Should set options with step and default start and end'() {
-			const h = harness(() => w(TimePicker, { step: 3600 }), [ compareInputId ]);
+			const h = harness(() => w(TimePicker, { step: 3600 }), [ comparewidgetId ]);
 			const expectedOptions = getOptions(undefined, undefined, 3600);
 
 			h.expect(() => getExpectedCombobox(false, expectedOptions));
 		},
 
 		'Should set options with start, end, and step'() {
-			const h = harness(() => w(TimePicker, { end: '01:00', start: '00:00' }), [ compareInputId ]);
+			const h = harness(() => w(TimePicker, { end: '01:00', start: '00:00' }), [ comparewidgetId ]);
 			const expectedOptions = getOptions('00:00', '01:00');
 
 			h.expect(() => getExpectedCombobox(false, expectedOptions));

--- a/src/time-picker/tests/unit/TimePicker.ts
+++ b/src/time-picker/tests/unit/TimePicker.ts
@@ -9,12 +9,12 @@ import TimePicker, { getOptions, parseUnits } from '../../index';
 import * as css from '../../../theme/time-picker.m.css';
 import ComboBox from '../../../combobox/index';
 import Label from '../../../label/index';
-import { noop, compareId, compareForId, MockMetaMixin } from '../../../common/tests/support/test-helpers';
+import { noop, compareId, compareInputId, compareForId, MockMetaMixin } from '../../../common/tests/support/test-helpers';
 
 const testProperties = {
 	clearable: true,
 	disabled: false,
-	id: 'foo',
+	inputId: 'foo',
 	invalid: true,
 	label: 'Some Field',
 	openOnFocus: false,
@@ -30,7 +30,7 @@ const getExpectedCombobox = function(useTestProperties = false, results?: any[])
 		clearable: useTestProperties ? true : undefined,
 		disabled: useTestProperties ? false : undefined,
 		getResultLabel: noop,
-		id: useTestProperties ? 'foo' : '',
+		inputId: useTestProperties ? 'foo' : '',
 		inputProperties: undefined,
 		invalid: useTestProperties ? true : undefined,
 		isResultDisabled: undefined,
@@ -129,14 +129,14 @@ registerSuite('TimePicker', {
 		},
 
 		'Should set options with step and default start and end'() {
-			const h = harness(() => w(TimePicker, { step: 3600 }), [ compareId ]);
+			const h = harness(() => w(TimePicker, { step: 3600 }), [ compareInputId ]);
 			const expectedOptions = getOptions(undefined, undefined, 3600);
 
 			h.expect(() => getExpectedCombobox(false, expectedOptions));
 		},
 
 		'Should set options with start, end, and step'() {
-			const h = harness(() => w(TimePicker, { end: '01:00', start: '00:00' }), [ compareId ]);
+			const h = harness(() => w(TimePicker, { end: '01:00', start: '00:00' }), [ compareInputId ]);
 			const expectedOptions = getOptions('00:00', '01:00');
 
 			h.expect(() => getExpectedCombobox(false, expectedOptions));

--- a/src/time-picker/tests/unit/TimePicker.ts
+++ b/src/time-picker/tests/unit/TimePicker.ts
@@ -9,7 +9,7 @@ import TimePicker, { getOptions, parseUnits } from '../../index';
 import * as css from '../../../theme/time-picker.m.css';
 import ComboBox from '../../../combobox/index';
 import Label from '../../../label/index';
-import { noop, compareId, comparewidgetId, compareForId, MockMetaMixin } from '../../../common/tests/support/test-helpers';
+import { noop, compareId, compareWidgetId, compareForId, MockMetaMixin } from '../../../common/tests/support/test-helpers';
 
 const testProperties = {
 	clearable: true,
@@ -129,14 +129,14 @@ registerSuite('TimePicker', {
 		},
 
 		'Should set options with step and default start and end'() {
-			const h = harness(() => w(TimePicker, { step: 3600 }), [ comparewidgetId ]);
+			const h = harness(() => w(TimePicker, { step: 3600 }), [ compareWidgetId ]);
 			const expectedOptions = getOptions(undefined, undefined, 3600);
 
 			h.expect(() => getExpectedCombobox(false, expectedOptions));
 		},
 
 		'Should set options with start, end, and step'() {
-			const h = harness(() => w(TimePicker, { end: '01:00', start: '00:00' }), [ comparewidgetId ]);
+			const h = harness(() => w(TimePicker, { end: '01:00', start: '00:00' }), [ compareWidgetId ]);
 			const expectedOptions = getOptions('00:00', '01:00');
 
 			h.expect(() => getExpectedCombobox(false, expectedOptions));


### PR DESCRIPTION
**Type:** bug
The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #529 

Renames `id` properties, primarily to `inputId` and `rootId`
