### PR TITLE
Add wrapping node so that the widget is not set as display none when used as a CE

### DIFF
--- a/src/tab/index.ts
+++ b/src/tab/index.ts
@@ -50,13 +50,15 @@ export class TabBase<P extends TabProperties = TabProperties> extends ThemedBase
 			show = false
 		} = this.properties;
 
-		return v('div', {
-			...formatAriaProperties(aria),
-			'aria-labelledby': labelledBy,
-			classes: this.theme([css.tab, !show ? css.hidden : null]),
-			id: widgetId,
-			role: 'tabpanel'
-		}, this.children);
+		return v('div', [
+			v('div', {
+				...formatAriaProperties(aria),
+				'aria-labelledby': labelledBy,
+				classes: this.theme([css.tab, !show ? css.hidden : null]),
+				id: widgetId,
+				role: 'tabpanel'
+			}, this.children)
+		]);
 	}
 }
 

--- a/src/tab/index.ts
+++ b/src/tab/index.ts
@@ -50,15 +50,15 @@ export class TabBase<P extends TabProperties = TabProperties> extends ThemedBase
 			show = false
 		} = this.properties;
 
-		return v('div', [
-			v('div', {
-				...formatAriaProperties(aria),
-				'aria-labelledby': labelledBy,
-				classes: this.theme([css.tab, !show ? css.hidden : null]),
-				id: widgetId,
-				role: 'tabpanel'
-			}, this.children)
-		]);
+		const hidden = this.theme(!show ? css.hidden : null);
+
+		return v('div', {
+			...formatAriaProperties(aria),
+			'aria-labelledby': labelledBy,
+			classes: this.theme([css.tab]),
+			id: widgetId,
+			role: 'tabpanel'
+		}, [ v('div', { classes: [ hidden ] }, this.children) ]);
 	}
 }
 

--- a/src/tab/tests/unit/Tab.ts
+++ b/src/tab/tests/unit/Tab.ts
@@ -11,12 +11,14 @@ registerSuite('Tab', {
 	tests: {
 		'default properties'() {
 			const h = harness(() => w(Tab, { key: 'foo' }));
-			h.expect(() => v('div', {
-				'aria-labelledby': undefined,
-				classes: [ css.tab, css.hidden ],
-				id: undefined,
-				role: 'tabpanel'
-			}, []));
+			h.expect(() => v('div', [
+				v('div', {
+					'aria-labelledby': undefined,
+					classes: [ css.tab, css.hidden ],
+					id: undefined,
+					role: 'tabpanel'
+				}, [])
+			]));
 		},
 
 		'custom properties and children'() {
@@ -35,13 +37,15 @@ registerSuite('Tab', {
 				labelledBy: 'id'
 			}, testChildren));
 
-			h.expect(() => v('div', {
-				'aria-labelledby': 'id',
-				'aria-describedby': 'foo',
-				classes: [ css.tab, null ],
-				id: 'foo',
-				role: 'tabpanel'
-			}, testChildren));
+			h.expect(() => v('div', [
+				v('div', {
+					'aria-labelledby': 'id',
+					'aria-describedby': 'foo',
+					classes: [ css.tab, null ],
+					id: 'foo',
+					role: 'tabpanel'
+				}, testChildren)
+			]));
 		}
 	}
 });

--- a/src/tab/tests/unit/Tab.ts
+++ b/src/tab/tests/unit/Tab.ts
@@ -11,13 +11,13 @@ registerSuite('Tab', {
 	tests: {
 		'default properties'() {
 			const h = harness(() => w(Tab, { key: 'foo' }));
-			h.expect(() => v('div', [
-				v('div', {
+			h.expect(() => v('div', {
 					'aria-labelledby': undefined,
-					classes: [ css.tab, css.hidden ],
+					classes: [ css.tab ],
 					id: undefined,
 					role: 'tabpanel'
-				}, [])
+			}, [
+				v('div', { classes: [ css.hidden ] }, [])
 			]));
 		},
 
@@ -37,14 +37,14 @@ registerSuite('Tab', {
 				labelledBy: 'id'
 			}, testChildren));
 
-			h.expect(() => v('div', [
-				v('div', {
-					'aria-labelledby': 'id',
-					'aria-describedby': 'foo',
-					classes: [ css.tab, null ],
-					id: 'foo',
-					role: 'tabpanel'
-				}, testChildren)
+			h.expect(() => v('div', {
+				'aria-labelledby': 'id',
+				'aria-describedby': 'foo',
+				classes: [ css.tab ],
+				id: 'foo',
+				role: 'tabpanel'
+			}, [
+				v('div', { classes: [ null ] }, testChildren)
 			]));
 		}
 	}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**

When used as a custom element, the `display` of the wrapping placeholder node is set to the same `display` as the root element of the Dojo widget, defaulting to `block`. Because the `Tab` widget sets the root node to be `display: none` it means that the placeholder node picks this up and none of the content is visible. Adding an extra node means that the CE will be picked up as `display: block` and then the inner node is conditionally set to `display: none` depending on the whether a tab is active.