### PR TITLE
Fix loader path and i18n properties to fix failing tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widgets",
-  "version": "2.0.0",
+  "version": "2.0.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -15,7 +15,7 @@
         "configstore": "3.1.2",
         "cross-spawn": "5.1.0",
         "detect-indent": "5.0.0",
-        "ejs": "2.5.9",
+        "ejs": "2.6.1",
         "execa": "0.8.0",
         "fs-extra": "5.0.0",
         "globby": "6.1.0",
@@ -47,9 +47,9 @@
       }
     },
     "@dojo/cli-build-widget": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/@dojo/cli-build-widget/-/cli-build-widget-2.0.0.tgz",
-      "integrity": "sha512-ASk9D0bVFln7virIr34TPV7kLyMEtQZOsRL94CFMIiKIqyVfnwrfBiqww4TxbuE2gN7X+tCI4xS8e5uXzw77ug==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/@dojo/cli-build-widget/-/cli-build-widget-2.0.2.tgz",
+      "integrity": "sha512-Vb7CplmVtmIOl6YMZg6R1pUttrDGa8l6lDDwTuXYj/5zrjrO43Uai1j07Igu2AaQ8pcEvFGrRC7mcC5zHmvGUg==",
       "dev": true,
       "requires": {
         "@dojo/has": "2.0.0",
@@ -74,7 +74,7 @@
         "optimize-css-assets-webpack-plugin": "3.2.0",
         "ora": "1.3.0",
         "pkg-dir": "2.0.0",
-        "postcss-cssnext": "3.0.2",
+        "postcss-cssnext": "3.1.0",
         "postcss-import": "11.0.0",
         "postcss-loader": "2.0.8",
         "slash": "1.0.0",
@@ -115,7 +115,7 @@
             "array-union": "1.0.2",
             "dir-glob": "2.0.0",
             "glob": "7.1.2",
-            "ignore": "3.3.8",
+            "ignore": "3.3.10",
             "pify": "3.0.0",
             "slash": "1.0.0"
           }
@@ -217,12 +217,6 @@
         "typescript": "2.6.2"
       }
     },
-    "@std/esm": {
-      "version": "0.19.7",
-      "resolved": "https://registry.npmjs.org/@std/esm/-/esm-0.19.7.tgz",
-      "integrity": "sha512-bPBbpu1vqgOOD70aMVG5tgioPdttKXQQFq6xodjZxVbPprtZIcm8NcTEJoB+/1QoH8z1TIqjaEN1Wm3YndnfNQ==",
-      "dev": true
-    },
     "@theintern/digdug": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.0.4.tgz",
@@ -270,7 +264,7 @@
       "integrity": "sha512-Iwrn+9v+OvLXJkvOR6IuxzYaLaG02XtlDiguArHxQZhQkRFXKf1edlAhUvbE886UKM5q4KIaB9NG7F7Ikjy8TA==",
       "dev": true,
       "requires": {
-        "@types/istanbul-lib-instrument": "1.7.1",
+        "@types/istanbul-lib-instrument": "1.7.2",
         "@types/source-map": "0.5.7",
         "@types/webpack": "3.0.14",
         "source-map": "0.5.7"
@@ -320,9 +314,9 @@
       }
     },
     "@types/babel-types": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.1.tgz",
-      "integrity": "sha512-EkcOk09rjhivbovP8WreGRbXW20YRfe/qdgXOGq3it3u3aAOWDRNsQhL/XPAWFF7zhZZ+uR+nT+3b+TCkIap1w==",
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/@types/babel-types/-/babel-types-7.0.4.tgz",
+      "integrity": "sha512-WiZhq3SVJHFRgRYLXvpf65XnV6ipVHhnNaNvE8yCimejrGglkg38kEj0JcizqwSHxmPSjcTlig/6JouxLGEhGw==",
       "dev": true
     },
     "@types/benchmark": {
@@ -338,7 +332,7 @@
       "dev": true,
       "requires": {
         "@types/connect": "3.4.32",
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.22"
       }
     },
     "@types/chai": {
@@ -353,7 +347,7 @@
       "integrity": "sha512-F9OalGhk60p/DnACfa1SWtmVTMni0+w9t/qfb5Bu7CsurkEjZFN7Z+ii/VGmYpaViPz7o3tBahRQae9O7skFlQ==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.22"
       }
     },
     "@types/connect": {
@@ -362,7 +356,7 @@
       "integrity": "sha512-4r8qa0quOvh7lGD0pre62CAb1oni1OO6ecJLGCezTmhQ8Fz50Arx9RUszryR8KlgK6avuSXvviL6yWyViQABOg==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.22"
       }
     },
     "@types/diff": {
@@ -383,7 +377,7 @@
       "integrity": "sha512-7dsoPp7r33mdPcxukSrs9WVQgI96fiqffC7K4XvXJnSrTtJov3x1CJUgid7msJ8yCbfkmXJoKJ3HXyQIwZD0NQ==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.22"
       }
     },
     "@types/express": {
@@ -393,18 +387,19 @@
       "dev": true,
       "requires": {
         "@types/body-parser": "1.17.0",
-        "@types/express-serve-static-core": "4.11.1",
+        "@types/express-serve-static-core": "4.16.0",
         "@types/serve-static": "1.13.2"
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.11.1",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.11.1.tgz",
-      "integrity": "sha512-EehCl3tpuqiM8RUb+0255M8PhhSwTtLfmO7zBBdv0ay/VTd/zmrqDfQdZFsa5z/PVMbH2yCMZPXsnrImpATyIw==",
+      "version": "4.16.0",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.0.tgz",
+      "integrity": "sha512-lTeoCu5NxJU4OD9moCgm0ESZzweAx0YqsAcab6OB0EB3+As1OaHtKnaGJvcngQxYsi9UNv0abn4/DRavrRxt4w==",
       "dev": true,
       "requires": {
         "@types/events": "1.2.0",
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.22",
+        "@types/range-parser": "1.2.2"
       }
     },
     "@types/fs-extra": {
@@ -413,7 +408,7 @@
       "integrity": "sha1-qHGcQXsIDAEtNJeyjiKKwJdF/fI=",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.22"
       }
     },
     "@types/glob": {
@@ -424,28 +419,28 @@
       "requires": {
         "@types/events": "1.2.0",
         "@types/minimatch": "3.0.3",
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.22"
       }
     },
     "@types/grunt": {
-      "version": "0.4.22",
-      "resolved": "https://registry.npmjs.org/@types/grunt/-/grunt-0.4.22.tgz",
-      "integrity": "sha512-fKrWJ+uFq9j3tP2RLm9cY7Z50LhhPnSHQCliCZP5lPAWC7TydnU+BcLR0KQIHe9Gbn1oGfkRIq3u56MNCC1qyw==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/@types/grunt/-/grunt-0.4.23.tgz",
+      "integrity": "sha512-tg7GE1d3GiT2yOsP6GlFmkii8+z15X8GNvlAoupAgP4McSfYQjYRTltpNrS1sX9n/ANUN2mnUmoqsGUCwNkg2g==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.22"
       }
     },
     "@types/handlebars": {
-      "version": "4.0.37",
-      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.37.tgz",
-      "integrity": "sha512-c/g99PQsJEFYdK3LT1qgPAZ61fu/oFOaEhov/6ZuUNMi1xQFbAOSThlX8fAQLf+QoGXtyv4S39OjIRXf3HkBtw==",
+      "version": "4.0.38",
+      "resolved": "https://registry.npmjs.org/@types/handlebars/-/handlebars-4.0.38.tgz",
+      "integrity": "sha512-oMzU0D7jDp+H2go/i0XqBHfr+HEhYD/e1TvkhHi3yrhQm/7JFR8FJMdvoH76X8G1FBpgc6Pwi+QslCJBeJ1N9g==",
       "dev": true
     },
     "@types/highlight.js": {
-      "version": "9.12.2",
-      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.2.tgz",
-      "integrity": "sha512-y5x0XD/WXDaGSyiTaTcKS4FurULJtSiYbGTeQd0m2LYZGBcZZ/7fM6t5H/DzeUF+kv8y6UfmF6yJABQsHcp9VQ==",
+      "version": "9.12.3",
+      "resolved": "https://registry.npmjs.org/@types/highlight.js/-/highlight.js-9.12.3.tgz",
+      "integrity": "sha512-pGF/zvYOACZ/gLGWdQH8zSwteQS1epp68yRcVLJMgUck/MjEn/FBYmPub9pXT8C1e4a8YZfHo1CKyV8q1vKUnQ==",
       "dev": true
     },
     "@types/http-errors": {
@@ -467,12 +462,12 @@
       "dev": true
     },
     "@types/istanbul-lib-instrument": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.1.tgz",
-      "integrity": "sha512-Ll2qAzv7NItqVliZZ8OMAgAvGstddK2995/7X5YPU84lD3CFnqDfP4sTu5Q1GKReh5Ttw3shKR2e3Fe6Xo0C7A==",
+      "version": "1.7.2",
+      "resolved": "https://registry.npmjs.org/@types/istanbul-lib-instrument/-/istanbul-lib-instrument-1.7.2.tgz",
+      "integrity": "sha512-SWIpdKneXqThfrKIokt9dXSPeslS2NWcxhtr+/a2+N81aLyOMAsVTMmwaKuCoEahcI0FfhY3/79AR6Vilk9i8A==",
       "dev": true,
       "requires": {
-        "@types/babel-types": "7.0.1",
+        "@types/babel-types": "7.0.4",
         "@types/istanbul-lib-coverage": "1.1.0",
         "source-map": "0.6.1"
       }
@@ -513,9 +508,9 @@
       "dev": true
     },
     "@types/lodash": {
-      "version": "4.14.108",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.108.tgz",
-      "integrity": "sha512-WD2vUOKfBBVHxWUV9iMR9RMfpuf8HquxWeAq2yqGVL7Nc4JW2+sQama0pREMqzNI3Tutj0PyxYUJwuoxxvX+xA==",
+      "version": "4.14.110",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.110.tgz",
+      "integrity": "sha512-iXYLa6olt4tnsCA+ZXeP6eEW3tk1SulWeYyP/yooWfAtXjozqXgtX4+XUtMuOCfYjKGz3F34++qUc3Q+TJuIIw==",
       "dev": true
     },
     "@types/marked": {
@@ -543,9 +538,9 @@
       "dev": true
     },
     "@types/node": {
-      "version": "9.6.8",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.8.tgz",
-      "integrity": "sha512-0PmgMBskTJa7zDyENW9C7Lunk+I0L2CHYF2RrBRljCmLSMM1fBHIIdvE1IboNNz7N6t+raJIj90YMvUYl2VT1g==",
+      "version": "9.6.22",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.22.tgz",
+      "integrity": "sha512-RIg9EkxzVMkNH0M4sLRngK23f5QiigJC0iODQmu4nopzstt8AjegYund3r82iMrd2BNCjcZVnklaItvKHaGfBA==",
       "dev": true
     },
     "@types/platform": {
@@ -554,13 +549,19 @@
       "integrity": "sha512-XI6JKLFNBmkADRd2FtUYtEuq5LDKTNXwUIodV3ZfTNkA+g4yo+rXXXdZL3fTE24S92BjpiEVaL3f64Fxm2JOgg==",
       "dev": true
     },
+    "@types/range-parser": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.2.tgz",
+      "integrity": "sha512-HtKGu+qG1NPvYe1z7ezLsyIaXYyi8SoAVqWDZgDQ8dLrsZvSzUNCwZyfX33uhWxL/SU0ZDQZ3nwZ0nimt507Kw==",
+      "dev": true
+    },
     "@types/resolve": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-0.0.4.tgz",
       "integrity": "sha1-m1htZalH3qiMS8JNoLkF/pUgoNU=",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.22"
       }
     },
     "@types/serve-static": {
@@ -569,7 +570,7 @@
       "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
       "dev": true,
       "requires": {
-        "@types/express-serve-static-core": "4.11.1",
+        "@types/express-serve-static-core": "4.16.0",
         "@types/mime": "2.0.0"
       }
     },
@@ -585,7 +586,7 @@
       "integrity": "sha1-32E73biCJe0JzlyDX2INyq8VXms=",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.22"
       }
     },
     "@types/sinon": {
@@ -610,9 +611,9 @@
       "dev": true
     },
     "@types/tapable": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.2.tgz",
-      "integrity": "sha512-42zEJkBpNfMEAvWR5WlwtTH22oDzcMjFsL9gDGExwF8X8WvAiw7Vwop7hPw03QT8TKfec83LwbHj6SvpqM4ELQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.3.tgz",
+      "integrity": "sha512-yz2OUW/HSKZnA2/hdxg5xoHxLbnzAbl1g5UW1eAJSYxVl2BmwKHt72w7Lfl4RU+BL/OWp/cGfSw+GPdN5kfqYg==",
       "dev": true
     },
     "@types/uglify-js": {
@@ -630,8 +631,8 @@
       "integrity": "sha512-HkN9be7+47PsMH+WjnhtoOpypaUgmpgggwL/P0r8fT7mzuw7c4cpho8eTsnrMz9Fdj35TBnqRcuxG/U7ZcDRJg==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8",
-        "@types/tapable": "1.0.2",
+        "@types/node": "9.6.22",
+        "@types/tapable": "1.0.3",
         "@types/uglify-js": "3.0.2"
       }
     },
@@ -641,7 +642,7 @@
       "integrity": "sha512-+30f9gcx24GZRD9EqqiQM+I5pRf/MJiJoEqp2X62QRwfEjdqyn9mPmjxZAEXBUVunWotE5qkadIPqf2MMcDYNw==",
       "dev": true,
       "requires": {
-        "@types/node": "9.6.8"
+        "@types/node": "9.6.22"
       }
     },
     "@types/yargs": {
@@ -673,9 +674,9 @@
       }
     },
     "acorn": {
-      "version": "5.5.3",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.5.3.tgz",
-      "integrity": "sha512-jd5MkIUlbbmb07nXH0DT3y7rDVtkzDi4XZOUVWAer8ajmF/DTSSbl5oNFyDOl/OXA33Bl79+ypHhl2pN20VeOQ==",
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-5.7.1.tgz",
+      "integrity": "sha512-d+nbxBUGKg7Arpsvbnlq61mc12ek3EY8EQldM3GPAhWJ1UVxC6TDGbIvUMNU6obBX3i1+ptCIzV4vq0gFPEGVQ==",
       "dev": true
     },
     "acorn-dynamic-import": {
@@ -701,7 +702,7 @@
       "integrity": "sha512-KjZwU26uG3u6eZcfGbTULzFcsoz6pegNKtHPksZPOUsiKo5bUmiBPa38FuHZ/Eun+XYh/JCCkS9AS3Lu4McQOQ==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3"
+        "acorn": "5.7.1"
       }
     },
     "agent-base": {
@@ -806,7 +807,7 @@
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
       "dev": true,
       "requires": {
-        "color-convert": "1.9.1"
+        "color-convert": "1.9.2"
       }
     },
     "ansi-wrap": {
@@ -975,6 +976,23 @@
       "dev": true,
       "requires": {
         "util": "0.10.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
+          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
+          "dev": true
+        },
+        "util": {
+          "version": "0.10.3",
+          "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
+          "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+          "dev": true,
+          "requires": {
+            "inherits": "2.0.1"
+          }
+        }
       }
     },
     "assert-plus": {
@@ -1002,9 +1020,9 @@
       "dev": true
     },
     "async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
-      "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/async/-/async-2.6.1.tgz",
+      "integrity": "sha512-fNEiL2+AZt6AlAw/29Cr0UDe4sRAHCpEHh54WMz+Bb7QfNcFw4h3loofyJpLeQs4Yx7yuqu/2dLgM5hKOs6HlQ==",
       "dev": true,
       "requires": {
         "lodash": "4.17.10"
@@ -1041,7 +1059,7 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000833",
+        "caniuse-db": "1.0.30000862",
         "normalize-range": "0.1.2",
         "num2fraction": "1.2.2",
         "postcss": "5.2.18",
@@ -1094,7 +1112,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -1244,7 +1262,7 @@
       "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
       "dev": true,
       "requires": {
-        "core-js": "2.5.5",
+        "core-js": "2.5.7",
         "regenerator-runtime": "0.11.1"
       }
     },
@@ -1370,9 +1388,9 @@
       "dev": true
     },
     "bcrypt-pbkdf": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.1.tgz",
-      "integrity": "sha1-Y7xdy2EzG5K8Bf1SiVPDNGKgb40=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
+      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
       "dev": true,
       "optional": true,
       "requires": {
@@ -1448,6 +1466,42 @@
       "integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
       "dev": true
     },
+    "body": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/body/-/body-5.1.0.tgz",
+      "integrity": "sha1-5LoM5BCkaTYyM2dgnstOZVMSUGk=",
+      "dev": true,
+      "requires": {
+        "continuable-cache": "0.3.1",
+        "error": "7.0.2",
+        "raw-body": "1.1.7",
+        "safe-json-parse": "1.0.1"
+      },
+      "dependencies": {
+        "bytes": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/bytes/-/bytes-1.0.0.tgz",
+          "integrity": "sha1-NWnt6Lo0MV+rmcPpLLBMciDeH6g=",
+          "dev": true
+        },
+        "raw-body": {
+          "version": "1.1.7",
+          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-1.1.7.tgz",
+          "integrity": "sha1-HQJ8K/oRasxmI7yo8AAWVyqH1CU=",
+          "dev": true,
+          "requires": {
+            "bytes": "1.0.0",
+            "string_decoder": "0.10.31"
+          }
+        },
+        "string_decoder": {
+          "version": "0.10.31",
+          "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+          "integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ=",
+          "dev": true
+        }
+      }
+    },
     "body-parser": {
       "version": "1.18.2",
       "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.18.2.tgz",
@@ -1471,6 +1525,12 @@
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
           "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
           "dev": true
+        },
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
         }
       }
     },
@@ -1481,12 +1541,12 @@
       "dev": true
     },
     "boom": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/boom/-/boom-4.3.1.tgz",
-      "integrity": "sha1-T4owBctKfjiJ90kDD9JbluAdLjE=",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
+      "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
       "dev": true,
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "0.9.1"
       }
     },
     "boxen": {
@@ -1613,8 +1673,8 @@
       "integrity": "sha1-C9dnBCWL6CmyOYu1Dkti0aFmsLk=",
       "dev": true,
       "requires": {
-        "caniuse-db": "1.0.30000833",
-        "electron-to-chromium": "1.3.45"
+        "caniuse-db": "1.0.30000862",
+        "electron-to-chromium": "1.3.50"
       }
     },
     "buffer": {
@@ -1624,24 +1684,24 @@
       "dev": true,
       "requires": {
         "base64-js": "1.3.0",
-        "ieee754": "1.1.11",
+        "ieee754": "1.1.12",
         "isarray": "1.0.0"
       }
     },
     "buffer-alloc": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.1.0.tgz",
-      "integrity": "sha1-BVFNM78WVtNUDGhPZbEgLpDsowM=",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
       "dev": true,
       "requires": {
-        "buffer-alloc-unsafe": "0.1.1",
-        "buffer-fill": "0.1.1"
+        "buffer-alloc-unsafe": "1.1.0",
+        "buffer-fill": "1.0.0"
       }
     },
     "buffer-alloc-unsafe": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-0.1.1.tgz",
-      "integrity": "sha1-/+H2dVHdBVc33iUzN7/oU9+rGmo=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
       "dev": true
     },
     "buffer-crc32": {
@@ -1651,15 +1711,15 @@
       "dev": true
     },
     "buffer-fill": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-0.1.1.tgz",
-      "integrity": "sha512-YgBMBzdRLEfgxJIGu2wrvI2E03tMCFU1p7d1KhB4BOoMN0VxmTFjSyN5JtKt9z8Z9JajMHruI6SE25W96wNv7Q==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
       "dev": true
     },
     "buffer-from": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.0.0.tgz",
-      "integrity": "sha512-83apNb8KK0Se60UE1+4Ukbe3HbfELJ6UlI4ldtOGs7So4KD26orJM8hIY9lxdzP+UpItH1Yh/Y8GUvNFWFFRxA==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.0.tgz",
+      "integrity": "sha512-c5mRlguI/Pe2dSZmpER62rSCu0ryKmWddzRYsuXc50U2/g8jMOulc31VZMa4mYx31U5xsmSOpDCgH88Vl9cDGQ==",
       "dev": true
     },
     "buffer-xor": {
@@ -1696,7 +1756,7 @@
         "chownr": "1.0.1",
         "glob": "7.1.2",
         "graceful-fs": "4.1.11",
-        "lru-cache": "4.1.2",
+        "lru-cache": "4.1.3",
         "mississippi": "2.0.0",
         "mkdirp": "0.5.1",
         "move-concurrently": "1.0.1",
@@ -1779,21 +1839,21 @@
       "dev": true,
       "requires": {
         "browserslist": "1.7.7",
-        "caniuse-db": "1.0.30000833",
+        "caniuse-db": "1.0.30000862",
         "lodash.memoize": "4.1.2",
         "lodash.uniq": "4.5.0"
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000833",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000833.tgz",
-      "integrity": "sha1-K9e+cqQBZY0svLj012AN7r6xxnY=",
+      "version": "1.0.30000862",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000862.tgz",
+      "integrity": "sha1-bB4pb4u+Xl6kbwQhXouQ7Y+52o0=",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000833",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000833.tgz",
-      "integrity": "sha512-tKNuKu4WLImh4NxoTgntxFpDrRiA0Q6Q1NycNhuMST0Kx+Pt8YnRDW6V8xsyH6AtO2CpAoibatEk5eaEhP3O1g==",
+      "version": "1.0.30000862",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000862.tgz",
+      "integrity": "sha512-e9DBeH0Oby7EbUQN3DRWKxgbpEJO3KAZUhP0xDmPA23Qr6PmvXI7Ojy8ZthsOsz+1iSoaV9G7eWJXUOyryJ6NA==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -1872,7 +1932,7 @@
       "requires": {
         "anymatch": "1.3.2",
         "async-each": "1.0.1",
-        "fsevents": "1.2.3",
+        "fsevents": "1.2.4",
         "glob-parent": "2.0.0",
         "inherits": "2.0.3",
         "is-binary-path": "1.0.1",
@@ -2150,15 +2210,6 @@
           "dev": true,
           "optional": true
         },
-        "boom": {
-          "version": "0.4.2",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-0.4.2.tgz",
-          "integrity": "sha1-emNune1O/O+xnO9JR6PGffrukRs=",
-          "dev": true,
-          "requires": {
-            "hoek": "0.9.1"
-          }
-        },
         "caseless": {
           "version": "0.6.0",
           "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.6.0.tgz",
@@ -2173,16 +2224,6 @@
           "optional": true,
           "requires": {
             "delayed-stream": "0.0.5"
-          }
-        },
-        "cryptiles": {
-          "version": "0.2.2",
-          "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
-          "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "0.4.2"
           }
         },
         "delayed-stream": {
@@ -2209,25 +2250,6 @@
             "combined-stream": "0.0.7",
             "mime": "1.2.11"
           }
-        },
-        "hawk": {
-          "version": "1.1.1",
-          "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
-          "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "boom": "0.4.2",
-            "cryptiles": "0.2.2",
-            "hoek": "0.9.1",
-            "sntp": "0.2.4"
-          }
-        },
-        "hoek": {
-          "version": "0.9.1",
-          "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
-          "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
-          "dev": true
         },
         "http-signature": {
           "version": "0.10.1",
@@ -2285,19 +2307,9 @@
             "node-uuid": "1.4.8",
             "oauth-sign": "0.4.0",
             "qs": "1.2.2",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
+            "stringstream": "0.0.6",
+            "tough-cookie": "2.4.3",
             "tunnel-agent": "0.4.3"
-          }
-        },
-        "sntp": {
-          "version": "0.2.4",
-          "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
-          "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
-          "dev": true,
-          "optional": true,
-          "requires": {
-            "hoek": "0.9.1"
           }
         },
         "tunnel-agent": {
@@ -2331,23 +2343,23 @@
       "dev": true,
       "requires": {
         "clone": "1.0.4",
-        "color-convert": "1.9.1",
+        "color-convert": "1.9.2",
         "color-string": "0.3.0"
       }
     },
     "color-convert": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
-      "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
+      "version": "1.9.2",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.2.tgz",
+      "integrity": "sha512-3NUJZdhMhcdPn8vJ9v2UQJoH0qqoGUkYTgFEPZaPjEtwmmKUfNV46zZmgB2M5M4DCEQHMaCfWHCxiBflLm04Tg==",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "1.1.1"
       }
     },
     "color-name": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.1.tgz",
+      "integrity": "sha1-SxQVMEz1ACjqgWQ2Q72C6gWANok=",
       "dev": true
     },
     "color-string": {
@@ -2356,7 +2368,7 @@
       "integrity": "sha1-J9RvtnAlxcL6JZk7+/V55HhBuZE=",
       "dev": true,
       "requires": {
-        "color-name": "1.1.3"
+        "color-name": "1.1.1"
       }
     },
     "colormin": {
@@ -2367,7 +2379,7 @@
       "requires": {
         "color": "0.11.4",
         "css-color-names": "0.0.4",
-        "has": "1.0.1"
+        "has": "1.0.3"
       }
     },
     "colors": {
@@ -2386,9 +2398,9 @@
       }
     },
     "commander": {
-      "version": "2.15.1",
-      "resolved": "https://registry.npmjs.org/commander/-/commander-2.15.1.tgz",
-      "integrity": "sha512-VlfT9F3V0v+jr4yxPc5gg9s62/fIVWsd2Bk2iD435um1NlGMYdVCq+MjcXnhYq2icNOizHr1kK+5TI6H0Hy0ag==",
+      "version": "2.16.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-2.16.0.tgz",
+      "integrity": "sha512-sVXqklSaotK9at437sFlFpyOcJonxe0yST/AG9DkQKUdIE6IqGIMv4SfAQSKaJbSdVEJYItASCrBiVQHq1HQew==",
       "dev": true
     },
     "commondir": {
@@ -2415,7 +2427,7 @@
       "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
       "dev": true,
       "requires": {
-        "buffer-from": "1.0.0",
+        "buffer-from": "1.1.0",
         "inherits": "2.0.3",
         "readable-stream": "2.3.6",
         "typedarray": "0.0.6"
@@ -2429,7 +2441,7 @@
       "requires": {
         "dot-prop": "4.2.0",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "unique-string": "1.0.0",
         "write-file-atomic": "2.3.0",
         "xdg-basedir": "3.0.0"
@@ -2466,6 +2478,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/content-type-parser/-/content-type-parser-1.0.2.tgz",
       "integrity": "sha512-lM4l4CnMEwOLHAHr/P6MEZwZFPJFtAAKgL6pogbXmVZggIqXhdB6RbBtPOTsw2FcXwYhehRGERJmRrjOiIB8pQ==",
+      "dev": true
+    },
+    "continuable-cache": {
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/continuable-cache/-/continuable-cache-0.3.1.tgz",
+      "integrity": "sha1-vXJ6f67XfnH/OYWskzUakSczrQ8=",
       "dev": true
     },
     "cookie": {
@@ -2566,9 +2584,9 @@
       }
     },
     "core-js": {
-      "version": "2.5.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+      "version": "2.5.7",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.7.tgz",
+      "integrity": "sha512-RszJCAxg/PP6uzXVXL6BsxSXx/B05oJAQ2vkJRjyjrEcNVycaqOmNb5OTxZPE3xa5gwZduqza6L9JOCenh/Ecw==",
       "dev": true
     },
     "core-util-is": {
@@ -2601,9 +2619,9 @@
       }
     },
     "create-ecdh": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.1.tgz",
-      "integrity": "sha512-iZvCCg8XqHQZ1ioNBTzXS/cQSkqkqcPs8xSX4upNB+DAk9Ht3uzQf2J32uAHNCne8LDmKr29AgZrEs4oIrwLuQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.3.tgz",
+      "integrity": "sha512-GbEHQPMOswGpKXM9kCWVrremUcBmjteUaQ01T9rkKCPDXfUHX0IoP9LpHYo2NPFampa4e+/pFDc3jQdxrxQLaw==",
       "dev": true,
       "requires": {
         "bn.js": "4.11.8",
@@ -2652,9 +2670,9 @@
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.2",
+        "lru-cache": "4.1.3",
         "shebang-command": "1.2.0",
-        "which": "1.3.0"
+        "which": "1.3.1"
       }
     },
     "cross-spawn-async": {
@@ -2663,28 +2681,18 @@
       "integrity": "sha1-hF/wwINKPe2dFg2sptOQkGuyiMw=",
       "dev": true,
       "requires": {
-        "lru-cache": "4.1.2",
-        "which": "1.3.0"
+        "lru-cache": "4.1.3",
+        "which": "1.3.1"
       }
     },
     "cryptiles": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-3.1.2.tgz",
-      "integrity": "sha1-qJ+7Ig9c4l7FboxKqKT9e1sNKf4=",
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/cryptiles/-/cryptiles-0.2.2.tgz",
+      "integrity": "sha1-7ZH/HxetE9N0gohZT4pIoNJvMlw=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "boom": "5.2.0"
-      },
-      "dependencies": {
-        "boom": {
-          "version": "5.2.0",
-          "resolved": "https://registry.npmjs.org/boom/-/boom-5.2.0.tgz",
-          "integrity": "sha512-Z5BTk6ZRe4tXXQlkqftmsAUANpXmuwlsF5Oov8ThoMbQRzdGTA1ngYRW160GexgOgjsFOKJz0LYhoNi+2AMBUw==",
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
-        }
+        "boom": "0.4.2"
       }
     },
     "crypto-browserify": {
@@ -2695,7 +2703,7 @@
       "requires": {
         "browserify-cipher": "1.0.1",
         "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.1",
+        "create-ecdh": "4.0.3",
         "create-hash": "1.2.0",
         "create-hmac": "1.1.7",
         "diffie-hellman": "5.0.3",
@@ -2746,7 +2754,7 @@
       "requires": {
         "inherits": "2.0.3",
         "source-map": "0.1.43",
-        "source-map-resolve": "0.5.1",
+        "source-map-resolve": "0.5.2",
         "urix": "0.1.0"
       },
       "dependencies": {
@@ -2864,7 +2872,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -2972,7 +2980,7 @@
         "autoprefixer": "6.7.7",
         "decamelize": "1.2.0",
         "defined": "1.0.0",
-        "has": "1.0.1",
+        "has": "1.0.3",
         "object-assign": "4.1.1",
         "postcss": "5.2.18",
         "postcss-calc": "5.3.1",
@@ -2983,7 +2991,7 @@
         "postcss-discard-empty": "2.1.0",
         "postcss-discard-overridden": "0.1.1",
         "postcss-discard-unused": "2.2.3",
-        "postcss-filter-plugins": "2.0.2",
+        "postcss-filter-plugins": "2.0.3",
         "postcss-merge-idents": "2.1.7",
         "postcss-merge-longhand": "2.0.2",
         "postcss-merge-rules": "2.1.2",
@@ -3049,7 +3057,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -3099,9 +3107,9 @@
       }
     },
     "cssom": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.2.tgz",
-      "integrity": "sha1-uANhcMefB6kP8vFuIihAJ6JDhIs=",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.4.tgz",
+      "integrity": "sha512-+7prCSORpXNeR4/fUP3rL+TzqtiFfhMvTd7uEqMdgPvLPt4+uzFUeufx5RHjGTACCargg/DiEt/moMQmvnfkog==",
       "dev": true
     },
     "cssstyle": {
@@ -3110,7 +3118,7 @@
       "integrity": "sha1-VBCXI0yyUTyDzu06zdwn/yeYfVQ=",
       "dev": true,
       "requires": {
-        "cssom": "0.3.2"
+        "cssom": "0.3.4"
       }
     },
     "ctype": {
@@ -3141,7 +3149,7 @@
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
       "dev": true,
       "requires": {
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.45"
       }
     },
     "dashdash": {
@@ -3209,7 +3217,7 @@
         "decompress-targz": "4.1.1",
         "decompress-unzip": "4.0.1",
         "graceful-fs": "4.1.11",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "pify": "2.3.0",
         "strip-dirs": "2.1.0"
       },
@@ -3230,7 +3238,7 @@
       "requires": {
         "file-type": "5.2.0",
         "is-stream": "1.1.0",
-        "tar-stream": "1.6.0"
+        "tar-stream": "1.6.1"
       }
     },
     "decompress-tarbz2": {
@@ -3274,7 +3282,7 @@
         "file-type": "3.9.0",
         "get-stream": "2.3.1",
         "pify": "2.3.0",
-        "yauzl": "2.9.1"
+        "yauzl": "2.10.0"
       },
       "dependencies": {
         "file-type": {
@@ -3317,9 +3325,9 @@
       "dev": true
     },
     "deep-extend": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.5.1.tgz",
-      "integrity": "sha512-N8vBdOa+DF7zkRrDCsaOXoCs/E2fJfx9B9MrKnnSiHNh4ws7eSys6YQE4KvT1cecKmOASYQBhbKjeuDD9lT81w==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
       "dev": true
     },
     "deep-is": {
@@ -3355,7 +3363,7 @@
       "dev": true,
       "requires": {
         "foreach": "2.0.5",
-        "object-keys": "1.0.11"
+        "object-keys": "1.0.12"
       }
     },
     "define-property": {
@@ -3621,9 +3629,9 @@
       "dev": true
     },
     "duplexify": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.5.4.tgz",
-      "integrity": "sha512-JzYSLYMhoVVBe8+mbHQ4KgpvHpm0DZpJuL8PY93Vyv1fW7jYJ90LoXa1di/CVbJM+TgMs91rbDapE/RNIfnJsA==",
+      "version": "3.6.0",
+      "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.6.0.tgz",
+      "integrity": "sha512-fO3Di4tBKJpYTFHAxTU00BcfWMY9w24r/x21a6rZRbsD/ToUgGxsMbiGRmB7uVAXeGKXD9MwiLZa5E97EVgIRQ==",
       "dev": true,
       "requires": {
         "end-of-stream": "1.4.1",
@@ -3649,15 +3657,15 @@
       "dev": true
     },
     "ejs": {
-      "version": "2.5.9",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.5.9.tgz",
-      "integrity": "sha512-GJCAeDBKfREgkBtgrYSf9hQy9kTb3helv0zGdzqhM7iAkW8FA/ZF97VQDbwFiwIT8MQLLOe5VlPZOEvZAqtUAQ==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-2.6.1.tgz",
+      "integrity": "sha512-0xy4A/twfrRCnkhfk8ErDi5DqdAsAqeGxht4xkCUrsvhhbQNs7E+4jV0CN7+NKIY0aHE72+XvqtBIXzD31ZbXQ==",
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.45",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.45.tgz",
-      "integrity": "sha1-RYrBscXHYM6IEaFtK/vZfsMLr7g=",
+      "version": "1.3.50",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.50.tgz",
+      "integrity": "sha1-dDi3b5K0G5GfP73TUPvQdX2s3fc=",
       "dev": true
     },
     "elliptic": {
@@ -3668,7 +3676,7 @@
       "requires": {
         "bn.js": "4.11.8",
         "brorand": "1.1.0",
-        "hash.js": "1.1.3",
+        "hash.js": "1.1.4",
         "hmac-drbg": "1.0.1",
         "inherits": "2.0.3",
         "minimalistic-assert": "1.0.1",
@@ -3723,19 +3731,37 @@
         "prr": "1.0.1"
       }
     },
+    "error": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/error/-/error-7.0.2.tgz",
+      "integrity": "sha1-pfdf/02ZJhJt2sDqXcOOaJFTywI=",
+      "dev": true,
+      "requires": {
+        "string-template": "0.2.1",
+        "xtend": "4.0.1"
+      },
+      "dependencies": {
+        "string-template": {
+          "version": "0.2.1",
+          "resolved": "https://registry.npmjs.org/string-template/-/string-template-0.2.1.tgz",
+          "integrity": "sha1-QpMuWYo1LQH8IuwzZ9nYTuxsmt0=",
+          "dev": true
+        }
+      }
+    },
     "error-ex": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
-      "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
+      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
       "dev": true,
       "requires": {
         "is-arrayish": "0.2.1"
       }
     },
     "es5-ext": {
-      "version": "0.10.42",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.42.tgz",
-      "integrity": "sha512-AJxO1rmPe1bDEfSR6TJ/FgMFYuTBhR5R57KW58iCkYACMyFbrkqVyzXSurYoScDGvgyMpk7uRF/lPUPPTmsRSA==",
+      "version": "0.10.45",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.45.tgz",
+      "integrity": "sha512-FkfM6Vxxfmztilbxxz5UKSD4ICMf5tSpRFtDNtkAhOxZ0EKtX6qwmXNyH/sFyIbX2P/nU5AMiA9jilWsUGJzCQ==",
       "dev": true,
       "requires": {
         "es6-iterator": "2.0.3",
@@ -3750,7 +3776,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.45",
         "es6-symbol": "3.1.1"
       }
     },
@@ -3761,7 +3787,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.45",
         "es6-iterator": "2.0.3",
         "es6-set": "0.1.5",
         "es6-symbol": "3.1.1",
@@ -3787,7 +3813,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.45",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1",
         "event-emitter": "0.3.5"
@@ -3800,7 +3826,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.45"
       }
     },
     "es6-weak-map": {
@@ -3810,7 +3836,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42",
+        "es5-ext": "0.10.45",
         "es6-iterator": "2.0.3",
         "es6-symbol": "3.1.1"
       }
@@ -3828,9 +3854,9 @@
       "dev": true
     },
     "escodegen": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.9.1.tgz",
-      "integrity": "sha512-6hTjO1NAWkHnDk3OqQ4YrCuwwmGHL9S3nPlzBOUG/R44rda3wLNrfvQ5fkSGjyhHFKM7ALPKcKGrwvCLe0lC7Q==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.10.0.tgz",
+      "integrity": "sha512-fjUOf8johsv23WuIKdNQU4P9t9jhQ4Qzx6pC2uW890OloK3Zs1ZAoCNpg/2larNF501jLl3UNy0kIRcF6VI22g==",
       "dev": true,
       "requires": {
         "esprima": "3.1.3",
@@ -3892,7 +3918,7 @@
       "dev": true,
       "requires": {
         "d": "1.0.0",
-        "es5-ext": "0.10.42"
+        "es5-ext": "0.10.45"
       }
     },
     "eventemitter2": {
@@ -3953,7 +3979,7 @@
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
       "dev": true,
       "requires": {
-        "fill-range": "2.2.3"
+        "fill-range": "2.2.4"
       }
     },
     "express": {
@@ -3994,6 +4020,12 @@
         "vary": "1.1.2"
       },
       "dependencies": {
+        "qs": {
+          "version": "6.5.1",
+          "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
+          "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+          "dev": true
+        },
         "safe-buffer": {
           "version": "5.1.1",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.1.tgz",
@@ -4036,7 +4068,7 @@
       "dev": true,
       "requires": {
         "chardet": "0.4.2",
-        "iconv-lite": "0.4.21",
+        "iconv-lite": "0.4.23",
         "tmp": "0.0.33"
       }
     },
@@ -4063,7 +4095,7 @@
       "integrity": "sha512-bt/LZ4m5Rqt/Crl2HiKuAl/oqg0psx1tsTLkvWbJen1CtD+fftkZhMaQ9HOtY2gWsl2Wq+sABmMVi9z3DhKWQQ==",
       "dev": true,
       "requires": {
-        "async": "2.6.0",
+        "async": "2.6.1",
         "loader-utils": "1.1.0",
         "schema-utils": "0.3.0",
         "webpack-sources": "1.1.0"
@@ -4109,9 +4141,9 @@
       }
     },
     "fd-slicer": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
-      "integrity": "sha1-i1vL2ewyfFBBv5qwI/1nUPEXfmU=",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
+      "integrity": "sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=",
       "dev": true,
       "requires": {
         "pend": "1.2.0"
@@ -4161,14 +4193,14 @@
       "dev": true
     },
     "fill-range": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
-      "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.4.tgz",
+      "integrity": "sha512-cnrcCbj01+j2gTG921VZPnHbjmdAf8oQV/iGeV2kZxGSyfYjjTyY79ErsK1WJWMpw6DaApEX72binqJE+/d+5Q==",
       "dev": true,
       "requires": {
         "is-number": "2.1.0",
         "isobject": "2.1.0",
-        "randomatic": "1.1.7",
+        "randomatic": "3.0.0",
         "repeat-element": "1.1.2",
         "repeat-string": "1.6.1"
       },
@@ -4451,7 +4483,7 @@
       "dev": true,
       "requires": {
         "commondir": "1.0.1",
-        "make-dir": "1.2.0",
+        "make-dir": "1.3.0",
         "pkg-dir": "2.0.0"
       }
     },
@@ -4602,7 +4634,7 @@
       "requires": {
         "graceful-fs": "4.1.11",
         "jsonfile": "4.0.0",
-        "universalify": "0.1.1"
+        "universalify": "0.1.2"
       }
     },
     "fs-write-stream-atomic": {
@@ -4624,14 +4656,14 @@
       "dev": true
     },
     "fsevents": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.3.tgz",
-      "integrity": "sha512-X+57O5YkDTiEQGiw8i7wYc2nQgweIekqkepI8Q3y4wVlurgBt2SuwxTeYUYMZIGpLZH3r/TsMjczCMXE5ZOt7Q==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.4.tgz",
+      "integrity": "sha512-z8H8/diyk76B7q5wg+Ud0+CqzcAF3mBBI/bA5ne5zrRUUIvNkJY//D3BqyH571KuAC4Nr7Rw7CjWX4r0y9DvNg==",
       "dev": true,
       "optional": true,
       "requires": {
         "nan": "2.10.0",
-        "node-pre-gyp": "0.9.1"
+        "node-pre-gyp": "0.10.0"
       },
       "dependencies": {
         "abbrev": {
@@ -4712,7 +4744,7 @@
           }
         },
         "deep-extend": {
-          "version": "0.4.2",
+          "version": "0.5.1",
           "bundled": true,
           "dev": true,
           "optional": true
@@ -4890,7 +4922,7 @@
           }
         },
         "node-pre-gyp": {
-          "version": "0.9.1",
+          "version": "0.10.0",
           "bundled": true,
           "dev": true,
           "optional": true,
@@ -4901,7 +4933,7 @@
             "nopt": "4.0.1",
             "npm-packlist": "1.1.10",
             "npmlog": "4.1.2",
-            "rc": "1.2.6",
+            "rc": "1.2.7",
             "rimraf": "2.6.2",
             "semver": "5.5.0",
             "tar": "4.4.1"
@@ -4999,12 +5031,12 @@
           "optional": true
         },
         "rc": {
-          "version": "1.2.6",
+          "version": "1.2.7",
           "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
-            "deep-extend": "0.4.2",
+            "deep-extend": "0.5.1",
             "ini": "1.3.5",
             "minimist": "1.2.0",
             "strip-json-comments": "2.0.1"
@@ -5159,12 +5191,12 @@
       "dev": true
     },
     "gaze": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.2.tgz",
-      "integrity": "sha1-hHIkZ3rbiHDWeSV+0ziP22HkAQU=",
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/gaze/-/gaze-1.1.3.tgz",
+      "integrity": "sha512-BRdNm8hbWzFzWHERTrejLqwHDfS4GibPoq5wjTPIoJHoBtKGPg3xAFfxmM+9ztbXelxcf2hwQcaz1PtmFeue8g==",
       "dev": true,
       "requires": {
-        "globule": "1.2.0"
+        "globule": "1.2.1"
       }
     },
     "generic-names": {
@@ -5361,9 +5393,9 @@
       }
     },
     "globule": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.0.tgz",
-      "integrity": "sha1-HcScaCLdnoovoAuiopUAboZkvQk=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/globule/-/globule-1.2.1.tgz",
+      "integrity": "sha512-g7QtgWF4uYSL5/dn71WxubOrS7JVGCnFPEnoeChJmBnyR9Mw8nGoEwOgJL/RC2Te0WhbsEUCejfH8SZNJ+adYQ==",
       "dev": true,
       "requires": {
         "glob": "7.1.2",
@@ -5403,9 +5435,9 @@
       "dev": true
     },
     "grunt": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.2.tgz",
-      "integrity": "sha1-TmpeaVtwRy/VME9fqeNCNoNqc7w=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/grunt/-/grunt-1.0.3.tgz",
+      "integrity": "sha512-/JzmZNPfKorlCrrmxWqQO4JVodO+DVd5XX4DkocL/1WlLlKVLE9+SdEIempOAxDhWPysLle6afvn/hg7Ck2k9g==",
       "dev": true,
       "requires": {
         "coffeescript": "1.10.0",
@@ -5416,14 +5448,15 @@
         "glob": "7.0.6",
         "grunt-cli": "1.2.0",
         "grunt-known-options": "1.1.0",
-        "grunt-legacy-log": "1.0.2",
-        "grunt-legacy-util": "1.0.0",
-        "iconv-lite": "0.4.21",
+        "grunt-legacy-log": "2.0.0",
+        "grunt-legacy-util": "1.1.1",
+        "iconv-lite": "0.4.23",
         "js-yaml": "3.5.5",
         "minimatch": "3.0.4",
+        "mkdirp": "0.5.1",
         "nopt": "3.0.6",
         "path-is-absolute": "1.0.1",
-        "rimraf": "2.2.8"
+        "rimraf": "2.6.2"
       },
       "dependencies": {
         "esprima": {
@@ -5481,12 +5514,6 @@
           "version": "1.1.7",
           "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.1.7.tgz",
           "integrity": "sha1-IDEU2CrSxe2ejgQRs5ModeiJ6Xs=",
-          "dev": true
-        },
-        "rimraf": {
-          "version": "2.2.8",
-          "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.2.8.tgz",
-          "integrity": "sha1-5Dm+Kq7jJzIZUnMPmaiSnk/FBYI=",
           "dev": true
         }
       }
@@ -5562,23 +5589,15 @@
       }
     },
     "grunt-contrib-watch": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.0.1.tgz",
-      "integrity": "sha512-8Zka/svGl6+ZwF7d6z/CfXwsb4cDODnajmZsY4nUAs9Ob0kJEcsLiDf5qm2HdDoEcm3NHjWCrFiWx+PZ2y4D7A==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/grunt-contrib-watch/-/grunt-contrib-watch-1.1.0.tgz",
+      "integrity": "sha512-yGweN+0DW5yM+oo58fRu/XIRrPcn3r4tQx+nL7eMRwjpvk+rQY6R8o94BPK0i2UhTg9FN21hS+m8vR8v9vXfeg==",
       "dev": true,
       "requires": {
-        "async": "1.5.2",
-        "gaze": "1.1.2",
+        "async": "2.6.1",
+        "gaze": "1.1.3",
         "lodash": "4.17.10",
-        "tiny-lr": "0.2.1"
-      },
-      "dependencies": {
-        "async": {
-          "version": "1.5.2",
-          "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
-          "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
-          "dev": true
-        }
+        "tiny-lr": "1.1.1"
       }
     },
     "grunt-dojo2": {
@@ -5594,7 +5613,7 @@
         "glob": "7.1.2",
         "grunt-contrib-clean": "1.1.0",
         "grunt-contrib-copy": "1.0.0",
-        "grunt-contrib-watch": "1.0.1",
+        "grunt-contrib-watch": "1.1.0",
         "grunt-postcss": "0.8.0",
         "grunt-text-replace": "0.4.0",
         "grunt-ts": "5.5.1",
@@ -5759,7 +5778,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           },
@@ -6004,7 +6023,7 @@
             "postcss-value-parser": "3.3.0",
             "promise-each": "2.2.0",
             "read-cache": "1.0.0",
-            "resolve": "1.7.1"
+            "resolve": "1.8.1"
           }
         },
         "postcss-initial": {
@@ -6143,7 +6162,7 @@
             "findup-sync": "0.3.0",
             "glob": "7.1.2",
             "optimist": "0.6.1",
-            "resolve": "1.7.1",
+            "resolve": "1.8.1",
             "tsutils": "1.9.1",
             "update-notifier": "2.5.0"
           }
@@ -6163,88 +6182,40 @@
       "dev": true
     },
     "grunt-legacy-log": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-1.0.2.tgz",
-      "integrity": "sha512-WdedTJ/6zCXnI/coaouzqvkI19uwqbcPkdsXiDRKJyB5rOUlOxnCnTVbpeUdEckKVir2uHF3rDBYppj2p6N3+g==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log/-/grunt-legacy-log-2.0.0.tgz",
+      "integrity": "sha512-1m3+5QvDYfR1ltr8hjiaiNjddxGdQWcH0rw1iKKiQnF0+xtgTazirSTGu68RchPyh1OBng1bBUjLmX8q9NpoCw==",
       "dev": true,
       "requires": {
         "colors": "1.1.2",
-        "grunt-legacy-log-utils": "1.0.0",
+        "grunt-legacy-log-utils": "2.0.1",
         "hooker": "0.2.3",
         "lodash": "4.17.10"
       }
     },
     "grunt-legacy-log-utils": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-1.0.0.tgz",
-      "integrity": "sha1-p7ji0Ps1taUPSvmG/BEnSevJbz0=",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-log-utils/-/grunt-legacy-log-utils-2.0.1.tgz",
+      "integrity": "sha512-o7uHyO/J+i2tXG8r2bZNlVk20vlIFJ9IEYyHMCQGfWYru8Jv3wTqKZzvV30YW9rWEjq0eP3cflQ1qWojIe9VFA==",
       "dev": true,
       "requires": {
-        "chalk": "1.1.3",
-        "lodash": "4.3.0"
-      },
-      "dependencies": {
-        "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "ansi-styles": {
-          "version": "2.2.1",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-          "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-          "dev": true
-        },
-        "chalk": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
-          "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
-          "dev": true
-        },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
-        },
-        "supports-color": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
-        }
+        "chalk": "2.4.1",
+        "lodash": "4.17.10"
       }
     },
     "grunt-legacy-util": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.0.0.tgz",
-      "integrity": "sha1-OGqnjcbtUJhsKxiVcmWxtIq7m4Y=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/grunt-legacy-util/-/grunt-legacy-util-1.1.1.tgz",
+      "integrity": "sha512-9zyA29w/fBe6BIfjGENndwoe1Uy31BIXxTH3s8mga0Z5Bz2Sp4UCjkeyv2tI449ymkx3x26B+46FV4fXEddl5A==",
       "dev": true,
       "requires": {
         "async": "1.5.2",
         "exit": "0.1.2",
         "getobject": "0.1.0",
         "hooker": "0.2.3",
-        "lodash": "4.3.0",
-        "underscore.string": "3.2.3",
-        "which": "1.2.14"
+        "lodash": "4.17.10",
+        "underscore.string": "3.3.4",
+        "which": "1.3.1"
       },
       "dependencies": {
         "async": {
@@ -6252,21 +6223,6 @@
           "resolved": "https://registry.npmjs.org/async/-/async-1.5.2.tgz",
           "integrity": "sha1-7GphrlZIDAw8skHJVhjiCJL5Zyo=",
           "dev": true
-        },
-        "lodash": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.3.0.tgz",
-          "integrity": "sha1-79nEpuxT87BUEkKZFcPkgk5NJaQ=",
-          "dev": true
-        },
-        "which": {
-          "version": "1.2.14",
-          "resolved": "https://registry.npmjs.org/which/-/which-1.2.14.tgz",
-          "integrity": "sha1-mofEN48D6CfOyvGs31bHNsAcFOU=",
-          "dev": true,
-          "requires": {
-            "isexe": "2.0.0"
-          }
         }
       }
     },
@@ -6325,7 +6281,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           },
@@ -6608,7 +6564,7 @@
             "form-data": "2.3.2",
             "make-error-cause": "1.2.2",
             "throwback": "1.1.1",
-            "tough-cookie": "2.3.4",
+            "tough-cookie": "2.4.3",
             "xtend": "4.0.1"
           }
         },
@@ -6642,7 +6598,7 @@
             "debug": "2.6.9",
             "detect-indent": "4.0.0",
             "graceful-fs": "4.1.11",
-            "has": "1.0.1",
+            "has": "1.0.3",
             "invariant": "2.2.4",
             "is-absolute": "0.2.6",
             "listify": "1.0.0",
@@ -6657,7 +6613,7 @@
             "popsicle-rewrite": "1.0.0",
             "popsicle-status": "2.0.1",
             "promise-finally": "2.2.1",
-            "rc": "1.2.7",
+            "rc": "1.2.8",
             "rimraf": "2.6.2",
             "sort-keys": "1.1.2",
             "string-template": "1.0.0",
@@ -6808,9 +6764,9 @@
       }
     },
     "has": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
-      "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+      "integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
       "dev": true,
       "requires": {
         "function-bind": "1.1.1"
@@ -6908,9 +6864,9 @@
       }
     },
     "hash.js": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
-      "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.4.tgz",
+      "integrity": "sha512-A6RlQvvZEtFS5fLU43IDu0QUmBy+fDO9VMdTXvufKwIkt/rFfvICAViCax5fbDO4zdNzaC3/27ZhKUok5bAJyw==",
       "dev": true,
       "requires": {
         "inherits": "2.0.3",
@@ -6918,15 +6874,16 @@
       }
     },
     "hawk": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/hawk/-/hawk-6.0.2.tgz",
-      "integrity": "sha512-miowhl2+U7Qle4vdLqDdPt9m09K6yZhkLDTWGoUiUzrQCn+mHHSmfJgAyGaLRZbPmTqfFFjRV1QWCW0VWUJBbQ==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/hawk/-/hawk-1.1.1.tgz",
+      "integrity": "sha1-h81JH5tG5OKurKM1QWdmiF0tHtk=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "boom": "4.3.1",
-        "cryptiles": "3.1.2",
-        "hoek": "4.2.1",
-        "sntp": "2.1.0"
+        "boom": "0.4.2",
+        "cryptiles": "0.2.2",
+        "hoek": "0.9.1",
+        "sntp": "0.2.4"
       }
     },
     "he": {
@@ -6947,15 +6904,15 @@
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
       "dev": true,
       "requires": {
-        "hash.js": "1.1.3",
+        "hash.js": "1.1.4",
         "minimalistic-assert": "1.0.1",
         "minimalistic-crypto-utils": "1.0.1"
       }
     },
     "hoek": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/hoek/-/hoek-4.2.1.tgz",
-      "integrity": "sha512-QLg82fGkfnJ/4iy1xZ81/9SIJiq1NGFUMGs6ParyjBZr6jW2Ufj/snDqTHixNlHdPNwN2RLVD0Pi3igeK9+JfA==",
+      "version": "0.9.1",
+      "resolved": "https://registry.npmjs.org/hoek/-/hoek-0.9.1.tgz",
+      "integrity": "sha1-PTIkYrrfB3Fup+uFuviAec3c5QU=",
       "dev": true
     },
     "homedir-polyfill": {
@@ -6974,9 +6931,9 @@
       "dev": true
     },
     "hosted-git-info": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.0.tgz",
-      "integrity": "sha512-lIbgIIQA3lz5XaB6vxakj6sDHADJiZadYEJB+FgA+C4nubM1NwcuvUr9EJPmnH1skZqpqUzWborWo8EIUi0Sdw==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-2.6.1.tgz",
+      "integrity": "sha512-Ba4+0M4YvIDUUsprMjhVTU1yN9F2/LJSAl69ZpzaLT4l4j5mwTS6jqqW9Ojvj6lKz/veqPzpJBqGbXspOb533A==",
       "dev": true
     },
     "html-comment-regex": {
@@ -7001,18 +6958,18 @@
       "dev": true
     },
     "html-minifier": {
-      "version": "3.5.15",
-      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.15.tgz",
-      "integrity": "sha512-OZa4rfb6tZOZ3Z8Xf0jKxXkiDcFWldQePGYFDcgKqES2sXeWaEv9y6QQvWUtX3ySI3feApQi5uCsHLINQ6NoAw==",
+      "version": "3.5.18",
+      "resolved": "https://registry.npmjs.org/html-minifier/-/html-minifier-3.5.18.tgz",
+      "integrity": "sha512-sczoq/9zeXiKZMj8tsQzHJE7EyjrpMHvblTLuh9o8h5923a6Ts5uQ/3YdY+xIqJYRjzHQPlrHjfjh0BtwPJG0g==",
       "dev": true,
       "requires": {
         "camel-case": "3.0.0",
         "clean-css": "4.1.11",
-        "commander": "2.15.1",
+        "commander": "2.16.0",
         "he": "1.1.1",
         "param-case": "2.1.1",
         "relateurl": "0.2.7",
-        "uglify-js": "3.3.23"
+        "uglify-js": "3.4.3"
       }
     },
     "html-webpack-include-assets-plugin": {
@@ -7033,7 +6990,7 @@
       "dev": true,
       "requires": {
         "bluebird": "3.5.1",
-        "html-minifier": "3.5.15",
+        "html-minifier": "3.5.18",
         "loader-utils": "0.2.17",
         "lodash": "4.17.10",
         "pretty-error": "2.1.1",
@@ -7128,9 +7085,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.4.12",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.12.tgz",
-      "integrity": "sha1-uc+/Sizybw/DSxDKFImid3HjR08=",
+      "version": "0.4.13",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.13.tgz",
+      "integrity": "sha1-O9bW/ebjFyyTNMOzO2wZPYD+ETc=",
       "dev": true
     },
     "http-proxy-agent": {
@@ -7152,7 +7109,7 @@
       "requires": {
         "assert-plus": "1.0.0",
         "jsprim": "1.4.1",
-        "sshpk": "1.14.1"
+        "sshpk": "1.14.2"
       }
     },
     "https-browserify": {
@@ -7173,9 +7130,9 @@
       }
     },
     "iconv-lite": {
-      "version": "0.4.21",
-      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.21.tgz",
-      "integrity": "sha512-En5V9za5mBt2oUA03WGD3TwDv0MKAruqsuxstbMUZaj9W9k/m1CV/9py3l0L5kw9Bln8fdHQmzHSYtvpvTLpKw==",
+      "version": "0.4.23",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.23.tgz",
+      "integrity": "sha512-neyTUVFtahjf0mB3dZT77u+8O0QB89jFdnBkd5P1JgYPbPaia3gXXOVL2fq8VyU2gMMD7SaN7QukTB/pmXYvDA==",
       "dev": true,
       "requires": {
         "safer-buffer": "2.1.2"
@@ -7197,9 +7154,9 @@
       }
     },
     "ieee754": {
-      "version": "1.1.11",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.11.tgz",
-      "integrity": "sha512-VhDzCKN7K8ufStx/CLj5/PDTMgph+qwN5Pkd5i0sGnVwk56zJ0lkT8Qzi1xqWLS0Wp29DgDtNeS7v8/wMoZeHg==",
+      "version": "1.1.12",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.12.tgz",
+      "integrity": "sha512-GguP+DRY+pJ3soyIiGPTvdiVXjZ+DbXOxGpXn3eMvNW4x4irjqXm4wHKscC+TfxSJ0yw/S1F24tqdMNsMZTiLA==",
       "dev": true
     },
     "iferr": {
@@ -7209,9 +7166,9 @@
       "dev": true
     },
     "ignore": {
-      "version": "3.3.8",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.8.tgz",
-      "integrity": "sha512-pUh+xUQQhQzevjRHHFqqcTy0/dP/kS9I8HSrUydhihjuD09W6ldVWFtIrwhXdUJHis3i2rZNqEHpZH/cbinFbg==",
+      "version": "3.3.10",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
+      "integrity": "sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==",
       "dev": true
     },
     "immediate": {
@@ -7335,11 +7292,11 @@
         "@types/http-errors": "1.5.34",
         "@types/istanbul-lib-coverage": "1.1.0",
         "@types/istanbul-lib-hook": "1.0.0",
-        "@types/istanbul-lib-instrument": "1.7.1",
+        "@types/istanbul-lib-instrument": "1.7.2",
         "@types/istanbul-lib-report": "1.1.0",
         "@types/istanbul-lib-source-maps": "1.2.1",
         "@types/istanbul-reports": "1.1.0",
-        "@types/lodash": "4.14.108",
+        "@types/lodash": "4.14.110",
         "@types/mime-types": "2.1.0",
         "@types/platform": "1.3.1",
         "@types/resolve": "0.0.4",
@@ -7868,23 +7825,6 @@
       "integrity": "sha1-PkcprB9f3gJc19g6iW2rn09n2w8=",
       "dev": true
     },
-    "is-odd": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-2.0.0.tgz",
-      "integrity": "sha512-OTiixgpZAT1M4NHgS5IguFp/Vz2VI3U7Goh4/HA1adtwyLtSBrxYlcSYkhpAE07s4fKEcjrFxyvtQBND4vFQyQ==",
-      "dev": true,
-      "requires": {
-        "is-number": "4.0.0"
-      },
-      "dependencies": {
-        "is-number": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
-          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
-          "dev": true
-        }
-      }
-    },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
@@ -8044,7 +7984,7 @@
         "once": "1.4.0",
         "resolve": "1.1.7",
         "supports-color": "3.2.3",
-        "which": "1.3.0",
+        "which": "1.3.1",
         "wordwrap": "1.0.0"
       },
       "dependencies": {
@@ -8247,9 +8187,9 @@
       }
     },
     "js-base64": {
-      "version": "2.4.3",
-      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.3.tgz",
-      "integrity": "sha512-H7ErYLM34CvDMto3GbD6xD0JLUGYXR3QTcH6B/tr4Hi/QpSThnCsIp+Sy5FRTw3B0d6py4HcNkW7nO/wdtGWEw==",
+      "version": "2.4.5",
+      "resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.4.5.tgz",
+      "integrity": "sha512-aUnNwqMOXw3yvErjMPSQu6qIIzUmT1e5KcU1OZxRDU1g/am6mzBvcrmLAYwzmB59BHPrh5/tKaiF4OPhqRWESQ==",
       "dev": true
     },
     "js-tokens": {
@@ -8290,29 +8230,29 @@
       "dev": true,
       "requires": {
         "abab": "1.0.4",
-        "acorn": "5.5.3",
+        "acorn": "5.7.1",
         "acorn-globals": "4.1.0",
         "array-equal": "1.0.0",
         "browser-process-hrtime": "0.1.2",
         "content-type-parser": "1.0.2",
-        "cssom": "0.3.2",
+        "cssom": "0.3.4",
         "cssstyle": "0.2.37",
         "domexception": "1.0.1",
-        "escodegen": "1.9.1",
+        "escodegen": "1.10.0",
         "html-encoding-sniffer": "1.0.2",
         "left-pad": "1.3.0",
         "nwmatcher": "1.4.4",
         "parse5": "4.0.0",
         "pn": "1.1.0",
-        "request": "2.85.0",
+        "request": "2.87.0",
         "request-promise-native": "1.0.5",
         "sax": "1.2.4",
         "symbol-tree": "3.2.2",
-        "tough-cookie": "2.3.4",
+        "tough-cookie": "2.4.3",
         "w3c-hr-time": "1.0.1",
         "webidl-conversions": "4.0.2",
         "whatwg-encoding": "1.0.3",
-        "whatwg-url": "6.4.1",
+        "whatwg-url": "6.5.0",
         "ws": "4.1.0",
         "xml-name-validator": "3.0.0"
       }
@@ -8641,6 +8581,12 @@
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY=",
       "dev": true
     },
+    "lodash.debounce": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/lodash.debounce/-/lodash.debounce-4.0.8.tgz",
+      "integrity": "sha1-gteb/zCmfEAF/9XiUVMArZyk168=",
+      "dev": true
+    },
     "lodash.memoize": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/lodash.memoize/-/lodash.memoize-4.1.2.tgz",
@@ -8764,25 +8710,19 @@
       "dev": true
     },
     "lru-cache": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.2.tgz",
-      "integrity": "sha512-wgeVXhrDwAWnIF/yZARsFnMBtdFXOg1b8RIrhilp+0iDYN4mdQcNZElDZ0e4B64BhaxeQ5zN7PMyvu7we1kPeQ==",
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.3.tgz",
+      "integrity": "sha512-fFEhvcgzuIoJVUF8fYr5KR0YqxD238zgObTps31YdADwPPAp82a4M8TrckkWyx7ekNlf9aBcVn81cFwwXngrJA==",
       "dev": true,
       "requires": {
         "pseudomap": "1.0.2",
         "yallist": "2.1.2"
       }
     },
-    "macaddress": {
-      "version": "0.2.8",
-      "resolved": "https://registry.npmjs.org/macaddress/-/macaddress-0.2.8.tgz",
-      "integrity": "sha1-WQTcU3w57G2+/q6QIycTX6hRHxI=",
-      "dev": true
-    },
     "make-dir": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.2.0.tgz",
-      "integrity": "sha512-aNUAa4UMg/UougV25bbrU4ZaaKNjJ/3/xnvg/twpmKROPdKZPZ9wGgI0opdZzO8q/zUFawoUuixuOv33eZ61Iw==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
+      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
       "dev": true,
       "requires": {
         "pify": "3.0.0"
@@ -8834,6 +8774,12 @@
       "version": "1.2.17",
       "resolved": "https://registry.npmjs.org/math-expression-evaluator/-/math-expression-evaluator-1.2.17.tgz",
       "integrity": "sha1-3oGf282E3M2PrlnGrreWFbnSZqw=",
+      "dev": true
+    },
+    "math-random": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/math-random/-/math-random-1.0.1.tgz",
+      "integrity": "sha1-izqsWIuKZuSXXjzepn97sylgH6w=",
       "dev": true
     },
     "md5.js": {
@@ -9018,13 +8964,13 @@
       "dev": true,
       "requires": {
         "concat-stream": "1.6.2",
-        "duplexify": "3.5.4",
+        "duplexify": "3.6.0",
         "end-of-stream": "1.4.1",
         "flush-write-stream": "1.0.3",
         "from2": "2.3.0",
         "parallel-transform": "1.1.0",
         "pump": "2.0.1",
-        "pumpify": "1.4.0",
+        "pumpify": "1.5.1",
         "stream-each": "1.2.2",
         "through2": "2.0.3"
       }
@@ -9105,9 +9051,9 @@
       "optional": true
     },
     "nanomatch": {
-      "version": "1.2.9",
-      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.9.tgz",
-      "integrity": "sha512-n8R9bS8yQ6eSXaV6jHUpKzD8gLsin02w1HSFiegwrs9E098Ylhw5jdyKPaYqvHknHaSCKTPp7C8dGCQ0q9koXA==",
+      "version": "1.2.13",
+      "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.13.tgz",
+      "integrity": "sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==",
       "dev": true,
       "requires": {
         "arr-diff": "4.0.0",
@@ -9115,7 +9061,6 @@
         "define-property": "2.0.2",
         "extend-shallow": "3.0.2",
         "fragment-cache": "0.2.1",
-        "is-odd": "2.0.0",
         "is-windows": "1.0.2",
         "kind-of": "6.0.2",
         "object.pick": "1.3.0",
@@ -9214,12 +9159,12 @@
         "querystring-es3": "0.2.1",
         "readable-stream": "2.3.6",
         "stream-browserify": "2.0.1",
-        "stream-http": "2.8.1",
+        "stream-http": "2.8.3",
         "string_decoder": "1.1.1",
         "timers-browserify": "2.0.10",
         "tty-browserify": "0.0.0",
         "url": "0.11.0",
-        "util": "0.10.3",
+        "util": "0.10.4",
         "vm-browserify": "0.0.4"
       }
     },
@@ -9250,7 +9195,7 @@
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
       "dev": true,
       "requires": {
-        "hosted-git-info": "2.6.0",
+        "hosted-git-info": "2.6.1",
         "is-builtin-module": "1.0.0",
         "semver": "5.0.3",
         "validate-npm-package-license": "3.0.3"
@@ -9354,9 +9299,9 @@
       }
     },
     "object-keys": {
-      "version": "1.0.11",
-      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.11.tgz",
-      "integrity": "sha1-xUYBd4rVYPEULODgG8yotW0TQm0=",
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.0.12.tgz",
+      "integrity": "sha512-FTMyFUm2wBcGHnH2eXmz7tC6IwlqQZ6mVZ+6dm6vZ4IQIHjs6FdNsQBuKGPuUUUY6NfJw2PshC08Tn6LzLDOag==",
       "dev": true
     },
     "object-visit": {
@@ -9377,7 +9322,7 @@
         "define-properties": "1.1.2",
         "function-bind": "1.1.1",
         "has-symbols": "1.0.0",
-        "object-keys": "1.0.11"
+        "object-keys": "1.0.12"
       }
     },
     "object.omit": {
@@ -9606,9 +9551,9 @@
       "dev": true
     },
     "p-limit": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
-      "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.3.0.tgz",
+      "integrity": "sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==",
       "dev": true,
       "requires": {
         "p-try": "1.0.0"
@@ -9620,7 +9565,7 @@
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
       "dev": true,
       "requires": {
-        "p-limit": "1.2.0"
+        "p-limit": "1.3.0"
       }
     },
     "p-try": {
@@ -9746,7 +9691,7 @@
       "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
       "dev": true,
       "requires": {
-        "error-ex": "1.3.1"
+        "error-ex": "1.3.2"
       }
     },
     "parse-passwd": {
@@ -9915,8 +9860,8 @@
           "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000833",
-            "electron-to-chromium": "1.3.45"
+            "caniuse-lite": "1.0.30000862",
+            "electron-to-chromium": "1.3.50"
           }
         }
       }
@@ -10037,7 +9982,7 @@
         "concat-stream": "1.6.2",
         "form-data": "2.3.2",
         "make-error-cause": "1.2.2",
-        "tough-cookie": "2.3.4"
+        "tough-cookie": "2.4.3"
       }
     },
     "popsicle-proxy-agent": {
@@ -10240,7 +10185,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10290,7 +10235,7 @@
       "dev": true,
       "requires": {
         "color": "2.0.1",
-        "postcss": "6.0.22",
+        "postcss": "6.0.23",
         "postcss-message-helpers": "2.0.0",
         "reduce-function-call": "1.0.2"
       },
@@ -10301,7 +10246,7 @@
           "integrity": "sha512-ubUCVVKfT7r2w2D3qtHakj8mbmKms+tThR8gI8zEYCbUBl8/voqFGt3kgBqGwXAopgXybnkuOq+qMYCRrp4cXw==",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1",
+            "color-convert": "1.9.2",
             "color-string": "1.5.2"
           }
         },
@@ -10311,14 +10256,14 @@
           "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
           "dev": true,
           "requires": {
-            "color-name": "1.1.3",
+            "color-name": "1.1.1",
             "simple-swizzle": "0.2.2"
           }
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "2.4.1",
@@ -10345,7 +10290,7 @@
           "integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1",
+            "color-convert": "1.9.2",
             "color-string": "1.5.2"
           }
         },
@@ -10355,7 +10300,7 @@
           "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
           "dev": true,
           "requires": {
-            "color-name": "1.1.3",
+            "color-name": "1.1.1",
             "simple-swizzle": "0.2.2"
           }
         }
@@ -10390,7 +10335,7 @@
           "integrity": "sha1-5I6DLYXxTvaU+0aIEcLVz+cptV0=",
           "dev": true,
           "requires": {
-            "color-convert": "1.9.1",
+            "color-convert": "1.9.2",
             "color-string": "1.5.2"
           }
         },
@@ -10400,7 +10345,7 @@
           "integrity": "sha1-JuRYFLw8mny9Z1FkikFDRRSnc6k=",
           "dev": true,
           "requires": {
-            "color-name": "1.1.3",
+            "color-name": "1.1.1",
             "simple-swizzle": "0.2.2"
           }
         }
@@ -10412,14 +10357,14 @@
       "integrity": "sha512-212hJUk9uSsbwO5ECqVjmh/iLsmiVL1xy9ce9TVf+X3cK/ZlUIlaMdoxje/YpsL9cmUH3I7io+/G2LyWx5rg1g==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.22",
+        "postcss": "6.0.23",
         "postcss-values-parser": "1.5.0"
       },
       "dependencies": {
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "2.4.1",
@@ -10445,15 +10390,15 @@
       "integrity": "sha1-N9XJNToHoJJwkSqCYGu0Kg1wLAQ=",
       "dev": true,
       "requires": {
-        "postcss": "6.0.22",
+        "postcss": "6.0.23",
         "postcss-value-parser": "3.3.0",
         "rgb-hex": "2.1.0"
       },
       "dependencies": {
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "2.4.1",
@@ -10520,7 +10465,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10607,7 +10552,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10639,9 +10584,9 @@
       }
     },
     "postcss-cssnext": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-cssnext/-/postcss-cssnext-3.0.2.tgz",
-      "integrity": "sha512-jA6kGdcUMZqLUgw6MdpyNWGFhk0LIITVhC/jTnLRZLoXSTR88qT2cFOn3LbY06udt1PVdTCHDG3plBjxVKf8BQ==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-cssnext/-/postcss-cssnext-3.1.0.tgz",
+      "integrity": "sha512-awPDhI4OKetcHCr560iVCoDuP6e/vn0r6EAqdWPpAavJMvkBSZ6kDpSN4b3mB3Ti57hQMunHHM8Wvx9PeuYXtA==",
       "dev": true,
       "requires": {
         "autoprefixer": "7.2.6",
@@ -10649,7 +10594,7 @@
         "chalk": "2.4.1",
         "pixrem": "4.0.1",
         "pleeease-filters": "4.0.0",
-        "postcss": "6.0.22",
+        "postcss": "6.0.23",
         "postcss-apply": "0.8.0",
         "postcss-attribute-case-insensitive": "2.0.0",
         "postcss-calc": "6.0.1",
@@ -10664,7 +10609,7 @@
         "postcss-custom-media": "6.0.0",
         "postcss-custom-properties": "6.3.1",
         "postcss-custom-selectors": "4.0.1",
-        "postcss-font-family-system-ui": "2.1.4",
+        "postcss-font-family-system-ui": "3.0.0",
         "postcss-font-variant": "3.0.0",
         "postcss-image-set-polyfill": "0.3.5",
         "postcss-initial": "2.0.0",
@@ -10684,10 +10629,10 @@
           "dev": true,
           "requires": {
             "browserslist": "2.11.3",
-            "caniuse-lite": "1.0.30000833",
+            "caniuse-lite": "1.0.30000862",
             "normalize-range": "0.1.2",
             "num2fraction": "1.2.2",
-            "postcss": "6.0.22",
+            "postcss": "6.0.23",
             "postcss-value-parser": "3.3.0"
           }
         },
@@ -10697,8 +10642,8 @@
           "integrity": "sha512-yWu5cXT7Av6mVwzWc8lMsJMHWn4xyjSuGYi4IozbVTLUOEYPSagUB8kiMDUHA1fS3zjr8nkxkn9jdvug4BBRmA==",
           "dev": true,
           "requires": {
-            "caniuse-lite": "1.0.30000833",
-            "electron-to-chromium": "1.3.45"
+            "caniuse-lite": "1.0.30000862",
+            "electron-to-chromium": "1.3.50"
           }
         },
         "caniuse-api": {
@@ -10708,15 +10653,15 @@
           "dev": true,
           "requires": {
             "browserslist": "2.11.3",
-            "caniuse-lite": "1.0.30000833",
+            "caniuse-lite": "1.0.30000862",
             "lodash.memoize": "4.1.2",
             "lodash.uniq": "4.5.0"
           }
         },
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "2.4.1",
@@ -10731,7 +10676,7 @@
           "dev": true,
           "requires": {
             "css-unit-converter": "1.1.1",
-            "postcss": "6.0.22",
+            "postcss": "6.0.23",
             "postcss-selector-parser": "2.2.3",
             "reduce-css-calc": "2.1.4"
           }
@@ -10764,13 +10709,13 @@
       "dev": true,
       "requires": {
         "balanced-match": "1.0.0",
-        "postcss": "6.0.22"
+        "postcss": "6.0.23"
       },
       "dependencies": {
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "2.4.1",
@@ -10845,7 +10790,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -10931,7 +10876,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11017,7 +10962,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11103,7 +11048,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11190,7 +11135,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11222,13 +11167,12 @@
       }
     },
     "postcss-filter-plugins": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.2.tgz",
-      "integrity": "sha1-bYWGJTTXNaxCDkqFgG4fXUKG2Ew=",
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/postcss-filter-plugins/-/postcss-filter-plugins-2.0.3.tgz",
+      "integrity": "sha512-T53GVFsdinJhgwm7rg1BzbeBRomOg9y5MBVhGcsV0CxurUdVj1UlPdKtn7aqYA/c/QVkzKMjq2bSV5dKG5+AwQ==",
       "dev": true,
       "requires": {
-        "postcss": "5.2.18",
-        "uniqid": "4.1.1"
+        "postcss": "5.2.18"
       },
       "dependencies": {
         "ansi-regex": {
@@ -11277,7 +11221,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11309,14 +11253,12 @@
       }
     },
     "postcss-font-family-system-ui": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/postcss-font-family-system-ui/-/postcss-font-family-system-ui-2.1.4.tgz",
-      "integrity": "sha512-TkrNpYF0wjn4AsOH5CZADN9ijwRZc/ogHpiGrNR/dHvaJPJS0nNIeVTxFXFkkB4lG+DRWiYbMsP+G/vPuOyLkA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/postcss-font-family-system-ui/-/postcss-font-family-system-ui-3.0.0.tgz",
+      "integrity": "sha512-58G/hTxMSSKlIRpcPUjlyo6hV2MEzvcVO2m4L/T7Bb2fJTG4DYYfQjQeRvuimKQh1V1sOzCIz99g+H2aFNtlQw==",
       "dev": true,
       "requires": {
-        "@std/esm": "0.19.7",
-        "postcss": "6.0.1",
-        "postcss-value-parser": "3.3.0"
+        "postcss": "6.0.1"
       }
     },
     "postcss-font-variant": {
@@ -11347,7 +11289,7 @@
         "postcss": "6.0.1",
         "postcss-value-parser": "3.3.0",
         "read-cache": "1.0.0",
-        "resolve": "1.7.1"
+        "resolve": "1.8.1"
       }
     },
     "postcss-initial": {
@@ -11425,7 +11367,7 @@
       "integrity": "sha1-TFUwMTwI4dWzu/PSu8dH4njuonA=",
       "dev": true,
       "requires": {
-        "has": "1.0.1",
+        "has": "1.0.3",
         "postcss": "5.2.18",
         "postcss-value-parser": "3.3.0"
       },
@@ -11476,7 +11418,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11562,7 +11504,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11652,7 +11594,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11746,7 +11688,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11833,7 +11775,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11922,7 +11864,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -11960,7 +11902,7 @@
       "dev": true,
       "requires": {
         "alphanum-sort": "1.0.2",
-        "has": "1.0.1",
+        "has": "1.0.3",
         "postcss": "5.2.18",
         "postcss-selector-parser": "2.2.3"
       },
@@ -12011,7 +11953,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12100,7 +12042,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12176,13 +12118,13 @@
       "integrity": "sha512-IkyWXICwagCnlaviRexi7qOdwPw3+xVVjgFfGsxmztvRVaNxAlrypOIKqDE5mxY+BVxnId1rnUKBRQoNE2VDaA==",
       "dev": true,
       "requires": {
-        "postcss": "6.0.22"
+        "postcss": "6.0.23"
       },
       "dependencies": {
         "postcss": {
-          "version": "6.0.22",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.22.tgz",
-          "integrity": "sha512-Toc9lLoUASwGqxBSJGTVcOQiDqjK+Z2XlWBg+IgYwQMY9vA2f7iMpXVc1GpPcfTSyM5lkxNo0oDwDRO+wm7XHA==",
+          "version": "6.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
           "dev": true,
           "requires": {
             "chalk": "2.4.1",
@@ -12247,7 +12189,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12336,7 +12278,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12423,7 +12365,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12529,7 +12471,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12615,7 +12557,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12652,7 +12594,7 @@
       "integrity": "sha1-/3b02CEkN7McKYpC0uFEQCV3GuE=",
       "dev": true,
       "requires": {
-        "has": "1.0.1",
+        "has": "1.0.3",
         "postcss": "5.2.18",
         "postcss-value-parser": "3.3.0"
       },
@@ -12703,7 +12645,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12848,7 +12790,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12936,7 +12878,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -12990,7 +12932,7 @@
       "integrity": "sha1-0hCd3AVbka9n/EyzsCWUZjnSryI=",
       "dev": true,
       "requires": {
-        "has": "1.0.1",
+        "has": "1.0.3",
         "postcss": "5.2.18",
         "uniqs": "2.0.0"
       },
@@ -13041,7 +12983,7 @@
           "dev": true,
           "requires": {
             "chalk": "1.1.3",
-            "js-base64": "2.4.3",
+            "js-base64": "2.4.5",
             "source-map": "0.5.7",
             "supports-color": "3.2.3"
           }
@@ -13175,6 +13117,12 @@
       "integrity": "sha1-8FKijacOYYkX7wqKw0wa5aaChrM=",
       "dev": true
     },
+    "psl": {
+      "version": "1.1.28",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.28.tgz",
+      "integrity": "sha512-+AqO1Ae+N/4r7Rvchrdm432afjT9hqJRyBN3DQv9At0tPz4hIFSGKbq64fN9dVoCow4oggIIax5/iONx0r9hZw==",
+      "dev": true
+    },
     "public-encrypt": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.2.tgz",
@@ -13199,12 +13147,12 @@
       }
     },
     "pumpify": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.4.0.tgz",
-      "integrity": "sha512-2kmNR9ry+Pf45opRVirpNuIFotsxUGLaYqxIwuR77AYrYRMuFCz9eryHBS52L360O+NcR383CL4QYlMKPq4zYA==",
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/pumpify/-/pumpify-1.5.1.tgz",
+      "integrity": "sha512-oClZI37HvuUJJxSKKrC17bZ9Cu0ZYhEAGPsPUy9KlMUmv9dKX2o77RUmq7f3XjIxbwyGwYzbzQ1L2Ks8sIradQ==",
       "dev": true,
       "requires": {
-        "duplexify": "3.5.4",
+        "duplexify": "3.6.0",
         "inherits": "2.0.3",
         "pump": "2.0.1"
       }
@@ -13222,9 +13170,9 @@
       "dev": true
     },
     "qs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.1.tgz",
-      "integrity": "sha512-eRzhrN1WSINYCDCbrz796z37LOe3m5tmW7RQf6oBntukAG1nmovJvhnwHHRMAfeoItc1m2Hk02WER2aQ/iqs+A==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
+      "integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
       "dev": true
     },
     "query-string": {
@@ -13250,43 +13198,27 @@
       "dev": true
     },
     "randomatic": {
-      "version": "1.1.7",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
-      "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.0.0.tgz",
+      "integrity": "sha512-VdxFOIEY3mNO5PtSRkkle/hPJDHvQhK21oa73K4yAc9qmp6N429gAyF1gZMOTMeS0/AYzaV/2Trcef+NaIonSA==",
       "dev": true,
       "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
+        "is-number": "4.0.0",
+        "kind-of": "6.0.2",
+        "math-random": "1.0.1"
       },
       "dependencies": {
         "is-number": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
-          "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
-          "dependencies": {
-            "kind-of": {
-              "version": "3.2.2",
-              "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
-              "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
-            }
-          }
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-4.0.0.tgz",
+          "integrity": "sha512-rSklcAIlf1OmFdyAqbnWTLVelsQ58uvZ66S/ZyawjWqIviTWCjg2PzVGw8WUA+nNuPTqb4wgA+NszrJ+08LlgQ==",
+          "dev": true
         },
         "kind-of": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
-          "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
+          "version": "6.0.2",
+          "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.2.tgz",
+          "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA==",
+          "dev": true
         }
       }
     },
@@ -13360,12 +13292,12 @@
       }
     },
     "rc": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.7.tgz",
-      "integrity": "sha512-LdLD8xD4zzLsAT5xyushXDNscEjB7+2ulnl8+r1pnESlYtlJtVSoCMBGr30eDRJ3+2Gq89jK9P9e4tCEH1+ywA==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
       "requires": {
-        "deep-extend": "0.5.1",
+        "deep-extend": "0.6.0",
         "ini": "1.3.5",
         "minimist": "1.2.0",
         "strip-json-comments": "2.0.1"
@@ -13482,7 +13414,7 @@
       "dev": true,
       "requires": {
         "ast-types": "0.9.12",
-        "core-js": "2.5.5",
+        "core-js": "2.5.7",
         "esprima": "4.0.0",
         "private": "0.1.8",
         "source-map": "0.6.1"
@@ -13502,7 +13434,7 @@
       "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
       "dev": true,
       "requires": {
-        "resolve": "1.7.1"
+        "resolve": "1.8.1"
       }
     },
     "redent": {
@@ -13552,9 +13484,9 @@
       }
     },
     "regenerate": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.3.3.tgz",
-      "integrity": "sha512-jVpo1GadrDAK59t/0jRx5VxYWQEDkkEKi6+HjE3joFVLfDOh9Xrdh0dF1eSq+BI/SwvTQ44gSscJ8N5zYL61sg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/regenerate/-/regenerate-1.4.0.tgz",
+      "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg==",
       "dev": true
     },
     "regenerator-runtime": {
@@ -13588,7 +13520,7 @@
       "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
       "dev": true,
       "requires": {
-        "regenerate": "1.3.3",
+        "regenerate": "1.4.0",
         "regjsgen": "0.2.0",
         "regjsparser": "0.1.5"
       }
@@ -13599,7 +13531,7 @@
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
       "dev": true,
       "requires": {
-        "rc": "1.2.7",
+        "rc": "1.2.8",
         "safe-buffer": "5.1.2"
       }
     },
@@ -13609,7 +13541,7 @@
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
       "dev": true,
       "requires": {
-        "rc": "1.2.7"
+        "rc": "1.2.8"
       }
     },
     "regjsgen": {
@@ -13749,9 +13681,9 @@
       }
     },
     "request": {
-      "version": "2.85.0",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.85.0.tgz",
-      "integrity": "sha512-8H7Ehijd4js+s6wuVPLjwORxD4zeuyjYugprdOXlPSqaApmL/QOy+EB/beICHVCHkGMKNh5rvihb5ov+IDw4mg==",
+      "version": "2.87.0",
+      "resolved": "https://registry.npmjs.org/request/-/request-2.87.0.tgz",
+      "integrity": "sha512-fcogkm7Az5bsS6Sl0sibkbhcKsnyon/jV1kF3ajGmF0c8HrttdKTPRT9hieOaQHA5HEq6r8OyWOo/o781C1tNw==",
       "dev": true,
       "requires": {
         "aws-sign2": "0.7.0",
@@ -13762,7 +13694,6 @@
         "forever-agent": "0.6.1",
         "form-data": "2.3.2",
         "har-validator": "5.0.3",
-        "hawk": "6.0.2",
         "http-signature": "1.2.0",
         "is-typedarray": "1.0.0",
         "isstream": "0.1.2",
@@ -13770,18 +13701,26 @@
         "mime-types": "2.1.18",
         "oauth-sign": "0.8.2",
         "performance-now": "2.1.0",
-        "qs": "6.5.1",
+        "qs": "6.5.2",
         "safe-buffer": "5.1.2",
-        "stringstream": "0.0.5",
         "tough-cookie": "2.3.4",
         "tunnel-agent": "0.6.0",
-        "uuid": "3.2.1"
+        "uuid": "3.3.2"
       },
       "dependencies": {
+        "tough-cookie": {
+          "version": "2.3.4",
+          "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
+          "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+          "dev": true,
+          "requires": {
+            "punycode": "1.4.1"
+          }
+        },
         "uuid": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
           "dev": true
         }
       }
@@ -13803,7 +13742,7 @@
       "requires": {
         "request-promise-core": "1.1.1",
         "stealthy-require": "1.1.1",
-        "tough-cookie": "2.3.4"
+        "tough-cookie": "2.4.3"
       }
     },
     "require-directory": {
@@ -13825,9 +13764,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.7.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.7.1.tgz",
-      "integrity": "sha512-c7rwLofp8g1U+h1KNyHL/jicrKg1Ek4q+Lr33AL65uZTinUZHe30D5HlyN5V9NW0JX1D5dXQ4jqW5l7Sy/kGfw==",
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.8.1.tgz",
+      "integrity": "sha512-AicPrAC7Qu1JxPCZ9ZgCZlY35QgFnNqc+0LtbRNxnVw4TXvjQ72wnuL9JQcEBgXkI9JM8MsT9kaQoHcpCRJOYA==",
       "dev": true,
       "requires": {
         "path-parse": "1.0.5"
@@ -13956,6 +13895,12 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+      "dev": true
+    },
+    "safe-json-parse": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/safe-json-parse/-/safe-json-parse-1.0.1.tgz",
+      "integrity": "sha1-PnZyPjjf3aE8mx0poeB//uSzC1c=",
       "dev": true
     },
     "safe-regex": {
@@ -14194,13 +14139,13 @@
       "integrity": "sha1-pNprY1/8zMoz9w0Xy5JZLeleVXo=",
       "dev": true,
       "requires": {
-        "is-arrayish": "0.3.1"
+        "is-arrayish": "0.3.2"
       },
       "dependencies": {
         "is-arrayish": {
-          "version": "0.3.1",
-          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.1.tgz",
-          "integrity": "sha1-wt/DhquqDD4zxI2z/ocFnmkGXv0=",
+          "version": "0.3.2",
+          "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.2.tgz",
+          "integrity": "sha512-eVRqCvVlZbuw3GrM63ovNSNAeA1K16kaR/LRY/92w0zxQ5/1YzwblUX652i4Xs9RwAGjW9d9y6X88t8OaAJfWQ==",
           "dev": true
         }
       }
@@ -14214,7 +14159,7 @@
         "formatio": "1.1.1",
         "lolex": "1.3.2",
         "samsam": "1.1.2",
-        "util": "0.10.3"
+        "util": "0.10.4"
       }
     },
     "slash": {
@@ -14250,7 +14195,7 @@
         "extend-shallow": "2.0.1",
         "map-cache": "0.2.2",
         "source-map": "0.5.7",
-        "source-map-resolve": "0.5.1",
+        "source-map-resolve": "0.5.2",
         "use": "3.1.0"
       },
       "dependencies": {
@@ -14347,12 +14292,13 @@
       }
     },
     "sntp": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/sntp/-/sntp-2.1.0.tgz",
-      "integrity": "sha512-FL1b58BDrqS3A11lJ0zEdnJ3UOKqVxawAkF3k7F0CVN7VQ34aZrV+G8BZ1WC9ZL7NyrwsW0oviwsWDgRuVYtJg==",
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/sntp/-/sntp-0.2.4.tgz",
+      "integrity": "sha1-+4hfGLDzqtGJ+CSGJTa87ux1CQA=",
       "dev": true,
+      "optional": true,
       "requires": {
-        "hoek": "4.2.1"
+        "hoek": "0.9.1"
       }
     },
     "sort-keys": {
@@ -14417,9 +14363,9 @@
       }
     },
     "source-map-resolve": {
-      "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
-      "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.2.tgz",
+      "integrity": "sha512-MjqsvNwyz1s0k81Goz/9vRBe9SZdB09Bdw+/zYyO+3CuPk6fouTaxscHkgtE8jKvf01kVfl8riHzERQ/kefaSA==",
       "dev": true,
       "requires": {
         "atob": "2.1.1",
@@ -14509,18 +14455,19 @@
       "dev": true
     },
     "sshpk": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.1.tgz",
-      "integrity": "sha1-Ew9Zde3a2WPx1W+SuaxsUfqfg+s=",
+      "version": "1.14.2",
+      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.14.2.tgz",
+      "integrity": "sha1-xvxhZIo9nE52T9P8306hBeSSupg=",
       "dev": true,
       "requires": {
         "asn1": "0.2.3",
         "assert-plus": "1.0.0",
-        "bcrypt-pbkdf": "1.0.1",
+        "bcrypt-pbkdf": "1.0.2",
         "dashdash": "1.14.1",
         "ecc-jsbn": "0.1.1",
         "getpass": "0.1.7",
         "jsbn": "0.1.1",
+        "safer-buffer": "2.1.2",
         "tweetnacl": "0.14.5"
       }
     },
@@ -14596,9 +14543,9 @@
       }
     },
     "stream-http": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.1.tgz",
-      "integrity": "sha512-cQ0jo17BLca2r0GfRdZKYAGLU6JRoIWxqSOakUMuKOT6MOK7AAlE856L33QuDmAy/eeOrhLee3dZKX0Uadu93A==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.3.tgz",
+      "integrity": "sha512-+TSkfINHDo4J+ZobQLWiMouQYB+UVYFttRA94FpEzzJ7ZdqcL4uUUQ7WkdkI4DSozGmgBUE/a47L+38PenXhUw==",
       "dev": true,
       "requires": {
         "builtin-status-codes": "3.0.0",
@@ -14652,10 +14599,11 @@
       }
     },
     "stringstream": {
-      "version": "0.0.5",
-      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.5.tgz",
-      "integrity": "sha1-TkhM1N5aC7vuGORjB3EKioFiGHg=",
-      "dev": true
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/stringstream/-/stringstream-0.0.6.tgz",
+      "integrity": "sha512-87GEBAkegbBcweToUrdzf3eLhWNg06FJTebl4BVJz/JgWy8CvEr9dRtX5qWphiynMSQlxxi+QqN0z5T32SLlhA==",
+      "dev": true,
+      "optional": true
     },
     "strip-ansi": {
       "version": "4.0.0",
@@ -14781,13 +14729,13 @@
       }
     },
     "tar-stream": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.0.tgz",
-      "integrity": "sha512-lh2iAPG/BHNmN6WB9Ybdynk9rEJ5GD/dy4zscHmVlwa1dq2tpE+BH78i5vjYwYVWEaOXGBjzxr89aVACF17Cpw==",
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.1.tgz",
+      "integrity": "sha512-IFLM5wp3QrJODQFPm6/to3LJZrONdBY/otxcvDIQzu217zKye6yVR3hhi9lAjrC2Z+m/j5oDxMPb1qcd8cIvpA==",
       "dev": true,
       "requires": {
         "bl": "1.2.2",
-        "buffer-alloc": "1.1.0",
+        "buffer-alloc": "1.2.0",
         "end-of-stream": "1.4.1",
         "fs-constants": "1.0.0",
         "readable-stream": "2.3.6",
@@ -14889,105 +14837,26 @@
       }
     },
     "tiny-lr": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-0.2.1.tgz",
-      "integrity": "sha1-s/26gC5dVqM8L28QeUsy5Hescp0=",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tiny-lr/-/tiny-lr-1.1.1.tgz",
+      "integrity": "sha512-44yhA3tsaRoMOjQQ+5v5mVdqef+kH6Qze9jTpqtVufgYjYt08zyZAwNwwVBj3i1rJMnR52IxOW0LK0vBzgAkuA==",
       "dev": true,
       "requires": {
-        "body-parser": "1.14.2",
-        "debug": "2.2.0",
+        "body": "5.1.0",
+        "debug": "3.1.0",
         "faye-websocket": "0.10.0",
         "livereload-js": "2.3.0",
-        "parseurl": "1.3.2",
-        "qs": "5.1.0"
+        "object-assign": "4.1.1",
+        "qs": "6.5.2"
       },
       "dependencies": {
-        "body-parser": {
-          "version": "1.14.2",
-          "resolved": "https://registry.npmjs.org/body-parser/-/body-parser-1.14.2.tgz",
-          "integrity": "sha1-EBXLH+LEQ4WCWVgdtTMy+NDPUPk=",
-          "dev": true,
-          "requires": {
-            "bytes": "2.2.0",
-            "content-type": "1.0.4",
-            "debug": "2.2.0",
-            "depd": "1.1.2",
-            "http-errors": "1.3.1",
-            "iconv-lite": "0.4.13",
-            "on-finished": "2.3.0",
-            "qs": "5.2.0",
-            "raw-body": "2.1.7",
-            "type-is": "1.6.16"
-          },
-          "dependencies": {
-            "qs": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/qs/-/qs-5.2.0.tgz",
-              "integrity": "sha1-qfMRQq9GjLcrJbMBNrokVoNJFr4=",
-              "dev": true
-            }
-          }
-        },
-        "bytes": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.2.0.tgz",
-          "integrity": "sha1-/TVGSkA/b5EXwt42Cez/nK4ABYg=",
-          "dev": true
-        },
         "debug": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-2.2.0.tgz",
-          "integrity": "sha1-+HBX6ZWxofauaklgZkE3vFbwOdo=",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
           "dev": true,
           "requires": {
-            "ms": "0.7.1"
-          }
-        },
-        "http-errors": {
-          "version": "1.3.1",
-          "resolved": "https://registry.npmjs.org/http-errors/-/http-errors-1.3.1.tgz",
-          "integrity": "sha1-GX4izevUGYWF6GlO9nhhl7ke2UI=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "statuses": "1.3.1"
-          }
-        },
-        "iconv-lite": {
-          "version": "0.4.13",
-          "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.13.tgz",
-          "integrity": "sha1-H4irpKsLFQjoMSrMOTRfNumS4vI=",
-          "dev": true
-        },
-        "ms": {
-          "version": "0.7.1",
-          "resolved": "https://registry.npmjs.org/ms/-/ms-0.7.1.tgz",
-          "integrity": "sha1-nNE8A62/8ltl7/3nzoZO6VIBcJg=",
-          "dev": true
-        },
-        "qs": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/qs/-/qs-5.1.0.tgz",
-          "integrity": "sha1-TZMuXH6kEcynajEtOaYGIA/VDNk=",
-          "dev": true
-        },
-        "raw-body": {
-          "version": "2.1.7",
-          "resolved": "https://registry.npmjs.org/raw-body/-/raw-body-2.1.7.tgz",
-          "integrity": "sha1-rf6s4uT7MJgFgBTQjActzFl1h3Q=",
-          "dev": true,
-          "requires": {
-            "bytes": "2.4.0",
-            "iconv-lite": "0.4.13",
-            "unpipe": "1.0.0"
-          },
-          "dependencies": {
-            "bytes": {
-              "version": "2.4.0",
-              "resolved": "https://registry.npmjs.org/bytes/-/bytes-2.4.0.tgz",
-              "integrity": "sha1-fZcZb51br39pNeJZhVSe3SpsIzk=",
-              "dev": true
-            }
+            "ms": "2.0.0"
           }
         }
       }
@@ -15077,11 +14946,12 @@
       }
     },
     "tough-cookie": {
-      "version": "2.3.4",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.3.4.tgz",
-      "integrity": "sha512-TZ6TTfI5NtZnuyy/Kecv+CnoROnyXn2DN97LontgQpCwsX2XyLYCC0ENhYkehSOwAp8rTQKc/NUIF7BkQ5rKLA==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+      "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
       "dev": true,
       "requires": {
+        "psl": "1.1.28",
         "punycode": "1.4.1"
       }
     },
@@ -15091,13 +14961,13 @@
       "integrity": "sha1-qLE/1r/SSJUZZ0zN5VujaTtwbQk=",
       "dev": true,
       "requires": {
-        "punycode": "2.1.0"
+        "punycode": "2.1.1"
       },
       "dependencies": {
         "punycode": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.0.tgz",
-          "integrity": "sha1-X4Y+3Im5bbCQdLrXlHvwkFbKTn0=",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+          "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
           "dev": true
         }
       }
@@ -15140,7 +15010,7 @@
         "mkdirp": "0.5.1",
         "source-map-support": "0.4.18",
         "tsconfig": "6.0.0",
-        "v8flags": "3.0.2",
+        "v8flags": "3.1.1",
         "yn": "2.0.0"
       },
       "dependencies": {
@@ -15176,14 +15046,14 @@
         "babel-code-frame": "6.26.0",
         "builtin-modules": "1.1.1",
         "chalk": "2.4.1",
-        "commander": "2.15.1",
+        "commander": "2.16.0",
         "diff": "3.5.0",
         "glob": "7.1.2",
         "minimatch": "3.0.4",
-        "resolve": "1.7.1",
+        "resolve": "1.8.1",
         "semver": "5.5.0",
         "tslib": "1.8.1",
-        "tsutils": "2.26.2"
+        "tsutils": "2.27.1"
       },
       "dependencies": {
         "semver": {
@@ -15216,9 +15086,9 @@
       }
     },
     "tsutils": {
-      "version": "2.26.2",
-      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.26.2.tgz",
-      "integrity": "sha512-uzwnhmrSbyinPCiwfzGsOY3IulBTwoky7r83HmZdz9QNCjhSCzavkh47KLWuU0zF2F2WbpmmzoJUIEiYyd+jEQ==",
+      "version": "2.27.1",
+      "resolved": "https://registry.npmjs.org/tsutils/-/tsutils-2.27.1.tgz",
+      "integrity": "sha512-AE/7uzp32MmaHvNNFES85hhUDHFdFZp6OAiZcd6y4ZKKIg6orJTm8keYWBhIhrJQH3a4LzNKat7ZPXZt5aTf6w==",
       "dev": true,
       "requires": {
         "tslib": "1.8.1"
@@ -15428,9 +15298,9 @@
       "dev": true,
       "requires": {
         "@types/fs-extra": "0.0.33",
-        "@types/handlebars": "4.0.37",
-        "@types/highlight.js": "9.12.2",
-        "@types/lodash": "4.14.108",
+        "@types/handlebars": "4.0.38",
+        "@types/highlight.js": "9.12.3",
+        "@types/lodash": "4.14.110",
         "@types/marked": "0.0.28",
         "@types/minimatch": "2.0.29",
         "@types/shelljs": "0.3.33",
@@ -15589,7 +15459,7 @@
         "debug": "2.6.9",
         "detect-indent": "5.0.0",
         "graceful-fs": "4.1.11",
-        "has": "1.0.1",
+        "has": "1.0.3",
         "invariant": "2.2.4",
         "is-absolute": "0.2.6",
         "jspm-config": "0.3.4",
@@ -15605,7 +15475,7 @@
         "popsicle-rewrite": "1.0.0",
         "popsicle-status": "2.0.1",
         "promise-finally": "3.0.0",
-        "rc": "1.2.7",
+        "rc": "1.2.8",
         "rimraf": "2.6.2",
         "sort-keys": "1.1.2",
         "string-template": "1.0.0",
@@ -15619,12 +15489,12 @@
       }
     },
     "uglify-js": {
-      "version": "3.3.23",
-      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.3.23.tgz",
-      "integrity": "sha512-Ks+KqLGDsYn4z+pU7JsKCzC0T3mPYl+rU+VcPZiQOazjE4Uqi4UCRY3qPMDbJi7ze37n1lDXj3biz1ik93vqvw==",
+      "version": "3.4.3",
+      "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.4.3.tgz",
+      "integrity": "sha512-RbOgGjF04sFUNSi8xGOTB9AmtVmMmVVAL5a7lxIgJ8urejJen+priq0ooRIHHa8AXI/dSvNF9yYMz9OP4PhybQ==",
       "dev": true,
       "requires": {
-        "commander": "2.15.1",
+        "commander": "2.16.0",
         "source-map": "0.6.1"
       }
     },
@@ -15742,7 +15612,7 @@
           "dev": true,
           "requires": {
             "base64-js": "0.0.8",
-            "ieee754": "1.1.11",
+            "ieee754": "1.1.12",
             "isarray": "1.0.0"
           }
         }
@@ -15761,10 +15631,14 @@
       "dev": true
     },
     "underscore.string": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.2.3.tgz",
-      "integrity": "sha1-gGmSYzZl1eX8tNsfs6hi62jp5to=",
-      "dev": true
+      "version": "3.3.4",
+      "resolved": "https://registry.npmjs.org/underscore.string/-/underscore.string-3.3.4.tgz",
+      "integrity": "sha1-LCo/n4PmR2L9xF5s6sZRQoZCE9s=",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "1.0.3",
+        "util-deprecate": "1.0.2"
+      }
     },
     "union-value": {
       "version": "1.0.0",
@@ -15806,15 +15680,6 @@
       "resolved": "https://registry.npmjs.org/uniq/-/uniq-1.0.1.tgz",
       "integrity": "sha1-sxxa6CVIRKOoKBVBzisEuGWnNP8=",
       "dev": true
-    },
-    "uniqid": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/uniqid/-/uniqid-4.1.1.tgz",
-      "integrity": "sha1-iSIN32t1GuUrX3JISGNShZa7hME=",
-      "dev": true,
-      "requires": {
-        "macaddress": "0.2.8"
-      }
     },
     "uniqs": {
       "version": "2.0.0",
@@ -15860,9 +15725,9 @@
       }
     },
     "universalify": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.1.tgz",
-      "integrity": "sha1-+nG63UQ3r0wUiEHjs7Fl+enlkLc=",
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+      "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
       "dev": true
     },
     "unpipe": {
@@ -15918,9 +15783,9 @@
       "dev": true
     },
     "upath": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/upath/-/upath-1.0.5.tgz",
-      "integrity": "sha512-qbKn90aDQ0YEwvXoLqj0oiuUYroLX2lVHZ+b+xwjozFasAOC4GneDq5+OaIG5Zj+jFmbz/uO+f7a9qxjktJQww==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/upath/-/upath-1.1.0.tgz",
+      "integrity": "sha512-bzpH/oBhoS/QI/YtbkqCg6VEiPYjSZtrHQM6/QnJS6OL9pKUFLqb3aFh4Scvwm45+7iAgiMkLhSbaZxUqmrprw==",
       "dev": true
     },
     "update-notifier": {
@@ -16013,20 +15878,12 @@
       }
     },
     "util": {
-      "version": "0.10.3",
-      "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
-      "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
+      "version": "0.10.4",
+      "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
+      "integrity": "sha512-0Pm9hTQ3se5ll1XihRic3FDIku70C+iHUdT/W926rSgHV5QgXsYbKZN8MSC3tJtSkhuROzvsQjAaFENRXr+19A==",
       "dev": true,
       "requires": {
-        "inherits": "2.0.1"
-      },
-      "dependencies": {
-        "inherits": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.1.tgz",
-          "integrity": "sha1-sX0I0ya0Qj5Wjv9xn5GwscvfafE=",
-          "dev": true
-        }
+        "inherits": "2.0.3"
       }
     },
     "util-deprecate": {
@@ -16054,9 +15911,9 @@
       "dev": true
     },
     "v8flags": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.0.2.tgz",
-      "integrity": "sha512-6sgSKoFw1UpUPd3cFdF7QGnrH6tDeBgW1F3v9gy8gLY0mlbiBXq8soy8aQpY6xeeCjH5K+JvC62Acp7gtl7wWA==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.1.tgz",
+      "integrity": "sha512-iw/1ViSEaff8NJ3HLyEjawk/8hjJib3E7pvG4pddVXfUg1983s3VGsiClDjhK64MQVDGqc1Q8r18S4VKQZS9EQ==",
       "dev": true,
       "requires": {
         "homedir-polyfill": "1.0.1"
@@ -16125,7 +15982,7 @@
       "integrity": "sha512-i6dHe3EyLjMmDlU1/bGQpEw25XSjkJULPuAVKCbNRefQVq48yXKUpwg538F7AZTf9kyr57zj++pQFltUa5H7yA==",
       "dev": true,
       "requires": {
-        "chokidar": "2.0.3",
+        "chokidar": "2.0.4",
         "graceful-fs": "4.1.11",
         "neo-async": "2.5.1"
       },
@@ -16182,23 +16039,24 @@
           }
         },
         "chokidar": {
-          "version": "2.0.3",
-          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.3.tgz",
-          "integrity": "sha512-zW8iXYZtXMx4kux/nuZVXjkLP+CyIK5Al5FHnj1OgTKGZfp4Oy6/ymtMSKFv3GD8DviEmUPmJg9eFdJ/JzudMg==",
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.0.4.tgz",
+          "integrity": "sha512-z9n7yt9rOvIJrMhvDtDictKrkFHeihkNl6uWMmZlmL6tJtX9Cs+87oK+teBx+JIgzvbX3yZHT3eF8vpbDxHJXQ==",
           "dev": true,
           "requires": {
             "anymatch": "2.0.0",
             "async-each": "1.0.1",
             "braces": "2.3.2",
-            "fsevents": "1.2.3",
+            "fsevents": "1.2.4",
             "glob-parent": "3.1.0",
             "inherits": "2.0.3",
             "is-binary-path": "1.0.1",
             "is-glob": "4.0.0",
+            "lodash.debounce": "4.0.8",
             "normalize-path": "2.1.1",
             "path-is-absolute": "1.0.1",
             "readdirp": "2.1.0",
-            "upath": "1.0.5"
+            "upath": "1.1.0"
           }
         },
         "expand-brackets": {
@@ -16451,7 +16309,7 @@
             "extglob": "2.0.4",
             "fragment-cache": "0.2.1",
             "kind-of": "6.0.2",
-            "nanomatch": "1.2.9",
+            "nanomatch": "1.2.13",
             "object.pick": "1.3.0",
             "regex-not": "1.0.2",
             "snapdragon": "0.8.2",
@@ -16478,11 +16336,11 @@
       "integrity": "sha512-5ZXLWWsMqHKFr5y0N3Eo5IIisxeEeRAajNq4mELb/WELOR7srdbQk2N5XiyNy2A/AgvlR3AmeBCZJW8lHrolbw==",
       "dev": true,
       "requires": {
-        "acorn": "5.5.3",
+        "acorn": "5.7.1",
         "acorn-dynamic-import": "2.0.2",
         "ajv": "5.5.2",
         "ajv-keywords": "2.1.1",
-        "async": "2.6.0",
+        "async": "2.6.1",
         "enhanced-resolve": "3.4.1",
         "escope": "3.6.0",
         "interpret": "1.1.0",
@@ -16734,8 +16592,8 @@
       "requires": {
         "acorn": "4.0.13",
         "chalk": "1.1.3",
-        "commander": "2.15.1",
-        "ejs": "2.5.9",
+        "commander": "2.16.0",
+        "ejs": "2.6.1",
         "express": "4.16.2",
         "filesize": "3.6.1",
         "gzip-size": "3.0.0",
@@ -16871,13 +16729,13 @@
         "chalk": "2.4.1",
         "log-symbols": "2.1.0",
         "loglevelnext": "1.0.5",
-        "uuid": "3.2.1"
+        "uuid": "3.3.2"
       },
       "dependencies": {
         "uuid": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.2.1.tgz",
-          "integrity": "sha512-jZnMwlb9Iku/O3smGWvZhauCf6cvvpKi4BKRiliS3cxnI+Gz9j5MEpTz2UFuXiKPJocb7gnsLHwiS05ige5BEA==",
+          "version": "3.3.2",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
           "dev": true
         }
       }
@@ -16904,7 +16762,7 @@
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
       "dev": true,
       "requires": {
-        "http-parser-js": "0.4.12",
+        "http-parser-js": "0.4.13",
         "websocket-extensions": "0.1.3"
       }
     },
@@ -16932,9 +16790,9 @@
       }
     },
     "whatwg-url": {
-      "version": "6.4.1",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.4.1.tgz",
-      "integrity": "sha512-FwygsxsXx27x6XXuExA/ox3Ktwcbf+OAvrKmLulotDAiO1Q6ixchPFaHYsis2zZBZSJTR0+dR+JVtf7MlbqZjw==",
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-6.5.0.tgz",
+      "integrity": "sha512-rhRZRqx/TLJQWUpQ6bmrt2UV4f0HCQ463yQuONJqC6fO2VoEb1pTYddbe59SkYq87aoM5A3bdhMZiUiVws+fzQ==",
       "dev": true,
       "requires": {
         "lodash.sortby": "4.7.0",
@@ -16949,9 +16807,9 @@
       "dev": true
     },
     "which": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
-      "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
       "dev": true,
       "requires": {
         "isexe": "2.0.0"
@@ -17143,13 +17001,13 @@
       }
     },
     "yauzl": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.9.1.tgz",
-      "integrity": "sha1-qBmB6nCleUYTOIPwKcWCGok1mn8=",
+      "version": "2.10.0",
+      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
+      "integrity": "sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=",
       "dev": true,
       "requires": {
         "buffer-crc32": "0.2.13",
-        "fd-slicer": "1.0.1"
+        "fd-slicer": "1.1.0"
       }
     },
     "yn": {

--- a/src/calendar/tests/unit/Calendar.ts
+++ b/src/calendar/tests/unit/Calendar.ts
@@ -46,8 +46,6 @@ const expected = function(popupOpen = false, selectedIndex = -1, weekdayLabel = 
 	dateIndex = -1;
 	return v('div', {
 		classes: css.root,
-		dir: '',
-		lang: null,
 		...overrides
 	}, [
 		w(DatePicker, {

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -155,7 +155,6 @@ const getExpectedVdom = function(useTestProperties = false, open = false, label 
 		'aria-haspopup': 'true',
 		'aria-readonly': readOnly ? `${readOnly}` : null,
 		'aria-required': null,
-		dir: '',
 		classes: [
 			css.root,
 			open ? css.open : null,
@@ -165,7 +164,6 @@ const getExpectedVdom = function(useTestProperties = false, open = false, label 
 			null
 		],
 		key: 'root',
-		lang: null,
 		role: 'combobox'
 	}, [
 		label ? w(Label, {

--- a/src/common/example/index.html
+++ b/src/common/example/index.html
@@ -17,7 +17,7 @@
 </head>
 <body>
 	<script src="../../../node_modules/@dojo/shim/util/amd.js"></script>
-	<script src="../../../node_modules/@dojo/loader/loader.min.js"></script>
+	<script src="../../../node_modules/@dojo/loader/loader.js"></script>
 	<link rel="stylesheet" href="./example.css">
 	<script>
 		require.config(shimAmdDependencies({

--- a/src/dialog/tests/unit/Dialog.ts
+++ b/src/dialog/tests/unit/Dialog.ts
@@ -36,9 +36,7 @@ const expectedCloseButton = function() {
 
 const expected = function(open = false, closeable = false, children: any[] = []) {
 	return v('div', {
-		classes: css.root,
-		dir: '',
-		lang: null
+		classes: css.root
 	}, open ? [
 		w(GlobalEvent, {
 			key: 'global',
@@ -112,9 +110,7 @@ registerSuite('Dialog', {
 			};
 
 			h.expect(() => v('div', {
-				classes: css.root,
-				dir: '',
-				lang: null
+				classes: css.root
 			}, [
 				w(GlobalEvent, {
 					key: 'global',
@@ -168,9 +164,7 @@ registerSuite('Dialog', {
 				title: 'foo'
 			}));
 			h.expect(() => v('div', {
-				classes: css.root,
-				dir: '',
-				lang: null
+				classes: css.root
 			}, [
 				w(GlobalEvent, {
 					key: 'global',

--- a/src/slide-pane/tests/unit/SlidePane.ts
+++ b/src/slide-pane/tests/unit/SlidePane.ts
@@ -36,8 +36,6 @@ registerSuite('SlidePane', {
 			h.expect(() => v('div', {
 				'aria-labelledby': '',
 				classes: css.root,
-				dir: '',
-				lang: null,
 				onmousedown: noop,
 				onmousemove: noop,
 				onmouseup: noop,
@@ -91,8 +89,6 @@ registerSuite('SlidePane', {
 
 			h.expect(() => v('div', {
 				'aria-labelledby': '',
-				dir: '',
-				lang: null,
 				onmousedown: noop,
 				onmousemove: noop,
 				onmouseup: noop,
@@ -150,8 +146,6 @@ registerSuite('SlidePane', {
 
 			h.expect(() => v('div', {
 				'aria-labelledby': '',
-				dir: '',
-				lang: null,
 				onmousedown: noop,
 				onmousemove: noop,
 				onmouseup: noop,
@@ -199,8 +193,6 @@ registerSuite('SlidePane', {
 			properties.open = false;
 			h.expect(() => v('div', {
 				'aria-labelledby': '',
-				dir: '',
-				lang: null,
 				onmousedown: noop,
 				onmousemove: noop,
 				onmouseup: noop,
@@ -456,8 +448,6 @@ registerSuite('SlidePane', {
 			function expected(open: boolean, transitionDone?: boolean) {
 				return v('div', {
 					'aria-labelledby': '',
-					dir: '',
-					lang: null,
 					onmousedown: noop,
 					onmousemove: noop,
 					onmouseup: noop,
@@ -525,8 +515,6 @@ registerSuite('SlidePane', {
 			function expected(closed: boolean, swipeState: any = {}) {
 				return v('div', {
 					'aria-labelledby': '',
-					dir: '',
-					lang: null,
 					onmousedown: noop,
 					onmousemove: noop,
 					onmouseup: noop,
@@ -603,8 +591,6 @@ registerSuite('SlidePane', {
 			function expected(closed = false, swipeState: any = {}) {
 				return v('div', {
 					'aria-labelledby': '',
-					dir: '',
-					lang: null,
 					onmousedown: noop,
 					onmousemove: noop,
 					onmouseup: noop,

--- a/src/tab-controller/tests/unit/TabButton.ts
+++ b/src/tab-controller/tests/unit/TabButton.ts
@@ -49,10 +49,8 @@ const expected = function(closeable = false, disabled = false, activeTab: number
 			closeable ? css.closeable : null,
 			disabled ? css.disabledTabButton : null
 		],
-		dir: '',
 		id: 'foo',
 		key: 'tab-button',
-		lang: null,
 		onclick: noop,
 		onkeydown: noop,
 		role: 'tab',

--- a/src/toolbar/tests/unit/Toolbar.ts
+++ b/src/toolbar/tests/unit/Toolbar.ts
@@ -21,9 +21,7 @@ registerSuite('Toolbar', {
 			const h = harness(() => w(Toolbar, {}));
 			h.expect(() => v('div', {
 				key: 'root',
-				lang: null,
-				classes: [ fixedCss.rootFixed, css.root, null ],
-				dir: ''
+				classes: [ fixedCss.rootFixed, css.root, null ]
 			}, [
 				w(GlobalEvent, { window: { resize: noop }, key: 'global' }),
 				null,
@@ -49,9 +47,7 @@ registerSuite('Toolbar', {
 
 			h.expect(() => v('div', {
 				key: 'root',
-				lang: null,
-				classes: [ fixedCss.rootFixed, css.root, null ],
-				dir: ''
+				classes: [ fixedCss.rootFixed, css.root, null ]
 			}, [
 				w(GlobalEvent, { window: { resize: noop }, key: 'global' }),
 				null,
@@ -64,9 +60,7 @@ registerSuite('Toolbar', {
 			const h = harness(() => w(Toolbar, { heading: 'test' }));
 			h.expect(() => v('div', {
 				key: 'root',
-				lang: null,
-				classes: [ fixedCss.rootFixed, css.root, null ],
-				dir: ''
+				classes: [ fixedCss.rootFixed, css.root, null ]
 			}, [
 				w(GlobalEvent, { window: { resize: noop }, key: 'global' }),
 				v('div', {
@@ -81,9 +75,7 @@ registerSuite('Toolbar', {
 			const h = harness(() => w(Toolbar, {}, [ 'test' ]));
 			h.expect(() => v('div', {
 				key: 'root',
-				lang: null,
-				classes: [ fixedCss.rootFixed, css.root, null ],
-				dir: ''
+				classes: [ fixedCss.rootFixed, css.root, null ]
 			}, [
 				w(GlobalEvent, { window: { resize: noop }, key: 'global' }),
 				null,
@@ -137,9 +129,7 @@ registerSuite('Toolbar', {
 
 			h.expect(() => v('div', {
 				key: 'root',
-				lang: null,
-				classes: [ fixedCss.rootFixed, css.root, null ],
-				dir: ''
+				classes: [ fixedCss.rootFixed, css.root, null ]
 			}, [
 				w(GlobalEvent, { window: { resize: noop }, key: 'global' }),
 				null,
@@ -161,9 +151,7 @@ registerSuite('Toolbar', {
 
 			h.expect(() => v('div', {
 				key: 'root',
-				lang: null,
-				classes: [ fixedCss.rootFixed, css.root, css.collapsed ],
-				dir: ''
+				classes: [ fixedCss.rootFixed, css.root, css.collapsed ]
 			}, [
 				w(GlobalEvent, { window: { resize: noop }, key: 'global' }),
 				v('div', {
@@ -178,9 +166,7 @@ registerSuite('Toolbar', {
 
 			h.expect(() => v('div', {
 				key: 'root',
-				lang: null,
-				classes: [ fixedCss.rootFixed, css.root, css.collapsed ],
-				dir: ''
+				classes: [ fixedCss.rootFixed, css.root, css.collapsed ]
 			}, [
 				w(GlobalEvent, { window: { resize: noop }, key: 'global' }),
 				v('div', {


### PR DESCRIPTION
**Type:** bug
The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Necessary to fix failing tests: updates the path to the dojo loader so examples and functional tests load, and updates unit tests as the I18n mixin no longer adds `dir` and `lang` attributes when not set (see https://github.com/dojo/widget-core/pull/951).
