### PR TITLE
Accessible grid sorting and filtering

### DIFF
--- a/src/grid/tests/unit/widgets/Header.ts
+++ b/src/grid/tests/unit/widgets/Header.ts
@@ -1,8 +1,11 @@
 const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
 
 import { stub } from 'sinon';
 import harness from '@dojo/framework/testing/harness';
 import { v, w } from '@dojo/framework/widget-core/d';
+import TextInput from '../../../../text-input/index';
+import Icon from '../../../../icon/index';
 
 import * as css from '../../../widgets/styles/Header.m.css';
 import Header from '../../../widgets/Header';
@@ -48,7 +51,7 @@ describe('Header', () => {
 		);
 		h.expect(() =>
 			v('div', { scrollLeft: 0, classes: [css.root, null], row: 'rowgroup' }, [
-				v('div', { classes: css.row, role: 'role' }, [
+				v('div', { classes: css.row, role: 'row' }, [
 					v('div', { classes: css.cell, role: 'columnheader' }, [v('div', {}, ['Title'])]),
 					v('div', { classes: css.cell, role: 'columnheader' }, [v('div', {}, ['First Name'])])
 				])
@@ -70,21 +73,32 @@ describe('Header', () => {
 
 		h.expect(() =>
 			v('div', { scrollLeft: 0, classes: [css.root, css.filterGroup], row: 'rowgroup' }, [
-				v('div', { classes: css.row, role: 'role' }, [
+				v('div', { classes: css.row, role: 'row' }, [
 					v('div', { classes: css.cell, role: 'columnheader' }, [v('div', {}, ['Title'])]),
 					v('div', { classes: css.cell, role: 'columnheader' }, [
-						v(
-							'div',
-							{
-								classes: [css.sortable, null, null, null],
+						v('div', {
+							classes: [css.sortable, null, null, null],
+							onclick: noop
+						}, [
+							'Custom Title',
+							v('button', {
+								classes: css.sort,
 								onclick: noop
-							},
-							['Custom Title']
-						),
-						v('input', {
-							classes: css.filter,
+							}, [
+								w(Icon, {
+									type: 'downIcon',
+									altText: 'Sort by Custom Title'
+								})
+							])
+						]),
+						w(TextInput, {
+							key: 'filter',
+							extraClasses: { root: css.filter },
+							label: 'Filter by Custom Title',
+							labelHidden: true,
+							type: 'search',
 							value: '',
-							oninput: noop
+							onInput: noop
 						})
 					])
 				])
@@ -110,21 +124,32 @@ describe('Header', () => {
 
 		h.expect(() =>
 			v('div', { scrollLeft: 0, classes: [css.root, css.filterGroup], row: 'rowgroup' }, [
-				v('div', { classes: css.row, role: 'role' }, [
+				v('div', { classes: css.row, role: 'row' }, [
 					v('div', { classes: css.cell, role: 'columnheader' }, [v('div', {}, ['Title'])]),
 					v('div', { classes: css.cell, role: 'columnheader' }, [
-						v(
-							'div',
-							{
-								classes: [css.sortable, css.sorted, null, css.asc],
+						v('div', {
+							classes: [css.sortable, css.sorted, null, css.asc],
+							onclick: noop
+						}, [
+							'Custom Title',
+							v('button', {
+								classes: css.sort,
 								onclick: noop
-							},
-							['Custom Title']
-						),
-						v('input', {
-							classes: css.filter,
+							}, [
+								w(Icon, {
+									type: 'upIcon',
+									altText: 'Sort by Custom Title'
+								})
+							])
+						]),
+						w(TextInput, {
+							key: 'filter',
+							extraClasses: { root: css.filter },
+							label: 'Filter by Custom Title',
+							labelHidden: true,
+							type: 'search',
 							value: '',
-							oninput: noop
+							onInput: noop
 						})
 					])
 				])
@@ -150,21 +175,32 @@ describe('Header', () => {
 
 		h.expect(() =>
 			v('div', { scrollLeft: 0, classes: [css.root, css.filterGroup], row: 'rowgroup' }, [
-				v('div', { classes: css.row, role: 'role' }, [
+				v('div', { classes: css.row, role: 'row' }, [
 					v('div', { classes: css.cell, role: 'columnheader' }, [v('div', {}, ['Title'])]),
 					v('div', { classes: css.cell, role: 'columnheader' }, [
-						v(
-							'div',
-							{
-								classes: [css.sortable, css.sorted, css.desc, null],
+					v('div', {
+							classes: [css.sortable, css.sorted, css.desc, null],
+							onclick: noop
+						}, [
+							'Custom Title',
+							v('button', {
+								classes: css.sort,
 								onclick: noop
-							},
-							['Custom Title']
-						),
-						v('input', {
-							classes: css.filter,
+							}, [
+								w(Icon, {
+									type: 'downIcon',
+									altText: 'Sort by Custom Title'
+								})
+							])
+						]),
+						w(TextInput, {
+							key: 'filter',
+							extraClasses: { root: css.filter },
+							label: 'Filter by Custom Title',
+							labelHidden: true,
+							type: 'search',
 							value: '',
-							oninput: noop
+							onInput: noop
 						})
 					])
 				])
@@ -190,25 +226,122 @@ describe('Header', () => {
 
 		h.expect(() =>
 			v('div', { scrollLeft: 0, classes: [css.root, css.filterGroup], row: 'rowgroup' }, [
-				v('div', { classes: css.row, role: 'role' }, [
+				v('div', { classes: css.row, role: 'row' }, [
 					v('div', { classes: css.cell, role: 'columnheader' }, [v('div', {}, ['Title'])]),
 					v('div', { classes: css.cell, role: 'columnheader' }, [
-						v(
-							'div',
-							{
-								classes: [css.sortable, null, null, null],
+						v('div', {
+							classes: [css.sortable, null, null, null],
+							onclick: noop
+						}, [
+							'Custom Title',
+							v('button', {
+								classes: css.sort,
 								onclick: noop
-							},
-							['Custom Title']
-						),
-						v('input', {
-							classes: css.filter,
+							}, [
+								w(Icon, {
+									type: 'downIcon',
+									altText: 'Sort by Custom Title'
+								})
+							])
+						]),
+						w(TextInput, {
+							key: 'filter',
+							extraClasses: { root: css.filter },
+							label: 'Filter by Custom Title',
+							labelHidden: true,
+							type: 'search',
 							value: 'my filter',
-							oninput: noop
+							onInput: noop
 						})
 					])
 				])
 			])
 		);
+	});
+
+	it('should call filterer on input', () => {
+		const sorterStub = stub();
+		const filtererStub = stub();
+		const h = harness(() =>
+			w(Header, {
+				columnConfig: advancedColumnConfig,
+				sorter: sorterStub,
+				filterer: filtererStub,
+				scrollLeft: 0
+			})
+		);
+
+		h.trigger('@filter', 'onInput', 'trillian');
+		assert.isTrue(filtererStub.calledWith('firstName', 'trillian'));
+	});
+
+	describe('sort interaction', () => {
+		it('should sort desc by default', () => {
+			const sorterStub = stub();
+			const filtererStub = stub();
+			const h = harness(() =>
+				w(Header, {
+					columnConfig: advancedColumnConfig,
+					sorter: sorterStub,
+					filterer: filtererStub,
+					scrollLeft: 0
+				})
+			);
+
+			h.trigger(`.${css.sort}`, 'onclick', {});
+			assert.isTrue(sorterStub.calledWith('firstName', 'desc'));
+			sorterStub.reset();
+
+			h.trigger(`.${css.sortable}`, 'onclick', {});
+			assert.isTrue(sorterStub.calledWith('firstName', 'desc'));
+		});
+
+		it('should sort asc on if currently desc', () => {
+			const sorterStub = stub();
+			const filtererStub = stub();
+			const h = harness(() =>
+				w(Header, {
+					columnConfig: advancedColumnConfig,
+					sorter: sorterStub,
+					filterer: filtererStub,
+					scrollLeft: 0,
+					sort: {
+						columnId: 'firstName',
+						direction: 'desc'
+					}
+				})
+			);
+
+			h.trigger(`.${css.sort}`, 'onclick', {});
+			assert.isTrue(sorterStub.calledWith('firstName', 'asc'));
+			sorterStub.reset();
+
+			h.trigger(`.${css.sortable}`, 'onclick', {});
+			assert.isTrue(sorterStub.calledWith('firstName', 'asc'));
+		});
+
+		it('should sort desc on if currently asc', () => {
+			const sorterStub = stub();
+			const filtererStub = stub();
+			const h = harness(() =>
+				w(Header, {
+					columnConfig: advancedColumnConfig,
+					sorter: sorterStub,
+					filterer: filtererStub,
+					scrollLeft: 0,
+					sort: {
+						columnId: 'firstName',
+						direction: 'asc'
+					}
+				})
+			);
+
+			h.trigger(`.${css.sort}`, 'onclick', {});
+			assert.isTrue(sorterStub.calledWith('firstName', 'desc'));
+			sorterStub.reset();
+
+			h.trigger(`.${css.sortable}`, 'onclick', {});
+			assert.isTrue(sorterStub.calledWith('firstName', 'desc'));
+		});
 	});
 });

--- a/src/grid/widgets/Header.ts
+++ b/src/grid/widgets/Header.ts
@@ -1,8 +1,10 @@
 import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
-import { v } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/widget-core/d';
 import ThemedMixin, { theme } from '@dojo/framework/widget-core/mixins/Themed';
 import { ColumnConfig, FilterOptions, SortOptions } from './../interfaces';
 import { DNode } from '@dojo/framework/widget-core/interfaces';
+import TextInput from '../../text-input/index';
+import Icon from '../../icon/index';
 
 import * as css from './styles/Header.m.css';
 
@@ -17,13 +19,19 @@ export interface HeaderProperties {
 
 @theme(css)
 export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
+	private _sortColumn(id: string) {
+		const { sort, sorter } = this.properties;
+		const direction = sort
+			? sort.columnId !== id ? 'desc' : sort.direction === 'desc' ? 'asc' : 'desc'
+			: 'desc';
+		sorter(id, direction);
+	}
+
 	protected render(): DNode {
 		const { columnConfig, sorter, sort, filterer, scrollLeft, filter } = this.properties;
 		const hasFilters = columnConfig.some((config) => !!config.filterable);
 		return v('div', { scrollLeft, classes: [css.root, hasFilters ? css.filterGroup : null], row: 'rowgroup' }, [
-			v(
-				'div',
-				{ classes: css.row, role: 'role' },
+			v('div', { classes: css.row, role: 'row' },
 				columnConfig.map((column) => {
 					let title: string | DNode;
 					if (typeof column.title === 'function') {
@@ -41,25 +49,39 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 								sort && sort.columnId === column.id && sort.direction === 'asc' ? css.asc : null
 							],
 							onclick: () => {
-								const direction = sort
-									? sort.columnId !== column.id ? 'desc' : sort.direction === 'desc' ? 'asc' : 'desc'
-									: 'desc';
-								sorter(column.id, direction);
+								this._sortColumn(column.id);
 							}
 						};
 					}
 
 					return v('div', { classes: css.cell, role: 'columnheader' }, [
-						v('div', headerProperties, [title]),
-						column.filterable
-							? v('input', {
-									classes: css.filter,
-									value: filter && filter.columnId === column.id ? filter.value : '',
-									oninput: (event: KeyboardEvent) => {
-										const target = event.target as HTMLInputElement;
-										filterer(column.id, target.value);
-									}
+						v('div', headerProperties, [
+							title,
+							column.sortable ? v('button', {
+								classes: css.sort,
+								onclick: () => {
+									this._sortColumn(column.id);
+								}
+							}, [
+								w(Icon, {
+									type: sort && sort.columnId === column.id && sort.direction === 'asc' ? 'upIcon' : 'downIcon',
+									altText: `Sort by ${title}`
 								})
+							])
+							: null
+						]),
+						column.filterable
+							? w(TextInput, {
+								key: 'filter',
+								extraClasses: { root: css.filter },
+								label: `Filter by ${title}`,
+								labelHidden: true,
+								type: 'search',
+								value: filter && filter.columnId === column.id ? filter.value : '',
+								onInput: (value: string) => {
+									filterer(column.id, value);
+								}
+							})
 							: null
 					]);
 				})

--- a/src/grid/widgets/styles/Header.m.css
+++ b/src/grid/widgets/styles/Header.m.css
@@ -41,14 +41,18 @@
 	color: var(--sort-color);
 }
 
-.sorted.desc:after {
-	content: '▼';
+.desc {}
+
+.asc {}
+
+.sort {
 	margin-left: 4px;
+	opacity: 0;
 }
 
-.sorted.asc:after {
-	content: '▲';
-	margin-left: 4px;
+.sort:focus,
+.sorted .sort {
+	opacity: 1;
 }
 
 .filter {

--- a/src/grid/widgets/styles/Header.m.css.d.ts
+++ b/src/grid/widgets/styles/Header.m.css.d.ts
@@ -6,4 +6,5 @@ export const row: string;
 export const sorted: string;
 export const desc: string;
 export const asc: string;
+export const sort: string;
 export const filter: string;


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #587 

Things to follow up on:
- is `search` the correct input type for a filtering input?
- the filter input's label text is included in the column header text read for each cell in its column, and does not seem to be overridable by `aria-label` or `aria-labelledby` on the column header element.
