### PR TITLE
Use resize observer in split pane

### DIFF
--- a/src/split-pane/example/index.ts
+++ b/src/split-pane/example/index.ts
@@ -23,6 +23,11 @@ export default class App extends WidgetBase {
 		this.invalidate();
 	}
 
+	private _changeCollapseWidth() {
+		this._collapseWidth = this._collapseWidth === 600 ? 350 : 600;
+		this.invalidate();
+	}
+
 	private _onResize = () => {
 		this.invalidate();
 	}
@@ -48,6 +53,7 @@ export default class App extends WidgetBase {
 			v('div', { styles: { marginBottom: '10px' } }, [
 				v('div', { styles: { marginBottom: '5px' } }, [ `Current Collapse Width: ${this._collapseWidth}` ]),
 				v('div', { styles: { marginBottom: '5px' } }, [ `Current Size: ${width}` ]),
+				v('button', { onclick: this._changeCollapseWidth }, [ `Change collapse width to ${this._collapseWidth === 600 ? '350' : '600' }` ]),
 				v('button', { onclick: this._changeToRow }, [ 'Change to row' ])
 			]),
 			v('div', {

--- a/src/split-pane/example/index.ts
+++ b/src/split-pane/example/index.ts
@@ -23,11 +23,6 @@ export default class App extends WidgetBase {
 		this.invalidate();
 	}
 
-	private _changeCollapseWidth() {
-		this._collapseWidth = this._collapseWidth === 600 ? 350 : 600;
-		this.invalidate();
-	}
-
 	private _onResize = () => {
 		this.invalidate();
 	}
@@ -53,8 +48,7 @@ export default class App extends WidgetBase {
 			v('div', { styles: { marginBottom: '10px' } }, [
 				v('div', { styles: { marginBottom: '5px' } }, [ `Current Collapse Width: ${this._collapseWidth}` ]),
 				v('div', { styles: { marginBottom: '5px' } }, [ `Current Size: ${width}` ]),
-				v('button', { onclick: this._changeToRow }, [ 'Change to row' ]),
-				v('button', { onclick: this._changeCollapseWidth }, [ `Change collapse width to ${this._collapseWidth === 600 ? '350' : '600' }` ])
+				v('button', { onclick: this._changeToRow }, [ 'Change to row' ])
 			]),
 			v('div', {
 				key: 'example-column',

--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -61,16 +61,15 @@ export class SplitPaneBase<P extends SplitPaneProperties = SplitPaneProperties> 
 
 	@diffProperty('collapseWidth')
 	@diffProperty('direction')
-	private collapseWidthDiff(oldProperties: SplitPaneProperties, { collapseWidth, direction, onCollapse }: SplitPaneProperties) {
-		if (collapseWidth) {
-			if (direction === Direction.row || collapseWidth < this._width && this._collapsed) {
-				this._collapsed = false;
-				this._resizeResultOverridden = true;
-			} else if (collapseWidth > this._width && !this._collapsed) {
-				this._collapsed = true;
-				this._resizeResultOverridden = true;
-				onCollapse && onCollapse(true);
-			}
+	private collapseWidthDiff(oldProperties: SplitPaneProperties, { collapseWidth = 600, direction, onCollapse }: SplitPaneProperties) {
+		if (direction === Direction.row || collapseWidth < this._width && this._collapsed) {
+			this._collapsed = false;
+			this._resizeResultOverridden = true;
+			onCollapse && onCollapse(false);
+		} else if (collapseWidth > this._width && !this._collapsed) {
+			this._collapsed = true;
+			this._resizeResultOverridden = true;
+			onCollapse && onCollapse(true);
 		}
 	}
 

--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -62,16 +62,14 @@ export class SplitPaneBase<P extends SplitPaneProperties = SplitPaneProperties> 
 	@diffProperty('collapseWidth')
 	@diffProperty('direction')
 	private collapseWidthDiff(oldProperties: SplitPaneProperties, { collapseWidth, direction, onCollapse }: SplitPaneProperties) {
-		if (collapseWidth) {
-			if (direction === Direction.row || collapseWidth < this._width && this._collapsed) {
-				this._collapsed = false;
-				this._resizeResultOverridden = true;
-				onCollapse && onCollapse(false);
-			} else if (collapseWidth > this._width && !this._collapsed) {
-				this._collapsed = true;
-				this._resizeResultOverridden = true;
-				onCollapse && onCollapse(true);
-			}
+		if (direction === Direction.row || (collapseWidth &&  collapseWidth < this._width && this._collapsed)) {
+			this._collapsed = false;
+			this._resizeResultOverridden = true;
+			onCollapse && onCollapse(false);
+		} else if (collapseWidth && (collapseWidth > this._width && !this._collapsed)) {
+			this._collapsed = true;
+			this._resizeResultOverridden = true;
+			onCollapse && onCollapse(true);
 		}
 	}
 

--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -61,15 +61,17 @@ export class SplitPaneBase<P extends SplitPaneProperties = SplitPaneProperties> 
 
 	@diffProperty('collapseWidth')
 	@diffProperty('direction')
-	private collapseWidthDiff(oldProperties: SplitPaneProperties, { collapseWidth = 600, direction, onCollapse }: SplitPaneProperties) {
-		if (direction === Direction.row || collapseWidth < this._width && this._collapsed) {
-			this._collapsed = false;
-			this._resizeResultOverridden = true;
-			onCollapse && onCollapse(false);
-		} else if (collapseWidth > this._width && !this._collapsed) {
-			this._collapsed = true;
-			this._resizeResultOverridden = true;
-			onCollapse && onCollapse(true);
+	private collapseWidthDiff(oldProperties: SplitPaneProperties, { collapseWidth, direction, onCollapse }: SplitPaneProperties) {
+		if (collapseWidth) {
+			if (direction === Direction.row || collapseWidth < this._width && this._collapsed) {
+				this._collapsed = false;
+				this._resizeResultOverridden = true;
+				onCollapse && onCollapse(false);
+			} else if (collapseWidth > this._width && !this._collapsed) {
+				this._collapsed = true;
+				this._resizeResultOverridden = true;
+				onCollapse && onCollapse(true);
+			}
 		}
 	}
 

--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -61,7 +61,7 @@ export class SplitPaneBase<P extends SplitPaneProperties = SplitPaneProperties> 
 
 	@diffProperty('collapseWidth')
 	@diffProperty('direction')
-	private collapseWidthDiff(oldProperties: SplitPaneProperties, { collapseWidth, direction }: SplitPaneProperties) {
+	private collapseWidthDiff(oldProperties: SplitPaneProperties, { collapseWidth, direction, onCollapse }: SplitPaneProperties) {
 		if (collapseWidth) {
 			if (direction === Direction.row || collapseWidth < this._width && this._collapsed) {
 				this._collapsed = false;
@@ -69,6 +69,7 @@ export class SplitPaneBase<P extends SplitPaneProperties = SplitPaneProperties> 
 			} else if (collapseWidth > this._width && !this._collapsed) {
 				this._collapsed = true;
 				this._resizeResultOverridden = true;
+				onCollapse && onCollapse(true);
 			}
 		}
 	}

--- a/src/split-pane/tests/unit/SplitPane.ts
+++ b/src/split-pane/tests/unit/SplitPane.ts
@@ -117,6 +117,9 @@ registerSuite('SplitPane', {
 			mockDimensionsGet.withArgs('root').returns({
 				offset: {
 					width: 200
+				},
+				size: {
+					width: 200
 				}
 			});
 			mockDimensionsGet.withArgs('divider').returns({
@@ -167,12 +170,22 @@ registerSuite('SplitPane', {
 		'Should collapse when width is less than collapse width'() {
 			const onCollapse = stub();
 			const mockMeta = stub();
+			const mockDimensionsGet = stub();
 
 			const metaReturn = {
 				get: generateMockResizeGet(300),
 				has: () => false
 			};
 			mockMeta.withArgs(Resize).returns(metaReturn);
+
+			mockDimensionsGet.returns({
+				size: {
+					width: 200
+				}
+			});
+			mockMeta.withArgs(Dimensions).returns({
+				get: mockDimensionsGet
+			});
 
 			const h = harness(() => w(MockMetaMixin(SplitPane, mockMeta), { onCollapse, collapseWidth: 400 }));
 			metaReturn.has = () => true;
@@ -192,9 +205,19 @@ registerSuite('SplitPane', {
 		'collapse is ignored when using Direction.Row configuration'() {
 			const onCollapse = stub();
 			const mockMeta = stub();
+			const mockDimensionsGet = stub();
 
 			mockMeta.withArgs(Resize).returns({
 				get: generateMockResizeGet(500)
+			});
+
+			mockDimensionsGet.returns({
+				size: {
+					width: 200
+				}
+			});
+			mockMeta.withArgs(Dimensions).returns({
+				get: mockDimensionsGet
 			});
 
 			const h = harness(() => w(MockMetaMixin(SplitPane, mockMeta), { onCollapse, direction: Direction.row }));

--- a/src/split-pane/tests/unit/SplitPane.ts
+++ b/src/split-pane/tests/unit/SplitPane.ts
@@ -221,7 +221,7 @@ registerSuite('SplitPane', {
 			});
 
 			const h = harness(() => w(MockMetaMixin(SplitPane, mockMeta), { onCollapse, direction: Direction.row }));
-			assert.isTrue(onCollapse.notCalled);
+			assert.isTrue(onCollapse.calledWith(false));
 		},
 
 		'Mouse move should call onResize for row'() {


### PR DESCRIPTION
**Type:** bug
The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Changes global resize observer to resizeObserver. Tidies up some implementation.

- No longer defaults to min collapsewidth of 600

Resolves #665 
