### PR TITLE
Slider focus

### DIFF
--- a/src/theme/slider.m.css
+++ b/src/theme/slider.m.css
@@ -1,7 +1,6 @@
 @import '../common/styles/variables.css';
 
-.root {
-}
+.root { }
 
 .outputTooltip {
 	left: 2.5em;
@@ -32,7 +31,6 @@
 .invalid .track {
 	border-color: var(--error-color);
 }
-
 .invalid .thumb::before {
 	background-color: var(--error-color);
 }
@@ -41,13 +39,11 @@
 .valid .inputWrapper::before {
 	border-color: var(--success-color);
 }
-
 .valid .inputWrapper::after {
 	background-color: var(--success-color);
 }
 
-.focused {
-}
+.focused { }
 
 .inputWrapper {
 
@@ -101,5 +97,4 @@
 	width: 2em;
 }
 
-.output {
-}
+.output { }

--- a/src/theme/slider.m.css
+++ b/src/theme/slider.m.css
@@ -1,6 +1,7 @@
 @import '../common/styles/variables.css';
 
-.root { }
+.root {
+}
 
 .outputTooltip {
 	left: 2.5em;
@@ -31,6 +32,7 @@
 .invalid .track {
 	border-color: var(--error-color);
 }
+
 .invalid .thumb::before {
 	background-color: var(--error-color);
 }
@@ -39,14 +41,25 @@
 .valid .inputWrapper::before {
 	border-color: var(--success-color);
 }
+
 .valid .inputWrapper::after {
 	background-color: var(--success-color);
 }
 
-.focused { }
+.focused {
+}
 
 .inputWrapper {
 
+}
+
+.focused input {
+	outline: none;
+}
+
+.focused .thumb {
+	box-shadow: 0 0 7px 3px var(--selected-background);
+	border-color: white;
 }
 
 .track {
@@ -88,4 +101,5 @@
 	width: 2em;
 }
 
-.output { }
+.output {
+}


### PR DESCRIPTION
Having the entire slider focused is causing issues with combining sliders to [create a range slider](https://github.com/dojo/widgets/issues/554).

Moving the focus ring from the entire slider input:

![image](https://user-images.githubusercontent.com/2008858/46094901-35144000-c189-11e8-8220-18a443be7433.png)

to the just the thumb:

![image](https://user-images.githubusercontent.com/2008858/46094876-1e6de900-c189-11e8-8364-b8647ea36cc5.png)
