### PR TITLE
Prevent default mouse down behavior

### DIFF
--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -69,6 +69,7 @@ export class SplitPaneBase<P extends SplitPaneProperties = SplitPaneProperties> 
 
 	private _onDragStart(event: MouseEvent & TouchEvent) {
 		event.stopPropagation();
+		event.preventDefault();
 		this._dragging = true;
 		this._position = this._getPosition(event);
 	}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

From what I understand, Firefox is interpreting this interaction as "the user wants to drag this image somewhere" which is more obvious in this screenshot:

![screen shot 2018-04-25 at 4 39 34 pm](https://user-images.githubusercontent.com/38750/39274363-57d603a4-48a7-11e8-9cdc-a4a20c043fe3.png)

Assuming this is the "default" interaction, I called `preventDefault()` on the event.

I'm attaching a small project [541.zip](https://github.com/dojo/widgets/files/1948922/541.zip) that should show this in action with and without `preventDefault()` applied to the event. You don't have to move your mouse particularly fast or do anything out of the ordinary. Just drag/move/drop until it happens – you don't even have to move your mouse in between drag/drops. By default, it won't apply `preventDefault()` but if you set the global `testPreventDefault = true` it will start applying this, and Firefox no longer has a problem with this interaction.

Resolves #536 
