### PR TITLE
Add onResultSelect Event to ComboBox

### DIFF
--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -40,7 +40,7 @@ import { customElement } from '@dojo/framework/widget-core/decorators/customElem
  * @property onFocus            Called when the input is focused
  * @property onMenuChange       Called when menu visibility changes
  * @property onRequestResults   Called when results are shown; should be used to set `results`
- * @property onResultSelect		Called when result is selected
+ * @property onResultSelect     Called when result is selected
  * @property openOnFocus        Determines whether the result list should open when the input is focused
  * @property readOnly           Prevents user interaction
  * @property required           Determines if this input is required, styles accordingly

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -40,6 +40,7 @@ import { customElement } from '@dojo/framework/widget-core/decorators/customElem
  * @property onFocus            Called when the input is focused
  * @property onMenuChange       Called when menu visibility changes
  * @property onRequestResults   Called when results are shown; should be used to set `results`
+ * @property onResultSelect		Called when result is selected
  * @property openOnFocus        Determines whether the result list should open when the input is focused
  * @property readOnly           Prevents user interaction
  * @property required           Determines if this input is required, styles accordingly
@@ -61,6 +62,7 @@ export interface ComboBoxProperties extends ThemedProperties, LabeledProperties 
 	onFocus?(value: string, key?: string | number): void;
 	onMenuChange?(open: boolean, key?: string | number): void;
 	onRequestResults?(key?: string | number): void;
+	onResultSelect?(result: any, key?: string | number): void;
 	openOnFocus?: boolean;
 	readOnly?: boolean;
 	required?: boolean;
@@ -103,7 +105,8 @@ export const ThemedBase = I18nMixin(ThemedMixin(WidgetBase));
 		'onChange',
 		'onFocus',
 		'onMenuChange',
-		'onRequestResults'
+		'onRequestResults',
+		'onResultSelect'
 	]
 })
 export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> extends ThemedBase<P, null> {
@@ -284,11 +287,13 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 		const {
 			key,
 			onChange,
+			onResultSelect,
 			results = []
 		} = this.properties;
 
 		this._callInputFocus = true;
 		this._closeMenu();
+		onResultSelect && onResultSelect(results[index], key);
 		onChange && onChange(this._getResultValue(results[index]), key);
 	}
 

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -217,12 +217,14 @@ registerSuite('ComboBox', {
 		'menu opens on input'() {
 			const onChange = sinon.stub();
 			const onRequestResults = sinon.stub();
+			const onResultSelect = sinon.stub();
 			const onMenuChange = sinon.stub();
 			const h = harness(() => w(ComboBox, {
 				...testProperties,
 				label: undefined,
 				onChange,
 				onRequestResults,
+				onResultSelect,
 				onMenuChange
 			}));
 
@@ -231,6 +233,7 @@ registerSuite('ComboBox', {
 
 			assert.isTrue(onChange.calledWith('foo'), 'onChange callback called with input value');
 			assert.isTrue(onRequestResults.calledOnce, 'onRequestResults callback called');
+			assert.isFalse(onResultSelect.called, 'onResultSelect is not called on input');
 			assert.isTrue(onMenuChange.calledOnce, 'onMenuChange called when menu is opened');
 		},
 
@@ -273,14 +276,17 @@ registerSuite('ComboBox', {
 
 		'menu closes on result selection'() {
 			const onChange = sinon.stub();
+			const onResultSelect = sinon.stub();
 			const h = harness(() => w(ComboBox, {
 				...testProperties,
-				onChange
+				onChange,
+				onResultSelect
 			}));
 
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
 			h.trigger('@listbox', 'onOptionSelect', testOptions[1], 1);
 			assert.isTrue(onChange.calledWith('Two'), 'onChange callback called with label of second option');
+			assert.isTrue(onResultSelect.calledWith(testOptions[1]), 'onResultSelect callback called with second option');
 			h.expect(() => getExpectedVdom(true, false, true, {}, true));
 		},
 
@@ -329,39 +335,47 @@ registerSuite('ComboBox', {
 
 		'enter and space select option'() {
 			const onChange = sinon.stub();
+			const onResultSelect = sinon.stub();
 			const h = harness(() => w(ComboBox, {
 				...testProperties,
-				onChange
+				onChange,
+				onResultSelect
 			}));
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
 			h.trigger('@textinput', 'onKeyDown', Keys.Enter, () => {});
 
 			assert.isTrue(onChange.calledWith('One'), 'enter triggers onChange callback called with label of first option');
+			assert.isTrue(onResultSelect.calledWith(testOptions[0]), 'enter triggers onResultSelect callback called with first option');
 			h.expect(() => getExpectedVdom(true, false, true, {}, true));
 
 			h.trigger('@textinput', 'onKeyDown', Keys.Enter, () => {});
 			assert.isFalse(onChange.calledTwice, 'enter does not trigger onChange when menu is closed');
+			assert.isFalse(onResultSelect.calledTwice, 'enter does not trigger onResultSelect when menu is closed');
 			onChange.reset();
 
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
 			h.trigger('@textinput', 'onKeyDown', Keys.Space, () => {});
 			assert.isTrue(onChange.calledWith('One'), 'space triggers onChange callback called with label of first option');
+			assert.isTrue(onResultSelect.calledWith(testOptions[0]), 'space triggers onResultSelect callback called with first option');
 			h.expect(() => getExpectedVdom(true, false, true, {}, true));
 		},
 
 		'disabled options are not selected'() {
 			const onChange = sinon.stub();
+			const onResultSelect = sinon.stub();
 			const preventDefault = sinon.stub();
 			const h = harness(() => w(ComboBox, {
 				...testProperties,
 				isResultDisabled: (result: any) => !!result.disabled,
-				onChange
+				onChange,
+				onResultSelect
 			}));
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
 			h.trigger('@textinput', 'onKeyDown', Keys.Up, preventDefault);
 			h.trigger('@textinput', 'onKeyDown', Keys.Enter, preventDefault);
 
 			assert.isFalse(onChange.called, 'onChange not called for disabled option');
+			assert.isFalse(onResultSelect.called, 'onResultSelect not called for disabled option');
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true, {
 				visualFocus: true,
 				getOptionDisabled: noop,
@@ -397,12 +411,15 @@ registerSuite('ComboBox', {
 
 		'clear button clears input'() {
 			const onChange = sinon.stub();
+			const onResultSelect = sinon.stub();
 			const h = harness(() => w(ComboBox, {
 				...testProperties,
-				onChange
+				onChange,
+				onResultSelect
 			}));
 			h.trigger(`.${css.clear}`, 'onclick', stubEvent);
 			assert.isTrue(onChange.calledWith(''), 'clear button calls onChange with an empty string');
+			assert.isFalse(onResultSelect.called, 'clear button does not call onResultSelect');
 		},
 
 		'inputProperties transferred to child input'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #485 

Adds the onResultSelect event, called when enter/select is pressed and via the nested Listbox `onOptionSelect` event.