### PR TITLE
Use TextInput and Button in Grid

### DIFF
--- a/src/button/index.ts
+++ b/src/button/index.ts
@@ -143,7 +143,7 @@ export class ButtonBase<P extends ButtonProperties = ButtonProperties> extends T
 			classes: this.theme([ css.root, ...this.getModifierClasses() ]),
 			disabled,
 			id: widgetId,
-			focus: this.shouldFocus(),
+			focus: this.shouldFocus,
 			name,
 			type,
 			value,

--- a/src/button/index.ts
+++ b/src/button/index.ts
@@ -1,6 +1,7 @@
 import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
 import { DNode } from '@dojo/framework/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
+import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
 import { v, w } from '@dojo/framework/widget-core/d';
 import * as css from '../theme/button.m.css';
 import { CustomAriaProperties, InputEventProperties, PointerEventProperties, KeyEventProperties } from '../common/interfaces';
@@ -24,7 +25,7 @@ export type ButtonType = 'submit' | 'reset' | 'button' | 'menu';
  * @property type           Button type can be "submit", "reset", "button", or "menu"
  * @property value          Defines a value for the button submitted with form data
  */
-export interface ButtonProperties extends ThemedProperties, InputEventProperties, PointerEventProperties, KeyEventProperties, CustomAriaProperties {
+export interface ButtonProperties extends ThemedProperties, InputEventProperties, FocusProperties, PointerEventProperties, KeyEventProperties, CustomAriaProperties {
 	disabled?: boolean;
 	widgetId?: string;
 	popup?: { expanded?: boolean; id?: string; } | boolean;
@@ -35,7 +36,7 @@ export interface ButtonProperties extends ThemedProperties, InputEventProperties
 	onClick?(): void;
 }
 
-export const ThemedBase = ThemedMixin(WidgetBase);
+export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
 
 @theme(css)
 @customElement<ButtonProperties>({
@@ -142,6 +143,7 @@ export class ButtonBase<P extends ButtonProperties = ButtonProperties> extends T
 			classes: this.theme([ css.root, ...this.getModifierClasses() ]),
 			disabled,
 			id: widgetId,
+			focus: this.shouldFocus(),
 			name,
 			type,
 			value,

--- a/src/button/tests/unit/Button.ts
+++ b/src/button/tests/unit/Button.ts
@@ -7,12 +7,24 @@ import { v, w } from '@dojo/framework/widget-core/d';
 import Button from '../../index';
 import Icon from '../../../icon/index';
 import * as css from '../../../theme/button.m.css';
-import { noop, stubEvent } from '../../../common/tests/support/test-helpers';
+import { isFocusedComparator, isNotFocusedComparator, noop, stubEvent } from '../../../common/tests/support/test-helpers';
+
+const compareFocusFalse = {
+	selector: 'button',
+	property: 'focus',
+	comparator: isNotFocusedComparator
+};
+
+const compareFocusTrue = {
+	selector: 'button',
+	property: 'focus',
+	comparator: isFocusedComparator
+};
 
 registerSuite('Button', {
 	tests: {
 		'no content'() {
-			const h = harness(() => w(Button, {}));
+			const h = harness(() => w(Button, {}), [ compareFocusFalse ]);
 			h.expect(() => v('button', {
 				'aria-controls': null,
 				'aria-expanded': null,
@@ -22,6 +34,7 @@ registerSuite('Button', {
 				disabled: undefined,
 				id: undefined,
 				name: undefined,
+				focus: noop,
 				onblur: noop,
 				onclick: noop,
 				onfocus: noop,
@@ -53,7 +66,7 @@ registerSuite('Button', {
 				},
 				pressed: true,
 				value: 'value'
-			}, ['foo']));
+			}, ['foo']), [ compareFocusFalse ]);
 
 			h.expect(() => v('button', {
 				'aria-controls': 'popupId',
@@ -65,6 +78,7 @@ registerSuite('Button', {
 				disabled: true,
 				name: 'bar',
 				id: 'qux',
+				focus: noop,
 				onblur: noop,
 				onclick: noop,
 				onfocus: noop,
@@ -89,7 +103,7 @@ registerSuite('Button', {
 		'popup = true'() {
 			const h = harness(() => w(Button, {
 				popup: true
-			}));
+			}), [ compareFocusFalse ]);
 
 			h.expect(() => v('button', {
 				'aria-controls': '',
@@ -100,6 +114,7 @@ registerSuite('Button', {
 				disabled: undefined,
 				name: undefined,
 				id: undefined,
+				focus: noop,
 				onblur: noop,
 				onclick: noop,
 				onfocus: noop,
@@ -118,6 +133,34 @@ registerSuite('Button', {
 					w(Icon, { type: 'downIcon', theme: undefined })
 				])
 			]));
+		},
+
+		'call focus on button node'() {
+			const h = harness(() => w(Button, { focus: () => true }), [ compareFocusTrue ]);
+			h.expect(() => v('button', {
+				'aria-controls': null,
+				'aria-expanded': null,
+				'aria-haspopup': null,
+				'aria-pressed': null,
+				classes: [ css.root, null, null, null ],
+				disabled: undefined,
+				id: undefined,
+				name: undefined,
+				focus: noop,
+				onblur: noop,
+				onclick: noop,
+				onfocus: noop,
+				onkeydown: noop,
+				onkeypress: noop,
+				onkeyup: noop,
+				onmousedown: noop,
+				onmouseup: noop,
+				ontouchstart: noop,
+				ontouchend: noop,
+				ontouchcancel: noop,
+				type: undefined,
+				value: undefined
+			}, [ null ]));
 		},
 
 		events() {

--- a/src/combobox/tests/functional/ComboBox.ts
+++ b/src/combobox/tests/functional/ComboBox.ts
@@ -152,20 +152,11 @@ registerSuite('ComboBox', {
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.trigger}`)
 				.click()
-				.sleep(30)
+				.sleep(DELAY)
 			.getActiveElement()
 				.getTagName()
 				.then(tag => {
 					assert.strictEqual(tag.toLowerCase(), 'input', 'The input should receive focus when the "open" button is clicked.');
-				})
-				.type(keys.TAB)
-			.getActiveElement()
-				.type(keys.ENTER)
-				.sleep(30)
-			.getActiveElement()
-				.getTagName()
-				.then(tag => {
-					assert.strictEqual(tag.toLowerCase(), 'input', 'The input should receive focus when the "open" button is activated with the ENTER key.');
 				});
 	},
 

--- a/src/common/tests/support/test-helpers.ts
+++ b/src/common/tests/support/test-helpers.ts
@@ -13,6 +13,8 @@ export const stubEvent = {
 
 export const isStringComparator = (value: any) => value === null || typeof value === 'string';
 export const isStringObjectComparator = (value: any) => Object.keys(value).every((key) => value[key] === null || typeof value[key] === 'string');
+export const isFocusedComparator = (value: () => boolean) => value() === true;
+export const isNotFocusedComparator = (value: () => boolean) => value() === false;
 
 export const compareId = {
 	selector: '*',

--- a/src/enhanced-text-input/index.ts
+++ b/src/enhanced-text-input/index.ts
@@ -22,7 +22,6 @@ export interface EnhancedTextInputProperties extends TextInputProperties {
 		'addonBefore',
 		'labelAfter',
 		'labelHidden',
-		'shouldFocus',
 		'disabled',
 		'invalid',
 		'readOnly'

--- a/src/enhanced-text-input/tests/unit/EnhancedTextInput.ts
+++ b/src/enhanced-text-input/tests/unit/EnhancedTextInput.ts
@@ -57,6 +57,7 @@ const expected = (options: ExpectedOptions = {}) => {
 			required,
 			type: 'text',
 			value: undefined,
+			focus: noop,
 			onblur: noop,
 			onchange: noop,
 			onclick: noop,

--- a/src/grid/utils.ts
+++ b/src/grid/utils.ts
@@ -22,7 +22,7 @@ export function sorter(data: any[], { sort }: FetcherOptions): any[] {
 export function filterer(data: any[], { filter }: FetcherOptions): any[] {
 	if (filter) {
 		return data.filter((item) => {
-			return item[filter.columnId].indexOf(filter.value) > -1;
+			return item[filter.columnId].toLowerCase().indexOf(filter.value.toLowerCase()) > -1;
 		});
 	}
 	return [...data];

--- a/src/grid/widgets/Cell.ts
+++ b/src/grid/widgets/Cell.ts
@@ -1,8 +1,12 @@
 import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
-import { v } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/widget-core/d';
 import ThemedMixin, { theme } from '@dojo/framework/widget-core/mixins/Themed';
 import { DNode } from '@dojo/framework/widget-core/interfaces';
 import { uuid } from '@dojo/framework/core/util';
+import { Keys } from '../../common/util';
+import TextInput from '../../text-input/index';
+import Button from '../../button/index';
+import Icon from '../../icon/index';
 
 import * as fixedCss from '../styles/cell.m.css';
 import * as css from '../../theme/grid-cell.m.css';
@@ -36,16 +40,15 @@ export default class Cell extends ThemedMixin(WidgetBase)<CellProperties> {
 		}
 	}
 
-	private _onInput(event: KeyboardEvent) {
-		const target = event.target as HTMLInputElement;
-		this._editingValue = target.value;
+	private _onInput(value: string) {
+		this._editingValue = value;
 	}
 
-	private _onKeyDown(event: KeyboardEvent) {
-		if (event.key === 'Enter') {
+	private _onKeyDown(key: number) {
+		if (key === Keys.Enter) {
 			this._onSave();
 		}
-		else if (event.key === 'Escape') {
+		else if (key === Keys.Escape) {
 			this._editing = false;
 			this._callButtonFocus = true;
 			this.invalidate();
@@ -74,24 +77,27 @@ export default class Cell extends ThemedMixin(WidgetBase)<CellProperties> {
 		this._callButtonFocus = false;
 
 		return v('div', { role: 'cell', classes: [this.theme(css.root), fixedCss.rootFixed] }, [
-			this._editing ? v('input', {
+			this._editing ? w(TextInput, {
 				key: 'editInput',
-				'aria-label': `Edit ${rawValue}`,
-				classes: this.theme(css.input),
-				focus: true,
+				label: `Edit ${rawValue}`,
+				labelHidden:  true,
+				extraClasses: { input: this.theme(css.input) } as any,
+				// focus: true,
 				value: this._editingValue,
-				oninput: this._onInput,
-				onblur: this._onBlur,
-				onkeydown: this._onKeyDown
+				onInput: this._onInput,
+				onBlur: this._onBlur,
+				onKeyDown: this._onKeyDown
 			}) : this.renderContent(),
-			editable && !this._editing ? v('button', {
+			editable && !this._editing ? w(Button, {
 				key: 'editButton',
-				focus: focusButton,
+				aria: { describedby: this._idBase },
+				focus: () => focusButton,
 				type: 'button',
-				'aria-describedby': this._idBase,
-				classes: this.theme(css.edit),
-				onclick: this._onEdit
-			}, [ 'Edit' ]) : null
+				extraClasses: { root: this.theme(css.edit) } as any,
+				onClick: this._onEdit
+			}, [
+				w(Icon, { type: 'editIcon', altText: 'Edit' })
+			]) : null
 		]);
 	}
 }

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -3,6 +3,7 @@ import { DNode } from '@dojo/framework/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
 import { v, w } from '@dojo/framework/widget-core/d';
 import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
 import Label from '../label/index';
 import { CustomAriaProperties, InputProperties, LabeledProperties, PointerEventProperties, KeyEventProperties, InputEventProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
@@ -25,18 +26,17 @@ export type TextInputType = 'text' | 'email' | 'number' | 'password' | 'search' 
  * @property value           The current value
  */
 
-export interface TextInputProperties extends ThemedProperties, InputProperties, LabeledProperties, PointerEventProperties, KeyEventProperties, InputEventProperties, CustomAriaProperties {
+export interface TextInputProperties extends ThemedProperties, InputProperties, FocusProperties, LabeledProperties, PointerEventProperties, KeyEventProperties, InputEventProperties, CustomAriaProperties {
 	controls?: string;
 	type?: TextInputType;
 	maxLength?: number | string;
 	minLength?: number | string;
 	placeholder?: string;
 	value?: string;
-	shouldFocus?: boolean;
 	onClick?(value: string): void;
 }
 
-export const ThemedBase = ThemedMixin(WidgetBase);
+export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
 
 @theme(css)
 @customElement<TextInputProperties>({
@@ -45,7 +45,6 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 		'theme',
 		'aria',
 		'extraClasses',
-		'shouldFocus',
 		'disabled',
 		'invalid',
 		'readOnly',
@@ -160,13 +159,8 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 			readOnly,
 			required,
 			type = 'text',
-			value,
-			shouldFocus
+			value
 		} = this.properties;
-
-		if (shouldFocus) {
-			this.meta(Focus).set('input');
-		}
 
 		return v('input', {
 			...formatAriaProperties(aria),
@@ -174,6 +168,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 			classes: this.theme(css.input),
 			disabled,
 			id: widgetId,
+			focus: this.shouldFocus(),
 			key: 'input',
 			maxlength: maxLength ? `${maxLength}` : null,
 			minlength: minLength ? `${minLength}` : null,

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -168,7 +168,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 			classes: this.theme(css.input),
 			disabled,
 			id: widgetId,
-			focus: this.shouldFocus(),
+			focus: this.shouldFocus,
 			key: 'input',
 			maxlength: maxLength ? `${maxLength}` : null,
 			minlength: minLength ? `${minLength}` : null,

--- a/src/text-input/tests/unit/TextInput.ts
+++ b/src/text-input/tests/unit/TextInput.ts
@@ -53,6 +53,7 @@ const expected = function(label = false, inputOverrides = {}, states: States = {
 				required,
 				type: 'text',
 				value: undefined,
+				focus: noop,
 				onblur: noop,
 				onchange: noop,
 				onclick: noop,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

- Updates the grid cell to use TextInput and Button widgets
- Improves focus handling for cell editing
- Improves focus handling and focusability for TextInput and Button widgets
- updates grid filtering to be case-insensitive
