### PR TITLE
Export classes rather than bases

### DIFF
--- a/src/accordion-pane/index.ts
+++ b/src/accordion-pane/index.ts
@@ -24,15 +24,13 @@ export interface AccordionPaneProperties extends ThemedProperties {
 	openKeys?: string[];
 }
 
-export const ThemedBase = ThemedMixin(WidgetBase);
-
 @theme(css)
 @customElement<AccordionPaneProperties>({
 	tag: 'dojo-accordion-pane',
 	properties: [ 'openKeys', 'theme', 'extraClasses', 'classes' ],
 	events: [ 'onRequestClose', 'onRequestOpen' ]
 })
-export class AccordionPaneBase<P extends AccordionPaneProperties = AccordionPaneProperties> extends ThemedBase<P, WNode<TitlePane>> {
+export class AccordionPane extends ThemedMixin(WidgetBase)<AccordionPaneProperties, WNode<TitlePane>> {
 	private _assignCallback(child: WNode<TitlePane>, functionName: 'onRequestClose' | 'onRequestOpen', callback: (key: string) => void) {
 		const existingProperty = child.properties[functionName];
 		const property = () => { callback.call(this, `${ child.properties.key }`); };
@@ -79,4 +77,4 @@ export class AccordionPaneBase<P extends AccordionPaneProperties = AccordionPane
 	}
 }
 
-export default class AccordionPane extends AccordionPaneBase<AccordionPaneProperties> {}
+export default AccordionPane;

--- a/src/button/index.ts
+++ b/src/button/index.ts
@@ -36,8 +36,6 @@ export interface ButtonProperties extends ThemedProperties, InputEventProperties
 	onClick?(): void;
 }
 
-export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
-
 @theme(css)
 @customElement<ButtonProperties>({
 	tag: 'dojo-button',
@@ -60,7 +58,7 @@ export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
 		'onTouchStart'
 	]
 })
-export class ButtonBase<P extends ButtonProperties = ButtonProperties> extends ThemedBase<P> {
+export class Button extends ThemedMixin(FocusMixin(WidgetBase))<ButtonProperties> {
 	private _onBlur (event: FocusEvent) {
 		this.properties.onBlur && this.properties.onBlur();
 	}
@@ -173,4 +171,4 @@ export class ButtonBase<P extends ButtonProperties = ButtonProperties> extends T
 	}
 }
 
-export default class Button extends ButtonBase<ButtonProperties> {}
+export default Button;

--- a/src/calendar/CalendarCell.ts
+++ b/src/calendar/CalendarCell.ts
@@ -32,10 +32,8 @@ export interface CalendarCellProperties extends ThemedProperties {
 	onKeyDown?(key: number, preventDefault: () => void): void;
 }
 
-export const ThemedBase = ThemedMixin(WidgetBase);
-
 @theme(css)
-export class CalendarCellBase<P extends CalendarCellProperties = CalendarCellProperties> extends ThemedBase<P, null> {
+export class CalendarCell extends ThemedMixin(WidgetBase)<CalendarCellProperties> {
 	private _onClick(event: MouseEvent) {
 		event.stopPropagation();
 		const { date, disabled = false, onClick } = this.properties;
@@ -92,4 +90,4 @@ export class CalendarCellBase<P extends CalendarCellProperties = CalendarCellPro
 	}
 }
 
-export default class CalendarCell extends CalendarCellBase<CalendarCellProperties> {}
+export default CalendarCell;

--- a/src/calendar/DatePicker.ts
+++ b/src/calendar/DatePicker.ts
@@ -56,12 +56,10 @@ export interface DatePickerProperties extends ThemedProperties {
 	onRequestYearChange?(year: number): void;
 }
 
-export const ThemedBase = ThemedMixin(WidgetBase);
-
 const BASE_YEAR = 2000;
 
 @theme(css)
-export class DatePickerBase<P extends DatePickerProperties = DatePickerProperties> extends ThemedBase<P, null> {
+export class DatePicker extends ThemedMixin(WidgetBase)<DatePickerProperties> {
 	private _idBase = uuid();
 	private _monthPopupOpen = false;
 	private _yearPopupOpen = false;
@@ -367,4 +365,4 @@ export class DatePickerBase<P extends DatePickerProperties = DatePickerPropertie
 	}
 }
 
-export default class DatePicker extends DatePickerBase<DatePickerProperties> {}
+export default DatePicker;

--- a/src/calendar/index.ts
+++ b/src/calendar/index.ts
@@ -79,8 +79,6 @@ const DEFAULT_WEEKDAYS: ShortLong<typeof commonBundle.messages>[] = [
 	{ short: 'satShort', long: 'saturday' }
 ];
 
-export const ThemedBase = I18nMixin(ThemedMixin(WidgetBase));
-
 @theme(css)
 @customElement<CalendarProperties>({
 	tag: 'dojo-calendar',
@@ -99,7 +97,7 @@ export const ThemedBase = I18nMixin(ThemedMixin(WidgetBase));
 	],
 	events: [ 'onDateSelect', 'onMonthChange', 'onYearChange' ]
 })
-export class CalendarBase<P extends CalendarProperties = CalendarProperties> extends ThemedBase<P, null> {
+export class Calendar extends I18nMixin(ThemedMixin(WidgetBase))<CalendarProperties> {
 	private _callDateFocus = false;
 	private _defaultDate = new Date();
 	private _focusedDay = 1;
@@ -456,4 +454,4 @@ export class CalendarBase<P extends CalendarProperties = CalendarProperties> ext
 	}
 }
 
-export default class Calendar extends CalendarBase<CalendarProperties> {}
+export default Calendar;

--- a/src/checkbox/index.ts
+++ b/src/checkbox/index.ts
@@ -38,8 +38,6 @@ export enum Mode {
 	toggle = 'toggle'
 }
 
-export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
-
 @theme(css)
 @customElement<CheckboxProperties>({
 	tag: 'dojo-checkbox',
@@ -72,7 +70,7 @@ export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
 		'onTouchStart'
 	]
 })
-export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> extends ThemedBase<P, null> {
+export class Checkbox extends ThemedMixin(FocusMixin(WidgetBase))<CheckboxProperties> {
 	private _onBlur (event: FocusEvent) {
 		const checkbox = event.target as HTMLInputElement;
 		this.properties.onBlur && this.properties.onBlur(checkbox.value, checkbox.checked);
@@ -233,4 +231,4 @@ export class CheckboxBase<P extends CheckboxProperties = CheckboxProperties> ext
 	}
 }
 
-export default class Checkbox extends CheckboxBase<CheckboxProperties> {}
+export default Checkbox;

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -77,8 +77,6 @@ export enum Operation {
 	decrease = -1
 }
 
-export const ThemedBase = I18nMixin(ThemedMixin(FocusMixin(WidgetBase)));
-
 @theme(css)
 @diffProperty('results', reference)
 @customElement<ComboBoxProperties>({
@@ -111,7 +109,7 @@ export const ThemedBase = I18nMixin(ThemedMixin(FocusMixin(WidgetBase)));
 		'onResultSelect'
 	]
 })
-export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> extends ThemedBase<P, null> {
+export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<ComboBoxProperties> {
 	private _activeIndex = 0;
 	private _ignoreBlur: boolean | undefined;
 	private _idBase = uuid();
@@ -508,4 +506,4 @@ export class ComboBoxBase<P extends ComboBoxProperties = ComboBoxProperties> ext
 	}
 }
 
-export default class ComboBox extends ComboBoxBase<ComboBoxProperties> {}
+export default ComboBox;

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -51,8 +51,6 @@ export interface DialogProperties extends ThemedProperties, CustomAriaProperties
 	underlay?: boolean;
 }
 
-export const ThemedBase = I18nMixin(ThemedMixin(WidgetBase));
-
 @theme(css)
 @customElement<DialogProperties>({
 	tag: 'dojo-dialog',
@@ -78,7 +76,7 @@ export const ThemedBase = I18nMixin(ThemedMixin(WidgetBase));
 		'onRequestClose'
 	]
 })
-export class DialogBase<P extends DialogProperties = DialogProperties> extends ThemedBase<P> {
+export class Dialog extends I18nMixin(ThemedMixin(WidgetBase))<DialogProperties> {
 	private _titleId = uuid();
 	private _wasOpen: boolean | undefined;
 	private _callFocus = false;
@@ -227,4 +225,4 @@ export class DialogBase<P extends DialogProperties = DialogProperties> extends T
 	}
 }
 
-export default class Dialog extends DialogBase<DialogProperties> {}
+export default Dialog;

--- a/src/icon/index.ts
+++ b/src/icon/index.ts
@@ -23,8 +23,6 @@ export interface IconProperties extends ThemedProperties, CustomAriaProperties {
 	altText?: string;
 }
 
-export const ThemedBase = ThemedMixin(WidgetBase);
-
 @theme(css)
 @customElement<IconProperties>({
 	tag: 'dojo-icon',
@@ -36,7 +34,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 	],
 	attributes: [ 'type', 'altText' ]
 })
-export class IconBase<P extends IconProperties = IconProperties> extends ThemedBase<P, null> {
+export class Icon extends ThemedMixin(WidgetBase)<IconProperties> {
 
 	protected renderAltText(altText: string): DNode {
 		return v('span', { classes: [ baseCss.visuallyHidden ] }, [ altText ]);
@@ -61,4 +59,4 @@ export class IconBase<P extends IconProperties = IconProperties> extends ThemedB
 	}
 }
 
-export default class Icon extends IconBase<IconProperties> {}
+export default Icon;

--- a/src/label/index.ts
+++ b/src/label/index.ts
@@ -35,8 +35,6 @@ export interface LabelProperties extends ThemedProperties, CustomAriaProperties 
 	widgetId?: string;
 }
 
-export const ThemedBase = ThemedMixin(WidgetBase);
-
 @theme(css)
 @customElement<LabelProperties>({
 	tag: 'dojo-label',
@@ -44,7 +42,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 	attributes: [],
 	events: []
 })
-export class LabelBase<P extends LabelProperties = LabelProperties> extends ThemedBase<P> {
+export class Label extends ThemedMixin(WidgetBase)<LabelProperties> {
 	protected getRootClasses(): (string | null)[] {
 		const {
 			disabled,
@@ -81,4 +79,4 @@ export class LabelBase<P extends LabelProperties = LabelProperties> extends Them
 	}
 }
 
-export default class Label extends LabelBase<LabelProperties> {}
+export default Label;

--- a/src/listbox/ListboxOption.ts
+++ b/src/listbox/ListboxOption.ts
@@ -17,10 +17,8 @@ export interface ListboxOptionProperties extends ThemedProperties {
 	onClick?(option: any, index: number, key?: string | number): void;
 }
 
-export const ThemedBase = ThemedMixin(WidgetBase);
-
 @theme(css)
-export class ListboxOptionBase<P extends ListboxOptionProperties = ListboxOptionProperties> extends ThemedBase<P, null> {
+export class ListboxOption extends ThemedMixin(WidgetBase)<ListboxOptionProperties> {
 	private _onClick(event: MouseEvent) {
 		event.stopPropagation();
 		const { index, key, option, onClick } = this.properties;
@@ -47,4 +45,4 @@ export class ListboxOptionBase<P extends ListboxOptionProperties = ListboxOption
 	}
 }
 
-export default class ListboxOption extends ListboxOptionBase<ListboxOptionProperties> {}
+export default ListboxOption;

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -63,8 +63,6 @@ export interface ListboxProperties extends ThemedProperties, FocusProperties, Cu
 	onOptionSelect?(option: any, index: number, key?: string | number): void;
 }
 
-export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
-
 @theme(css)
 @diffProperty('optionData', reference)
 @customElement<ListboxProperties>({
@@ -91,7 +89,7 @@ export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
 		'onOptionSelect'
 	]
 })
-export class ListboxBase<P extends ListboxProperties = ListboxProperties> extends ThemedBase<P, null> {
+export class Listbox extends ThemedMixin(FocusMixin(WidgetBase))<ListboxProperties> {
 	private _boundRenderOption = this.renderOption.bind(this);
 	private _idBase = uuid();
 
@@ -265,4 +263,4 @@ export class ListboxBase<P extends ListboxProperties = ListboxProperties> extend
 	}
 }
 
-export default class Listbox extends ListboxBase<ListboxProperties> {}
+export default Listbox;

--- a/src/progress/index.ts
+++ b/src/progress/index.ts
@@ -28,8 +28,6 @@ export interface ProgressProperties extends ThemedProperties, CustomAriaProperti
 	widgetId?: string;
 }
 
-export const ThemedBase = ThemedMixin(WidgetBase);
-
 @theme(css)
 @customElement<ProgressProperties>({
 	tag: 'dojo-progress',
@@ -37,7 +35,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 	attributes: [ 'widgetId' ],
 	events: [ ]
 })
-export class ProgressBase<P extends ProgressProperties = ProgressProperties> extends ThemedBase<P, null> {
+export class Progress extends ThemedMixin(WidgetBase)<ProgressProperties> {
 	private _output(value: number, percent: number) {
 		const { output } = this.properties;
 		return output ? output(value, percent) : `${percent}%`;
@@ -83,4 +81,4 @@ export class ProgressBase<P extends ProgressProperties = ProgressProperties> ext
 	}
 }
 
-export default class Progress extends ProgressBase<ProgressProperties> {}
+export default Progress;

--- a/src/radio/index.ts
+++ b/src/radio/index.ts
@@ -24,8 +24,6 @@ export interface RadioProperties extends ThemedProperties, LabeledProperties, In
 	value?: string;
 }
 
-export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
-
 @theme(css)
 @customElement<RadioProperties>({
 	tag: 'dojo-radio',
@@ -58,7 +56,7 @@ export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
 		'onTouchStart'
 	]
 })
-export class RadioBase<P extends RadioProperties = RadioProperties> extends ThemedBase<P, null> {
+export class Radio extends ThemedMixin(FocusMixin(WidgetBase))<RadioProperties> {
 	private _uuid = uuid();
 
 	private _onBlur (event: FocusEvent) {
@@ -189,4 +187,4 @@ export class RadioBase<P extends RadioProperties = RadioProperties> extends Them
 	}
 }
 
-export default class Radio extends RadioBase<RadioProperties> {}
+export default Radio;

--- a/src/range-slider/index.ts
+++ b/src/range-slider/index.ts
@@ -39,8 +39,6 @@ export interface RangeSliderProperties extends ThemedProperties, LabeledProperti
 	onFocus?(value?: string | number | boolean): void;
 }
 
-export const ThemedBase = ThemedMixin(WidgetBase);
-
 function extractValue(event: Event): number {
 	const value = (event.target as HTMLInputElement).value;
 	return parseFloat(value);
@@ -92,7 +90,7 @@ type MinMaxCallback = (minValue: number, maxValue: number) => void;
 		'onTouchStart'
 	]
 })
-export class RangeSliderBase<P extends RangeSliderProperties = RangeSliderProperties> extends ThemedBase<P, null> {
+export class RangeSlider extends ThemedMixin(WidgetBase)<RangeSliderProperties> {
 	// id used to associate input with output
 	private _widgetId = uuid();
 	private _minLabelId = uuid();
@@ -386,4 +384,4 @@ export class RangeSliderBase<P extends RangeSliderProperties = RangeSliderProper
 	}
 }
 
-export default class RangeSlider extends RangeSliderBase<RangeSliderProperties> {}
+export default RangeSlider;

--- a/src/select/index.ts
+++ b/src/select/index.ts
@@ -48,8 +48,6 @@ export interface SelectProperties extends ThemedProperties, InputProperties, Foc
 	value?: string;
 }
 
-export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
-
 @theme(css)
 @diffProperty('options', reference)
 @customElement<SelectProperties>({
@@ -81,7 +79,7 @@ export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
 		'onFocus'
 	]
 })
-export class SelectBase<P extends SelectProperties = SelectProperties> extends ThemedBase<P, null> {
+export class Select extends ThemedMixin(FocusMixin(WidgetBase))<SelectProperties> {
 	private _focusedIndex: number;
 	private _focusNode = 'trigger';
 	private _ignoreBlur = false;
@@ -446,4 +444,4 @@ export class SelectBase<P extends SelectProperties = SelectProperties> extends T
 	}
 }
 
-export default class Select extends SelectBase<SelectProperties> {}
+export default Select;

--- a/src/slide-pane/index.ts
+++ b/src/slide-pane/index.ts
@@ -58,8 +58,6 @@ enum Plane {
 	y
 }
 
-export const ThemedBase = I18nMixin(ThemedMixin(WidgetBase));
-
 @theme(css)
 @customElement<SlidePaneProperties>({
 	tag: 'dojo-slide-pane',
@@ -70,7 +68,7 @@ export const ThemedBase = I18nMixin(ThemedMixin(WidgetBase));
 		'onRequestClose'
 	]
 })
-export class SlidePaneBase<P extends SlidePaneProperties = SlidePaneProperties> extends ThemedBase<P> {
+export class SlidePane extends I18nMixin(ThemedMixin(WidgetBase))<SlidePaneProperties> {
 	private _initialPosition = 0;
 	private _slideIn: boolean | undefined;
 	private _swiping: boolean | undefined;
@@ -329,4 +327,4 @@ export class SlidePaneBase<P extends SlidePaneProperties = SlidePaneProperties> 
 	}
 }
 
-export default class SlidePane extends SlidePaneBase<SlidePaneProperties> {}
+export default SlidePane;

--- a/src/slider/index.ts
+++ b/src/slider/index.ts
@@ -40,8 +40,6 @@ export interface SliderProperties extends ThemedProperties, LabeledProperties, I
 	inputStyles?: Partial<CSSStyleDeclaration>;
 }
 
-export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
-
 function extractValue(event: Event): number {
 	const value = (event.target as HTMLInputElement).value;
 	return parseFloat(value);
@@ -87,7 +85,7 @@ function extractValue(event: Event): number {
 		'onTouchStart'
 	]
 })
-export class SliderBase<P extends SliderProperties = SliderProperties> extends ThemedBase<P, null> {
+export class Slider extends ThemedMixin(FocusMixin(WidgetBase))<SliderProperties> {
 	// id used to associate input with output
 	private _widgetId = uuid();
 
@@ -304,4 +302,4 @@ export class SliderBase<P extends SliderProperties = SliderProperties> extends T
 	}
 }
 
-export default class Slider extends SliderBase<SliderProperties> {}
+export default Slider;

--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -131,8 +131,8 @@ export class SplitPane extends ThemedMixin(WidgetBase)<SplitPaneProperties> {
 		return content ? [ content ] : [];
 	}
 
-	private _shouldCollapse(dimensions: ContentRect) {
-		const { onCollapse, direction, collapseWidth } = this.properties;
+	private _shouldCollapse(dimensions: ContentRect, collapseWidth: number) {
+		const { onCollapse, direction } = this.properties;
 
 		if (direction === Direction.row) {
 			return false;
@@ -162,7 +162,7 @@ export class SplitPane extends ThemedMixin(WidgetBase)<SplitPaneProperties> {
 			const { shouldCollapse } = this.meta(Resize).get('root', {
 				shouldCollapse: (dimensions) => {
 					this._resizeResultOverridden = false;
-					return this._shouldCollapse(dimensions);
+					return this._shouldCollapse(dimensions, collapseWidth);
 				}
 			});
 

--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -37,8 +37,6 @@ export interface SplitPaneProperties extends ThemedProperties {
 	onCollapse?(collapsed: boolean): void;
 }
 
-export const ThemedBase = ThemedMixin(WidgetBase);
-
 const DEFAULT_SIZE = 100;
 
 @theme(css)
@@ -51,7 +49,7 @@ const DEFAULT_SIZE = 100;
 		'onResize'
 	]
 })
-export class SplitPaneBase<P extends SplitPaneProperties = SplitPaneProperties> extends ThemedBase<P> {
+export class SplitPane extends ThemedMixin(WidgetBase)<SplitPaneProperties> {
 	private _dragging: boolean | undefined;
 	private _lastSize?: number;
 	private _position = 0;
@@ -228,4 +226,4 @@ export class SplitPaneBase<P extends SplitPaneProperties = SplitPaneProperties> 
 	}
 }
 
-export default class SplitPane extends SplitPaneBase<SplitPaneProperties> {}
+export default SplitPane;

--- a/src/tab-controller/index.ts
+++ b/src/tab-controller/index.ts
@@ -40,8 +40,6 @@ export interface TabControllerProperties extends ThemedProperties, FocusProperti
 	onRequestTabClose?(index: number, key: string): void;
 }
 
-export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
-
 @theme(css)
 @customElement<TabControllerProperties>({
 	tag: 'dojo-tab-controller',
@@ -52,7 +50,7 @@ export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
 		'onRequestTabClose'
 	]
 })
-export class TabControllerBase<P extends TabControllerProperties = TabControllerProperties> extends ThemedBase<P, WNode<Tab>> {
+export class TabController extends ThemedMixin(FocusMixin(WidgetBase))<TabControllerProperties, WNode<Tab>> {
 	private _id = uuid();
 
 	private get _tabs(): WNode<Tab>[] {
@@ -257,4 +255,4 @@ export class TabControllerBase<P extends TabControllerProperties = TabController
 	}
 }
 
-export default class TabController extends TabControllerBase<TabControllerProperties> {}
+export default TabController;

--- a/src/tab/index.ts
+++ b/src/tab/index.ts
@@ -31,8 +31,6 @@ export interface TabProperties extends ThemedProperties, CustomAriaProperties {
 	labelledBy?: string;
 }
 
-export const ThemedBase = ThemedMixin(WidgetBase);
-
 @theme(css)
 @customElement<TabProperties>({
 	tag: 'dojo-tab',
@@ -41,7 +39,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 	attributes: [ 'key', 'labelledBy', 'widgetId', 'label' ],
 	events: [ ]
 })
-export class TabBase<P extends TabProperties = TabProperties> extends ThemedBase<P> {
+export class Tab extends ThemedMixin(WidgetBase)<TabProperties> {
 	render(): DNode {
 		const {
 			aria = {},
@@ -62,4 +60,4 @@ export class TabBase<P extends TabProperties = TabProperties> extends ThemedBase
 	}
 }
 
-export default class Tab extends TabBase<TabProperties> {}
+export default Tab;

--- a/src/text-area/index.ts
+++ b/src/text-area/index.ts
@@ -39,8 +39,6 @@ export interface TextareaProperties extends ThemedProperties, InputProperties, F
 	helperText?: string;
 }
 
-export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
-
 @theme(css)
 @customElement<TextareaProperties>({
 	tag: 'dojo-text-area',
@@ -74,7 +72,7 @@ export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
 		'onTouchStart'
 	]
 })
-export class TextareaBase<P extends TextareaProperties = TextareaProperties> extends ThemedBase<P, null> {
+export class Textarea extends ThemedMixin(FocusMixin(WidgetBase))<TextareaProperties> {
 	private _onBlur (event: FocusEvent) {
 		this.properties.onBlur && this.properties.onBlur((event.target as HTMLInputElement).value);
 	}
@@ -226,4 +224,4 @@ export class TextareaBase<P extends TextareaProperties = TextareaProperties> ext
 	}
 }
 
-export default class Textarea extends TextareaBase<TextareaProperties> {}
+export default Textarea;

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -63,8 +63,6 @@ export interface TextInputProperties extends ThemedProperties, FocusProperties, 
 	label?: string;
 }
 
-export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
-
 function formatAutocomplete(autocomplete: string | boolean | undefined): string | undefined {
 	if (typeof autocomplete === 'boolean') {
 		return autocomplete ? 'on' : 'off';
@@ -129,7 +127,7 @@ function patternDiffer(previousProperty: string | undefined, newProperty: string
 @diffProperty('pattern', patternDiffer)
 @diffProperty('leading', reference)
 @diffProperty('trailing', reference)
-export class TextInputBase<P extends TextInputProperties = TextInputProperties> extends ThemedBase<P, null> {
+export class TextInput extends ThemedMixin(FocusMixin(WidgetBase))<TextInputProperties> {
 	private _onBlur (event: FocusEvent) {
 		this.properties.onBlur && this.properties.onBlur((event.target as HTMLInputElement).value);
 	}
@@ -336,4 +334,4 @@ export class TextInputBase<P extends TextInputProperties = TextInputProperties> 
 	}
 }
 
-export default class TextInput extends TextInputBase<TextInputProperties> {}
+export default TextInput;

--- a/src/time-picker/index.ts
+++ b/src/time-picker/index.ts
@@ -156,8 +156,6 @@ export function parseUnits (value: string | TimeUnits): TimeUnits {
 	return value;
 }
 
-export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
-
 @theme(css)
 @customElement<TimePickerProperties>({
 	tag: 'dojo-time-picker',
@@ -190,7 +188,7 @@ export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
 		'onRequestOptions'
 	]
 })
-export class TimePickerBase<P extends TimePickerProperties = TimePickerProperties> extends ThemedBase<P, null> {
+export class TimePicker extends ThemedMixin(FocusMixin(WidgetBase))<TimePickerProperties> {
 	protected options: TimeUnits[] | null = null;
 
 	private _uuid: string;
@@ -412,4 +410,4 @@ export class TimePickerBase<P extends TimePickerProperties = TimePickerPropertie
 	}
 }
 
-export default class TimePicker extends TimePickerBase<TimePickerProperties> {}
+export default TimePicker;

--- a/src/title-pane/index.ts
+++ b/src/title-pane/index.ts
@@ -33,8 +33,6 @@ export interface TitlePaneProperties extends ThemedProperties, FocusProperties {
 	title: string;
 }
 
-export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
-
 @theme(css)
 @customElement<TitlePaneProperties>({
 	tag: 'dojo-title-pane',
@@ -45,7 +43,7 @@ export const ThemedBase = ThemedMixin(FocusMixin(WidgetBase));
 		'onRequestOpen'
 	]
 })
-export class TitlePaneBase<P extends TitlePaneProperties = TitlePaneProperties> extends ThemedBase<P> {
+export class TitlePane extends ThemedMixin(FocusMixin(WidgetBase))<TitlePaneProperties> {
 	private _id = uuid();
 	private _open: boolean | undefined;
 
@@ -166,4 +164,4 @@ export class TitlePaneBase<P extends TitlePaneProperties = TitlePaneProperties> 
 	}
 }
 
-export default class TitlePane extends TitlePaneBase<TitlePaneProperties> {}
+export default TitlePane;

--- a/src/toolbar/index.ts
+++ b/src/toolbar/index.ts
@@ -29,8 +29,6 @@ export interface ToolbarProperties extends ThemedProperties {
 	heading?: string;
 }
 
-export const ThemedBase = I18nMixin(ThemedMixin(WidgetBase));
-
 @theme(css)
 @customElement<ToolbarProperties>({
 	tag: 'dojo-toolbar',
@@ -40,7 +38,7 @@ export const ThemedBase = I18nMixin(ThemedMixin(WidgetBase));
 		'onCollapse'
 	]
 })
-export class ToolbarBase<P extends ToolbarProperties = ToolbarProperties> extends ThemedBase<P> {
+export class Toolbar extends I18nMixin(ThemedMixin(WidgetBase))<ToolbarProperties> {
 	private _collapsed = false;
 	private _open = false;
 
@@ -140,4 +138,4 @@ export class ToolbarBase<P extends ToolbarProperties = ToolbarProperties> extend
 	}
 }
 
-export default class Toolbar extends ToolbarBase<ToolbarProperties> {}
+export default Toolbar;

--- a/src/tooltip/index.ts
+++ b/src/tooltip/index.ts
@@ -35,8 +35,6 @@ export enum Orientation {
 const fixedOrientationCss: {[key: string]: any} = fixedCss;
 const orientationCss: {[key: string]: any} = css;
 
-export const ThemedBase = ThemedMixin(WidgetBase);
-
 @theme(css)
 @customElement<TooltipProperties>({
 	tag: 'dojo-tooltip',
@@ -44,7 +42,7 @@ export const ThemedBase = ThemedMixin(WidgetBase);
 	attributes: [ 'orientation' ],
 	events: [ ]
 })
-export class TooltipBase<P extends TooltipProperties = TooltipProperties> extends ThemedBase<P> {
+export class Tooltip extends ThemedMixin(WidgetBase)<TooltipProperties> {
 	protected getFixedModifierClasses(): (string | null)[] {
 		const { orientation = Orientation.right } = this.properties;
 
@@ -89,4 +87,4 @@ export class TooltipBase<P extends TooltipProperties = TooltipProperties> extend
 	}
 }
 
-export default class Tooltip extends TooltipBase<TooltipProperties> {}
+export default Tooltip;


### PR DESCRIPTION
The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Remove bases with generic typings from widgets.
This is part of a move towards encouraging extension via properties instead of class extension. The abstraction involved with having `protected` functions internally and ensuring we don't break those api's is hard to manage and this is not the way we wish to support people using and customising our widgets etc.

Resolves #684 
