### PR TITLE
Add height CE property to Grid

### DIFF
--- a/src/grid/widgets/Grid.ts
+++ b/src/grid/widgets/Grid.ts
@@ -40,6 +40,7 @@ export interface GridProperties<S> {
 @customElement<GridProperties<any>>({
 	tag: 'dojo-grid',
 	properties: [
+		'height',
 		'fetcher',
 		'updater',
 		'columnConfig',


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

Add missing height property to custom element.