### PR TITLE
remove default clearable padding

### DIFF
--- a/src/theme/combobox.m.css
+++ b/src/theme/combobox.m.css
@@ -11,10 +11,6 @@
 	box-sizing: border-box;
 }
 
-.clearable {
-	padding-right: 4em;
-}
-
 .controls {
 	position: relative;
 }
@@ -50,3 +46,4 @@
 .valid { }
 .invalid { }
 .open { }
+.clearable { }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Removes the unnecessary padding that is added by default when the clearable property is set.

Resolves #527 
