### PR TITLE
showOutput code and tests

### DIFF
--- a/src/slider/example/index.ts
+++ b/src/slider/example/index.ts
@@ -8,6 +8,7 @@ export class App extends WidgetBase<WidgetProperties> {
 	private _tribbleValue: number | undefined;
 	private _verticalValue: number | undefined;
 	private _verticalInvalid: boolean | undefined;
+	private _outputlessValue: number | undefined;
 
 	onTribbleInput(value: number) {
 		this._tribbleValue = value;
@@ -17,6 +18,11 @@ export class App extends WidgetBase<WidgetProperties> {
 	onVerticalInput(value: number) {
 		this._verticalValue = value;
 		this._verticalInvalid = value > 50;
+		this.invalidate();
+	}
+
+	onOutputlessInput(value: number) {
+		this._outputlessValue = value;
 		this.invalidate();
 	}
 
@@ -76,6 +82,14 @@ export class App extends WidgetBase<WidgetProperties> {
 					outputIsTooltip: true,
 					onChange: this.onVerticalInput,
 					onInput: this.onVerticalInput
+				})
+			]),
+			v('h1', {}, ['Slider with no output']),
+			v('div', { id: 'example-s4' }, [
+				w(Slider, {
+					showOutput: false,
+					value: this._outputlessValue,
+					onInput: this.onOutputlessInput
 				})
 			])
 		]);

--- a/src/slider/index.ts
+++ b/src/slider/index.ts
@@ -19,6 +19,7 @@ import { customElement } from '@dojo/widget-core/decorators/customElement';
  * @property max               The maximum value for the slider
  * @property min               The minimum value for the slider
  * @property output            An optional function that returns a string or DNode for custom output format
+ * @property showOutput        Toggles visibility of slider output
  * @property step              Size of the slider increment
  * @property vertical          Orients the slider vertically, false by default.
  * @property verticalHeight    Length of the vertical slider (only used if vertical is true)
@@ -29,6 +30,7 @@ export interface SliderProperties extends ThemedProperties, LabeledProperties, I
 	min?: number;
 	output?(value: number): DNode;
 	outputIsTooltip?: boolean;
+	showOutput?: boolean;
 	step?: number;
 	vertical?: boolean;
 	verticalHeight?: string;
@@ -60,6 +62,7 @@ function extractValue(event: Event): number {
 		'min',
 		'output',
 		'outputIsTooltip',
+		'showOutput',
 		'step',
 		'vertical',
 		'value'
@@ -217,6 +220,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 			name,
 			readOnly,
 			required,
+			showOutput = true,
 			step = 1,
 			vertical = false,
 			verticalHeight = '200px',
@@ -269,7 +273,7 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 				ontouchcancel: this._onTouchCancel
 			}),
 			this.renderControls(percentValue),
-			this.renderOutput(value, percentValue)
+			showOutput ? this.renderOutput(value, percentValue) : null
 		]);
 
 		const children = [

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -13,7 +13,7 @@ import { compareId, compareForId, createHarness, MockMetaMixin, noop, stubEvent 
 const compareFor = { selector: '*', property: 'for', comparator: (property: any) => typeof property === 'string' };
 const harness = createHarness([ compareId, compareForId, compareFor ]);
 
-const expected = function(label = false, tooltip = false, overrides = {}, child = '0', progress = '0%', focused = false) {
+const expected = function(label = false, tooltip = false, overrides = {}, child = '0', progress = '0%', focused = false, showOutput = true) {
 
 	return v('div', {
 		key: 'root',
@@ -78,12 +78,12 @@ const expected = function(label = false, tooltip = false, overrides = {}, child 
 					styles: { left: progress }
 				})
 			]),
-			v('output', {
+			showOutput ? v('output', {
 				classes: [ css.output, tooltip ? css.outputTooltip : null ],
 				for: '',
 				tabIndex: -1,
 				styles: progress !== '0%' ? { left: progress } : {}
-			}, [ child ])
+			}, [ child ]) : null
 		])
 	]);
 };
@@ -118,6 +118,13 @@ registerSuite('Slider', {
 				step: '5',
 				value: '35'
 			}, 'tribbles', '50%'));
+		},
+
+		'with showOutput false'() {
+			const h = harness(() => w(Slider, {
+				showOutput: false
+			}));
+			h.expect(() => expected(undefined, undefined, {}, undefined, undefined, undefined, false));
 		},
 
 		'focussed class'() {


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue #559 
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR (I did not include a functional test because I could not find a way to test for the node NOT existing with Intern.)

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds `showOutput` option to `Slider` so you can remove the output node from the rendering. Same property as `Progress`.

Resolves #559 
