### PR TITLE
Ensure that the store id as the path to subscribe to changes

### DIFF
--- a/src/grid/widgets/Grid.ts
+++ b/src/grid/widgets/Grid.ts
@@ -68,9 +68,10 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 
 	@diffProperty('store', reference)
 	protected onStoreProperty(previous: any, current: any) {
+		const { storeId = '_grid' } = current;
 		this._handle.remove();
 		this._store = current.store;
-		this._handle = this._store.onChange(this._store.path('_grid'), () => {
+		this._handle = this._store.onChange(this._store.path(storeId), () => {
 			this.invalidate();
 		});
 	}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Subscribe to the store using the custom `storeId` when passed.

Resolves #639 
