### PR TITLE
Add missing parenthesis to GlobalEvent example

### DIFF
--- a/src/global-event/README.md
+++ b/src/global-event/README.md
@@ -20,7 +20,7 @@ w(GlobalEvent, {
 
 // Used in the DNode tree
 v('div', { key: 'root' }, [
-	w(GlobalEvent, { window: click: () => {} }),
+	w(GlobalEvent, { window: { click: () => {} } }),
 	w(Button, { /* button options */ })
 ]);
 ```


### PR DESCRIPTION
**Type:** bug
The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Readme for `GlobalEvent` was missing parenthesis around the object
