### PR TITLE
add calendar min max properties

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widgets",
-  "version": "6.0.0-alpha.2",
+  "version": "6.0.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -236,7 +236,7 @@
         },
         "lodash": {
           "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "resolved": "http://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
           "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
           "dev": true
         },
@@ -1122,6 +1122,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1133,6 +1134,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -1614,7 +1616,7 @@
     },
     "babel-plugin-syntax-object-rest-spread": {
       "version": "6.13.0",
-      "resolved": "https://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
+      "resolved": "http://registry.npmjs.org/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz",
       "integrity": "sha1-/WU28rzhODb/o6VFjEkDpZe7O/U=",
       "dev": true
     },
@@ -4185,7 +4187,7 @@
     },
     "es6-promisify": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/es6-promisify/-/es6-promisify-5.0.0.tgz",
       "integrity": "sha1-UQnWLz5W6pZ8S2NQWu8IKRyKUgM=",
       "dev": true,
       "requires": {
@@ -4362,7 +4364,7 @@
       "dependencies": {
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         }
@@ -5281,7 +5283,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5302,12 +5305,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5322,17 +5327,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5449,7 +5457,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5461,6 +5470,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5475,6 +5485,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5482,12 +5493,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5506,6 +5519,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5586,7 +5600,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5598,6 +5613,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5683,7 +5699,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5719,6 +5736,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5738,6 +5756,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5781,12 +5800,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6058,7 +6079,7 @@
       "dependencies": {
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         }
@@ -6977,7 +6998,7 @@
         },
         "es6-promise": {
           "version": "0.1.2",
-          "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-0.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/es6-promise/-/es6-promise-0.1.2.tgz",
           "integrity": "sha1-8RLCn+paCZhTn8tqL9IUQ9KPBfc=",
           "dev": true
         },
@@ -9047,7 +9068,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -9234,7 +9256,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -9344,7 +9366,7 @@
     },
     "minimist": {
       "version": "0.0.8",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "resolved": "http://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
       "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
       "dev": true
     },
@@ -9389,7 +9411,7 @@
     },
     "mkdirp": {
       "version": "0.5.1",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "resolved": "http://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
       "dev": true,
       "requires": {
@@ -9795,7 +9817,7 @@
     },
     "onecolor": {
       "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/onecolor/-/onecolor-2.4.2.tgz",
+      "resolved": "http://registry.npmjs.org/onecolor/-/onecolor-2.4.2.tgz",
       "integrity": "sha1-pT7D/xccNEYBbdUhDRobVEv32HQ=",
       "dev": true
     },
@@ -9959,7 +9981,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         }
@@ -10299,7 +10321,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -10344,7 +10366,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -10431,7 +10453,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -10476,7 +10498,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -10592,7 +10614,7 @@
         },
         "semver": {
           "version": "5.0.3",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
+          "resolved": "http://registry.npmjs.org/semver/-/semver-5.0.3.tgz",
           "integrity": "sha1-d0Zt5YnNXTyV8TiqeLxWmjy10no=",
           "dev": true
         }
@@ -10695,7 +10717,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -10740,7 +10762,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -10836,7 +10858,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -10881,7 +10903,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -10924,7 +10946,7 @@
     },
     "postcss-color-gray": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-3.0.1.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-color-gray/-/postcss-color-gray-3.0.1.tgz",
       "integrity": "sha1-dEMu3mbdg7HRNjVlxos3bhj/Z3A=",
       "dev": true,
       "requires": {
@@ -10948,7 +10970,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -11013,7 +11035,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -11090,7 +11112,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -11135,7 +11157,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -11179,7 +11201,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -11244,7 +11266,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -11333,7 +11355,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -11378,7 +11400,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -11421,7 +11443,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -11466,7 +11488,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -11602,7 +11624,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -11623,7 +11645,7 @@
         },
         "color": {
           "version": "0.10.1",
-          "resolved": "https://registry.npmjs.org/color/-/color-0.10.1.tgz",
+          "resolved": "http://registry.npmjs.org/color/-/color-0.10.1.tgz",
           "integrity": "sha1-wEGI34KiCd3rzOzazT7DIPGTc58=",
           "dev": true,
           "requires": {
@@ -11666,7 +11688,7 @@
         },
         "postcss-attribute-case-insensitive": {
           "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-1.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/postcss-attribute-case-insensitive/-/postcss-attribute-case-insensitive-1.0.1.tgz",
           "integrity": "sha1-zrc3d+EGFn6yM/GTjJvZ8uaXMI0=",
           "dev": true,
           "requires": {
@@ -11687,7 +11709,7 @@
         },
         "postcss-color-hex-alpha": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/postcss-color-hex-alpha/-/postcss-color-hex-alpha-2.0.0.tgz",
           "integrity": "sha1-RP1uyt5mAoZIyIHLZQTNy/3GzQk=",
           "dev": true,
           "requires": {
@@ -11698,7 +11720,7 @@
         },
         "postcss-color-rebeccapurple": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-2.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/postcss-color-rebeccapurple/-/postcss-color-rebeccapurple-2.0.1.tgz",
           "integrity": "sha1-dMZETny7fYVhO19yht96SRYIRRw=",
           "dev": true,
           "requires": {
@@ -11708,7 +11730,7 @@
           "dependencies": {
             "color": {
               "version": "0.11.4",
-              "resolved": "https://registry.npmjs.org/color/-/color-0.11.4.tgz",
+              "resolved": "http://registry.npmjs.org/color/-/color-0.11.4.tgz",
               "integrity": "sha1-bXtcdPtl6EHNSHkq0e1eB7kE12Q=",
               "dev": true,
               "requires": {
@@ -11730,7 +11752,7 @@
         },
         "postcss-custom-media": {
           "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-5.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/postcss-custom-media/-/postcss-custom-media-5.0.1.tgz",
           "integrity": "sha1-E40loYS/LrVN4S1VpsAcMKnYvYE=",
           "dev": true,
           "requires": {
@@ -11749,7 +11771,7 @@
         },
         "postcss-custom-selectors": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/postcss-custom-selectors/-/postcss-custom-selectors-3.0.0.tgz",
           "integrity": "sha1-j4Ekn17Qeo0JF89qOf5bBWt/lqw=",
           "dev": true,
           "requires": {
@@ -11779,7 +11801,7 @@
         },
         "postcss-font-variant": {
           "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-2.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/postcss-font-variant/-/postcss-font-variant-2.0.1.tgz",
           "integrity": "sha1-fKKRA/WfoCyjrOLKIrL3VoU9Tvg=",
           "dev": true,
           "requires": {
@@ -11798,7 +11820,7 @@
         },
         "postcss-media-minmax": {
           "version": "2.1.2",
-          "resolved": "https://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-2.1.2.tgz",
+          "resolved": "http://registry.npmjs.org/postcss-media-minmax/-/postcss-media-minmax-2.1.2.tgz",
           "integrity": "sha1-RExc+JJqteT9iiUJ6Sl+dRZJzfg=",
           "dev": true,
           "requires": {
@@ -11807,7 +11829,7 @@
         },
         "postcss-nesting": {
           "version": "2.3.1",
-          "resolved": "https://registry.npmjs.org/postcss-nesting/-/postcss-nesting-2.3.1.tgz",
+          "resolved": "http://registry.npmjs.org/postcss-nesting/-/postcss-nesting-2.3.1.tgz",
           "integrity": "sha1-lKa2pO9wf77CCof+5clXdZtOAc8=",
           "dev": true,
           "requires": {
@@ -11816,7 +11838,7 @@
         },
         "postcss-pseudo-class-any-link": {
           "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-1.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/postcss-pseudo-class-any-link/-/postcss-pseudo-class-any-link-1.0.0.tgz",
           "integrity": "sha1-kDI5GWQB0zX+c6x1YYb6YuaTryY=",
           "dev": true,
           "requires": {
@@ -11826,7 +11848,7 @@
           "dependencies": {
             "postcss-selector-parser": {
               "version": "1.3.3",
-              "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz",
+              "resolved": "http://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-1.3.3.tgz",
               "integrity": "sha1-0u4Z33pk+O8hwacchvfUg1yIwoE=",
               "dev": true,
               "requires": {
@@ -11848,7 +11870,7 @@
         },
         "postcss-selector-matches": {
           "version": "2.0.5",
-          "resolved": "https://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-2.0.5.tgz",
+          "resolved": "http://registry.npmjs.org/postcss-selector-matches/-/postcss-selector-matches-2.0.5.tgz",
           "integrity": "sha1-+g9Dvle2jneqTNEYBwI0kqExAn8=",
           "dev": true,
           "requires": {
@@ -11858,7 +11880,7 @@
         },
         "postcss-selector-not": {
           "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-2.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/postcss-selector-not/-/postcss-selector-not-2.0.0.tgz",
           "integrity": "sha1-xzrSGj91I0vuf+4mnhVP1qhpeY0=",
           "dev": true,
           "requires": {
@@ -11893,7 +11915,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -11935,7 +11957,7 @@
     },
     "postcss-custom-properties": {
       "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-7.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-custom-properties/-/postcss-custom-properties-7.0.0.tgz",
       "integrity": "sha512-dl/CNaM6z2RBa0vZZqsV6Hunj4HD6Spu7FcAkiVp5B2tgm6xReKKYzI7x7QNx3wTMBNj5v+ylfVcQGMW4xdkHw==",
       "dev": true,
       "requires": {
@@ -12253,7 +12275,7 @@
     },
     "postcss-focus-visible": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-3.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-focus-visible/-/postcss-focus-visible-3.0.0.tgz",
       "integrity": "sha512-6i3HsOrWNelxBYPh/HWAXF9lPwCFAfFVlUTZqsLRXYMPhcXH1eXdItozRBvT9l5pYF4ddJJbgk4JOp0au0QToA==",
       "dev": true,
       "requires": {
@@ -12275,7 +12297,7 @@
     },
     "postcss-focus-within": {
       "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-2.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-focus-within/-/postcss-focus-within-2.0.0.tgz",
       "integrity": "sha512-LTbT/dxZ3FahpOv1XZMyRLNnBk5QWVU4HL/p82iFkzoPNVhNQazaYIujHXTOAKea5clgjbj6GdFj7mU7qzy1kQ==",
       "dev": true,
       "requires": {
@@ -12504,7 +12526,7 @@
     },
     "postcss-logical": {
       "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/postcss-logical/-/postcss-logical-1.1.1.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-logical/-/postcss-logical-1.1.1.tgz",
       "integrity": "sha512-ZJgyLJlp3uPKae9+6sJKFjD06UZzb/m3M1LPeHsaBMvvyatcNWwCfOZVIq00fJdxUqa9QeuQO6RZElKmRdWMEg==",
       "dev": true,
       "requires": {
@@ -13082,7 +13104,7 @@
     },
     "postcss-page-break": {
       "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-page-break/-/postcss-page-break-1.0.0.tgz",
+      "resolved": "http://registry.npmjs.org/postcss-page-break/-/postcss-page-break-1.0.0.tgz",
       "integrity": "sha512-FgjJ7q/cQFbfQFdmm15XDu+DjNb6Tcn7LYm+o1CxyHV5p6pCm0jkRhuU+PF6FaMrSTfy5nF8nuWhwOtUQyWiYA==",
       "dev": true,
       "requires": {
@@ -13252,7 +13274,7 @@
         },
         "chalk": {
           "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
+          "resolved": "http://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
           "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
           "dev": true,
           "requires": {
@@ -13297,7 +13319,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "resolved": "http://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
@@ -14001,7 +14023,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -14840,7 +14862,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         }
@@ -15513,7 +15535,7 @@
         },
         "get-stream": {
           "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+          "resolved": "http://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
           "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ=",
           "dev": true
         }
@@ -15873,7 +15895,7 @@
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "resolved": "http://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
         },
@@ -17097,7 +17119,7 @@
     },
     "uuid": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
+      "resolved": "http://registry.npmjs.org/uuid/-/uuid-2.0.3.tgz",
       "integrity": "sha1-Z+LoY3lyFVMN/zGOW/nc6/1Hsho=",
       "dev": true
     },

--- a/src/calendar/CalendarCell.ts
+++ b/src/calendar/CalendarCell.ts
@@ -12,9 +12,9 @@ import * as css from '../theme/calendar.m.css';
  *
  * @property callFocus        Used to immediately call focus on the cell
  * @property date             Integer date value
- * @property disabled         Boolean, whether the date selectable
- * @property currentMonth     Boolean, whether the date is in the displayed month
+ * @property disabled         Boolean, whether the date is in the displayed month
  * @property focusable        Boolean, whether the date can receive tab focus
+ * @property outOfRange       Boolean, true if the date is outside the min/max
  * @property selected         True if the date is currently selected
  * @property today            True if the date the same as the current day
  * @property onClick          Callback function for the click event
@@ -24,12 +24,12 @@ import * as css from '../theme/calendar.m.css';
 export interface CalendarCellProperties extends ThemedProperties {
 	callFocus?: boolean;
 	date: number;
-	currentMonth?: boolean;
 	disabled?: boolean;
 	focusable?: boolean;
+	outOfRange?: boolean;
 	selected?: boolean;
 	today?: boolean;
-	onClick?(date: number, currentMonth: boolean): void;
+	onClick?(date: number, disabled: boolean): void;
 	onFocusCalled?(): void;
 	onKeyDown?(key: number, preventDefault: () => void): void;
 }
@@ -40,8 +40,8 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 export class CalendarCellBase<P extends CalendarCellProperties = CalendarCellProperties> extends ThemedBase<P, null> {
 	private _onClick(event: MouseEvent) {
 		event.stopPropagation();
-		const { date, currentMonth = true, onClick } = this.properties;
-		onClick && onClick(date, currentMonth);
+		const { date, disabled = false, onClick } = this.properties;
+		onClick && onClick(date, disabled);
 	}
 
 	private _onKeyDown(event: KeyboardEvent) {
@@ -57,13 +57,14 @@ export class CalendarCellBase<P extends CalendarCellProperties = CalendarCellPro
 	protected getModifierClasses(): (string | null)[] {
 		const {
 			disabled = false,
+			outOfRange = false,
 			selected = false,
-			currentMonth = true,
 			today = false
 		} = this.properties;
 
 		return [
-			(disabled || !currentMonth) ? css.inactiveDate : null,
+			(disabled || outOfRange) ? css.inactiveDate : null,
+			outOfRange ? css.outOfRange : null,
 			selected ? css.selectedDate : null,
 			today ? css.todayDate : null
 		];

--- a/src/calendar/CalendarCell.ts
+++ b/src/calendar/CalendarCell.ts
@@ -12,8 +12,9 @@ import * as css from '../theme/calendar.m.css';
  *
  * @property callFocus        Used to immediately call focus on the cell
  * @property date             Integer date value
- * @property disabled         Boolean, whether or not the date is in the current month
- * @property focusable        Boolean, whether or not the date can receive focus
+ * @property disabled         Boolean, whether the date selectable
+ * @property currentMonth     Boolean, whether the date is in the displayed month
+ * @property focusable        Boolean, whether the date can receive tab focus
  * @property selected         True if the date is currently selected
  * @property today            True if the date the same as the current day
  * @property onClick          Callback function for the click event
@@ -23,11 +24,12 @@ import * as css from '../theme/calendar.m.css';
 export interface CalendarCellProperties extends ThemedProperties {
 	callFocus?: boolean;
 	date: number;
+	currentMonth?: boolean;
 	disabled?: boolean;
 	focusable?: boolean;
 	selected?: boolean;
 	today?: boolean;
-	onClick?(date: number, disabled: boolean): void;
+	onClick?(date: number, currentMonth: boolean): void;
 	onFocusCalled?(): void;
 	onKeyDown?(key: number, preventDefault: () => void): void;
 }
@@ -38,8 +40,8 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 export class CalendarCellBase<P extends CalendarCellProperties = CalendarCellProperties> extends ThemedBase<P, null> {
 	private _onClick(event: MouseEvent) {
 		event.stopPropagation();
-		const { date, disabled = false, onClick } = this.properties;
-		onClick && onClick(date, disabled);
+		const { date, currentMonth = true, onClick } = this.properties;
+		onClick && onClick(date, currentMonth);
 	}
 
 	private _onKeyDown(event: KeyboardEvent) {
@@ -56,11 +58,12 @@ export class CalendarCellBase<P extends CalendarCellProperties = CalendarCellPro
 		const {
 			disabled = false,
 			selected = false,
+			currentMonth = true,
 			today = false
 		} = this.properties;
 
 		return [
-			disabled ? css.inactiveDate : null,
+			(disabled || !currentMonth) ? css.inactiveDate : null,
 			selected ? css.selectedDate : null,
 			today ? css.todayDate : null
 		];

--- a/src/calendar/DatePicker.ts
+++ b/src/calendar/DatePicker.ts
@@ -6,6 +6,7 @@ import { uuid } from '@dojo/framework/core/util';
 import { DNode } from '@dojo/framework/widget-core/interfaces';
 import calendarBundle from './nls/Calendar';
 import { Keys } from '../common/util';
+import { monthInMin, monthInMax } from './date-utils';
 
 import Icon from '../icon/index';
 import * as baseCss from '../common/styles/base.m.css';
@@ -201,10 +202,7 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 			maxDate
 		} = this.properties;
 
-		const date = new Date(year, month, 1);
-		minDate = minDate ? new Date(minDate.getFullYear(), minDate.getMonth(), 1) : date;
-		maxDate = maxDate ? new Date(maxDate.getFullYear(), maxDate.getMonth(), 1) : date;
-		return date >= minDate && date <= maxDate;
+		return monthInMin(year, month, minDate) && monthInMax(year, month, maxDate);
 	}
 
 	private _yearInMinMax(year: number) {
@@ -398,14 +396,14 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 						tabIndex: this._yearPopupOpen ? 0 : -1,
 						type: 'button',
 						onclick: this._onYearPageDown,
-						disabled: !this._yearInMinMax(minYear - 1)
+						disabled: !this._yearInMinMax(year - 1)
 					}, this.renderPagingButtonContent(Paging.previous)),
 					v('button', {
 						classes: this.theme(css.next),
 						tabIndex: this._yearPopupOpen ? 0 : -1,
 						type: 'button',
 						onclick: this._onYearPageUp,
-						disabled: !this._yearInMinMax(maxYear + 1)
+						disabled: !this._yearInMinMax(year + 1)
 					}, this.renderPagingButtonContent(Paging.next))
 				])
 			])

--- a/src/calendar/DatePicker.ts
+++ b/src/calendar/DatePicker.ts
@@ -39,6 +39,8 @@ export enum Controls {
  * @property year                 Currently displayed year
  * @property yearRange            Number of years to display in a single page of the year popup
  * @property renderMonthLabel     Format the displayed current month and year
+ * @property minDate              Minimum date to be picked
+ * @property maxDate              Maximum date to be picked
  * @property onPopupChange        Called when a user action occurs that triggers a change in the month or year popup state
  * @property onRequestMonthChange Called when a month should change; receives the zero-based month number
  * @property onRequestYearChange  Called when a year should change; receives the year as an integer
@@ -50,6 +52,8 @@ export interface DatePickerProperties extends ThemedProperties {
 	monthNames: { short: string; long: string; }[];
 	year: number;
 	yearRange?: number;
+	minDate?: Date;
+	maxDate?: Date;
 	renderMonthLabel?(month: number, year: number): string;
 	onPopupChange?(open: boolean): void;
 	onRequestMonthChange?(month: number): void;
@@ -157,9 +161,20 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 
 	private _onYearRadioChange(event: Event) {
 		event.stopPropagation();
-		const { onRequestYearChange } = this.properties;
+		const { onRequestYearChange, month } = this.properties;
+		const newYear = parseInt((event.target as HTMLInputElement).value, 10);
+		if (!this._monthInMinMax(newYear, month)) {
+			// we know the year is valid but the month is out of range
+			const { minDate, maxDate, onRequestMonthChange } = this.properties;
+			if (minDate && newYear === minDate.getFullYear()) {
+				onRequestMonthChange && onRequestMonthChange(minDate.getMonth());
+			}
+			else if (maxDate && newYear === maxDate.getFullYear()) {
+				onRequestMonthChange && onRequestMonthChange(maxDate.getMonth());
+			}
+		}
 		this._yearPage = 0;
-		onRequestYearChange && onRequestYearChange(parseInt((event.target as HTMLInputElement).value, 10));
+		onRequestYearChange && onRequestYearChange(newYear);
 	}
 
 	private _openMonthPopup() {
@@ -178,6 +193,28 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 		this._monthPopupOpen = false;
 		this.invalidate();
 		onPopupChange && onPopupChange(this._getPopupState());
+	}
+
+	private _monthInMinMax(year: number, month: number) {
+		let {
+			minDate,
+			maxDate
+		} = this.properties;
+
+		const date = new Date(year, month, 1);
+		minDate = minDate ? new Date(minDate.getFullYear(), minDate.getMonth(), 1) : date;
+		maxDate = maxDate ? new Date(maxDate.getFullYear(), maxDate.getMonth(), 1) : date;
+		return date >= minDate && date <= maxDate;
+	}
+
+	private _yearInMinMax(year: number) {
+		const {
+			minDate,
+			maxDate
+		} = this.properties;
+		const minYear = minDate ? minDate.getFullYear() : year;
+		const maxYear = maxDate ? maxDate.getFullYear() : year;
+		return year >= minYear && year <= maxYear;
 	}
 
 	protected renderControlsTrigger(type: Controls): DNode {
@@ -213,7 +250,7 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 	}
 
 	protected renderMonthRadios(): DNode[] {
-		const { month } = this.properties;
+		const { year, month } = this.properties;
 
 		return this.properties.monthNames.map((monthName, i) => v('label', {
 			key: `${this._idBase}_month_radios_${i}`,
@@ -230,6 +267,7 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 				tabIndex: this._monthPopupOpen ? 0 : -1,
 				type: 'radio',
 				value: `${i}`,
+				disabled: !this._monthInMinMax(year, i),
 				onchange: this._onMonthRadioChange
 			}),
 			v('abbr', {
@@ -271,6 +309,7 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 					tabIndex: this._yearPopupOpen ? 0 : -1,
 					type: 'radio',
 					value: `${i}`,
+					disabled: !this._yearInMinMax(i),
 					onchange: this._onYearRadioChange
 				}),
 				v('abbr', {
@@ -289,6 +328,11 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 			month,
 			year
 		} = this.properties;
+
+		const {
+			first: minYear,
+			last: maxYear
+		} = this._getYearRange();
 
 		return v('div', {
 			classes: this.theme(css.datePicker)
@@ -353,13 +397,15 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 						classes: this.theme(css.previous),
 						tabIndex: this._yearPopupOpen ? 0 : -1,
 						type: 'button',
-						onclick: this._onYearPageDown
+						onclick: this._onYearPageDown,
+						disabled: !this._yearInMinMax(minYear - 1)
 					}, this.renderPagingButtonContent(Paging.previous)),
 					v('button', {
 						classes: this.theme(css.next),
 						tabIndex: this._yearPopupOpen ? 0 : -1,
 						type: 'button',
-						onclick: this._onYearPageUp
+						onclick: this._onYearPageUp,
+						disabled: !this._yearInMinMax(maxYear + 1)
 					}, this.renderPagingButtonContent(Paging.next))
 				])
 			])

--- a/src/calendar/date-utils.ts
+++ b/src/calendar/date-utils.ts
@@ -1,0 +1,15 @@
+export function monthInMin(year: number, month: number, minDate?: Date) {
+	if (minDate) {
+		return new Date(year, month, 1) >= new Date(minDate.getFullYear(), minDate.getMonth(), 1);
+	}
+	return true;
+}
+
+export function monthInMax(year: number, month: number, maxDate?: Date) {
+	if (maxDate) {
+		const thisMonth = new Date(year, month, 1);
+		const max = new Date(maxDate.getFullYear(), maxDate.getMonth(), 1);
+		return thisMonth <= max;
+	}
+	return true;
+}

--- a/src/calendar/example/index.ts
+++ b/src/calendar/example/index.ts
@@ -8,9 +8,14 @@ export default class App extends WidgetBase {
 	private _year: number | undefined;
 	private _selectedDate: Date | undefined;
 
+	private _month2: number | undefined;
+	private _year2: number | undefined;
+	private _selectedDate2: Date | undefined;
+
 	render() {
 		return v('div', {}, [
 			w(Calendar, {
+				key: 'calendar-start-sunday',
 				month: this._month,
 				selectedDate: this._selectedDate,
 				year: this._year,
@@ -27,7 +32,29 @@ export default class App extends WidgetBase {
 					this.invalidate();
 				}
 			}),
-			this._selectedDate ? v('p', [ `Selected Date: ${this._selectedDate.toDateString()}` ]) : null
+			this._selectedDate ? v('p', [ `Selected Date: ${this._selectedDate.toDateString()}` ]) : null,
+			v('hr'),
+			v('p', {}, ['Calendar starts on Monday']),
+			w(Calendar, {
+				key: 'calendar-start-monday',
+				month: this._month2,
+				selectedDate: this._selectedDate2,
+				firstDayOfTheWeek: 1,
+				year: this._year2,
+				onMonthChange: (month: number) => {
+					this._month2 = month;
+					this.invalidate();
+				},
+				onYearChange: (year: number) => {
+					this._year2 = year;
+					this.invalidate();
+				},
+				onDateSelect: (date: Date) => {
+					this._selectedDate2 = date;
+					this.invalidate();
+				}
+			}),
+			this._selectedDate ? v('p', [ `Selected Date: ${this._selectedDate2.toDateString()}` ]) : null
 		]);
 	}
 }

--- a/src/calendar/example/index.ts
+++ b/src/calendar/example/index.ts
@@ -17,6 +17,8 @@ export default class App extends WidgetBase {
 			w(Calendar, {
 				key: 'calendar-start-sunday',
 				month: this._month,
+				// minDate: new Date(2014, 4, 9),
+				// maxDate: new Date(2018, 9, 4),
 				selectedDate: this._selectedDate,
 				year: this._year,
 				onMonthChange: (month: number) => {

--- a/src/calendar/example/index.ts
+++ b/src/calendar/example/index.ts
@@ -54,7 +54,7 @@ export default class App extends WidgetBase {
 					this.invalidate();
 				}
 			}),
-			this._selectedDate ? v('p', [ `Selected Date: ${this._selectedDate2.toDateString()}` ]) : null
+			this._selectedDate2 ? v('p', [ `Selected Date: ${this._selectedDate2.toDateString()}` ]) : null
 		]);
 	}
 }

--- a/src/calendar/example/index.ts
+++ b/src/calendar/example/index.ts
@@ -7,18 +7,18 @@ export default class App extends WidgetBase {
 	private _month: number | undefined;
 	private _year: number | undefined;
 	private _selectedDate: Date | undefined;
-
-	private _month2: number | undefined;
-	private _year2: number | undefined;
-	private _selectedDate2: Date | undefined;
+	private _today = new Date();
+	private _minDate = new Date(2017, 3, 16);
+	private _maxDate = new Date(this._today.getFullYear(), this._today.getMonth() + 1, 15);
 
 	render() {
 		return v('div', {}, [
+			v('p', [`You may select days between ${this._minDate.toDateString()} and ${this._maxDate.toDateString()}`]),
 			w(Calendar, {
 				key: 'calendar-start-sunday',
 				month: this._month,
-				// minDate: new Date(2014, 4, 9),
-				// maxDate: new Date(2018, 9, 4),
+				minDate: this._minDate,
+				maxDate: this._maxDate,
 				selectedDate: this._selectedDate,
 				year: this._year,
 				onMonthChange: (month: number) => {
@@ -34,29 +34,7 @@ export default class App extends WidgetBase {
 					this.invalidate();
 				}
 			}),
-			this._selectedDate ? v('p', [ `Selected Date: ${this._selectedDate.toDateString()}` ]) : null,
-			v('hr'),
-			v('p', {}, ['Calendar starts on Monday']),
-			w(Calendar, {
-				key: 'calendar-start-monday',
-				month: this._month2,
-				selectedDate: this._selectedDate2,
-				firstDayOfTheWeek: 1,
-				year: this._year2,
-				onMonthChange: (month: number) => {
-					this._month2 = month;
-					this.invalidate();
-				},
-				onYearChange: (year: number) => {
-					this._year2 = year;
-					this.invalidate();
-				},
-				onDateSelect: (date: Date) => {
-					this._selectedDate2 = date;
-					this.invalidate();
-				}
-			}),
-			this._selectedDate2 ? v('p', [ `Selected Date: ${this._selectedDate2.toDateString()}` ]) : null
+			this._selectedDate ? v('p', {key: 'sunday-selected'}, [ `Selected Date: ${this._selectedDate.toDateString()}` ]) : null
 		]);
 	}
 }

--- a/src/calendar/example/index.ts
+++ b/src/calendar/example/index.ts
@@ -34,7 +34,7 @@ export default class App extends WidgetBase {
 					this.invalidate();
 				}
 			}),
-			this._selectedDate ? v('p', {key: 'sunday-selected'}, [ `Selected Date: ${this._selectedDate.toDateString()}` ]) : null
+			this._selectedDate ? v('p', [ `Selected Date: ${this._selectedDate.toDateString()}` ]) : null
 		]);
 	}
 }

--- a/src/calendar/index.ts
+++ b/src/calendar/index.ts
@@ -295,7 +295,7 @@ export class CalendarBase<P extends CalendarProperties = CalendarProperties> ext
 		} = this._getMonthYear();
 		const {
 			onMonthChange,
-			onYearChange,
+			onYearChange
 		} = this.properties;
 
 		if (!this._monthInMin(month === 0 ? year - 1 : year, month === 0 ? 11 : month - 1)) {

--- a/src/calendar/index.ts
+++ b/src/calendar/index.ts
@@ -351,7 +351,7 @@ export class CalendarBase<P extends CalendarProperties = CalendarProperties> ext
 
 		const date = dateObj.getDate();
 		const { theme, classes } = this.properties;
-		const outOfRange = ((minDate && dateObj < minDate) || (maxDate && dateObj > maxDate));
+		const outOfRange = Boolean((minDate && dateObj < minDate) || (maxDate && dateObj > maxDate));
 		const focusable = currentMonth && date === this._focusedDay;
 
 		return w(CalendarCell, {

--- a/src/calendar/index.ts
+++ b/src/calendar/index.ts
@@ -272,14 +272,14 @@ export class CalendarBase<P extends CalendarProperties = CalendarProperties> ext
 
 	private _ensureDayIsInMinMax(newDate: Date, update: (day: number) => void) {
 		const {
-			minDate = newDate,
-			maxDate = newDate
+			minDate,
+			maxDate
 		} = this.properties;
 
-		if (newDate < minDate) {
+		if (minDate && newDate < minDate) {
 			update(minDate.getDate());
 		}
-		else if (newDate > maxDate) {
+		else if (maxDate && newDate > maxDate) {
 			update(maxDate.getDate());
 		}
 	}
@@ -345,13 +345,13 @@ export class CalendarBase<P extends CalendarProperties = CalendarProperties> ext
 
 	protected renderDateCell(dateObj: Date, index: number, selected: boolean, currentMonth: boolean, today: boolean): DNode {
 		const {
-			minDate = dateObj,
-			maxDate = dateObj
+			minDate,
+			maxDate
 		} = this.properties;
 
 		const date = dateObj.getDate();
 		const { theme, classes } = this.properties;
-		const outOfRange = (dateObj < minDate || dateObj > maxDate);
+		const outOfRange = ((minDate && dateObj < minDate) || (maxDate && dateObj > maxDate));
 		const focusable = currentMonth && date === this._focusedDay;
 
 		return w(CalendarCell, {

--- a/src/calendar/index.ts
+++ b/src/calendar/index.ts
@@ -315,7 +315,30 @@ export class CalendarBase<P extends CalendarProperties = CalendarProperties> ext
 		this._onMonthIncrement();
 	}
 
+	private _checkFocusedDate() {
+		const {
+			month,
+			year
+		} = this._getMonthYear();
+		const {
+			minDate,
+			maxDate
+		} = this.properties;
+		const focusedDate = new Date(year, month, this._focusedDay);
+
+		if (!this._dateInMinMax(focusedDate)) {
+			if (minDate && minDate.getFullYear() === year && minDate.getMonth() === month) {
+				this._focusedDay = minDate.getDate();
+			}
+			else if (maxDate && maxDate.getFullYear() === year && maxDate.getMonth() === month) {
+				this._focusedDay = maxDate.getDate();
+			}
+		}
+
+	}
+
 	private _renderDateGrid(selectedDate?: Date) {
+		this._checkFocusedDate();
 		const {
 			month,
 			year

--- a/src/calendar/tests/functional/Calendar.ts
+++ b/src/calendar/tests/functional/Calendar.ts
@@ -15,11 +15,15 @@ const DELAY = 500;
 const today = new Date();
 const firstDay = new Date(today.getFullYear(), today.getMonth(), 1).getDay();
 
+function firstDayCssSelector(firstDayOfMonth = firstDay) {
+	return `tbody > tr:first-child > td:nth-child(${firstDayOfMonth + 1})`;
+}
+
 function openMonthPicker(remote: Remote) {
 	return remote
 		.get(`http://localhost:9000/_build/common/example/?id=${uuid()}#calendar`)
 		.setFindTimeout(5000)
-		.findByCssSelector(`.${css.monthTrigger}`)
+		.findByClassName(css.monthTrigger)
 			.click()
 			.sleep(DELAY)
 			.end();
@@ -29,7 +33,7 @@ function openYearPicker(remote: Remote) {
 	return remote
 		.get(`http://localhost:9000/_build/common/example/?id=${uuid()}#calendar`)
 		.setFindTimeout(5000)
-		.findByCssSelector(`.${css.yearTrigger}`)
+		.findByClassName(css.yearTrigger)
 			.click()
 			.sleep(DELAY)
 			.end();
@@ -39,7 +43,7 @@ function clickDate(remote: Remote) {
 	return remote
 		.get(`http://localhost:9000/_build/common/example/?id=${uuid()}#calendar`)
 		.setFindTimeout(5000)
-		.findByCssSelector(`tbody > tr:first-child > td:nth-child(${firstDay + 1})`)
+		.findByCssSelector(firstDayCssSelector())
 			.click()
 			.sleep(DELAY)
 			.end();
@@ -48,13 +52,13 @@ function clickDate(remote: Remote) {
 registerSuite('Calendar', {
 	'Open month picker'() {
 		return openMonthPicker(this.remote)
-			.findByCssSelector(`.${css.monthGrid}`)
+			.findByClassName(css.monthGrid)
 				.getAttribute('aria-hidden')
 				.then((hidden: string) => {
 					assert.strictEqual(hidden, 'false', 'The month dialog should open on first click');
 				})
 				.end()
-			.findByCssSelector(`.${css.dateGrid}`)
+			.findByClassName(css.dateGrid)
 				.getAttribute('class')
 				.then((className: string) => {
 					assert.include(className, baseCss.visuallyHidden, 'date grid is hidden when month popup is open');
@@ -68,11 +72,11 @@ registerSuite('Calendar', {
 
 	'Close month picker'() {
 		return openMonthPicker(this.remote)
-			.findByCssSelector(`.${css.monthTrigger}`)
+			.findByClassName(css.monthTrigger)
 				.click()
 				.sleep(DELAY)
 				.end()
-			.findByCssSelector(`.${css.monthGrid}`)
+			.findByClassName(css.monthGrid)
 				.getAttribute('aria-hidden')
 				.then((hidden: string) => {
 					assert.strictEqual(hidden, 'true', 'The month dialog should close on second click');
@@ -87,13 +91,13 @@ registerSuite('Calendar', {
 
 	'Open year picker'() {
 		return openYearPicker(this.remote)
-			.findByCssSelector(`.${css.yearGrid}`)
+			.findByClassName(css.yearGrid)
 				.getAttribute('aria-hidden')
 				.then((hidden: string) => {
 					assert.strictEqual(hidden, 'false', 'The month dialog should open on first click');
 				})
 				.end()
-			.findByCssSelector(`.${css.dateGrid}`)
+			.findByClassName(css.dateGrid)
 				.getAttribute('class')
 				.then((className: string) => {
 					assert.include(className, baseCss.visuallyHidden, 'date grid is hidden when month popup is open');
@@ -122,7 +126,7 @@ registerSuite('Calendar', {
 					assert.include(label, 'January', 'Clicking first month radio focuses button and changes text to January');
 				})
 				.end()
-			.findByCssSelector(`.${css.monthGrid}`)
+			.findByClassName(css.monthGrid)
 				.getAttribute('aria-hidden')
 				.then((hidden: string) => {
 					assert.strictEqual(hidden, 'true', 'Clicking month radio closes popup');
@@ -132,7 +136,7 @@ registerSuite('Calendar', {
 	'Correct dates are disabled'() {
 		const disabledDateSelector = firstDay === 0 ? 'tbody tr:last-child td:last-child' : `tbody tr:first-child td:nth-child(${firstDay})`;
 		return clickDate(this.remote)
-			.findByCssSelector(`tbody tr:first-child td:nth-child(${firstDay + 1})`)
+			.findByCssSelector(firstDayCssSelector())
 				.getVisibleText()
 				.then(text => {
 					assert.strictEqual(text, '1', 'Month starts on correct day');
@@ -155,7 +159,7 @@ registerSuite('Calendar', {
 		}
 
 		return clickDate(this.remote)
-			.findByCssSelector(`tbody tr:first-child td:nth-child(${firstDay + 1})`)
+			.findByCssSelector(firstDayCssSelector())
 				.pressKeys(keys.ARROW_RIGHT)
 				.end()
 			.sleep(DELAY)
@@ -165,7 +169,7 @@ registerSuite('Calendar', {
 					assert.strictEqual(text, '2', 'Right arrow moves active element to second day');
 				})
 				.end()
-			.findByCssSelector(`tbody tr:first-child td:nth-child(${firstDay + 1})`)
+			.findByCssSelector(firstDayCssSelector())
 				.pressKeys(keys.ARROW_DOWN)
 				.end()
 			.sleep(DELAY)
@@ -175,7 +179,7 @@ registerSuite('Calendar', {
 					assert.strictEqual(text, '9', 'Down arrow moves active element to next week');
 				})
 				.end()
-			.findByCssSelector(`tbody tr:first-child td:nth-child(${firstDay + 1})`)
+			.findByCssSelector(firstDayCssSelector())
 				.pressKeys(keys.ARROW_LEFT)
 				.end()
 			.sleep(DELAY)
@@ -185,7 +189,7 @@ registerSuite('Calendar', {
 					assert.strictEqual(text, '8', 'Left arrow moves active element to previous day');
 				})
 				.end()
-			.findByCssSelector(`tbody tr:first-child td:nth-child(${firstDay + 1})`)
+			.findByCssSelector(firstDayCssSelector())
 				.pressKeys(keys.ARROW_UP)
 				.end()
 			.sleep(DELAY)
@@ -195,7 +199,7 @@ registerSuite('Calendar', {
 					assert.strictEqual(text, '1', 'Up arrow moves active element to previous week');
 				})
 				.end()
-			.findByCssSelector(`tbody tr:first-child td:nth-child(${firstDay + 1})`)
+			.findByCssSelector(firstDayCssSelector())
 				.pressKeys(keys.PAGE_DOWN)
 				.end()
 			.sleep(DELAY)
@@ -207,7 +211,7 @@ registerSuite('Calendar', {
 					assert.strictEqual(text, `${monthLengh}`, 'Page down moves to last day');
 				})
 				.end()
-			.findByCssSelector(`tbody tr:first-child td:nth-child(${firstDay + 1})`)
+			.findByCssSelector(firstDayCssSelector())
 				.pressKeys(keys.PAGE_UP)
 				.end()
 			.sleep(DELAY)
@@ -219,10 +223,10 @@ registerSuite('Calendar', {
 				.end();
 	},
 
-	'Clicking disabled date moves focus'() {
+	'Clicking other month date moves focus'() {
 		let clickedDate = '';
 		return clickDate(this.remote)
-			.findByCssSelector(`.${css.inactiveDate}`)
+			.findByClassName(css.inactiveDate)
 				.getVisibleText()
 				.then(text => {
 					clickedDate = text;
@@ -238,6 +242,54 @@ registerSuite('Calendar', {
 				.getAttribute('class')
 				.then((className: string) => {
 					assert.include(className, css.selectedDate, 'Clicked date has selected class');
+				});
+	},
+
+	'The calendar is constrained by the max date'() {
+		const firstDayOfNextMonth = new Date(today.getFullYear(), today.getMonth() + 1, 1).getDay();
+		return clickDate(this.remote)
+			.findDisplayedByClassName(css.next)
+				.click()
+				.end()
+			.sleep(DELAY)
+			.findDisplayedByClassName(css.next)
+				.isEnabled()
+				.then(enabled => {
+					assert.isFalse(enabled, 'The next month button should be disabled');
+				})
+				.end()
+			.findByCssSelector(firstDayCssSelector(firstDayOfNextMonth))
+				.click()
+				.sleep(DELAY)
+				.pressKeys([keys.ARROW_DOWN, keys.ARROW_DOWN])
+				.end()
+			.sleep(DELAY)
+			.getActiveElement()
+				.getVisibleText()
+				.then(text => {
+					assert.strictEqual(text, '15', 'Max date is able to have focus');
+				})
+				.pressKeys(keys.ARROW_RIGHT)
+				.end()
+			.sleep(DELAY)
+			.getActiveElement()
+				.getVisibleText()
+				.then(text => {
+					assert.strictEqual(text, '15', 'Focus does not go beyond max date');
+				})
+				.pressKeys(keys.ARROW_DOWN)
+				.end()
+			.sleep(DELAY)
+			.getActiveElement()
+				.getVisibleText()
+				.then(text => {
+					assert.strictEqual(text, '15', 'Focus does not go beyond max date');
+				})
+				.end()
+			.findByCssSelector(`tbody > tr:nth-child(4) > td:first-child`)
+				.getAttribute('class')
+				.then((className: string) => {
+					assert.include(className, css.inactiveDate, 'The second half of next month is innactive');
 				});
 	},
 

--- a/src/calendar/tests/unit/Calendar.ts
+++ b/src/calendar/tests/unit/Calendar.ts
@@ -661,14 +661,14 @@ registerSuite('Calendar with min-max', {
 			);
 		},
 
-		'Sets the selected date to the minimum if outside the min/max'() {
+		'Allows the selected date even if outside the min/max'() {
 			const h = harness(() => w(Calendar, {
 				selectedDate: new Date('June 1, 2017'),
 				minDate: minDateInMonth,
 				maxDate: maxDateInMonth
 			}));
 
-			h.expect(baseMinMaxTemplate.setProperty('@date-6', 'selected', true));
+			h.expect(baseMinMaxTemplate.setProperty('@date-4', 'selected', true));
 		},
 
 		'Click to select date does not click disabled dates'() {

--- a/src/calendar/tests/unit/Calendar.ts
+++ b/src/calendar/tests/unit/Calendar.ts
@@ -19,14 +19,14 @@ import {
 	noop,
 	stubEvent
 } from '../../../common/tests/support/test-helpers';
+import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
 import { register } from '@dojo/framework/widget-core/registerCustomElement';
 
-const testDate = new Date('June 3 2017');
+const testDate = new Date('June 5 2017');
 const harness = createHarness([ compareId, compareLabelId, compareAriaLabelledBy ]);
 
-let dateIndex = -1;
-const expectedDateCell = function(date: number, currentMonth: boolean, selectedIndex = 0, disabled = false) {
-	dateIndex++;
+/** Index of current expected date cell. Used by date cell factory function */
+const expectedDateCell = function(dateIndex: number, date: number, currentMonth: boolean, disabled = false, selectedIndex = -1) {
 	return w(CalendarCell, {
 		key: `date-${dateIndex}`,
 		callFocus: false,
@@ -38,7 +38,7 @@ const expectedDateCell = function(date: number, currentMonth: boolean, selectedI
 		theme: undefined,
 		classes: undefined,
 		today: false,
-		onClick: noop,
+		onClick: disabled ? undefined : noop,
 		onFocusCalled: noop,
 		onKeyDown: noop
 	});
@@ -46,7 +46,7 @@ const expectedDateCell = function(date: number, currentMonth: boolean, selectedI
 
 const expected = function(popupOpen = false, selectedIndex = -1, weekdayLabel = '', customMonthLabel = false, describedby = '') {
 	const overrides = describedby ? { 'aria-describedby': describedby } : {};
-	dateIndex = -1;
+	let dateIndex = 0;
 	return v('div', {
 		classes: css.root,
 		...overrides
@@ -85,58 +85,58 @@ const expected = function(popupOpen = false, selectedIndex = -1, weekdayLabel = 
 			]),
 			v('tbody', [
 				v('tr', [
-					expectedDateCell(28, false, selectedIndex),
-					expectedDateCell(29, false, selectedIndex),
-					expectedDateCell(30, false, selectedIndex),
-					expectedDateCell(31, false, selectedIndex),
-					expectedDateCell(1, true, selectedIndex),
-					expectedDateCell(2, true, selectedIndex),
-					expectedDateCell(3, true, selectedIndex)
+					expectedDateCell(dateIndex++, 28, false, false, selectedIndex),
+					expectedDateCell(dateIndex++, 29, false, false, selectedIndex),
+					expectedDateCell(dateIndex++, 30, false, false, selectedIndex),
+					expectedDateCell(dateIndex++, 31, false, false, selectedIndex),
+					expectedDateCell(dateIndex++, 1, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 2, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 3, true, false, selectedIndex)
 				]),
 				v('tr', [
-					expectedDateCell(4, true, selectedIndex),
-					expectedDateCell(5, true, selectedIndex),
-					expectedDateCell(6, true, selectedIndex),
-					expectedDateCell(7, true, selectedIndex),
-					expectedDateCell(8, true, selectedIndex),
-					expectedDateCell(9, true, selectedIndex),
-					expectedDateCell(10, true, selectedIndex)
+					expectedDateCell(dateIndex++, 4, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 5, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 6, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 7, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 8, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 9, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 10, true, false, selectedIndex)
 				]),
 				v('tr', [
-					expectedDateCell(11, true, selectedIndex),
-					expectedDateCell(12, true, selectedIndex),
-					expectedDateCell(13, true, selectedIndex),
-					expectedDateCell(14, true, selectedIndex),
-					expectedDateCell(15, true, selectedIndex),
-					expectedDateCell(16, true, selectedIndex),
-					expectedDateCell(17, true, selectedIndex)
+					expectedDateCell(dateIndex++, 11, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 12, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 13, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 14, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 15, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 16, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 17, true, false, selectedIndex)
 				]),
 				v('tr', [
-					expectedDateCell(18, true, selectedIndex),
-					expectedDateCell(19, true, selectedIndex),
-					expectedDateCell(20, true, selectedIndex),
-					expectedDateCell(21, true, selectedIndex),
-					expectedDateCell(22, true, selectedIndex),
-					expectedDateCell(23, true, selectedIndex),
-					expectedDateCell(24, true, selectedIndex)
+					expectedDateCell(dateIndex++, 18, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 19, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 20, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 21, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 22, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 23, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 24, true, false, selectedIndex)
 				]),
 				v('tr', [
-					expectedDateCell(25, true, selectedIndex),
-					expectedDateCell(26, true, selectedIndex),
-					expectedDateCell(27, true, selectedIndex),
-					expectedDateCell(28, true, selectedIndex),
-					expectedDateCell(29, true, selectedIndex),
-					expectedDateCell(30, true, selectedIndex),
-					expectedDateCell(1, false, selectedIndex)
+					expectedDateCell(dateIndex++, 25, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 26, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 27, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 28, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 29, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 30, true, false, selectedIndex),
+					expectedDateCell(dateIndex++, 1, false, false, selectedIndex)
 				]),
 				v('tr', [
-					expectedDateCell(2, false, selectedIndex),
-					expectedDateCell(3, false, selectedIndex),
-					expectedDateCell(4, false, selectedIndex),
-					expectedDateCell(5, false, selectedIndex),
-					expectedDateCell(6, false, selectedIndex),
-					expectedDateCell(7, false, selectedIndex),
-					expectedDateCell(8, false, selectedIndex)
+					expectedDateCell(dateIndex++, 2, false, false, selectedIndex),
+					expectedDateCell(dateIndex++, 3, false, false, selectedIndex),
+					expectedDateCell(dateIndex++, 4, false, false, selectedIndex),
+					expectedDateCell(dateIndex++, 5, false, false, selectedIndex),
+					expectedDateCell(dateIndex++, 6, false, false, selectedIndex),
+					expectedDateCell(dateIndex++, 7, false, false, selectedIndex),
+					expectedDateCell(dateIndex++, 8, false, false, selectedIndex)
 				])
 			])
 		]),
@@ -166,6 +166,128 @@ const expected = function(popupOpen = false, selectedIndex = -1, weekdayLabel = 
 		])
 	]);
 };
+const baseTemplate = assertionTemplate(() => {
+	let dateIndex = 0;
+	return v('div', {
+		classes: css.root
+	}, [
+		w(DatePicker, {
+			key: 'date-picker',
+			labelId: '',
+			labels: DEFAULT_LABELS,
+			month: 5,
+			monthNames: DEFAULT_MONTHS,
+			renderMonthLabel: undefined,
+			theme: undefined,
+			classes: undefined,
+			year: 2017,
+			minDate: undefined,
+			maxDate: undefined,
+			onPopupChange: noop,
+			onRequestMonthChange: noop,
+			onRequestYearChange: noop
+		}),
+		v('table', {
+			cellspacing: '0',
+			cellpadding: '0',
+			role: 'grid',
+			'aria-labelledby': '', // this._monthLabelId,
+			classes: [ css.dateGrid, null ]
+		}, [
+			v('thead', [
+				v('tr', DEFAULT_WEEKDAYS.map((weekday: { short: string; long: string; }) => v('th', {
+						role: 'columnheader',
+						classes: css.weekday
+					}, [
+						v('abbr', { title: weekday.long }, [ weekday.short ])
+					])
+				))
+			]),
+			v('tbody', [
+				v('tr', [
+					expectedDateCell(dateIndex++, 28, false),
+					expectedDateCell(dateIndex++, 29, false),
+					expectedDateCell(dateIndex++, 30, false),
+					expectedDateCell(dateIndex++, 31, false),
+					expectedDateCell(dateIndex++, 1, true),
+					expectedDateCell(dateIndex++, 2, true),
+					expectedDateCell(dateIndex++, 3, true)
+				]),
+				v('tr', [
+					expectedDateCell(dateIndex++, 4, true),
+					expectedDateCell(dateIndex++, 5, true),
+					expectedDateCell(dateIndex++, 6, true),
+					expectedDateCell(dateIndex++, 7, true),
+					expectedDateCell(dateIndex++, 8, true),
+					expectedDateCell(dateIndex++, 9, true),
+					expectedDateCell(dateIndex++, 10, true)
+				]),
+				v('tr', [
+					expectedDateCell(dateIndex++, 11, true),
+					expectedDateCell(dateIndex++, 12, true),
+					expectedDateCell(dateIndex++, 13, true),
+					expectedDateCell(dateIndex++, 14, true),
+					expectedDateCell(dateIndex++, 15, true),
+					expectedDateCell(dateIndex++, 16, true),
+					expectedDateCell(dateIndex++, 17, true)
+				]),
+				v('tr', [
+					expectedDateCell(dateIndex++, 18, true),
+					expectedDateCell(dateIndex++, 19, true),
+					expectedDateCell(dateIndex++, 20, true),
+					expectedDateCell(dateIndex++, 21, true),
+					expectedDateCell(dateIndex++, 22, true),
+					expectedDateCell(dateIndex++, 23, true),
+					expectedDateCell(dateIndex++, 24, true)
+				]),
+				v('tr', [
+					expectedDateCell(dateIndex++, 25, true),
+					expectedDateCell(dateIndex++, 26, true),
+					expectedDateCell(dateIndex++, 27, true),
+					expectedDateCell(dateIndex++, 28, true),
+					expectedDateCell(dateIndex++, 29, true),
+					expectedDateCell(dateIndex++, 30, true),
+					expectedDateCell(dateIndex++, 1, false)
+				]),
+				v('tr', [
+					expectedDateCell(dateIndex++, 2, false),
+					expectedDateCell(dateIndex++, 3, false),
+					expectedDateCell(dateIndex++, 4, false),
+					expectedDateCell(dateIndex++, 5, false),
+					expectedDateCell(dateIndex++, 6, false),
+					expectedDateCell(dateIndex++, 7, false),
+					expectedDateCell(dateIndex++, 8, false)
+				])
+			])
+		]),
+		v('div', {
+			classes: [ css.controls, null ]
+		}, [
+			v('button', {
+				'assertion-key': 'previousMonth',
+				classes: css.previous,
+				disabled: false,
+				tabIndex: 0,
+				type: 'button',
+				onclick: noop
+			}, [
+				w(Icon, { type: 'leftIcon', theme: undefined, classes: undefined }),
+				v('span', { classes: [ baseCss.visuallyHidden ] }, [ 'Previous Month' ])
+			]),
+			v('button', {
+				'assertion-key': 'nextMonth',
+				classes: css.next,
+				disabled: false,
+				tabIndex: 0,
+				type: 'button',
+				onclick: noop
+			}, [
+				w(Icon, { type: 'rightIcon', theme: undefined, classes: undefined }),
+				v('span', { classes: [ baseCss.visuallyHidden ] }, [ 'Next Month' ])
+			])
+		])
+	]);
+});
 
 registerSuite('Calendar', {
 	tests: {
@@ -182,7 +304,7 @@ registerSuite('Calendar', {
 				selectedDate: testDate
 			}));
 
-			h.expect(() => expected(false, 6));
+			h.expect(() => expected(false, 8));
 		},
 
 		'Renders with custom properties'() {
@@ -411,246 +533,130 @@ registerSuite('Calendar', {
 	}
 });
 
+const minDateInMonth = new Date('June 3, 2017');
+const maxDateInMonth = new Date('June 29, 2017');
+
+let dateIndex = 28;
+const baseMinMaxTemplate = baseTemplate
+	.setProperty('@date-picker', 'minDate', minDateInMonth)
+	.setProperty('@date-picker', 'maxDate', maxDateInMonth)
+	.replace('tbody tr:first-child', [
+		expectedDateCell(0, 28, false, true),
+		expectedDateCell(1, 29, false, true),
+		expectedDateCell(2, 30, false, true),
+		expectedDateCell(3, 31, false, true),
+		expectedDateCell(4, 1, true, true),
+		expectedDateCell(5, 2, true, true),
+		expectedDateCell(6, 3, true, false)
+	])
+	.replace('tbody tr:nth-child(5)', [
+		expectedDateCell(dateIndex++, 25, true, false),
+		expectedDateCell(dateIndex++, 26, true, false),
+		expectedDateCell(dateIndex++, 27, true, false),
+		expectedDateCell(dateIndex++, 28, true, false),
+		expectedDateCell(dateIndex++, 29, true, false),
+		expectedDateCell(dateIndex++, 30, true, true),
+		expectedDateCell(dateIndex++, 1, false, true)
+	]).replace('tbody tr:last-child', [
+		expectedDateCell(dateIndex++, 2, false, true),
+		expectedDateCell(dateIndex++, 3, false, true),
+		expectedDateCell(dateIndex++, 4, false, true),
+		expectedDateCell(dateIndex++, 5, false, true),
+		expectedDateCell(dateIndex++, 6, false, true),
+		expectedDateCell(dateIndex++, 7, false, true),
+		expectedDateCell(dateIndex++, 8, false, true)
+	])
+	.setProperty('~previousMonth', 'disabled', true)
+	.setProperty('~nextMonth', 'disabled', true);
+
+
 registerSuite('Calendar with min-max', {
 	tests: {
-		'Render specific month with default props'() {
-			const h = harness(() => w(Calendar, {
-				month: testDate.getMonth(),
-				year: testDate.getFullYear()
-			}));
-			h.expect(expected);
-		},
+		'Render specific month not limited by min/max'() {
+			const minDate = new Date('May 15, 2017');
+			const maxDate = new Date('July 15, 2017');
 
-		'Render specific month and year with selectedDate'() {
-			const h = harness(() => w(Calendar, {
-				selectedDate: testDate
-			}));
-
-			h.expect(() => expected(false, 6));
-		},
-
-		'Renders with custom properties'() {
-			let properties: any = {
-				aria: { describedBy: 'foo' },
-				labels: DEFAULT_LABELS,
-				month: testDate.getMonth(),
-				monthNames: DEFAULT_MONTHS,
-				selectedDate: new Date('June 1 2017'),
-				weekdayNames: DEFAULT_WEEKDAYS,
-				year: testDate.getFullYear(),
-				renderMonthLabel: (month: number, year: number) => 'Foo',
-				renderWeekdayCell: (day: { short: string; long: string; }) => 'Bar'
-			};
-			const h = harness(() => w(Calendar, properties));
-
-			h.expect(() => expected(false, 4, 'Bar', true, 'foo'));
-			properties = {
-				month: testDate.getMonth(),
-				year: testDate.getFullYear()
-			};
-			h.expect(expected);
-		},
-
-		'Click to select date'() {
-			let selectedDate = testDate;
 			const h = harness(() => w(Calendar, {
 				month: testDate.getMonth(),
 				year: testDate.getFullYear(),
+				minDate,
+				maxDate
+			}));
+			h.expect(baseTemplate
+				.setProperty('@date-picker', 'minDate', minDate)
+				.setProperty('@date-picker', 'maxDate', maxDate)
+			);
+		},
+
+		'Render the month and year with min and max date limitations'() {
+			const h = harness(() => w(Calendar, {
+				selectedDate: testDate,
+				minDate: minDateInMonth,
+				maxDate: maxDateInMonth
+			}));
+
+			h.expect(baseMinMaxTemplate.setProperty('@date-8', 'selected', true));
+		},
+
+		'Sets the selected date to the minimum if outside the min/max'() {
+			const h = harness(() => w(Calendar, {
+				selectedDate: new Date('June 1, 2017'),
+				minDate: minDateInMonth,
+				maxDate: maxDateInMonth
+			}));
+
+			h.expect(baseMinMaxTemplate.setProperty('@date-6', 'selected', true));
+		},
+
+		'Click to select date does not click disabled dates'() {
+			const defaultDate = testDate.toDateString();
+			let selectedDate = testDate.toDateString();
+			const h = harness(() => w(Calendar, {
+				month: testDate.getMonth(),
+				year: testDate.getFullYear(),
+				minDate: minDateInMonth,
+				maxDate: maxDateInMonth,
 				onDateSelect: (date: Date) => {
-					selectedDate = date;
+					selectedDate = date.toDateString();
 				}
 			}));
-			h.trigger('@date-4', 'onClick', 1, true);
-
-			assert.strictEqual(selectedDate.getDate(), 1, 'Clicking cell selects correct date');
-			assert.strictEqual(selectedDate.getMonth(), 5, 'Clicking active date maintains current month');
-			assert.strictEqual(selectedDate.getFullYear(), 2017, 'Clicking date keeps current year');
-		},
-
-		'Clicking on dates outside the current month changes the month'() {
-			let currentMonth = testDate.getMonth();
-			let selectedDate = testDate;
-			let properties = {
-				month: currentMonth,
-				year: testDate.getFullYear(),
-				onMonthChange: (month: number) => {
-					currentMonth = month;
-				},
-				onDateSelect: (date: Date) => {
-					selectedDate = date;
-				}
-			};
-			const h = harness(() => w(Calendar, properties));
-
-			h.trigger('@date-34', 'onClick', 1, false);
-			assert.strictEqual(currentMonth, 6, 'Month changes to July');
-			assert.strictEqual(selectedDate.getMonth(), 6, 'selected date in July');
-			assert.strictEqual(selectedDate.getDate(), 1, 'selected correct date in July');
 
 			h.trigger('@date-2', 'onClick', 30, false);
-			assert.strictEqual(currentMonth, 4, 'Month changes to May');
-			assert.strictEqual(selectedDate.getMonth(), 4, 'selected date in May');
-			assert.strictEqual(selectedDate.getDate(), 30, 'selected correct date in May');
+			assert.strictEqual(selectedDate, defaultDate, 'Clicking disabled date from last month does not select');
+
+			h.trigger('@date-5', 'onClick', 2, true);
+			assert.strictEqual(selectedDate, defaultDate, 'Clicking disabled date at beginning of the month does not select');
+
+			h.trigger('@date-33', 'onClick', 30, true);
+			assert.strictEqual(selectedDate, defaultDate, 'Clicking disabled date at end of the month does not select');
+
+			h.trigger('@date-35', 'onClick', 2, false);
+			assert.strictEqual(selectedDate, defaultDate, 'Clicking disabled date in next month does not select');
+
+			h.trigger('@date-20', 'onClick', 17, true);
+			assert.strictEqual(selectedDate, new Date('June 17, 2017').toDateString(), 'Clicking active selects');
 		},
 
-		'Keyboard date select'() {
-			let selectedDate = testDate;
-			const h = harness(() => w(Calendar, {
-				month: testDate.getMonth(),
-				year: testDate.getFullYear(),
-				onDateSelect: (date: Date) => {
-					selectedDate = date;
-				}
-			}));
-
-			// right arrow, then select
-			h.trigger('@date-4', 'onKeyDown', Keys.Right, () => {});
-			h.trigger('@date-4', 'onFocusCalled');
-			h.trigger('@date-5', 'onKeyDown', Keys.Enter, () => {});
-			assert.strictEqual(selectedDate.getDate(), 2, 'Right arrow + enter selects second day');
-			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
-
-			h.trigger('@date-5', 'onKeyDown', Keys.Down, () => {});
-			h.trigger('@date-12', 'onKeyDown', Keys.Enter, () => {});
-			assert.strictEqual(selectedDate.getDate(), 9, 'Down arrow + enter selects one week down');
-			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
-
-			h.trigger('@date-12', 'onKeyDown', Keys.Left, () => {});
-			h.trigger('@date-11', 'onKeyDown', Keys.Space, () => {});
-
-			assert.strictEqual(selectedDate.getDate(), 8, 'Left arrow + space selects previous day');
-			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
-
-			h.trigger('@date-11', 'onKeyDown', Keys.Up, () => {});
-			h.trigger('@date-4', 'onKeyDown', Keys.Space, () => {});
-
-			assert.strictEqual(selectedDate.getDate(), 1, 'Left arrow + space selects previous day');
-			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
-
-			h.trigger('@date-4', 'onKeyDown', Keys.PageDown, () => {});
-			h.trigger('@date-33', 'onKeyDown', Keys.Space, () => {});
-
-			assert.strictEqual(selectedDate.getDate(), 30, 'Page Down + space selects last day');
-			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
-
-			h.trigger('@date-33', 'onKeyDown', Keys.PageUp, () => {});
-			h.trigger('@date-4', 'onKeyDown', Keys.Space, () => {});
-
-			assert.strictEqual(selectedDate.getDate(), 1, 'Page Up + space selects first day');
-			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
-		},
-
-		'Arrow keys can change month'() {
-			let currentMonth = testDate.getMonth();
+		'Arrow keys keep month in min/max'() {
+			let originalMonth = testDate.getMonth();
+			let currentMonth = originalMonth;
 			const h = harness(() => w(Calendar, {
 				month: currentMonth,
 				year: testDate.getFullYear(),
+				minDate: minDateInMonth,
+				maxDate: maxDateInMonth,
 				onMonthChange: (month: number) => {
 					currentMonth = month;
 				}
 			}));
 
 			h.trigger('@date-4', 'onKeyDown', Keys.Left, () => {});
-			assert.strictEqual(currentMonth, testDate.getMonth() - 1, 'Going left from the first day goes to previous month');
+			assert.strictEqual(currentMonth, originalMonth, 'Going left from the first day does not change the month');
 
 			h.trigger('@date-4', 'onKeyDown', Keys.PageDown, () => {});
 			h.trigger('@date-4', 'onKeyDown', Keys.Right, () => {});
-			assert.strictEqual(currentMonth, testDate.getMonth(), 'Going right from the last day goes to next month');
+			assert.strictEqual(currentMonth, testDate.getMonth(), 'Going right from the last day does not change the month');
 		},
 
-		'Month changes wrap and change year'() {
-			let currentMonth = 0;
-			let currentYear = 2017;
-			let properties = {
-				month: currentMonth,
-				year: currentYear,
-				onMonthChange: (month: number) => {
-					currentMonth = month;
-				},
-				onYearChange: (year: number) => {
-					currentYear = year;
-				}
-			};
-			const h = harness(() => w(Calendar, properties));
-
-			h.trigger('@date-0', 'onKeyDown', Keys.Up, () => {});
-
-			assert.strictEqual(currentMonth, 11, 'Previous month wraps from January to December');
-			assert.strictEqual(currentYear, 2016, 'Year decrements when month wraps');
-
-			properties = {
-				month: 11,
-				year: 2017,
-				onMonthChange: (month: number) => {
-					currentMonth = month;
-				},
-				onYearChange: (year: number) => {
-					currentYear = year;
-				}
-			};
-
-			h.trigger('@date-35', 'onKeyDown', Keys.Down, () => {});
-
-			assert.strictEqual(currentMonth, 0, 'Next month wraps from December to January');
-			assert.strictEqual(currentYear, 2018, 'Year increments when month wraps');
-		},
-
-		'Month popup events change month and year'() {
-			let currentMonth = testDate.getMonth();
-			let currentYear = testDate.getFullYear();
-			const h = harness(() => w(Calendar, {
-				month: currentMonth,
-				year: currentYear,
-				onMonthChange: (month: number) => {
-					currentMonth = month;
-				},
-				onYearChange: (year: number) => {
-					currentYear = year;
-				}
-			}));
-
-			h.trigger('@date-picker', 'onRequestMonthChange', 2);
-			assert.strictEqual(currentMonth, 2, 'Popup month change event triggers calendar month change event');
-
-			h.trigger('@date-picker', 'onRequestYearChange', 2018);
-			assert.strictEqual(currentYear, 2018, 'Popup year change triggers calendar year change');
-		},
-
-		'Previous button should decrement month'() {
-			let currentMonth = testDate.getMonth();
-			const h = harness(() => w(Calendar, {
-				month: currentMonth,
-				onMonthChange: (month: number) => {
-					currentMonth = month;
-				}
-			}));
-
-			h.trigger(`.${css.previous}`, 'onclick', stubEvent);
-			assert.strictEqual(currentMonth, testDate.getMonth() - 1, 'Previous button decrements month');
-		},
-
-		'Next button should increment month'() {
-			let currentMonth = testDate.getMonth();
-			const h = harness(() => w(Calendar, {
-				month: currentMonth,
-				onMonthChange: (month: number) => {
-					currentMonth = month;
-				}
-			}));
-
-			h.trigger(`.${css.next}`, 'onclick', stubEvent);
-			assert.strictEqual(currentMonth, testDate.getMonth() + 1, 'Next button increments month');
-		},
-
-		'onPopupChange should control visibility'() {
-			let properties: any = {};
-			const h = harness(() => w(Calendar, properties));
-			h.trigger('@date-picker', 'onPopupChange', true);
-			properties = {
-				month: testDate.getMonth(),
-				year: testDate.getFullYear()
-			};
-			h.expect(() => expected(true));
-		}
 	}
 });

--- a/src/calendar/tests/unit/Calendar.ts
+++ b/src/calendar/tests/unit/Calendar.ts
@@ -161,6 +161,130 @@ const expected = function(popupOpen = false, selectedIndex = -1, weekdayLabel = 
 	]);
 };
 
+const expectedMondayStart = function(popupOpen = false, selectedIndex = -1, weekdayLabel = '', customMonthLabel = false, describedby = '') {
+	const overrides = describedby ? { 'aria-describedby': describedby } : {};
+	dateIndex = -1;
+	let weekdayNames = [];
+	for (let i = 0; i < DEFAULT_WEEKDAYS.length; i++) {
+		weekdayNames.push(DEFAULT_WEEKDAYS[(i + 1) % 7]);
+	}
+	return v('div', {
+		classes: css.root,
+		dir: '',
+		lang: null,
+		...overrides
+	}, [
+		w(DatePicker, {
+			key: 'date-picker',
+			labelId: '',
+			labels: DEFAULT_LABELS,
+			month: 5,
+			monthNames: DEFAULT_MONTHS,
+			renderMonthLabel: customMonthLabel ? noop : undefined,
+			theme: undefined,
+			year: 2017,
+			onPopupChange: noop,
+			onRequestMonthChange: noop,
+			onRequestYearChange: noop
+		}),
+		v('table', {
+			cellspacing: '0',
+			cellpadding: '0',
+			role: 'grid',
+			'aria-labelledby': '', // this._monthLabelId,
+			classes: [ css.dateGrid, popupOpen ? baseCss.visuallyHidden : null ]
+		}, [
+			v('thead', [
+				v('tr', weekdayNames.map((weekday: { short: string; long: string; }) => v('th', {
+						role: 'columnheader',
+						classes: css.weekday
+					}, [
+						weekdayLabel ? weekdayLabel : v('abbr', { title: weekday.long }, [ weekday.short ])
+					])
+				))
+			]),
+			v('tbody', [
+				v('tr', [
+					expectedDateCell(29, false, selectedIndex),
+					expectedDateCell(30, false, selectedIndex),
+					expectedDateCell(31, false, selectedIndex),
+					expectedDateCell(1, true, selectedIndex),
+					expectedDateCell(2, true, selectedIndex),
+					expectedDateCell(3, true, selectedIndex),
+					expectedDateCell(4, true, selectedIndex)
+				]),
+				v('tr', [
+					expectedDateCell(5, true, selectedIndex),
+					expectedDateCell(6, true, selectedIndex),
+					expectedDateCell(7, true, selectedIndex),
+					expectedDateCell(8, true, selectedIndex),
+					expectedDateCell(9, true, selectedIndex),
+					expectedDateCell(10, true, selectedIndex),
+					expectedDateCell(11, true, selectedIndex)
+				]),
+				v('tr', [
+					expectedDateCell(12, true, selectedIndex),
+					expectedDateCell(13, true, selectedIndex),
+					expectedDateCell(14, true, selectedIndex),
+					expectedDateCell(15, true, selectedIndex),
+					expectedDateCell(16, true, selectedIndex),
+					expectedDateCell(17, true, selectedIndex),
+					expectedDateCell(18, true, selectedIndex)
+				]),
+				v('tr', [
+					expectedDateCell(19, true, selectedIndex),
+					expectedDateCell(20, true, selectedIndex),
+					expectedDateCell(21, true, selectedIndex),
+					expectedDateCell(22, true, selectedIndex),
+					expectedDateCell(23, true, selectedIndex),
+					expectedDateCell(24, true, selectedIndex),
+					expectedDateCell(25, true, selectedIndex)
+				]),
+				v('tr', [
+					expectedDateCell(26, true, selectedIndex),
+					expectedDateCell(27, true, selectedIndex),
+					expectedDateCell(28, true, selectedIndex),
+					expectedDateCell(29, true, selectedIndex),
+					expectedDateCell(30, true, selectedIndex),
+					expectedDateCell(1, false, selectedIndex),
+					expectedDateCell(2, false, selectedIndex)
+				]),
+				v('tr', [
+					expectedDateCell(3, false, selectedIndex),
+					expectedDateCell(4, false, selectedIndex),
+					expectedDateCell(5, false, selectedIndex),
+					expectedDateCell(6, false, selectedIndex),
+					expectedDateCell(7, false, selectedIndex),
+					expectedDateCell(8, false, selectedIndex),
+					expectedDateCell(9, false, selectedIndex)
+				])
+			])
+		]),
+		v('div', {
+			classes: [ css.controls, popupOpen ? baseCss.visuallyHidden : null ]
+		}, [
+			v('button', {
+				classes: css.previous,
+				tabIndex: popupOpen ? -1 : 0,
+				type: 'button',
+				onclick: noop
+			}, [
+				w(Icon, { type: 'leftIcon', theme: undefined }),
+				v('span', { classes: [ baseCss.visuallyHidden ] }, [ 'Previous Month' ])
+			]),
+			v('button', {
+				classes: css.next,
+				tabIndex: popupOpen ? -1 : 0,
+				type: 'button',
+				onclick: noop
+			}, [
+				w(Icon, { type: 'rightIcon', theme: undefined }),
+				v('span', { classes: [ baseCss.visuallyHidden ] }, [ 'Next Month' ])
+			])
+		])
+	]);
+};
+
 registerSuite('Calendar', {
 	tests: {
 		'Render specific month with default props'() {
@@ -169,6 +293,15 @@ registerSuite('Calendar', {
 				year: testDate.getFullYear()
 			}));
 			h.expect(expected);
+		},
+
+		'Render month with a Monday firstDayOfTheWeek'() {
+			const h = harness(() => w(Calendar, {
+				month: testDate.getMonth(),
+				year: testDate.getFullYear(),
+				firstDayOfTheWeek: 1
+			}));
+			h.expect(expectedMondayStart);
 		},
 
 		'Render specific month and year with selectedDate'() {

--- a/src/calendar/tests/unit/Calendar.ts
+++ b/src/calendar/tests/unit/Calendar.ts
@@ -19,23 +19,25 @@ import {
 	noop,
 	stubEvent
 } from '../../../common/tests/support/test-helpers';
+import { register } from '@dojo/framework/widget-core/registerCustomElement';
 
 const testDate = new Date('June 3 2017');
 const harness = createHarness([ compareId, compareLabelId, compareAriaLabelledBy ]);
 
 let dateIndex = -1;
-const expectedDateCell = function(date: number, active: boolean, selectedIndex = 0) {
+const expectedDateCell = function(date: number, currentMonth: boolean, selectedIndex = 0, disabled = false) {
 	dateIndex++;
 	return w(CalendarCell, {
 		key: `date-${dateIndex}`,
 		callFocus: false,
 		date,
-		disabled: !active,
-		focusable: date === 1 && active,
+		disabled,
+		currentMonth,
+		focusable: date === 1 && currentMonth,
 		selected: dateIndex === selectedIndex,
 		theme: undefined,
 		classes: undefined,
-		today: active && new Date().toDateString() === new Date(`June ${date} 2017`).toDateString(),
+		today: false,
 		onClick: noop,
 		onFocusCalled: noop,
 		onKeyDown: noop
@@ -59,6 +61,8 @@ const expected = function(popupOpen = false, selectedIndex = -1, weekdayLabel = 
 			theme: undefined,
 			classes: undefined,
 			year: 2017,
+			minDate: undefined,
+			maxDate: undefined,
 			onPopupChange: noop,
 			onRequestMonthChange: noop,
 			onRequestYearChange: noop
@@ -141,6 +145,7 @@ const expected = function(popupOpen = false, selectedIndex = -1, weekdayLabel = 
 		}, [
 			v('button', {
 				classes: css.previous,
+				disabled: false,
 				tabIndex: popupOpen ? -1 : 0,
 				type: 'button',
 				onclick: noop
@@ -150,135 +155,12 @@ const expected = function(popupOpen = false, selectedIndex = -1, weekdayLabel = 
 			]),
 			v('button', {
 				classes: css.next,
+				disabled: false,
 				tabIndex: popupOpen ? -1 : 0,
 				type: 'button',
 				onclick: noop
 			}, [
 				w(Icon, { type: 'rightIcon', theme: undefined, classes: undefined }),
-				v('span', { classes: [ baseCss.visuallyHidden ] }, [ 'Next Month' ])
-			])
-		])
-	]);
-};
-
-const expectedMondayStart = function(popupOpen = false, selectedIndex = -1, weekdayLabel = '', customMonthLabel = false, describedby = '') {
-	const overrides = describedby ? { 'aria-describedby': describedby } : {};
-	dateIndex = -1;
-	let weekdayNames = [];
-	for (let i = 0; i < DEFAULT_WEEKDAYS.length; i++) {
-		weekdayNames.push(DEFAULT_WEEKDAYS[(i + 1) % 7]);
-	}
-	return v('div', {
-		classes: css.root,
-		dir: '',
-		lang: null,
-		...overrides
-	}, [
-		w(DatePicker, {
-			key: 'date-picker',
-			labelId: '',
-			labels: DEFAULT_LABELS,
-			month: 5,
-			monthNames: DEFAULT_MONTHS,
-			renderMonthLabel: customMonthLabel ? noop : undefined,
-			theme: undefined,
-			year: 2017,
-			onPopupChange: noop,
-			onRequestMonthChange: noop,
-			onRequestYearChange: noop
-		}),
-		v('table', {
-			cellspacing: '0',
-			cellpadding: '0',
-			role: 'grid',
-			'aria-labelledby': '', // this._monthLabelId,
-			classes: [ css.dateGrid, popupOpen ? baseCss.visuallyHidden : null ]
-		}, [
-			v('thead', [
-				v('tr', weekdayNames.map((weekday: { short: string; long: string; }) => v('th', {
-						role: 'columnheader',
-						classes: css.weekday
-					}, [
-						weekdayLabel ? weekdayLabel : v('abbr', { title: weekday.long }, [ weekday.short ])
-					])
-				))
-			]),
-			v('tbody', [
-				v('tr', [
-					expectedDateCell(29, false, selectedIndex),
-					expectedDateCell(30, false, selectedIndex),
-					expectedDateCell(31, false, selectedIndex),
-					expectedDateCell(1, true, selectedIndex),
-					expectedDateCell(2, true, selectedIndex),
-					expectedDateCell(3, true, selectedIndex),
-					expectedDateCell(4, true, selectedIndex)
-				]),
-				v('tr', [
-					expectedDateCell(5, true, selectedIndex),
-					expectedDateCell(6, true, selectedIndex),
-					expectedDateCell(7, true, selectedIndex),
-					expectedDateCell(8, true, selectedIndex),
-					expectedDateCell(9, true, selectedIndex),
-					expectedDateCell(10, true, selectedIndex),
-					expectedDateCell(11, true, selectedIndex)
-				]),
-				v('tr', [
-					expectedDateCell(12, true, selectedIndex),
-					expectedDateCell(13, true, selectedIndex),
-					expectedDateCell(14, true, selectedIndex),
-					expectedDateCell(15, true, selectedIndex),
-					expectedDateCell(16, true, selectedIndex),
-					expectedDateCell(17, true, selectedIndex),
-					expectedDateCell(18, true, selectedIndex)
-				]),
-				v('tr', [
-					expectedDateCell(19, true, selectedIndex),
-					expectedDateCell(20, true, selectedIndex),
-					expectedDateCell(21, true, selectedIndex),
-					expectedDateCell(22, true, selectedIndex),
-					expectedDateCell(23, true, selectedIndex),
-					expectedDateCell(24, true, selectedIndex),
-					expectedDateCell(25, true, selectedIndex)
-				]),
-				v('tr', [
-					expectedDateCell(26, true, selectedIndex),
-					expectedDateCell(27, true, selectedIndex),
-					expectedDateCell(28, true, selectedIndex),
-					expectedDateCell(29, true, selectedIndex),
-					expectedDateCell(30, true, selectedIndex),
-					expectedDateCell(1, false, selectedIndex),
-					expectedDateCell(2, false, selectedIndex)
-				]),
-				v('tr', [
-					expectedDateCell(3, false, selectedIndex),
-					expectedDateCell(4, false, selectedIndex),
-					expectedDateCell(5, false, selectedIndex),
-					expectedDateCell(6, false, selectedIndex),
-					expectedDateCell(7, false, selectedIndex),
-					expectedDateCell(8, false, selectedIndex),
-					expectedDateCell(9, false, selectedIndex)
-				])
-			])
-		]),
-		v('div', {
-			classes: [ css.controls, popupOpen ? baseCss.visuallyHidden : null ]
-		}, [
-			v('button', {
-				classes: css.previous,
-				tabIndex: popupOpen ? -1 : 0,
-				type: 'button',
-				onclick: noop
-			}, [
-				w(Icon, { type: 'leftIcon', theme: undefined }),
-				v('span', { classes: [ baseCss.visuallyHidden ] }, [ 'Previous Month' ])
-			]),
-			v('button', {
-				classes: css.next,
-				tabIndex: popupOpen ? -1 : 0,
-				type: 'button',
-				onclick: noop
-			}, [
-				w(Icon, { type: 'rightIcon', theme: undefined }),
 				v('span', { classes: [ baseCss.visuallyHidden ] }, [ 'Next Month' ])
 			])
 		])
@@ -293,15 +175,6 @@ registerSuite('Calendar', {
 				year: testDate.getFullYear()
 			}));
 			h.expect(expected);
-		},
-
-		'Render month with a Monday firstDayOfTheWeek'() {
-			const h = harness(() => w(Calendar, {
-				month: testDate.getMonth(),
-				year: testDate.getFullYear(),
-				firstDayOfTheWeek: 1
-			}));
-			h.expect(expectedMondayStart);
 		},
 
 		'Render specific month and year with selectedDate'() {
@@ -343,14 +216,14 @@ registerSuite('Calendar', {
 					selectedDate = date;
 				}
 			}));
-			h.trigger('@date-4', 'onClick', 1, false);
+			h.trigger('@date-4', 'onClick', 1, true);
 
 			assert.strictEqual(selectedDate.getDate(), 1, 'Clicking cell selects correct date');
-			assert.strictEqual(selectedDate.getMonth(), 5, 'Clicking active date has correct month');
+			assert.strictEqual(selectedDate.getMonth(), 5, 'Clicking active date maintains current month');
 			assert.strictEqual(selectedDate.getFullYear(), 2017, 'Clicking date keeps current year');
 		},
 
-		'Clicking on disabled dates changes month'() {
+		'Clicking on dates outside the current month changes the month'() {
 			let currentMonth = testDate.getMonth();
 			let selectedDate = testDate;
 			let properties = {
@@ -365,12 +238,256 @@ registerSuite('Calendar', {
 			};
 			const h = harness(() => w(Calendar, properties));
 
-			h.trigger('@date-34', 'onClick', 1, true);
+			h.trigger('@date-34', 'onClick', 1, false);
 			assert.strictEqual(currentMonth, 6, 'Month changes to July');
 			assert.strictEqual(selectedDate.getMonth(), 6, 'selected date in July');
 			assert.strictEqual(selectedDate.getDate(), 1, 'selected correct date in July');
 
-			h.trigger('@date-2', 'onClick', 30, true);
+			h.trigger('@date-2', 'onClick', 30, false);
+			assert.strictEqual(currentMonth, 4, 'Month changes to May');
+			assert.strictEqual(selectedDate.getMonth(), 4, 'selected date in May');
+			assert.strictEqual(selectedDate.getDate(), 30, 'selected correct date in May');
+		},
+
+		'Keyboard date select'() {
+			let selectedDate = testDate;
+			const h = harness(() => w(Calendar, {
+				month: testDate.getMonth(),
+				year: testDate.getFullYear(),
+				onDateSelect: (date: Date) => {
+					selectedDate = date;
+				}
+			}));
+
+			// right arrow, then select
+			h.trigger('@date-4', 'onKeyDown', Keys.Right, () => {});
+			h.trigger('@date-4', 'onFocusCalled');
+			h.trigger('@date-5', 'onKeyDown', Keys.Enter, () => {});
+			assert.strictEqual(selectedDate.getDate(), 2, 'Right arrow + enter selects second day');
+			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
+
+			h.trigger('@date-5', 'onKeyDown', Keys.Down, () => {});
+			h.trigger('@date-12', 'onKeyDown', Keys.Enter, () => {});
+			assert.strictEqual(selectedDate.getDate(), 9, 'Down arrow + enter selects one week down');
+			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
+
+			h.trigger('@date-12', 'onKeyDown', Keys.Left, () => {});
+			h.trigger('@date-11', 'onKeyDown', Keys.Space, () => {});
+
+			assert.strictEqual(selectedDate.getDate(), 8, 'Left arrow + space selects previous day');
+			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
+
+			h.trigger('@date-11', 'onKeyDown', Keys.Up, () => {});
+			h.trigger('@date-4', 'onKeyDown', Keys.Space, () => {});
+
+			assert.strictEqual(selectedDate.getDate(), 1, 'Left arrow + space selects previous day');
+			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
+
+			h.trigger('@date-4', 'onKeyDown', Keys.PageDown, () => {});
+			h.trigger('@date-33', 'onKeyDown', Keys.Space, () => {});
+
+			assert.strictEqual(selectedDate.getDate(), 30, 'Page Down + space selects last day');
+			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
+
+			h.trigger('@date-33', 'onKeyDown', Keys.PageUp, () => {});
+			h.trigger('@date-4', 'onKeyDown', Keys.Space, () => {});
+
+			assert.strictEqual(selectedDate.getDate(), 1, 'Page Up + space selects first day');
+			assert.strictEqual(selectedDate.getMonth(), 5, 'Selected date is same month');
+		},
+
+		'Arrow keys can change month'() {
+			let currentMonth = testDate.getMonth();
+			const h = harness(() => w(Calendar, {
+				month: currentMonth,
+				year: testDate.getFullYear(),
+				onMonthChange: (month: number) => {
+					currentMonth = month;
+				}
+			}));
+
+			h.trigger('@date-4', 'onKeyDown', Keys.Left, () => {});
+			assert.strictEqual(currentMonth, testDate.getMonth() - 1, 'Going left from the first day goes to previous month');
+
+			h.trigger('@date-4', 'onKeyDown', Keys.PageDown, () => {});
+			h.trigger('@date-4', 'onKeyDown', Keys.Right, () => {});
+			assert.strictEqual(currentMonth, testDate.getMonth(), 'Going right from the last day goes to next month');
+		},
+
+		'Month changes wrap and change year'() {
+			let currentMonth = 0;
+			let currentYear = 2017;
+			let properties = {
+				month: currentMonth,
+				year: currentYear,
+				onMonthChange: (month: number) => {
+					currentMonth = month;
+				},
+				onYearChange: (year: number) => {
+					currentYear = year;
+				}
+			};
+			const h = harness(() => w(Calendar, properties));
+
+			h.trigger('@date-0', 'onKeyDown', Keys.Up, () => {});
+
+			assert.strictEqual(currentMonth, 11, 'Previous month wraps from January to December');
+			assert.strictEqual(currentYear, 2016, 'Year decrements when month wraps');
+
+			properties = {
+				month: 11,
+				year: 2017,
+				onMonthChange: (month: number) => {
+					currentMonth = month;
+				},
+				onYearChange: (year: number) => {
+					currentYear = year;
+				}
+			};
+
+			h.trigger('@date-35', 'onKeyDown', Keys.Down, () => {});
+
+			assert.strictEqual(currentMonth, 0, 'Next month wraps from December to January');
+			assert.strictEqual(currentYear, 2018, 'Year increments when month wraps');
+		},
+
+		'Month popup events change month and year'() {
+			let currentMonth = testDate.getMonth();
+			let currentYear = testDate.getFullYear();
+			const h = harness(() => w(Calendar, {
+				month: currentMonth,
+				year: currentYear,
+				onMonthChange: (month: number) => {
+					currentMonth = month;
+				},
+				onYearChange: (year: number) => {
+					currentYear = year;
+				}
+			}));
+
+			h.trigger('@date-picker', 'onRequestMonthChange', 2);
+			assert.strictEqual(currentMonth, 2, 'Popup month change event triggers calendar month change event');
+
+			h.trigger('@date-picker', 'onRequestYearChange', 2018);
+			assert.strictEqual(currentYear, 2018, 'Popup year change triggers calendar year change');
+		},
+
+		'Previous button should decrement month'() {
+			let currentMonth = testDate.getMonth();
+			const h = harness(() => w(Calendar, {
+				month: currentMonth,
+				onMonthChange: (month: number) => {
+					currentMonth = month;
+				}
+			}));
+
+			h.trigger(`.${css.previous}`, 'onclick', stubEvent);
+			assert.strictEqual(currentMonth, testDate.getMonth() - 1, 'Previous button decrements month');
+		},
+
+		'Next button should increment month'() {
+			let currentMonth = testDate.getMonth();
+			const h = harness(() => w(Calendar, {
+				month: currentMonth,
+				onMonthChange: (month: number) => {
+					currentMonth = month;
+				}
+			}));
+
+			h.trigger(`.${css.next}`, 'onclick', stubEvent);
+			assert.strictEqual(currentMonth, testDate.getMonth() + 1, 'Next button increments month');
+		},
+
+		'onPopupChange should control visibility'() {
+			let properties: any = {};
+			const h = harness(() => w(Calendar, properties));
+			h.trigger('@date-picker', 'onPopupChange', true);
+			properties = {
+				month: testDate.getMonth(),
+				year: testDate.getFullYear()
+			};
+			h.expect(() => expected(true));
+		}
+	}
+});
+
+registerSuite('Calendar with min-max', {
+	tests: {
+		'Render specific month with default props'() {
+			const h = harness(() => w(Calendar, {
+				month: testDate.getMonth(),
+				year: testDate.getFullYear()
+			}));
+			h.expect(expected);
+		},
+
+		'Render specific month and year with selectedDate'() {
+			const h = harness(() => w(Calendar, {
+				selectedDate: testDate
+			}));
+
+			h.expect(() => expected(false, 6));
+		},
+
+		'Renders with custom properties'() {
+			let properties: any = {
+				aria: { describedBy: 'foo' },
+				labels: DEFAULT_LABELS,
+				month: testDate.getMonth(),
+				monthNames: DEFAULT_MONTHS,
+				selectedDate: new Date('June 1 2017'),
+				weekdayNames: DEFAULT_WEEKDAYS,
+				year: testDate.getFullYear(),
+				renderMonthLabel: (month: number, year: number) => 'Foo',
+				renderWeekdayCell: (day: { short: string; long: string; }) => 'Bar'
+			};
+			const h = harness(() => w(Calendar, properties));
+
+			h.expect(() => expected(false, 4, 'Bar', true, 'foo'));
+			properties = {
+				month: testDate.getMonth(),
+				year: testDate.getFullYear()
+			};
+			h.expect(expected);
+		},
+
+		'Click to select date'() {
+			let selectedDate = testDate;
+			const h = harness(() => w(Calendar, {
+				month: testDate.getMonth(),
+				year: testDate.getFullYear(),
+				onDateSelect: (date: Date) => {
+					selectedDate = date;
+				}
+			}));
+			h.trigger('@date-4', 'onClick', 1, true);
+
+			assert.strictEqual(selectedDate.getDate(), 1, 'Clicking cell selects correct date');
+			assert.strictEqual(selectedDate.getMonth(), 5, 'Clicking active date maintains current month');
+			assert.strictEqual(selectedDate.getFullYear(), 2017, 'Clicking date keeps current year');
+		},
+
+		'Clicking on dates outside the current month changes the month'() {
+			let currentMonth = testDate.getMonth();
+			let selectedDate = testDate;
+			let properties = {
+				month: currentMonth,
+				year: testDate.getFullYear(),
+				onMonthChange: (month: number) => {
+					currentMonth = month;
+				},
+				onDateSelect: (date: Date) => {
+					selectedDate = date;
+				}
+			};
+			const h = harness(() => w(Calendar, properties));
+
+			h.trigger('@date-34', 'onClick', 1, false);
+			assert.strictEqual(currentMonth, 6, 'Month changes to July');
+			assert.strictEqual(selectedDate.getMonth(), 6, 'selected date in July');
+			assert.strictEqual(selectedDate.getDate(), 1, 'selected correct date in July');
+
+			h.trigger('@date-2', 'onClick', 30, false);
 			assert.strictEqual(currentMonth, 4, 'Month changes to May');
 			assert.strictEqual(selectedDate.getMonth(), 4, 'selected date in May');
 			assert.strictEqual(selectedDate.getDate(), 30, 'selected correct date in May');

--- a/src/calendar/tests/unit/CalendarCell.ts
+++ b/src/calendar/tests/unit/CalendarCell.ts
@@ -50,29 +50,48 @@ registerSuite('CalendarCell', {
 			]));
 		},
 
+		'Calendar cells for other months display as inactive'() {
+			const h = harness(() => w(CalendarCell, {
+				date: 30,
+				currentMonth: false
+			}));
+
+			h.expect(() => v('td', {
+				key: 'root',
+				role: 'gridcell',
+				'aria-selected': 'false',
+				tabIndex: -1,
+				classes: [ css.date, css.inactiveDate, null, null ],
+				onclick: noop,
+				onkeydown: noop
+			}, [
+				v('span', {}, [ '30' ])
+			]));
+		},
+
 		'Click handler called with correct arguments'() {
 			let clickedDate = 0;
-			let clickedDisabled = false;
+			let clickedCurrentMonth = false;
 			let date = 1;
-			let disabled = true;
+			let currentMonth = false;
 			const h = harness(() => w(CalendarCell, {
 				date,
-				disabled,
-				onClick: (date: number, disabled: boolean) => {
-					clickedDate = date;
-					clickedDisabled = disabled;
+				currentMonth,
+				onClick: (callbackDate: number, callbackCurrentMonth: boolean) => {
+					clickedDate = callbackDate;
+					clickedCurrentMonth = callbackCurrentMonth;
 				}
 			}));
 
 			h.trigger('td', 'onclick', stubEvent);
 			assert.strictEqual(clickedDate, 1);
-			assert.isTrue(clickedDisabled);
+			assert.isFalse(clickedCurrentMonth);
 
-			disabled = false;
 			date = 2;
+			currentMonth = true;
 			h.trigger('td', 'onclick', stubEvent);
 			assert.strictEqual(clickedDate, 2);
-			assert.isFalse(clickedDisabled, 'disabled defaults to false');
+			assert.isTrue(clickedCurrentMonth);
 		},
 
 		'Keydown handler called'() {

--- a/src/calendar/tests/unit/CalendarCell.ts
+++ b/src/calendar/tests/unit/CalendarCell.ts
@@ -20,7 +20,7 @@ registerSuite('CalendarCell', {
 				role: 'gridcell',
 				'aria-selected': 'false',
 				tabIndex: -1,
-				classes: [ css.date, null, null, null ],
+				classes: [ css.date, null, null, null, null ],
 				onclick: noop,
 				onkeydown: noop
 			}, [
@@ -31,7 +31,7 @@ registerSuite('CalendarCell', {
 		'Calendar cell with custom properties'() {
 			const h = harness(() => w(CalendarCell, {
 				date: 2,
-				disabled: true,
+				outOfRange: true,
 				focusable: true,
 				selected: true,
 				today: true
@@ -42,7 +42,7 @@ registerSuite('CalendarCell', {
 				role: 'gridcell',
 				'aria-selected': 'true',
 				tabIndex: 0,
-				classes: [ css.date, css.inactiveDate, css.selectedDate, css.todayDate ],
+				classes: [ css.date, css.inactiveDate, css.outOfRange, css.selectedDate, css.todayDate ],
 				onclick: noop,
 				onkeydown: noop
 			}, [
@@ -53,7 +53,7 @@ registerSuite('CalendarCell', {
 		'Calendar cells for other months display as inactive'() {
 			const h = harness(() => w(CalendarCell, {
 				date: 30,
-				currentMonth: false
+				disabled: true
 			}));
 
 			h.expect(() => v('td', {
@@ -61,7 +61,26 @@ registerSuite('CalendarCell', {
 				role: 'gridcell',
 				'aria-selected': 'false',
 				tabIndex: -1,
-				classes: [ css.date, css.inactiveDate, null, null ],
+				classes: [ css.date, css.inactiveDate, null, null, null ],
+				onclick: noop,
+				onkeydown: noop
+			}, [
+				v('span', {}, [ '30' ])
+			]));
+		},
+
+		'Calendar cells for out of range dates display as inactive'() {
+			const h = harness(() => w(CalendarCell, {
+				date: 30,
+				outOfRange: true
+			}));
+
+			h.expect(() => v('td', {
+				key: 'root',
+				role: 'gridcell',
+				'aria-selected': 'false',
+				tabIndex: -1,
+				classes: [ css.date, css.inactiveDate, css.outOfRange, null, null ],
 				onclick: noop,
 				onkeydown: noop
 			}, [
@@ -73,10 +92,10 @@ registerSuite('CalendarCell', {
 			let clickedDate = 0;
 			let clickedCurrentMonth = false;
 			let date = 1;
-			let currentMonth = false;
+			let disabled = true;
 			const h = harness(() => w(CalendarCell, {
 				date,
-				currentMonth,
+				disabled,
 				onClick: (callbackDate: number, callbackCurrentMonth: boolean) => {
 					clickedDate = callbackDate;
 					clickedCurrentMonth = callbackCurrentMonth;
@@ -85,13 +104,13 @@ registerSuite('CalendarCell', {
 
 			h.trigger('td', 'onclick', stubEvent);
 			assert.strictEqual(clickedDate, 1);
-			assert.isFalse(clickedCurrentMonth);
+			assert.isTrue(clickedCurrentMonth);
 
+			disabled = false;
 			date = 2;
-			currentMonth = true;
 			h.trigger('td', 'onclick', stubEvent);
 			assert.strictEqual(clickedDate, 2);
-			assert.isTrue(clickedCurrentMonth);
+			assert.isFalse(clickedCurrentMonth);
 		},
 
 		'Keydown handler called'() {
@@ -122,7 +141,7 @@ registerSuite('CalendarCell', {
 				role: 'gridcell',
 				'aria-selected': 'false',
 				tabIndex: -1,
-				classes: [ css.date, null, null, null ],
+				classes: [ css.date, null, null, null, null ],
 				onclick: noop,
 				onkeydown: noop
 			}, [
@@ -138,7 +157,7 @@ registerSuite('CalendarCell', {
 				role: 'gridcell',
 				'aria-selected': 'false',
 				tabIndex: -1,
-				classes: [ css.date, null, null, null ],
+				classes: [ css.date, null, null, null, null ],
 				onclick: noop,
 				onkeydown: noop
 			}, [

--- a/src/calendar/tests/unit/date-utils.ts
+++ b/src/calendar/tests/unit/date-utils.ts
@@ -1,0 +1,42 @@
+const { registerSuite } = intern.getInterface('object');
+const { assert } = intern.getPlugin('chai');
+
+import { monthInMin, monthInMax } from '../../date-utils';
+
+registerSuite('Calendar date utils', {
+	tests: {
+		'monthInMin checks year/month against the first of the year'() {
+			const janFirst2019 = new Date('2019-01-01');
+
+			assert.isFalse(monthInMin(2018, 10, janFirst2019));
+			assert.isFalse(monthInMin(2018, 11, janFirst2019));
+			assert.isTrue(monthInMin(2019, 0, janFirst2019));
+			assert.isTrue(monthInMin(2019, 1, janFirst2019));
+		},
+		'monthInMin checks year/month against the last day the year'() {
+			const decThirtyFirst2018 = new Date('2018-12-31');
+
+			assert.isFalse(monthInMin(2018, 9, decThirtyFirst2018));
+			assert.isFalse(monthInMin(2018, 10, decThirtyFirst2018));
+			assert.isTrue(monthInMin(2018, 11, decThirtyFirst2018));
+			assert.isTrue(monthInMin(2019, 1, decThirtyFirst2018));
+		},
+		'monthInMin checks year/month against leap day'() {
+			const febTwentyNine2020 = new Date('2020-02-29');
+
+			assert.isFalse(monthInMin(2019, 11, febTwentyNine2020));
+			assert.isFalse(monthInMin(2020, 0, febTwentyNine2020));
+			assert.isTrue(monthInMin(2020, 1, febTwentyNine2020));
+			assert.isTrue(monthInMin(2020, 2, febTwentyNine2020));
+		},
+		'monthInMin supports out of index months'() {
+			const janFirst2019 = new Date('2019-01-01');
+
+			assert.isFalse(monthInMin(2017, 14, janFirst2019));
+			assert.isTrue(monthInMin(2018, 12, janFirst2019));
+			assert.isFalse(monthInMin(2019, -1, janFirst2019));
+			assert.isTrue(monthInMin(2020, -2, janFirst2019));
+		}
+
+	}
+});

--- a/src/theme/calendar.m.css
+++ b/src/theme/calendar.m.css
@@ -13,6 +13,8 @@
 	background-color: var(--disabled-color);
 }
 
+.outOfRange {}
+
 .selectedDate {
 	background-color: var(--selected-background);
 	color: var(--selected-color);

--- a/src/theme/calendar.m.css.d.ts
+++ b/src/theme/calendar.m.css.d.ts
@@ -1,5 +1,6 @@
 export const root: string;
 export const inactiveDate: string;
+export const outOfRange: string;
 export const selectedDate: string;
 export const todayDate: string;
 export const date: string;


### PR DESCRIPTION
**Type:** Feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR (TBD)

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:** This PR adds `minDate`/`maxDate` properties to the `DatePicker` and `Calendar` widgets. It also modifies the `CalendarCell` widget to separate disabled cells from the `currentMonth` indicator.

The previous/next month buttons are disabled if the next month is outside the min/max. The radio buttons on the month/date select windows are disabled if the month is outside the min/max but the links are not removed (though they don't work). Currently there is not separate styling for disabled vs other-month cells.

![calendar-min-max](https://user-images.githubusercontent.com/11273838/48285287-f96ec600-e416-11e8-8086-54bae5e52dd2.gif)


Resolves #538
