### PR TITLE
Fix helperText on Enhanced Text Input

### DIFF
--- a/src/enhanced-text-input/index.ts
+++ b/src/enhanced-text-input/index.ts
@@ -70,9 +70,12 @@ export default class EnhancedTextInput extends TextInputBase<EnhancedTextInputPr
 		} = this.properties;
 
 		return v('div', { classes: this.theme(css.inputWrapper) }, [
-			...addonBefore.map((addon: DNode) => this.renderAddon(addon, true)),
-			this.renderInput(),
-			...addonAfter.map((addon: DNode) => this.renderAddon(addon))
+			v('div', { classes: this.theme(css.inputWrapperInner) }, [
+				...addonBefore.map((addon: DNode) => this.renderAddon(addon, true)),
+				this.renderInput(),
+				...addonAfter.map((addon: DNode) => this.renderAddon(addon))
+			]),
+			this.renderHelperText()
 		]);
 	}
 }

--- a/src/enhanced-text-input/tests/unit/EnhancedTextInput.ts
+++ b/src/enhanced-text-input/tests/unit/EnhancedTextInput.ts
@@ -29,6 +29,7 @@ interface ExpectedOptions {
 	states?: States;
 	focused?: boolean;
 	invalid?: boolean;
+	helperText?: string;
 }
 
 const expected = (options: ExpectedOptions = {}) => {
@@ -39,7 +40,8 @@ const expected = (options: ExpectedOptions = {}) => {
 		label = false,
 		states = {},
 		focused = false,
-		invalid
+		invalid,
+		helperText
 	} = options;
 	const { readOnly, disabled, required } = states;
 	const children = [
@@ -111,7 +113,20 @@ const expected = (options: ExpectedOptions = {}) => {
 			required,
 			forId: ''
 		}, [ 'foo' ]) : null,
-		v('div', { classes: css.inputWrapper }, children)
+		v('div', { classes: css.inputWrapper }, [
+			v('div', { classes: css.inputWrapperInner }, children),
+			helperText ? v('div', {
+				classes: [
+					css.helperTextWrapper,
+					invalid ? css.invalid : null
+				]
+			}, [
+				v('div', {
+					classes: css.helperText,
+					title: helperText
+				}, [helperText])
+			]) : null
+		])
 	]);
 };
 
@@ -218,6 +233,14 @@ registerSuite('EnhancedTextInput', {
 				});
 				const h = harness(() => w(MockMetaMixin(EnhancedTextInput, mockMeta), {}));
 				h.expect(() => expected({ focused: true }));
+			},
+
+			'helperText'() {
+				const h = harness(() => w(EnhancedTextInput, {
+					label: 'foo',
+					helperText: 'test'
+				}));
+				h.expect(() => expected({ label: true, helperText: 'test' }));
 			},
 
 			events() {

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -170,7 +170,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 
 	private _validate() {
 		const { properties: { validate, onValidate, value }, _state: state } = this;
-		if (!validate || value === undefined || value === null) {
+		if (!validate || value === undefined || value === null || (state.valid === undefined && !value)) {
 			return;
 		}
 

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -284,9 +284,7 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 			])
 		}, [
 			v('div', {
-				classes: this.theme([
-					css.helperText
-				]),
+				classes: this.theme(css.helperText),
 				title: text
 			}, [text])
 		]) : null;

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -49,7 +49,7 @@ export interface TextInputProperties extends ThemedProperties, FocusProperties, 
 	pattern?: string | RegExp;
 	autocomplete?: boolean | string;
 	onClick?(value: string): void;
-	validate?: ((value: string) => { message: string; valid: boolean; }) | boolean;
+	validate?: ((value: string) => { message: string; valid: boolean; } | void) | boolean;
 	onValidate?: (valid: boolean, message?: string) => void;
 }
 
@@ -170,14 +170,14 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 
 	private _validate() {
 		const { properties: { validate, onValidate, value }, _state: state } = this;
-		if (!validate || value === undefined || value === null || (state.valid === undefined && !value)) {
+		if (!validate || value === undefined || value === null) {
 			return;
 		}
 
 		let { valid, message } = this.meta(InputValidity).get('input', value);
 
 		if (typeof validate === 'function') {
-			const { valid: customValid, message: customMessage } = validate(value);
+			const { valid: customValid = valid, message: customMessage = message } = validate(value) || {};
 			valid = customValid;
 			message = customMessage;
 		}

--- a/src/text-input/tests/unit/TextInput.ts
+++ b/src/text-input/tests/unit/TextInput.ts
@@ -88,9 +88,7 @@ const expected = function({ label = false, inputOverrides = {}, states = {}, foc
 				]
 			}, [
 				v('div', {
-					classes: [
-						css.helperText
-					],
+					classes: css.helperText,
 					title: helperText
 				}, [helperText])
 			]) : null

--- a/src/theme/enhanced-text-input.m.css
+++ b/src/theme/enhanced-text-input.m.css
@@ -13,6 +13,20 @@
 	flex: 1 1 auto;
 }
 
-.inputWrapper {
+.invalid {
+	composes: invalid from './text-input.m.css';
+}
+
+.helperTextWrapper {
+	composes: helperTextWrapper from './text-input.m.css';
+}
+
+.helperText {
+	composes: helperText from './text-input.m.css';
+}
+
+.inputWrapper { }
+
+.inputWrapperInner {
 	display: flex;
 }

--- a/src/theme/enhanced-text-input.m.css.d.ts
+++ b/src/theme/enhanced-text-input.m.css.d.ts
@@ -2,4 +2,8 @@ export const addon: string;
 export const addonAfter: string;
 export const addonBefore: string;
 export const input: string;
+export const invalid: string;
+export const helperTextWrapper: string;
+export const helperText: string;
 export const inputWrapper: string;
+export const inputWrapperInner: string;

--- a/src/theme/text-input.m.css
+++ b/src/theme/text-input.m.css
@@ -7,6 +7,7 @@
 .focused {}
 .readonly {}
 .required {}
+.invalid {}
 
 .helperTextWrapper {
 }

--- a/src/theme/text-input.m.css.d.ts
+++ b/src/theme/text-input.m.css.d.ts
@@ -5,7 +5,7 @@ export const disabled: string;
 export const focused: string;
 export const readonly: string;
 export const required: string;
+export const invalid: string;
 export const helperTextWrapper: string;
 export const helperText: string;
-export const invalid: string;
 export const valid: string;


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This fixes an oversight where `helperText` does not render properly on the next line for the Enhanced Text Input widget. It also prevents validation from running and showing errors until the field actually has some kind of value.
