### PR TITLE
Grid propagate theme down to all child widgets

### DIFF
--- a/src/grid/tests/unit/widgets/Body.ts
+++ b/src/grid/tests/unit/widgets/Body.ts
@@ -87,6 +87,7 @@ describe('Body', () => {
 			page.push(item);
 			rows.push(
 				w(Row, {
+					theme: undefined,
 					id: i,
 					key: i,
 					item,
@@ -178,6 +179,7 @@ describe('Body', () => {
 			page.push(item);
 			rows.push(
 				w(Row, {
+					theme: undefined,
 					id: i,
 					key: i,
 					item,

--- a/src/grid/tests/unit/widgets/Cell.ts
+++ b/src/grid/tests/unit/widgets/Cell.ts
@@ -39,6 +39,7 @@ const expectedEditing = function() {
 		classes: [css.root, fixedCss.rootFixed]
 	}, [
 		w(TextInput, {
+			theme: undefined,
 			key: 'input',
 			label: 'Edit id',
 			labelHidden:  true,
@@ -63,6 +64,7 @@ const expectedEditable = function(focusButton = false) {
 			ondblclick: noop
 		}, [ 'id' ]),
 		w(Button, {
+			theme: undefined,
 			key: 'button',
 			aria: { describedby: '' },
 			focus: noop,
@@ -70,7 +72,7 @@ const expectedEditable = function(focusButton = false) {
 			extraClasses: { root: css.edit },
 			onClick: noop
 		}, [
-			w(Icon, { type: 'editIcon', altText: 'Edit' })
+			w(Icon, { theme: undefined, type: 'editIcon', altText: 'Edit' })
 		])
 	]);
 };

--- a/src/grid/tests/unit/widgets/Grid.ts
+++ b/src/grid/tests/unit/widgets/Grid.ts
@@ -73,6 +73,7 @@ describe('Grid', () => {
 					row: 'rowgroup'
 				}, [
 					w(Header, {
+						theme: undefined,
 						key: 'header-row',
 						columnConfig: filterableConfig,
 						sorter: noop,
@@ -82,6 +83,7 @@ describe('Grid', () => {
 					})
 				]),
 				w(Body, {
+					theme: undefined,
 					key: 'body',
 					pages: {},
 					totalRows: undefined,
@@ -95,6 +97,7 @@ describe('Grid', () => {
 				}),
 				v('div', { key: 'footer' }, [
 					w(Footer, {
+						theme: undefined,
 						key: 'footer-row',
 						total: undefined,
 						page: 1,
@@ -140,6 +143,7 @@ describe('Grid', () => {
 					row: 'rowgroup'
 				}, [
 					w(Header, {
+						theme: undefined,
 						key: 'header-row',
 						columnConfig: filterableConfig,
 						sorter: noop,
@@ -155,6 +159,7 @@ describe('Grid', () => {
 					})
 				]),
 				w(Body, {
+					theme: undefined,
 					key: 'body',
 					pages: {
 						'page-1': [{ id: 'id' }]
@@ -170,6 +175,7 @@ describe('Grid', () => {
 				}),
 				v('div', { key: 'footer' }, [
 					w(Footer, {
+						theme: undefined,
 						key: 'footer-row',
 						total: 100,
 						page: 10,
@@ -199,6 +205,7 @@ describe('Grid', () => {
 					row: 'rowgroup'
 				}, [
 					w(Header, {
+						theme: undefined,
 						key: 'header-row',
 						columnConfig,
 						sorter: noop,
@@ -208,6 +215,7 @@ describe('Grid', () => {
 					})
 				]),
 				w(Body, {
+					theme: undefined,
 					key: 'body',
 					pages: {},
 					totalRows: undefined,
@@ -221,6 +229,7 @@ describe('Grid', () => {
 				}),
 				v('div', { key: 'footer' }, [
 					w(Footer, {
+						theme: undefined,
 						key: 'footer-row',
 						total: undefined,
 						page: 1,
@@ -250,6 +259,7 @@ describe('Grid', () => {
 					row: 'rowgroup'
 				}, [
 					w(Header, {
+						theme: undefined,
 						key: 'header-row',
 						columnConfig,
 						sorter: noop,
@@ -259,6 +269,7 @@ describe('Grid', () => {
 					})
 				]),
 				w(Body, {
+					theme: undefined,
 					key: 'body',
 					pages: {},
 					totalRows: undefined,
@@ -272,6 +283,7 @@ describe('Grid', () => {
 				}),
 				v('div', { key: 'footer' }, [
 					w(Footer, {
+						theme: undefined,
 						key: 'footer-row',
 						total: undefined,
 						page: 1,
@@ -292,6 +304,7 @@ describe('Grid', () => {
 					row: 'rowgroup'
 				}, [
 					w(Header, {
+						theme: undefined,
 						key: 'header-row',
 						columnConfig,
 						sorter: noop,
@@ -301,6 +314,7 @@ describe('Grid', () => {
 					})
 				]),
 				w(Body, {
+					theme: undefined,
 					key: 'body',
 					pages: {},
 					totalRows: undefined,
@@ -314,6 +328,7 @@ describe('Grid', () => {
 				}),
 				v('div', { key: 'footer' }, [
 					w(Footer, {
+						theme: undefined,
 						key: 'footer-row',
 						total: undefined,
 						page: 1,

--- a/src/grid/tests/unit/widgets/Header.ts
+++ b/src/grid/tests/unit/widgets/Header.ts
@@ -82,12 +82,14 @@ describe('Header', () => {
 							onclick: noop
 						}, [
 							w(Icon, {
+								theme: undefined,
 								type: 'downIcon',
 								altText: 'Sort by Custom Title'
 							})
 						])
 					]),
 					w(TextInput, {
+						theme: undefined,
 						key: 'filter',
 						extraClasses: { root: css.filter },
 						label: 'Filter by Custom Title',
@@ -130,12 +132,14 @@ describe('Header', () => {
 							onclick: noop
 						}, [
 							w(Icon, {
+								theme: undefined,
 								type: 'upIcon',
 								altText: 'Sort by Custom Title'
 							})
 						])
 					]),
 					w(TextInput, {
+						theme: undefined,
 						key: 'filter',
 						extraClasses: { root: css.filter },
 						label: 'Filter by Custom Title',
@@ -178,12 +182,14 @@ describe('Header', () => {
 							onclick: noop
 						}, [
 							w(Icon, {
+								theme: undefined,
 								type: 'downIcon',
 								altText: 'Sort by Custom Title'
 							})
 						])
 					]),
 					w(TextInput, {
+						theme: undefined,
 						key: 'filter',
 						extraClasses: { root: css.filter },
 						label: 'Filter by Custom Title',
@@ -226,12 +232,14 @@ describe('Header', () => {
 							onclick: noop
 						}, [
 							w(Icon, {
+								theme: undefined,
 								type: 'downIcon',
 								altText: 'Sort by Custom Title'
 							})
 						])
 					]),
 					w(TextInput, {
+						theme: undefined,
 						key: 'filter',
 						extraClasses: { root: css.filter },
 						label: 'Filter by Custom Title',

--- a/src/grid/tests/unit/widgets/Row.ts
+++ b/src/grid/tests/unit/widgets/Row.ts
@@ -25,7 +25,7 @@ describe('Row', () => {
 		const h = harness(() => w(Row, { id: 1, item: { id: 'id' }, columnConfig: [columnConfig], updater: noop }));
 		h.expect(() =>
 			v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row', 'aria-rowindex': '2' }, [
-				w(Cell, { key: 'id', updater: noop, value: 'id', editable: undefined, rawValue: 'id' })
+				w(Cell, { theme: undefined, key: 'id', updater: noop, value: 'id', editable: undefined, rawValue: 'id' })
 			])
 		);
 	});
@@ -39,7 +39,7 @@ describe('Row', () => {
 		const h = harness(() => w(Row, { id: 1, item: { id: 'id' }, columnConfig: [columnConfig], updater: noop }));
 		h.expect(() =>
 			v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row', 'aria-rowindex': '2' }, [
-				w(Cell, { key: 'id', updater: noop, value: 'transformed', editable: undefined, rawValue: 'id' })
+				w(Cell, { theme: undefined, key: 'id', updater: noop, value: 'transformed', editable: undefined, rawValue: 'id' })
 			])
 		);
 	});

--- a/src/grid/widgets/Body.ts
+++ b/src/grid/widgets/Body.ts
@@ -95,7 +95,8 @@ export default class Body<S> extends ThemedMixin(WidgetBase)<BodyProperties<S>> 
 			columnConfig,
 			placeholderRowRenderer = defaultPlaceholderRowRenderer,
 			pageChange,
-			totalRows
+			totalRows,
+			theme
 		} = this.properties;
 
 		const startPage = Math.max(Math.ceil(start / pageSize), 1);
@@ -127,6 +128,7 @@ export default class Body<S> extends ThemedMixin(WidgetBase)<BodyProperties<S>> 
 			if (item) {
 				rows.push(
 					w(Row, {
+						theme,
 						id: i,
 						key: i,
 						item,

--- a/src/grid/widgets/Cell.ts
+++ b/src/grid/widgets/Cell.ts
@@ -79,10 +79,11 @@ export default class Cell extends ThemedMixin(FocusMixin(WidgetBase))<CellProper
 	}
 
 	protected render(): DNode {
-		let { editable, rawValue, value } = this.properties;
+		let { editable, rawValue, value, theme } = this.properties;
 
 		return v('div', { role: 'cell', classes: [this.theme(css.root), fixedCss.rootFixed] }, [
 			this._editing ? w(TextInput, {
+				theme,
 				key: 'input',
 				label: `Edit ${rawValue}`,
 				labelHidden:  true,
@@ -94,6 +95,7 @@ export default class Cell extends ThemedMixin(FocusMixin(WidgetBase))<CellProper
 				onKeyDown: this._onKeyDown
 			}) : this.renderContent(),
 			editable && !this._editing ? w(Button, {
+				theme,
 				key: 'button',
 				aria: { describedby: this._idBase },
 				focus: this._focusKey === 'button' ? this.shouldFocus : () => false,
@@ -101,7 +103,7 @@ export default class Cell extends ThemedMixin(FocusMixin(WidgetBase))<CellProper
 				extraClasses: { root: this.theme(css.edit) } as any,
 				onClick: this._onEdit
 			}, [
-				w(Icon, { type: 'editIcon', altText: 'Edit' })
+				w(Icon, { theme, type: 'editIcon', altText: 'Edit' })
 			]) : null
 		]);
 	}

--- a/src/grid/widgets/Grid.ts
+++ b/src/grid/widgets/Grid.ts
@@ -111,7 +111,7 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 	}
 
 	protected render(): DNode {
-		const { columnConfig, storeId } = this._getProperties();
+		const { columnConfig, storeId, theme } = this._getProperties();
 
 		if (!columnConfig || !this.properties.fetcher) {
 			return null;
@@ -141,6 +141,7 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 				row: 'rowgroup'
 			}, [
 				w(Header, {
+					theme,
 					key: 'header-row',
 					columnConfig,
 					sorter: this._sorter,
@@ -150,6 +151,7 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 				})
 			]),
 			w(Body, {
+				theme,
 				key: 'body',
 				pages,
 				totalRows: meta.total,
@@ -163,6 +165,7 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 			}),
 			v('div', { key: 'footer' }, [
 				w(Footer, {
+					theme,
 					key: 'footer-row',
 					total: meta.total,
 					page: meta.page,

--- a/src/grid/widgets/Header.ts
+++ b/src/grid/widgets/Header.ts
@@ -28,7 +28,7 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 	}
 
 	protected render(): DNode {
-		const { columnConfig, sorter, sort, filterer, filter } = this.properties;
+		const { columnConfig, sorter, sort, filterer, filter, theme } = this.properties;
 		return v('div', { classes: [this.theme(css.root), fixedCss.rootFixed], role: 'row' },
 			columnConfig.map((column) => {
 				let title: string | DNode;
@@ -68,6 +68,7 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 							}
 						}, [
 							w(Icon, {
+								theme,
 								type: sort && sort.columnId === column.id && sort.direction === 'asc' ? 'upIcon' : 'downIcon',
 								altText: `Sort by ${title}`
 							})
@@ -76,6 +77,7 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 					]),
 					column.filterable
 						? w(TextInput, {
+							theme,
 							key: 'filter',
 							extraClasses: { root: css.filter },
 							label: `Filter by ${title}`,

--- a/src/grid/widgets/Row.ts
+++ b/src/grid/widgets/Row.ts
@@ -18,7 +18,7 @@ export interface RowProperties {
 @theme(css)
 export default class Row extends ThemedMixin(WidgetBase)<RowProperties> {
 	protected render(): DNode {
-		const { item, columnConfig, id } = this.properties;
+		const { item, columnConfig, id, theme } = this.properties;
 		let columns = columnConfig.map(
 			(config) => {
 				let value: string | DNode = `${item[config.id]}`;
@@ -26,6 +26,7 @@ export default class Row extends ThemedMixin(WidgetBase)<RowProperties> {
 					value = config.renderer({ value });
 				}
 				return w(Cell, {
+					theme,
 					key: config.id,
 					updater: (updatedValue: string) => {
 						this.properties.updater(id, config.id, updatedValue);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Pass `theme` property to all child widgets.
