### PR TITLE
Listbox and select fixes

### DIFF
--- a/src/listbox/example/index.ts
+++ b/src/listbox/example/index.ts
@@ -13,6 +13,8 @@ export default class App extends WidgetBase {
 	private _listbox1Index = 0;
 	private _listbox1Value: string | undefined;
 	private _listbox2Index = 0;
+	private _listbox3Index = 49;
+	private _listbox3Value: string | undefined = 'West Virginia';
 
 	_options: CustomOption[] = [
 		{ value: 'Maine' },
@@ -124,6 +126,26 @@ export default class App extends WidgetBase {
 				onOptionSelect: (option: any, index: number) => {
 					this._moreOptions[index].selected = !this._moreOptions[index].selected;
 					this._moreOptions = [ ...this._moreOptions ];
+					this.invalidate();
+				}
+			}),
+			v('br'),
+			v('label', { for: 'listbox3' }, [ 'Pre-selected value listbox example' ]),
+			w(Listbox, {
+				key: 'listbox3',
+				activeIndex: this._listbox3Index,
+				widgetId: 'listbox3',
+				optionData: this._options,
+				getOptionLabel: (option: CustomOption) => option.value,
+				getOptionDisabled: (option: CustomOption) => !!option.disabled,
+				getOptionSelected: (option: CustomOption) => option.value === this._listbox3Value,
+				onActiveIndexChange: (index: number) => {
+					this._listbox3Index = index;
+					this.invalidate();
+				},
+				onOptionSelect: (option: any) => {
+					this._listbox3Value = option.value;
+					this._options = [ ...this._options ];
 					this.invalidate();
 				}
 			})

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -174,17 +174,8 @@ export class ListboxBase<P extends ListboxProperties = ListboxProperties> extend
 		}
 	}
 
-	protected animateScroll(scrollValue: number) {
-		this.meta(ScrollMeta).scroll('root', scrollValue);
-	}
-
-	@diffProperty('activeIndex', auto)
-	protected calculateScroll(previousProperties: ListboxProperties, newProperties: ListboxProperties) {
-		this._calculateScroll(newProperties);
-	}
-
 	@afterRender()
-	protected afterRender(dNode: DNode) {
+	private afterRender(dNode: DNode) {
 		if (!this._rendered) {
 			const dimensionMeta = this.meta(Dimensions);
 			if (dimensionMeta && dimensionMeta.get('root').offset.height) {
@@ -194,6 +185,15 @@ export class ListboxBase<P extends ListboxProperties = ListboxProperties> extend
 		}
 
 		return dNode;
+	}
+
+	protected animateScroll(scrollValue: number) {
+		this.meta(ScrollMeta).scroll('root', scrollValue);
+	}
+
+	@diffProperty('activeIndex', auto)
+	protected calculateScroll(previousProperties: ListboxProperties, newProperties: ListboxProperties) {
+		this._calculateScroll(newProperties);
 	}
 
 	protected getModifierClasses() {

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -1,6 +1,5 @@
-import { auto, reference } from '@dojo/framework/widget-core/diff';
+import { reference } from '@dojo/framework/widget-core/diff';
 import { diffProperty } from '@dojo/framework/widget-core/decorators/diffProperty';
-import { afterRender } from '@dojo/framework/widget-core/decorators/afterRender';
 import Dimensions from '@dojo/framework/widget-core/meta/Dimensions';
 import { DNode } from '@dojo/framework/widget-core/interfaces';
 import { CustomAriaProperties } from '../common/interfaces';
@@ -15,6 +14,7 @@ import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
 import * as css from '../theme/listbox.m.css';
 import ListboxOption from './ListboxOption';
 import { Focus } from '@dojo/framework/widget-core/meta/Focus';
+import Resize from '@dojo/framework/widget-core/meta/Resize';
 import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
 
 /* Default scroll meta */
@@ -177,15 +177,6 @@ export class ListboxBase<P extends ListboxProperties = ListboxProperties> extend
 		}
 	}
 
-	@diffProperty('activeIndex', auto)
-	protected calculateScroll(previousProperties: ListboxProperties, properties: ListboxProperties) {
-		this._calculateScroll(properties);
-	}
-
-	protected onAttach() {
-		this._calculateScroll(this.properties);
-	}
-
 	protected getModifierClasses() {
 		const { visualFocus } = this.properties;
 		const focus = this.meta(Focus).get('root');
@@ -254,6 +245,9 @@ export class ListboxBase<P extends ListboxProperties = ListboxProperties> extend
 			tabIndex = 0
 		} = this.properties;
 		const themeClasses = this.getModifierClasses();
+
+		this.meta(Resize).get('root');
+		this._calculateScroll(this.properties);
 
 		return v('div', {
 			...formatAriaProperties(aria),

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -163,7 +163,7 @@ export class ListboxBase<P extends ListboxProperties = ListboxProperties> extend
 	}
 
 	private _calculateScroll() {
-		const activeIndex = typeof this.properties.activeIndex === 'undefined' ? 0 : this.properties.activeIndex;
+		const { activeIndex = 0 } = this.properties;
 		const menuDimensions = this.meta(Dimensions).get('root');
 		const scrollOffset = menuDimensions.scroll.top;
 		const menuHeight = menuDimensions.offset.height;

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -162,7 +162,8 @@ export class ListboxBase<P extends ListboxProperties = ListboxProperties> extend
 		this.meta(ScrollMeta).scroll('root', scrollValue);
 	}
 
-	private _calculateScroll({ activeIndex = 0}: ListboxProperties) {
+	private _calculateScroll() {
+		const activeIndex = typeof this.properties.activeIndex === 'undefined' ? 0 : this.properties.activeIndex;
 		const menuDimensions = this.meta(Dimensions).get('root');
 		const scrollOffset = menuDimensions.scroll.top;
 		const menuHeight = menuDimensions.offset.height;
@@ -247,7 +248,7 @@ export class ListboxBase<P extends ListboxProperties = ListboxProperties> extend
 		const themeClasses = this.getModifierClasses();
 
 		this.meta(Resize).get('root');
-		this._calculateScroll(this.properties);
+		this._calculateScroll();
 
 		return v('div', {
 			...formatAriaProperties(aria),

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -94,7 +94,6 @@ export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
 export class ListboxBase<P extends ListboxProperties = ListboxProperties> extends ThemedBase<P, null> {
 	private _boundRenderOption = this.renderOption.bind(this);
 	private _idBase = uuid();
-	private _rendered = false;
 
 	private _getOptionDisabled(option: any, index: number) {
 		const { getOptionDisabled } = this.properties;
@@ -159,7 +158,11 @@ export class ListboxBase<P extends ListboxProperties = ListboxProperties> extend
 		}
 	}
 
-	private _calculateScroll({ activeIndex = 0 }: ListboxProperties) {
+	protected animateScroll(scrollValue: number) {
+		this.meta(ScrollMeta).scroll('root', scrollValue);
+	}
+
+	private _calculateScroll({ activeIndex = 0}: ListboxProperties) {
 		const menuDimensions = this.meta(Dimensions).get('root');
 		const scrollOffset = menuDimensions.scroll.top;
 		const menuHeight = menuDimensions.offset.height;
@@ -174,26 +177,13 @@ export class ListboxBase<P extends ListboxProperties = ListboxProperties> extend
 		}
 	}
 
-	@afterRender()
-	private afterRender(dNode: DNode) {
-		if (!this._rendered) {
-			const dimensionMeta = this.meta(Dimensions);
-			if (dimensionMeta && dimensionMeta.get('root').offset.height) {
-				this._rendered = true;
-				this._calculateScroll(this.properties);
-			}
-		}
-
-		return dNode;
-	}
-
-	protected animateScroll(scrollValue: number) {
-		this.meta(ScrollMeta).scroll('root', scrollValue);
-	}
-
 	@diffProperty('activeIndex', auto)
-	protected calculateScroll(previousProperties: ListboxProperties, newProperties: ListboxProperties) {
-		this._calculateScroll(newProperties);
+	protected calculateScroll(previousProperties: ListboxProperties, properties: ListboxProperties) {
+		this._calculateScroll(properties);
+	}
+
+	protected onAttach() {
+		this._calculateScroll(this.properties);
 	}
 
 	protected getModifierClasses() {

--- a/src/listbox/tests/functional/Listbox.ts
+++ b/src/listbox/tests/functional/Listbox.ts
@@ -10,6 +10,7 @@ import { uuid } from '@dojo/framework/core/util';
 const axe = services.axe;
 const DELAY = 300;
 const ERROR_MARGIN = 5;
+const LIST_BOX_3_SELECTOR = '#listbox3';
 
 function getPage(remote: Remote) {
 	return remote
@@ -97,6 +98,40 @@ registerSuite('Listbox', {
 				.then(({ y }: { y: number; }) => {
 					assert.isAtLeast(y, menuTop - ERROR_MARGIN, 'scroll back up');
 				});
+	},
+
+	'an initial selected value should be visible'() {
+		const { touchEnabled } = this.remote.session.capabilities;
+		let menuBottom: number;
+		let menuTop: number;
+		let itemHeight: number;
+
+		if (touchEnabled) {
+			this.skip('Arrow keys required for tests.');
+		}
+
+		return getPage(this.remote)
+			.findByCssSelector(LIST_BOX_3_SELECTOR)
+				.getPosition()
+				.then(({ y }: { y: number; }) => {
+					menuTop = y;
+				})
+				.getSize()
+				.then(({ height }: { height: number }) => {
+					menuBottom = menuTop + height;
+				})
+				.end()
+			.findByCssSelector(`${LIST_BOX_3_SELECTOR} .${css.activeOption}`)
+				.getSize()
+				.then(({ height }: { height: number }) => {
+					itemHeight = height;
+				})
+				.getPosition()
+				.then(({ y }: { y: number; }) => {
+					assert.isAtLeast(y, menuTop - ERROR_MARGIN);
+					assert.isAtMost(Math.floor(y), Math.ceil(menuBottom - itemHeight) + ERROR_MARGIN, 'scrolled down');
+				})
+				.end();
 	},
 
 	'keys move and select active option'() {

--- a/src/listbox/tests/unit/Listbox.ts
+++ b/src/listbox/tests/unit/Listbox.ts
@@ -5,6 +5,8 @@ import * as sinon from 'sinon';
 import { DNode } from '@dojo/framework/widget-core/interfaces';
 import { Keys } from '../../../common/util';
 import Focus from '@dojo/framework/widget-core/meta/Focus';
+import Resize from '@dojo/framework/widget-core/meta/Resize';
+import Dimensions from '@dojo/framework/widget-core/meta/Dimensions';
 import { v, w } from '@dojo/framework/widget-core/d';
 
 import Listbox from '../../index';
@@ -190,6 +192,22 @@ registerSuite('Listbox', {
 			});
 			mockMeta.withArgs(Focus).returns({
 				get: mockFocusGet
+			});
+			mockMeta.withArgs(Resize).returns({
+				get: () => {}
+			});
+			mockMeta.withArgs(Dimensions).returns({
+				get: sinon.stub().returns({
+					scroll: {
+						height: 0,
+						top: 0
+					},
+					offset: {
+						height: 0,
+						top: 0
+					}
+				}),
+				has: () => false
 			});
 			const h = harness(() => w(MockMetaMixin(Listbox, mockMeta), {}));
 			h.expect(() => v('div', {

--- a/src/select/index.ts
+++ b/src/select/index.ts
@@ -82,7 +82,7 @@ export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
 	]
 })
 export class SelectBase<P extends SelectProperties = SelectProperties> extends ThemedBase<P, null> {
-	private _focusedIndex = 0;
+	private _focusedIndex: number;
 	private _focusNode = 'trigger';
 	private _ignoreBlur = false;
 	private _open = false;
@@ -138,7 +138,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 		} = this.properties;
 		event.stopPropagation();
 		const value = (<HTMLInputElement> event.target).value;
-		const option = find(options, (option: any, index: number) => getOptionValue ? getOptionValue(option, index) === value : false);
+		const option = find(options, (option: any, index: number) => getOptionValue ? getOptionValue(option, index) === value : option === value);
 		option && onChange && onChange(option, key);
 	}
 
@@ -258,7 +258,7 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 
 		/* create option nodes */
 		const optionNodes = options.map((option, i) => v('option', {
-			value: getOptionValue ? getOptionValue(option, i) : '',
+			value: getOptionValue ? getOptionValue(option, i) : undefined,
 			id: getOptionId ? getOptionId(option, i) : undefined,
 			disabled: getOptionDisabled ? getOptionDisabled(option, i) : undefined,
 			selected: getOptionSelected ? getOptionSelected(option, i) : undefined
@@ -299,11 +299,18 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 			onChange
 		} = this.properties;
 
+		if (this._focusedIndex === undefined) {
+			options.map(getOptionSelected).forEach((isSelected, index) => {
+				if (isSelected) {
+					this._focusedIndex = index;
+				}
+			});
+		}
+
 		const {
 			_open,
-			_focusedIndex
+			_focusedIndex = 0
 		} = this;
-
 		// create dropdown trigger and select box
 		return v('div', {
 			key: 'wrapper',

--- a/src/select/tests/unit/Select.ts
+++ b/src/select/tests/unit/Select.ts
@@ -119,25 +119,25 @@ const expectedNative = function(useTestProperties = false, withStates = false) {
 			...describedBy
 		}, [
 			v('option', {
-				value: useTestProperties ? 'one' : '',
+				value: useTestProperties ? 'one' : undefined,
 				id: useTestProperties ? 'one' : undefined,
 				disabled: useTestProperties ? false : undefined,
 				selected: useTestProperties ? false : undefined
 			}, [ useTestProperties ? 'One' : `${testOptions[0]}` ]),
 			v('option', {
-				value: useTestProperties ? 'two' : '',
+				value: useTestProperties ? 'two' : undefined,
 				id: useTestProperties ? 'two' : undefined,
 				disabled: useTestProperties ? false : undefined,
 				selected: useTestProperties ? true : undefined
 			}, [ useTestProperties ? 'Two' : `${testOptions[1]}` ]),
 			v('option', {
-				value: useTestProperties ? 'three' : '',
+				value: useTestProperties ? 'three' : undefined,
 				id: useTestProperties ? 'three' : undefined,
 				disabled: useTestProperties ? false : undefined,
 				selected: useTestProperties ? false : undefined
 			}, [ useTestProperties ? 'Three' : `${testOptions[2]}` ]),
 			v('option', {
-				value: useTestProperties ? 'four' : '',
+				value: useTestProperties ? 'four' : undefined,
 				id: useTestProperties ? 'four' : undefined,
 				disabled: useTestProperties ? true : undefined,
 				selected: useTestProperties ? false : undefined
@@ -151,7 +151,8 @@ const expectedNative = function(useTestProperties = false, withStates = false) {
 	return vdom;
 };
 
-const expectedSingle = function(useTestProperties = false, withStates = false, open = false, placeholder = '', activeIndex = 0) {
+const expectedSingle = function(useTestProperties = false, withStates = false, open = false, placeholder = '', activeIndex = -1) {
+	activeIndex = activeIndex >= 0 ? activeIndex : useTestProperties ? 1 : 0;
 	const describedBy = useTestProperties ? { 'aria-describedby': 'foo' } : {};
 	const vdom = v('div', {
 		classes: [ css.inputWrapper, open ? css.open : null ],
@@ -350,7 +351,7 @@ registerSuite('Select', {
 				const h = harness(() => w(Select, testProperties));
 				h.expect(() => expected(expectedSingle(true)));
 				h.trigger('@trigger', 'onclick', stubEvent);
-				h.expect(() => expected(expectedSingle(true, false, true, '', 0)));
+				h.expect(() => expected(expectedSingle(true, false, true, '')));
 				h.trigger('@trigger', 'onclick', stubEvent);
 				h.expect(() => expected(expectedSingle(true)));
 			},
@@ -358,7 +359,7 @@ registerSuite('Select', {
 			'focus listbox on open'() {
 				const h = harness(() => w(Select, testProperties), [ compareListboxFocused ]);
 				h.trigger('@trigger', 'onclick', stubEvent);
-				h.expect(() => expected(expectedSingle(true, false, true, '', 0)));
+				h.expect(() => expected(expectedSingle(true, false, true, '')));
 			},
 
 			'focus trigger on escape to close'() {
@@ -391,14 +392,14 @@ registerSuite('Select', {
 				}));
 
 				h.trigger('@trigger', 'onclick', stubEvent);
-				h.expect(() => expected(expectedSingle(true, false, true, '', 0)));
-				h.trigger('@listbox', 'onOptionSelect', testOptions[1]);
+				h.expect(() => expected(expectedSingle(true, false, true, '')));
+				h.trigger('@listbox', 'onOptionSelect', testOptions[2]);
 				h.expect(() => expected(expectedSingle(true)));
 				assert.isTrue(onChange.calledOnce, 'onChange handler called when option selected');
 
 				// open widget a second time
 				h.trigger('@trigger', 'onclick', stubEvent);
-				h.expect(() => expected(expectedSingle(true, false, true, '', 0)));
+				h.expect(() => expected(expectedSingle(true, false, true, '')));
 				h.trigger('@trigger', 'onmousedown');
 				h.trigger(`.${css.dropdown}`, 'onfocusout');
 				h.trigger('@trigger', 'onclick', stubEvent);
@@ -451,7 +452,7 @@ registerSuite('Select', {
 							onkeydown: noop
 						}, [
 							w(Listbox, {
-								activeIndex: 0,
+								activeIndex: 1,
 								widgetId: '',
 								focus: noop,
 								key: 'listbox',
@@ -475,8 +476,8 @@ registerSuite('Select', {
 			'change active option'() {
 				const h = harness(() => w(Select, testProperties));
 				h.expect(() => expected(expectedSingle(true)));
-				h.trigger('@listbox', 'onActiveIndexChange', 1);
-				h.expect(() => expected(expectedSingle(true, false, false, '', 1)));
+				h.trigger('@listbox', 'onActiveIndexChange', 2);
+				h.expect(() => expected(expectedSingle(true, false, false, '', 2)));
 			},
 
 			'open/close with keyboard'() {
@@ -489,13 +490,13 @@ registerSuite('Select', {
 					which: Keys.Down, ...stubEvent
 				});
 
-				h.expect(() => expected(expectedSingle(true, false, true, '', 0)));
+				h.expect(() => expected(expectedSingle(true, false, true, '')));
 
 				h.trigger(`.${css.dropdown}`, 'onkeydown', {
 					which: Keys.Down, ...stubEvent
 				});
 
-				h.expect(() => expected(expectedSingle(true, false, true, '', 0)));
+				h.expect(() => expected(expectedSingle(true, false, true, '')));
 
 				h.trigger(`.${css.dropdown}`, 'onkeydown', {
 					which: Keys.Escape, ...stubEvent
@@ -519,7 +520,7 @@ registerSuite('Select', {
 				}));
 				h.trigger('@trigger', 'onclick', stubEvent);
 				h.trigger('@trigger', 'onblur');
-				h.expect(() => expected(expectedSingle(true, false, true, '', 0)));
+				h.expect(() => expected(expectedSingle(true, false, true, '')));
 
 				h.trigger(`.${css.dropdown}`, 'onfocusout');
 				h.expect(() => expected(expectedSingle(true)));
@@ -536,7 +537,7 @@ registerSuite('Select', {
 
 				h.trigger('@trigger', 'onclick', stubEvent);
 				h.trigger('@trigger', 'onblur');
-				h.expect(() => expected(expectedSingle(true, false, true, '', 0)));
+				h.expect(() => expected(expectedSingle(true, false, true, '')));
 
 				h.trigger('@trigger', 'onblur');
 				h.expect(() => expected(expectedSingle(true)));
@@ -562,10 +563,10 @@ registerSuite('Select', {
 				}));
 
 				h.trigger('@trigger', 'onkeydown', {
-					...stubEvent, key: 'T'
+					...stubEvent, key: 'O'
 				});
 
-				h.expect(() => expected(expectedSingle(true, false, false, '', 1)));
+				h.expect(() => expected(expectedSingle(true, false, false, '', 0)));
 			},
 
 			'select option in menu based on input key'() {
@@ -579,14 +580,14 @@ registerSuite('Select', {
 				});
 
 				h.trigger('@listbox', 'onKeyDown', {
-					...stubEvent, key: 'T'
+					...stubEvent, key: 'O'
 				});
 
 				h.trigger('@trigger', 'onkeydown', {
 					...stubEvent, which: Keys.Enter
 				});
 
-				h.expect(() => expected(expectedSingle(true, false, true, '', 1)));
+				h.expect(() => expected(expectedSingle(true, false, true, '', 0)));
 			},
 
 			'select option in menu based on multiple input keys'() {
@@ -628,7 +629,7 @@ registerSuite('Select', {
 					...stubEvent, key: 'o'
 				});
 
-				h.expect(() => expected(expectedSingle(true, false, false, '', 0)));
+				h.expect(() => expected(expectedSingle(true, false, false, '', 1)));
 			}
 		}
 	}


### PR DESCRIPTION
* Fix listbox and select initial value behavior

* Fix native select behavior with simple options

**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
There were a couple of related issues causing the behavior described in 659 and 656. The select widget was passing `''` as the value for `option` elements when there was no value, resulting in empty `value` attributes after some related vdom fixes. It was also not properly treating the option text as the value when no value was specified. This resulted in `onChange` never being called and selections not being persisted for the native select.

Additionally, the select was not passing in the appropriate `activeIndex` to the listbox in the custom select scenario, so an initial selected value would be selected but not displayed. Fixing this revealed a related issue in listbox as it was not properly scrolling to an initially provided `activeIndex`. I'm not sure I'm using the correct approach for this last fix. The issue is that the `activeIndex` property diff for an initial value runs when the element has a height of `0`, so it does not scroll. I attempted to resolve this using an `@afterRender` decorator to check for the first render where the element has height and perform a scroll calculation at that time to handle the initial value of `activeIndex`. 

Resolves #659 #656 
