### PR TITLE
Allow custom first day of the week for calendar widget

### DIFF
--- a/src/calendar/example/index.ts
+++ b/src/calendar/example/index.ts
@@ -55,7 +55,7 @@ export class App extends WidgetBase<WidgetProperties> {
 					this.invalidate();
 				}
 			}),
-			this._selectedDate ? v('p', [ `Selected Date: ${this._selectedDate2.toDateString()}` ]) : null
+			this._selectedDate2 ? v('p', [ `Selected Date: ${this._selectedDate2.toDateString()}` ]) : null
 		]);
 	}
 }

--- a/src/calendar/example/index.ts
+++ b/src/calendar/example/index.ts
@@ -9,9 +9,14 @@ export class App extends WidgetBase<WidgetProperties> {
 	private _year: number | undefined;
 	private _selectedDate: Date | undefined;
 
+	private _month2: number | undefined;
+	private _year2: number | undefined;
+	private _selectedDate2: Date | undefined;
+
 	render() {
 		return v('div', {}, [
 			w(Calendar, {
+				key: 'calendar-start-sunday',
 				month: this._month,
 				selectedDate: this._selectedDate,
 				year: this._year,
@@ -28,7 +33,29 @@ export class App extends WidgetBase<WidgetProperties> {
 					this.invalidate();
 				}
 			}),
-			this._selectedDate ? v('p', [ `Selected Date: ${this._selectedDate.toDateString()}` ]) : null
+			this._selectedDate ? v('p', [ `Selected Date: ${this._selectedDate.toDateString()}` ]) : null,
+			v('hr'),
+			v('p', {}, ['Calendar starts on Monday']),
+			w(Calendar, {
+				key: 'calendar-start-monday',
+				month: this._month2,
+				selectedDate: this._selectedDate2,
+				firstDayOfTheWeek: 1,
+				year: this._year2,
+				onMonthChange: (month: number) => {
+					this._month2 = month;
+					this.invalidate();
+				},
+				onYearChange: (year: number) => {
+					this._year2 = year;
+					this.invalidate();
+				},
+				onDateSelect: (date: Date) => {
+					this._selectedDate2 = date;
+					this.invalidate();
+				}
+			}),
+			this._selectedDate ? v('p', [ `Selected Date: ${this._selectedDate2.toDateString()}` ]) : null
 		]);
 	}
 }

--- a/src/calendar/tests/unit/Calendar.ts
+++ b/src/calendar/tests/unit/Calendar.ts
@@ -161,6 +161,130 @@ const expected = function(popupOpen = false, selectedIndex = -1, weekdayLabel = 
 	]);
 };
 
+const expectedMondayStart = function(popupOpen = false, selectedIndex = -1, weekdayLabel = '', customMonthLabel = false, describedby = '') {
+	const overrides = describedby ? { 'aria-describedby': describedby } : {};
+	dateIndex = -1;
+	let weekdayNames = [];
+	for (let i = 0; i < DEFAULT_WEEKDAYS.length; i++) {
+		weekdayNames.push(DEFAULT_WEEKDAYS[(i + 1) % 7]);
+	}
+	return v('div', {
+		classes: css.root,
+		dir: '',
+		lang: null,
+		...overrides
+	}, [
+		w(DatePicker, {
+			key: 'date-picker',
+			labelId: '',
+			labels: DEFAULT_LABELS,
+			month: 5,
+			monthNames: DEFAULT_MONTHS,
+			renderMonthLabel: customMonthLabel ? noop : undefined,
+			theme: undefined,
+			year: 2017,
+			onPopupChange: noop,
+			onRequestMonthChange: noop,
+			onRequestYearChange: noop
+		}),
+		v('table', {
+			cellspacing: '0',
+			cellpadding: '0',
+			role: 'grid',
+			'aria-labelledby': '', // this._monthLabelId,
+			classes: [ css.dateGrid, popupOpen ? baseCss.visuallyHidden : null ]
+		}, [
+			v('thead', [
+				v('tr', weekdayNames.map((weekday: { short: string; long: string; }) => v('th', {
+						role: 'columnheader',
+						classes: css.weekday
+					}, [
+						weekdayLabel ? weekdayLabel : v('abbr', { title: weekday.long }, [ weekday.short ])
+					])
+				))
+			]),
+			v('tbody', [
+				v('tr', [
+					expectedDateCell(29, false, selectedIndex),
+					expectedDateCell(30, false, selectedIndex),
+					expectedDateCell(31, false, selectedIndex),
+					expectedDateCell(1, true, selectedIndex),
+					expectedDateCell(2, true, selectedIndex),
+					expectedDateCell(3, true, selectedIndex),
+					expectedDateCell(4, true, selectedIndex)
+				]),
+				v('tr', [
+					expectedDateCell(5, true, selectedIndex),
+					expectedDateCell(6, true, selectedIndex),
+					expectedDateCell(7, true, selectedIndex),
+					expectedDateCell(8, true, selectedIndex),
+					expectedDateCell(9, true, selectedIndex),
+					expectedDateCell(10, true, selectedIndex),
+					expectedDateCell(11, true, selectedIndex)
+				]),
+				v('tr', [
+					expectedDateCell(12, true, selectedIndex),
+					expectedDateCell(13, true, selectedIndex),
+					expectedDateCell(14, true, selectedIndex),
+					expectedDateCell(15, true, selectedIndex),
+					expectedDateCell(16, true, selectedIndex),
+					expectedDateCell(17, true, selectedIndex),
+					expectedDateCell(18, true, selectedIndex)
+				]),
+				v('tr', [
+					expectedDateCell(19, true, selectedIndex),
+					expectedDateCell(20, true, selectedIndex),
+					expectedDateCell(21, true, selectedIndex),
+					expectedDateCell(22, true, selectedIndex),
+					expectedDateCell(23, true, selectedIndex),
+					expectedDateCell(24, true, selectedIndex),
+					expectedDateCell(25, true, selectedIndex)
+				]),
+				v('tr', [
+					expectedDateCell(26, true, selectedIndex),
+					expectedDateCell(27, true, selectedIndex),
+					expectedDateCell(28, true, selectedIndex),
+					expectedDateCell(29, true, selectedIndex),
+					expectedDateCell(30, true, selectedIndex),
+					expectedDateCell(1, false, selectedIndex),
+					expectedDateCell(2, false, selectedIndex)
+				]),
+				v('tr', [
+					expectedDateCell(3, false, selectedIndex),
+					expectedDateCell(4, false, selectedIndex),
+					expectedDateCell(5, false, selectedIndex),
+					expectedDateCell(6, false, selectedIndex),
+					expectedDateCell(7, false, selectedIndex),
+					expectedDateCell(8, false, selectedIndex),
+					expectedDateCell(9, false, selectedIndex)
+				])
+			])
+		]),
+		v('div', {
+			classes: [ css.controls, popupOpen ? baseCss.visuallyHidden : null ]
+		}, [
+			v('button', {
+				classes: css.previous,
+				tabIndex: popupOpen ? -1 : 0,
+				type: 'button',
+				onclick: noop
+			}, [
+				w(Icon, { type: 'leftIcon', theme: undefined }),
+				v('span', { classes: [ baseCss.visuallyHidden ] }, [ 'Previous Month' ])
+			]),
+			v('button', {
+				classes: css.next,
+				tabIndex: popupOpen ? -1 : 0,
+				type: 'button',
+				onclick: noop
+			}, [
+				w(Icon, { type: 'rightIcon', theme: undefined }),
+				v('span', { classes: [ baseCss.visuallyHidden ] }, [ 'Next Month' ])
+			])
+		])
+	]);
+};
+
 registerSuite('Calendar', {
 	tests: {
 		'Render specific month with default props'() {
@@ -169,6 +293,15 @@ registerSuite('Calendar', {
 				year: testDate.getFullYear()
 			}));
 			h.expect(expected);
+		},
+
+		'Render month with a Monday firstDayOfTheWeek'() {
+			const h = harness(() => w(Calendar, {
+				month: testDate.getMonth(),
+				year: testDate.getFullYear(),
+				firstDayOfTheWeek: 1
+			}));
+			h.expect(expectedMondayStart);
 		},
 
 		'Render specific month and year with selectedDate'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #539 

This does not address locale first day of the week as suggested by @dylans, but the functionality to set the start date now exists so it would just be a matter of tying things to the locale data as it is available.
