### PR TITLE
Change comobobox getResultLabel type to match select and listbox

### DIFF
--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -28,8 +28,9 @@ import { customElement } from '@dojo/widget-core/decorators/customElement';
  * @property clearable          Determines whether the input should be able to be cleared
  * @property disabled           Prevents user interaction and styles content accordingly
  * @property getResultLabel     Can be used to get the text label of a result based on the underlying result object
- * @property getResultSelected  Can be used to highlight the selected result. Defaults to checking the result label.
- * @property widgetId            Optional id string for the combobox, set on the text input
+ * @property getResultSelected  Can be used to highlight the selected result. Defaults to checking the result label
+ * @property getResultValue     Can be used to define a value returned by onChange when a given result is selected. Defaults to getResultLabel
+ * @property widgetId           Optional id string for the combobox, set on the text input
  * @property inputProperties    TextInput properties to set on the underlying input
  * @property invalid            Determines if this input is valid
  * @property isResultDisabled   Used to determine if an item should be disabled
@@ -50,12 +51,13 @@ export interface ComboBoxProperties extends ThemedProperties, LabeledProperties 
 	disabled?: boolean;
 	getResultLabel?(result: any): DNode;
 	getResultSelected?(result: any): boolean;
+	getResultValue?(result: any): string;
 	widgetId?: string;
 	inputProperties?: TextInputProperties;
 	invalid?: boolean;
 	isResultDisabled?(result: any): boolean;
 	onBlur?(value: string, key?: string | number): void;
-	onChange?(value: DNode, key?: string | number): void;
+	onChange?(value: string, key?: string | number): void;
 	onFocus?(value: string, key?: string | number): void;
 	onMenuChange?(open: boolean, key?: string | number): void;
 	onRequestResults?(key?: string | number): void;
@@ -132,6 +134,12 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 		const { getResultSelected, value } = this.properties;
 
 		return getResultSelected ? getResultSelected(result) : this._getResultLabel(result) === value;
+	}
+
+	private _getResultValue(result: any) {
+		const { getResultValue = this.properties.getResultLabel } = this.properties;
+
+		return getResultValue ? `${getResultValue(result)}` : `${result}`;
 	}
 
 	private _getResultId(result: any, index: number) {
@@ -281,7 +289,7 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 
 		this._callInputFocus = true;
 		this._closeMenu();
-		onChange && onChange(this._getResultLabel(results[index]), key);
+		onChange && onChange(this._getResultValue(results[index]), key);
 	}
 
 	private _moveActiveIndex(operation: Operation) {

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -48,14 +48,14 @@ import { customElement } from '@dojo/widget-core/decorators/customElement';
 export interface ComboBoxProperties extends ThemedProperties, LabeledProperties {
 	clearable?: boolean;
 	disabled?: boolean;
-	getResultLabel?(result: any): string;
+	getResultLabel?(result: any): DNode;
 	getResultSelected?(result: any): boolean;
 	widgetId?: string;
 	inputProperties?: TextInputProperties;
 	invalid?: boolean;
 	isResultDisabled?(result: any): boolean;
 	onBlur?(value: string, key?: string | number): void;
-	onChange?(value: string, key?: string | number): void;
+	onChange?(value: DNode, key?: string | number): void;
 	onFocus?(value: string, key?: string | number): void;
 	onMenuChange?(open: boolean, key?: string | number): void;
 	onRequestResults?(key?: string | number): void;

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -382,6 +382,19 @@ registerSuite('ComboBox', {
 			assert.isFalse(onChange.called, 'onChange not called for no results');
 		},
 
+		'onChange uses custom getResultValue'() {
+			const onChange = sinon.stub();
+			const h = harness(() => w(ComboBox, {
+				...testProperties,
+				onChange,
+				getResultValue: (result: any) => result.value
+			}));
+
+			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
+			h.trigger('@listbox', 'onOptionSelect', testOptions[1], 1);
+			assert.isTrue(onChange.calledWith('two'), 'onChange callback called with value of second option');
+		},
+
 		'clear button clears input'() {
 			const onChange = sinon.stub();
 			const h = harness(() => w(ComboBox, {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Both `Select` and `Listbox` allow a `DNode` return type for `getOptionLabel`. It makes sense to update `ComboBox` to allow the same.
