### PR TITLE
Custom Filter Renderer

### DIFF
--- a/src/grid/README.md
+++ b/src/grid/README.md
@@ -152,14 +152,14 @@ The filter renderer can be used to render a custom column filter. The renderer r
 
 ```ts
 export interface FilterRenderer {
-	(filterValue: string, doFilter: (value: string) => void, title?: string | DNode): DNode;
+	(columnConfig: ColumnConfig, filterValue: string, doFilter: (value: string) => void, title?: string | DNode): DNode;
 }
 ```
 
 Example:
 
 ```ts
-function filterRenderer(filterValue: string, doFilter: Function, title?: string | DNode) => {
+function filterRenderer(columnConfig: ColumnConfig, filterValue: string, doFilter: Function, title?: string | DNode) => {
 	return v('div', [
 		v('input', { value: filterValue, onInput: doFilter }),
 		v('span', [ title ])

--- a/src/grid/README.md
+++ b/src/grid/README.md
@@ -146,6 +146,27 @@ function sortRenderer(column: ColumnConfig, direction: 'asc' | 'desc' | undefine
 }
 ```
 
+#### `filterRenderer`
+
+The filter renderer can be used to render a custom column filter. The renderer receives the current filter value, `doFilter` function and an optional column title.
+
+```ts
+export interface FilterRenderer {
+	(filterValue: string, doFilter: (value: string) => void, title?: string | DNode): DNode;
+}
+```
+
+Example:
+
+```ts
+function filterRenderer(filterValue: string, doFilter: Function, title?: string | DNode) => {
+	return v('div', [
+		v('input', { value: filterValue, onInput: doFilter }),
+		v('span', [ title ])
+	]);
+}
+```
+
 ## Helpers
 
 A collection of helpers are available in the `@dojo/widgets/grid/utils` module that can be used to create custom `fetcher` and `updater` from a known data set.

--- a/src/grid/tests/unit/widgets/Grid.ts
+++ b/src/grid/tests/unit/widgets/Grid.ts
@@ -83,6 +83,7 @@ describe('Grid', () => {
 						filterer: noop,
 						classes: undefined,
 						theme: undefined,
+						filterRenderer: undefined,
 						sortRenderer: undefined
 					})
 				]),
@@ -165,6 +166,7 @@ describe('Grid', () => {
 						filterer: noop,
 						classes: undefined,
 						theme: undefined,
+						filterRenderer: undefined,
 						sortRenderer: undefined
 					})
 				]),
@@ -230,6 +232,7 @@ describe('Grid', () => {
 						filterer: noop,
 						classes: undefined,
 						theme: undefined,
+						filterRenderer: undefined,
 						sortRenderer: undefined
 					})
 				]),
@@ -290,6 +293,7 @@ describe('Grid', () => {
 						filterer: noop,
 						classes: undefined,
 						theme: undefined,
+						filterRenderer: undefined,
 						sortRenderer: undefined
 					})
 				]),
@@ -348,6 +352,7 @@ describe('Grid', () => {
 						filterer: noop,
 						classes: undefined,
 						theme: undefined,
+						filterRenderer: undefined,
 						sortRenderer: undefined
 					})
 				]),
@@ -397,6 +402,7 @@ describe('Grid', () => {
 						filterer: noop,
 						classes: undefined,
 						theme: undefined,
+						filterRenderer: undefined,
 						sortRenderer: undefined
 					})
 				]),

--- a/src/grid/tests/unit/widgets/Header.ts
+++ b/src/grid/tests/unit/widgets/Header.ts
@@ -442,10 +442,10 @@ describe('Header', () => {
 					columnConfig: advancedColumnConfig,
 					sorter: sorterStub,
 					filterer: filtererStub,
-					filterRenderer: (filterValue: string, doFilter: Function, title?: any) => {
+					filterRenderer: (columnConfig: ColumnConfig, filterValue: string, doFilter: Function, title?: any) => {
 						return v('div', [
 							v('input', { value: filterValue, onInput: doFilter }),
-							v('span', [ title ])
+							v('span', [ `${title} - ${columnConfig.id}` ])
 						]);
 					}
 				})
@@ -474,7 +474,7 @@ describe('Header', () => {
 						]),
 						v('div', [
 							v('input', { value: '', onInput: noop }),
-							v('span', [ 'Custom Title' ])
+							v('span', [ 'Custom Title - firstName' ])
 						])
 					])
 				])

--- a/src/grid/tests/unit/widgets/Header.ts
+++ b/src/grid/tests/unit/widgets/Header.ts
@@ -177,7 +177,7 @@ describe('Header', () => {
 			v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row' }, [
 				v('div', { classes: [css.cell, fixedCss.cellFixed], role: 'columnheader', 'aria-sort': null }, [v('div', {}, ['Title'])]),
 				v('div', { classes: [css.cell, fixedCss.cellFixed], role: 'columnheader', 'aria-sort': 'descending' }, [
-				v('div', {
+					v('div', {
 						classes: [css.sortable, css.sorted, css.desc, null],
 						onclick: noop
 					}, [
@@ -369,9 +369,9 @@ describe('Header', () => {
 							classes: [css.sortable, css.sorted, null, css.asc],
 							onclick: noop
 						}, [
-								'Custom Title',
-								v('div', { key: 'sort', onclick: noop }, ['custom renderer - asc - Custom Title'])
-							]),
+							'Custom Title',
+							v('div', { key: 'sort', onclick: noop }, ['custom renderer - asc - Custom Title'])
+						]),
 						w(TextInput, {
 							key: 'filter',
 							extraClasses: { root: css.filter },
@@ -415,9 +415,9 @@ describe('Header', () => {
 							classes: [css.sortable, css.sorted, css.desc, null],
 							onclick: noop
 						}, [
-								'Custom Title',
-								v('div', { key: 'sort', onclick: noop }, ['custom renderer - desc - Custom Title'])
-							]),
+							'Custom Title',
+							v('div', { key: 'sort', onclick: noop }, ['custom renderer - desc - Custom Title'])
+						]),
 						w(TextInput, {
 							key: 'filter',
 							extraClasses: { root: css.filter },
@@ -432,6 +432,54 @@ describe('Header', () => {
 					])
 				])
 			);
+		});
+
+		it('should use custom filter renderer', () => {
+			const sorterStub = stub();
+			const filtererStub = stub();
+			const h = harness(() =>
+				w(Header, {
+					columnConfig: advancedColumnConfig,
+					sorter: sorterStub,
+					filterer: filtererStub,
+					filterRenderer: (filterValue: string, doFilter: Function, title?: any) => {
+						return v('div', [
+							v('input', { value: filterValue, onInput: doFilter }),
+							v('span', [ title ])
+						]);
+					}
+				})
+			);
+
+			h.expect(() =>
+				v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row' }, [
+					v('div', { classes: [css.cell, fixedCss.cellFixed], role: 'columnheader', 'aria-sort': null }, [v('div', {}, ['Title'])]),
+					v('div', { classes: [css.cell, fixedCss.cellFixed], role: 'columnheader', 'aria-sort': null }, [
+						v('div', {
+							classes: [css.sortable, null, null, null],
+							onclick: noop
+						}, [
+							'Custom Title',
+							v('button', {
+								classes: css.sort,
+								onclick: noop
+							}, [
+								w(Icon, {
+									type: 'downIcon',
+									altText: 'Sort by Custom Title',
+									classes: undefined,
+									theme: undefined
+								})
+							])
+						]),
+						v('div', [
+							v('input', { value: '', onInput: noop }),
+							v('span', [ 'Custom Title' ])
+						])
+					])
+				])
+			);
+
 		});
 	});
 });

--- a/src/grid/widgets/Grid.ts
+++ b/src/grid/widgets/Grid.ts
@@ -12,7 +12,7 @@ import Resize from '@dojo/framework/widget-core/meta/Resize';
 import { Fetcher, ColumnConfig, GridState, Updater } from './../interfaces';
 import { fetcherProcess, pageChangeProcess, sortProcess, filterProcess, updaterProcess } from './../processes';
 
-import Header, { SortRenderer } from './Header';
+import Header, { SortRenderer, FilterRenderer } from './Header';
 import Body from './Body';
 import Footer from './Footer';
 import * as css from '../../theme/grid.m.css';
@@ -29,6 +29,7 @@ const defaultGridMeta = {
 
 export interface CustomRenderers {
 	sortRenderer?: SortRenderer;
+	filterRenderer?: FilterRenderer;
 }
 
 export interface GridProperties<S> extends ThemedProperties {
@@ -120,7 +121,7 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 
 	protected render(): DNode {
 		const { columnConfig, storeId, theme, classes, customRenderers = {} } = this._getProperties();
-		const { sortRenderer } = customRenderers;
+		const { sortRenderer, filterRenderer } = customRenderers;
 
 		if (!columnConfig || !this.properties.fetcher) {
 			return null;
@@ -158,7 +159,8 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 					sort: meta.sort,
 					filter: meta.filter,
 					filterer: this._filterer,
-					sortRenderer
+					sortRenderer,
+					filterRenderer
 				})
 			]),
 			w(Body, {

--- a/src/grid/widgets/Header.ts
+++ b/src/grid/widgets/Header.ts
@@ -14,7 +14,7 @@ export interface SortRenderer {
 }
 
 export interface FilterRenderer {
-	(filterValue: string, doFilter: (value: string) => void, title?: string | DNode): DNode;
+	(column: ColumnConfig, filterValue: string, doFilter: (value: string) => void, title?: string | DNode): DNode;
 }
 
 export interface HeaderProperties {
@@ -58,7 +58,7 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 		]);
 	}
 
-	private _filterRenderer = (filterValue: string, doFilter: (value: string) => void, title?: string | DNode) => {
+	private _filterRenderer = (columnConfig: ColumnConfig, filterValue: string, doFilter: (value: string) => void, title?: string | DNode) => {
 		const { theme, classes } = this.properties;
 		return w(TextInput, {
 			key: 'filter',
@@ -127,7 +127,7 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 									this._sortColumn(column.id);
 								}) : null
 						]),
-						column.filterable ? filterRenderer(filterValue, doFilter, title) : null
+						column.filterable ? filterRenderer(column, filterValue, doFilter, title) : null
 					]);
 			})
 		);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Implements a custom `filterRenderer` that can be used to customise the filter input to display for filterable columns.