### PR TITLE
Pass direction to custom sorter

### DIFF
--- a/src/grid/README.md
+++ b/src/grid/README.md
@@ -134,15 +134,15 @@ The sort renderer receives the column configuration, the sort order and a functi
 
 ```ts
 interface SortRenderer {
-	(column: ColumnConfig, ascending: boolean, sorter: () => void): DNode;
+	(column: ColumnConfig, direction: 'asc' | 'desc' | undefined, sorter: () => void): DNode;
 }
 ```
 
 Example:
 
 ```ts
-function sortRenderer(column: ColumnConfig, ascending: boolean, sorter: () => void) {
-	return v('button', { onclick: sorter }, [ `sort - ${ascending ? 'asc' : 'desc'}` ]);
+function sortRenderer(column: ColumnConfig, direction: 'asc' | 'desc' | undefined, sorter: () => void) {
+	return v('button', { onclick: sorter }, [ `sort - ${direction || 'unsorted'}` ]);
 }
 ```
 

--- a/src/grid/tests/unit/widgets/Header.ts
+++ b/src/grid/tests/unit/widgets/Header.ts
@@ -354,9 +354,9 @@ describe('Header', () => {
 						columnId: 'firstName',
 						direction: 'asc'
 					},
-					sortRenderer: (column: ColumnConfig, ascending: boolean, sorter: () => void) => {
+					sortRenderer: (column: ColumnConfig, direction: any, sorter: () => void) => {
 						const title = typeof column.title === 'string' ? column.title : column.title();
-						return v('div', { key: 'sort', onclick: sorter }, [`custom renderer - ${ascending} - ${title}`]);
+						return v('div', { key: 'sort', onclick: sorter }, [`custom renderer - ${direction} - ${title}`]);
 					}
 				})
 			);
@@ -370,7 +370,7 @@ describe('Header', () => {
 							onclick: noop
 						}, [
 								'Custom Title',
-								v('div', { key: 'sort', onclick: noop }, ['custom renderer - true - Custom Title'])
+								v('div', { key: 'sort', onclick: noop }, ['custom renderer - asc - Custom Title'])
 							]),
 						w(TextInput, {
 							key: 'filter',
@@ -400,9 +400,9 @@ describe('Header', () => {
 						columnId: 'firstName',
 						direction: 'desc'
 					},
-					sortRenderer: (column: ColumnConfig, ascending: boolean, sorter: () => void) => {
+					sortRenderer: (column: ColumnConfig, direction: any, sorter: () => void) => {
 						const title = typeof column.title === 'string' ? column.title : column.title();
-						return v('div', { key: 'sort', onclick: sorter }, [`custom renderer - ${ascending} - ${title}`]);
+						return v('div', { key: 'sort', onclick: sorter }, [`custom renderer - ${direction} - ${title}`]);
 					}
 				})
 			);
@@ -416,7 +416,7 @@ describe('Header', () => {
 							onclick: noop
 						}, [
 								'Custom Title',
-								v('div', { key: 'sort', onclick: noop }, ['custom renderer - false - Custom Title'])
+								v('div', { key: 'sort', onclick: noop }, ['custom renderer - desc - Custom Title'])
 							]),
 						w(TextInput, {
 							key: 'filter',

--- a/src/grid/widgets/Header.ts
+++ b/src/grid/widgets/Header.ts
@@ -10,7 +10,7 @@ import * as css from '../../theme/grid-header.m.css';
 import * as fixedCss from '../styles/header.m.css';
 
 export interface SortRenderer {
-	(column: ColumnConfig, ascending: boolean, sorter: () => void): DNode;
+	(column: ColumnConfig, direction: undefined | 'asc' | 'desc', sorter: () => void): DNode;
 }
 
 export interface HeaderProperties {
@@ -41,13 +41,13 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 		sorter(id, direction);
 	}
 
-	private _sortRenderer = (column: ColumnConfig, ascending: boolean, sorter: () => void) => {
+	private _sortRenderer = (column: ColumnConfig, direction: undefined | 'asc' | 'desc', sorter: () => void) => {
 		const { theme, classes } = this.properties;
 		return v('button', { classes: this.theme(css.sort), onclick: sorter }, [
 			w(Icon, {
 				theme,
 				classes,
-				type: ascending ? 'upIcon' : 'downIcon',
+				type: direction === 'asc' ? 'upIcon' : 'downIcon',
 				altText: `Sort by ${this._getColumnTitle(column)}`
 			})
 		]);
@@ -76,6 +76,7 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 				}
 
 				const filterKeys = Object.keys(filter);
+				const direction = !isSorted ? undefined : isSortedAsc ? 'asc' : 'desc';
 
 				return v('div', {
 					'aria-sort': isSorted ? isSortedAsc ? 'ascending' : 'descending' : null,
@@ -86,7 +87,7 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 							title,
 							column.sortable ? sortRenderer(
 								column,
-								isSortedAsc,
+								direction,
 								() => {
 									this._sortColumn(column.id);
 								}) : null


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Pass direction rather than a boolean for sort direction, undefined means unsorted.

Resolves #648 