### PR TITLE
Making .outputTooltip class on slider themable

### DIFF
--- a/src/slider/index.ts
+++ b/src/slider/index.ts
@@ -194,7 +194,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 		}
 
 		return v('output', {
-			classes: [ this.theme(css.output), outputIsTooltip ? fixedCss.outputTooltip : null ],
+			classes: this.theme([css.output, outputIsTooltip ? css.outputTooltip : null]),
 			for: this._widgetId,
 			styles: outputStyles,
 			tabIndex: -1 /* needed so Edge doesn't select the element while tabbing through */

--- a/src/slider/styles/slider.m.css
+++ b/src/slider/styles/slider.m.css
@@ -25,12 +25,6 @@
 	position: absolute;
 }
 
-.outputTooltip {
-	left: 2.5em;
-	position: absolute;
-	top: 2.5em;
-}
-
 /* Make native input invisible */
 .nativeInput {
 	appearance: none;

--- a/src/slider/styles/slider.m.css.d.ts
+++ b/src/slider/styles/slider.m.css.d.ts
@@ -3,5 +3,4 @@ export const inputWrapperFixed: string;
 export const fillFixed: string;
 export const trackFixed: string;
 export const thumbFixed: string;
-export const outputTooltip: string;
 export const nativeInput: string;

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -79,7 +79,7 @@ const expected = function(label = false, tooltip = false, overrides = {}, child 
 				})
 			]),
 			v('output', {
-				classes: [ css.output, tooltip ? fixedCss.outputTooltip : null ],
+				classes: [ css.output, tooltip ? css.outputTooltip : null ],
 				for: '',
 				tabIndex: -1,
 				styles: progress !== '0%' ? { left: progress } : {}
@@ -276,7 +276,7 @@ registerSuite('Slider', {
 							})
 						]),
 						v('output', {
-							classes: [ css.output, fixedCss.outputTooltip ],
+							classes: [ css.output, css.outputTooltip ],
 							for: '',
 							styles: { top: '80%' },
 							tabIndex: -1

--- a/src/theme/slider.m.css
+++ b/src/theme/slider.m.css
@@ -2,6 +2,12 @@
 
 .root { }
 
+.outputTooltip {
+	left: 2.5em;
+	position: absolute;
+	top: 2.5em;
+}
+
 /* vertical slider */
 .vertical .input,
 .vertical .track {

--- a/src/theme/slider.m.css.d.ts
+++ b/src/theme/slider.m.css.d.ts
@@ -1,4 +1,5 @@
 export const root: string;
+export const outputTooltip: string;
 export const vertical: string;
 export const input: string;
 export const track: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Making `.outputTooltip` class themable by removing it from the fixed CSS and adding it to the theme CSS.

Resolves #533 
