### PR TITLE
use reference diffProperty

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widgets",
-  "version": "6.0.0-alpha.3",
+  "version": "6.0.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -690,9 +690,9 @@
       "dev": true
     },
     "@types/q": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.1.tgz",
-      "integrity": "sha512-eqz8c/0kwNi/OEHQfvIuJVLTst3in0e7uTKeuY+WL/zfKn0xVujOTp42bS/vUUokhK5P2BppLd9JXMOMHcgbjA==",
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@types/q/-/q-1.5.2.tgz",
+      "integrity": "sha512-ce5d3q03Ex0sy4R14722Rmt6MT07Ua+k4FwDfdcToYJcMKNtRVQvJ6JCAPdAmAnbRb6CsX6aYb9m96NGod9uTw==",
       "dev": true
     },
     "@types/range-parser": {
@@ -1369,9 +1369,9 @@
       "dev": true
     },
     "async-each": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.1.tgz",
-      "integrity": "sha1-GdOGodntxufByF04iu28xW0zYC0=",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.2.tgz",
+      "integrity": "sha512-6xrbvN0MOBKSJDdonmSSz2OwFSgxRaVtBDes26mj9KIGtDo+g9xosFRSC+i1gQh2oAN/tQ62AI/pGZGQjVOiRg==",
       "dev": true
     },
     "async-limiter": {
@@ -2211,15 +2211,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000946",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000946.tgz",
-      "integrity": "sha512-qjpdekHW9uyy1U/VxuoR9ppn8HjoBxsR5dRTpumUeoYgL8IWUeos+QpJh9DaDdjaKitkNzgAFMXCZLDYKWWyEQ==",
+      "version": "1.0.30000947",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000947.tgz",
+      "integrity": "sha512-hCrT/wM4PuUHif1+2XbQbutQJynvTNWK3yGzIgnyHdhtuuuUfyvNHKbpYIjWzYT3MrARw2zew6R44lWyxhE+Qg==",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000946",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000946.tgz",
-      "integrity": "sha512-ZVXtMoZ3Mfq69Ikv587Av+5lwGVJsG98QKUucVmtFBf0tl1kOCfLQ5o6Z2zBNis4Mx3iuH77WxEUpdP6t7f2CQ==",
+      "version": "1.0.30000947",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000947.tgz",
+      "integrity": "sha512-ubgBUfufe5Oi3W1+EHyh2C3lfBIEcZ6bTuvl5wNOpIuRB978GF/Z+pQ7pGGUpeYRB0P+8C7i/3lt6xkeu2hwnA==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -3972,9 +3972,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.115",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.115.tgz",
-      "integrity": "sha512-mN2qeapQWdi2B9uddxTZ4nl80y46hbyKY5Wt9Yjih+QZFQLdaujEDK4qJky35WhyxMzHF3ZY41Lgjd2BPDuBhg==",
+      "version": "1.3.116",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.116.tgz",
+      "integrity": "sha512-NKwKAXzur5vFCZYBHpdWjTMO8QptNLNP80nItkSIgUOapPAo9Uia+RvkCaZJtO7fhQaVElSvBPWEc2ku6cKsPA==",
       "dev": true
     },
     "elliptic": {
@@ -9375,9 +9375,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.12.1",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.12.1.tgz",
-      "integrity": "sha512-JY7V6lRkStKcKTvHO5NVSQRv+RV+FIL5pvDoLiAtSL9pKlC5x9PKQcZDsq7m4FO4d57mkhC6Z+QhAh3Jdk5JFw==",
+      "version": "2.13.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.0.tgz",
+      "integrity": "sha512-5DDQvN0luhXdut8SCwzm/ZuAX2W+fwhqNzfq7CZ+OJzQ6NwpcqmIGyLD1R8MEt7BeErzcsI0JLr4pND2pNp2Cw==",
       "dev": true,
       "optional": true
     },

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -11,6 +11,7 @@ import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/text-input.m.css';
 import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
 import diffProperty from '@dojo/framework/widget-core/decorators/diffProperty';
+import { reference } from '@dojo/framework/widget-core/diff';
 import InputValidity from '../common/InputValidity';
 import HelperText from '../helper-text/index';
 
@@ -126,6 +127,8 @@ function patternDiffer(previousProperty: string | undefined, newProperty: string
 	]
 })
 @diffProperty('pattern', patternDiffer)
+@diffProperty('leading', reference)
+@diffProperty('trailing', reference)
 export class TextInputBase<P extends TextInputProperties = TextInputProperties> extends ThemedBase<P, null> {
 	private _onBlur (event: FocusEvent) {
 		this.properties.onBlur && this.properties.onBlur((event.target as HTMLInputElement).value);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR uses the `diffProperty` `reference` function to ensure that the `TextInput` re-renders when a new `leading` / `trailing` render function is passed.

This will cause the widget to re-render if the user passes a new `leading` / `trailing` function but will have the side effect that it will also re-render whenever the parent re-renders if the user is using an arrow function or a bind within their renderers.

The most efficient way to use these functions is with named functions / widget-level functions (making use of the autobind functionality).

`w('TextInput', { leading: this.renderLeading }`
or in the case of a changing leading render:
`w('TextInput', { leading: this.toggle ? this.renderA : this.renderZ }`

Resolves #687 
