### PR TITLE
Update listbox option focus styles

### DIFF
--- a/src/theme/listbox.m.css
+++ b/src/theme/listbox.m.css
@@ -16,8 +16,8 @@
 
 .focused .activeOption,
 .root:focus .activeOption {
-	background-color: var(--selected-background);
-	color: var(--selected-color);
+	box-shadow: inset 0 0 1px 0 var(--component-background);
+	outline: 4px auto var(--selected-background);
 }
 .disabledOption {
 	background-color: var(--disabled-color);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #589, updates focus style to contrast with the options' selected style
