### PR TITLE
Add pattern and autocomplete properties

### DIFF
--- a/src/enhanced-text-input/tests/unit/EnhancedTextInput.ts
+++ b/src/enhanced-text-input/tests/unit/EnhancedTextInput.ts
@@ -44,6 +44,7 @@ const expected = (options: ExpectedOptions = {}) => {
 	const children = [
 		v('input', {
 			'aria-invalid': invalid ? 'true' : null,
+			autocomplete: undefined,
 			classes: css.input,
 			disabled,
 			id: '',
@@ -52,6 +53,7 @@ const expected = (options: ExpectedOptions = {}) => {
 			minlength: null,
 			name: undefined,
 			placeholder: undefined,
+			pattern: undefined,
 			readOnly,
 			'aria-readonly': readOnly ? 'true' : null,
 			required,

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -33,6 +33,8 @@ export interface TextInputProperties extends ThemedProperties, InputProperties, 
 	minLength?: number | string;
 	placeholder?: string;
 	value?: string;
+	pattern?: string | RegExp;
+	autocomplete?: string;
 	onClick?(value: string): void;
 }
 
@@ -51,7 +53,7 @@ export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
 		'labelAfter',
 		'labelHidden'
 	],
-	attributes: [ 'widgetId', 'label', 'placeholder', 'controls', 'type', 'minLength', 'maxLength', 'value', 'name' ],
+	attributes: [ 'widgetId', 'label', 'placeholder', 'controls', 'type', 'minLength', 'maxLength', 'value', 'name', 'pattern', 'autocomplete' ],
 	events: [
 		'onBlur',
 		'onChange',
@@ -159,12 +161,15 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 			readOnly,
 			required,
 			type = 'text',
-			value
+			value,
+			pattern,
+			autocomplete
 		} = this.properties;
 
 		return v('input', {
 			...formatAriaProperties(aria),
 			'aria-invalid': invalid ? 'true' : null,
+			autocomplete,
 			classes: this.theme(css.input),
 			disabled,
 			id: widgetId,
@@ -173,6 +178,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 			maxlength: maxLength ? `${maxLength}` : null,
 			minlength: minLength ? `${minLength}` : null,
 			name,
+			pattern: pattern instanceof RegExp ? pattern.source : pattern,
 			placeholder,
 			readOnly,
 			'aria-readonly': readOnly ? 'true' : null,

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -34,11 +34,18 @@ export interface TextInputProperties extends ThemedProperties, InputProperties, 
 	placeholder?: string;
 	value?: string;
 	pattern?: string | RegExp;
-	autocomplete?: string;
+	autocomplete?: boolean | string;
 	onClick?(value: string): void;
 }
 
 export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
+
+function formatAutocomplete(autocomplete: string | boolean | undefined): string | undefined {
+	if (typeof autocomplete === 'boolean') {
+		return autocomplete ? 'on' : 'off';
+	}
+	return autocomplete;
+}
 
 @theme(css)
 @customElement<TextInputProperties>({
@@ -169,7 +176,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 		return v('input', {
 			...formatAriaProperties(aria),
 			'aria-invalid': invalid ? 'true' : null,
-			autocomplete,
+			autocomplete: formatAutocomplete(autocomplete),
 			classes: this.theme(css.input),
 			disabled,
 			id: widgetId,

--- a/src/text-input/tests/unit/TextInput.ts
+++ b/src/text-input/tests/unit/TextInput.ts
@@ -129,12 +129,25 @@ registerSuite('TextInput', {
 				}));
 			},
 			'regexp'() {
-				const h = harness(() => w(TextInput, {
+				const properties = {
 					pattern: /^foo|bar$/
-				}));
+				};
+				const h = harness(() => w(TextInput, properties));
 
 				h.expect(() => expected(false, {
 					pattern: '^foo|bar$'
+				}));
+
+				(properties.pattern.compile as any)('^bar|baz$');
+
+				h.expect(() => expected(false, {
+					pattern: '^bar|baz$'
+				}));
+
+				properties.pattern = /^ham|spam$/;
+
+				h.expect(() => expected(false, {
+					pattern: '^ham|spam$'
 				}));
 			}
 		},

--- a/src/text-input/tests/unit/TextInput.ts
+++ b/src/text-input/tests/unit/TextInput.ts
@@ -44,6 +44,7 @@ const expected = function(label = false, inputOverrides = {}, states: States = {
 				id: '',
 				disabled,
 				'aria-invalid': invalid ? 'true' : null,
+				autocomplete: undefined,
 				maxlength: null,
 				minlength: null,
 				name: undefined,
@@ -54,6 +55,7 @@ const expected = function(label = false, inputOverrides = {}, states: States = {
 				type: 'text',
 				value: undefined,
 				focus: noop,
+				pattern: undefined,
 				onblur: noop,
 				onchange: noop,
 				onclick: noop,
@@ -86,6 +88,7 @@ registerSuite('TextInput', {
 					controls: 'foo',
 					describedBy: 'bar'
 				},
+				autocomplete: 'on',
 				widgetId: 'foo',
 				maxLength: 50,
 				minLength: 10,
@@ -98,6 +101,7 @@ registerSuite('TextInput', {
 			h.expect(() => expected(false, {
 				'aria-controls': 'foo',
 				'aria-describedby': 'bar',
+				autocomplete: 'on',
 				id: 'foo',
 				maxlength: '50',
 				minlength: '10',
@@ -114,6 +118,27 @@ registerSuite('TextInput', {
 			}));
 
 			h.expect(() => expected(true));
+		},
+
+		'pattern': {
+			'string'() {
+				const h = harness(() => w(TextInput, {
+					pattern: '^foo|bar$'
+				}));
+
+				h.expect(() => expected(false, {
+					pattern: '^foo|bar$'
+				}));
+			},
+			'regexp'() {
+				const h = harness(() => w(TextInput, {
+					pattern: /^foo|bar$/
+				}));
+
+				h.expect(() => expected(false, {
+					pattern: '^foo|bar$'
+				}));
+			}
 		},
 
 		'state classes'() {

--- a/src/text-input/tests/unit/TextInput.ts
+++ b/src/text-input/tests/unit/TextInput.ts
@@ -88,7 +88,6 @@ registerSuite('TextInput', {
 					controls: 'foo',
 					describedBy: 'bar'
 				},
-				autocomplete: 'on',
 				widgetId: 'foo',
 				maxLength: 50,
 				minLength: 10,
@@ -101,7 +100,6 @@ registerSuite('TextInput', {
 			h.expect(() => expected(false, {
 				'aria-controls': 'foo',
 				'aria-describedby': 'bar',
-				autocomplete: 'on',
 				id: 'foo',
 				maxlength: '50',
 				minlength: '10',
@@ -137,6 +135,36 @@ registerSuite('TextInput', {
 
 				h.expect(() => expected(false, {
 					pattern: '^foo|bar$'
+				}));
+			}
+		},
+
+		'autocomplete': {
+			'true'() {
+				const h = harness(() => w(TextInput, {
+					autocomplete: true
+				}));
+
+				h.expect(() => expected(false, {
+					autocomplete: 'on'
+				}));
+			},
+			'false'() {
+				const h = harness(() => w(TextInput, {
+					autocomplete: false
+				}));
+
+				h.expect(() => expected(false, {
+					autocomplete: 'off'
+				}));
+			},
+			'string'() {
+				const h = harness(() => w(TextInput, {
+					autocomplete: 'name'
+				}));
+
+				h.expect(() => expected(false, {
+					autocomplete: 'name'
 				}));
 			}
 		},


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds `pattern` and `autocomplete` properties and passes them through to the `<input>` node

Resolves #553
