### PR TITLE
Custom Sort Renderer

### DIFF
--- a/src/grid/tests/unit/widgets/Grid.ts
+++ b/src/grid/tests/unit/widgets/Grid.ts
@@ -80,7 +80,8 @@ describe('Grid', () => {
 						filter: undefined,
 						filterer: noop,
 						classes: undefined,
-						theme: undefined
+						theme: undefined,
+						sortRenderer: undefined
 					})
 				]),
 				w(Body, {
@@ -159,7 +160,8 @@ describe('Grid', () => {
 						},
 						filterer: noop,
 						classes: undefined,
-						theme: undefined
+						theme: undefined,
+						sortRenderer: undefined
 					})
 				]),
 				w(Body, {
@@ -218,7 +220,8 @@ describe('Grid', () => {
 						filter: undefined,
 						filterer: noop,
 						classes: undefined,
-						theme: undefined
+						theme: undefined,
+						sortRenderer: undefined
 					})
 				]),
 				w(Body, {
@@ -275,7 +278,8 @@ describe('Grid', () => {
 						filter: undefined,
 						filterer: noop,
 						classes: undefined,
-						theme: undefined
+						theme: undefined,
+						sortRenderer: undefined
 					})
 				]),
 				w(Body, {
@@ -323,7 +327,8 @@ describe('Grid', () => {
 						filter: undefined,
 						filterer: noop,
 						classes: undefined,
-						theme: undefined
+						theme: undefined,
+						sortRenderer: undefined
 					})
 				]),
 				w(Body, {

--- a/src/grid/tests/unit/widgets/Header.ts
+++ b/src/grid/tests/unit/widgets/Header.ts
@@ -10,6 +10,7 @@ import Icon from '../../../../icon/index';
 import * as css from '../../../../theme/grid-header.m.css';
 import * as fixedCss from '../../../styles/header.m.css';
 import Header from '../../../widgets/Header';
+import { ColumnConfig } from '../../../interfaces';
 
 const noop = () => {};
 
@@ -339,6 +340,98 @@ describe('Header', () => {
 
 			h.trigger(`.${css.sortable}`, 'onclick', {});
 			assert.isTrue(sorterStub.calledWith('firstName', 'desc'));
+		});
+
+		it('should use a custom sort renderer for asc', () => {
+			const sorterStub = stub();
+			const filtererStub = stub();
+			const h = harness(() =>
+				w(Header, {
+					columnConfig: advancedColumnConfig,
+					sorter: sorterStub,
+					filterer: filtererStub,
+					sort: {
+						columnId: 'firstName',
+						direction: 'asc'
+					},
+					sortRenderer: (column: ColumnConfig, ascending: boolean, sorter: () => void) => {
+						const title = typeof column.title === 'string' ? column.title : column.title();
+						return v('div', { key: 'sort', onclick: sorter }, [`custom renderer - ${ascending} - ${title}`]);
+					}
+				})
+			);
+
+			h.expect(() =>
+				v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row' }, [
+					v('div', { classes: [css.cell, fixedCss.cellFixed], role: 'columnheader', 'aria-sort': null }, [v('div', {}, ['Title'])]),
+					v('div', { classes: [css.cell, fixedCss.cellFixed], role: 'columnheader', 'aria-sort': 'ascending' }, [
+						v('div', {
+							classes: [css.sortable, css.sorted, null, css.asc],
+							onclick: noop
+						}, [
+								'Custom Title',
+								v('div', { key: 'sort', onclick: noop }, ['custom renderer - true - Custom Title'])
+							]),
+						w(TextInput, {
+							key: 'filter',
+							extraClasses: { root: css.filter },
+							label: 'Filter by Custom Title',
+							labelHidden: true,
+							type: 'search',
+							value: '',
+							onInput: noop,
+							classes: undefined,
+							theme: undefined
+						})
+					])
+				])
+			);
+		});
+
+		it('should use a custom sort renderer for desc', () => {
+			const sorterStub = stub();
+			const filtererStub = stub();
+			const h = harness(() =>
+				w(Header, {
+					columnConfig: advancedColumnConfig,
+					sorter: sorterStub,
+					filterer: filtererStub,
+					sort: {
+						columnId: 'firstName',
+						direction: 'desc'
+					},
+					sortRenderer: (column: ColumnConfig, ascending: boolean, sorter: () => void) => {
+						const title = typeof column.title === 'string' ? column.title : column.title();
+						return v('div', { key: 'sort', onclick: sorter }, [`custom renderer - ${ascending} - ${title}`]);
+					}
+				})
+			);
+
+			h.expect(() =>
+				v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row' }, [
+					v('div', { classes: [css.cell, fixedCss.cellFixed], role: 'columnheader', 'aria-sort': null }, [v('div', {}, ['Title'])]),
+					v('div', { classes: [css.cell, fixedCss.cellFixed], role: 'columnheader', 'aria-sort': 'descending' }, [
+						v('div', {
+							classes: [css.sortable, css.sorted, css.desc, null],
+							onclick: noop
+						}, [
+								'Custom Title',
+								v('div', { key: 'sort', onclick: noop }, ['custom renderer - false - Custom Title'])
+							]),
+						w(TextInput, {
+							key: 'filter',
+							extraClasses: { root: css.filter },
+							label: 'Filter by Custom Title',
+							labelHidden: true,
+							type: 'search',
+							value: '',
+							onInput: noop,
+							classes: undefined,
+							theme: undefined
+						})
+					])
+				])
+			);
 		});
 	});
 });

--- a/src/grid/widgets/Grid.ts
+++ b/src/grid/widgets/Grid.ts
@@ -12,7 +12,7 @@ import Resize from '@dojo/framework/widget-core/meta/Resize';
 import { Fetcher, ColumnConfig, GridState, Updater } from './../interfaces';
 import { fetcherProcess, pageChangeProcess, sortProcess, filterProcess, updaterProcess } from './../processes';
 
-import Header from './Header';
+import Header, { SortRenderer } from './Header';
 import Body from './Body';
 import Footer from './Footer';
 import * as css from '../../theme/grid.m.css';
@@ -27,6 +27,10 @@ const defaultGridMeta = {
 	editedRow: undefined
 };
 
+export interface CustomRenderers {
+	sortRenderer?: SortRenderer;
+}
+
 export interface GridProperties<S> extends ThemedProperties {
 	columnConfig: ColumnConfig[];
 	fetcher: Fetcher<S>;
@@ -34,6 +38,7 @@ export interface GridProperties<S> extends ThemedProperties {
 	updater?: Updater<S>;
 	store?: Store<S>;
 	storeId?: string;
+	customRenderers?: CustomRenderers;
 }
 
 @theme(css)
@@ -113,7 +118,8 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 	}
 
 	protected render(): DNode {
-		const { columnConfig, storeId, theme, classes } = this._getProperties();
+		const { columnConfig, storeId, theme, classes, customRenderers = {} } = this._getProperties();
+		const { sortRenderer } = customRenderers;
 
 		if (!columnConfig || !this.properties.fetcher) {
 			return null;
@@ -150,7 +156,8 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 					sorter: this._sorter,
 					sort: meta.sort,
 					filter: meta.filter,
-					filterer: this._filterer
+					filterer: this._filterer,
+					sortRenderer
 				})
 			]),
 			w(Body, {

--- a/src/grid/widgets/Header.ts
+++ b/src/grid/widgets/Header.ts
@@ -43,18 +43,14 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 
 	private _sortRenderer(column: ColumnConfig, ascending: boolean, sorter: () => void) {
 		const { columnConfig, sort, filterer, filter = {}, theme, classes } = this.properties;
-		return v('button', { classes: this.theme(css.sort),
-			onclick: () => {
-				this._sortColumn(column.id);
-			}
-		}, [
-				w(Icon, {
-					theme,
-					classes,
-					type: ascending ? 'upIcon' : 'downIcon',
-					altText: `Sort by ${this._getColumnTitle(column)}`
-				})
-			]);
+		return v('button', { classes: this.theme(css.sort), onclick: sorter }, [
+			w(Icon, {
+				theme,
+				classes,
+				type: ascending ? 'upIcon' : 'downIcon',
+				altText: `Sort by ${this._getColumnTitle(column)}`
+			})
+		]);
 	}
 
 	protected render(): DNode {

--- a/src/grid/widgets/Header.ts
+++ b/src/grid/widgets/Header.ts
@@ -41,7 +41,7 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 		sorter(id, direction);
 	}
 
-	private _sortRenderer(column: ColumnConfig, ascending: boolean, sorter: () => void) {
+	private _sortRenderer = (column: ColumnConfig, ascending: boolean, sorter: () => void) => {
 		const { columnConfig, sort, filterer, filter = {}, theme, classes } = this.properties;
 		return v('button', { classes: this.theme(css.sort), onclick: sorter }, [
 			w(Icon, {

--- a/src/grid/widgets/Header.ts
+++ b/src/grid/widgets/Header.ts
@@ -9,6 +9,10 @@ import Icon from '../../icon/index';
 import * as css from '../../theme/grid-header.m.css';
 import * as fixedCss from '../styles/header.m.css';
 
+export interface SortRenderer {
+	(column: ColumnConfig, ascending: boolean, sorter: () => void): DNode;
+}
+
 export interface HeaderProperties {
 	columnConfig: ColumnConfig[];
 	sorter: (columnId: string, direction: 'asc' | 'desc') => void;
@@ -17,10 +21,18 @@ export interface HeaderProperties {
 		[index: string]: string;
 	};
 	sort?: SortOptions;
+	sortRenderer?: SortRenderer;
 }
 
 @theme(css)
 export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
+	private _getColumnTitle(column: ColumnConfig): string | DNode {
+		if (typeof column.title === 'function') {
+			return column.title();
+		}
+		return column.title;
+	}
+
 	private _sortColumn(id: string) {
 		const { sort, sorter } = this.properties;
 		const direction = sort
@@ -29,19 +41,30 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 		sorter(id, direction);
 	}
 
+	private _sortRenderer(column: ColumnConfig, ascending: boolean, sorter: () => void) {
+		const { columnConfig, sort, filterer, filter = {}, theme, classes } = this.properties;
+		return v('button', { classes: this.theme(css.sort),
+			onclick: () => {
+				this._sortColumn(column.id);
+			}
+		}, [
+				w(Icon, {
+					theme,
+					classes,
+					type: ascending ? 'upIcon' : 'downIcon',
+					altText: `Sort by ${this._getColumnTitle(column)}`
+				})
+			]);
+	}
+
 	protected render(): DNode {
-		const { columnConfig, sorter, sort, filterer, filter = {}, theme, classes } = this.properties;
+		const { columnConfig, sorter, sort, filterer, filter = {}, theme, classes, sortRenderer = this._sortRenderer } = this.properties;
 		return v('div', { classes: [this.theme(css.root), fixedCss.rootFixed], role: 'row' },
 			columnConfig.map((column) => {
-				let title: string | DNode;
-				if (typeof column.title === 'function') {
-					title = column.title();
-				} else {
-					title = column.title;
-				}
+				const title = this._getColumnTitle(column);
 				let headerProperties = {};
 				const isSorted = sort && sort.columnId === column.id;
-				const isSortedAsc = sort && sort.columnId === column.id && sort.direction === 'asc';
+				const isSortedAsc = Boolean(sort && sort.columnId === column.id && sort.direction === 'asc');
 				if (column.sortable) {
 					headerProperties = {
 						classes: [
@@ -63,39 +86,31 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 					classes: [this.theme(css.cell), fixedCss.cellFixed],
 					role: 'columnheader'
 				}, [
-					v('div', headerProperties, [
-						title,
-						column.sortable ? v('button', {
-							classes: this.theme(css.sort),
-							onclick: () => {
-								this._sortColumn(column.id);
-							}
-						}, [
-							w(Icon, {
+						v('div', headerProperties, [
+							title,
+							column.sortable ? sortRenderer(
+								column,
+								isSortedAsc,
+								() => {
+									this._sortColumn(column.id);
+								}) : null
+						]),
+						column.filterable
+							? w(TextInput, {
+								key: 'filter',
 								theme,
 								classes,
-								type: sort && sort.columnId === column.id && sort.direction === 'asc' ? 'upIcon' : 'downIcon',
-								altText: `Sort by ${title}`
+								extraClasses: { root: css.filter },
+								label: `Filter by ${title}`,
+								labelHidden: true,
+								type: 'search',
+								value: filterKeys.indexOf(column.id) > -1 ? filter[column.id] : '',
+								onInput: (value: string) => {
+									filterer(column.id, value);
+								}
 							})
-						])
-						: null
-					]),
-					column.filterable
-						? w(TextInput, {
-							key: 'filter',
-							theme,
-							classes,
-							extraClasses: { root: css.filter },
-							label: `Filter by ${title}`,
-							labelHidden: true,
-							type: 'search',
-							value: filterKeys.indexOf(column.id) > -1 ? filter[column.id] : '',
-							onInput: (value: string) => {
-								filterer(column.id, value);
-							}
-						})
-						: null
-				]);
+							: null
+					]);
 			})
 		);
 	}

--- a/src/grid/widgets/Header.ts
+++ b/src/grid/widgets/Header.ts
@@ -42,7 +42,7 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 	}
 
 	private _sortRenderer = (column: ColumnConfig, ascending: boolean, sorter: () => void) => {
-		const { columnConfig, sort, filterer, filter = {}, theme, classes } = this.properties;
+		const { theme, classes } = this.properties;
 		return v('button', { classes: this.theme(css.sort), onclick: sorter }, [
 			w(Icon, {
 				theme,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds an optional API for custom grid renderers. Implements a `sortRenderer` that can be used to customise the sort button to display when a column is sorted.

Example:

```ts
function sortRenderer(column: ColumnConfig, ascending: boolean, sorter: () => void) {
    return v('button', { onclick: sorter }, [ `sort - ${ascending ? 'asc' : 'desc'}` ]);
}
```

Resolves #625