### PR TITLE
add open class to open dialog

### DIFF
--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -191,7 +191,7 @@ export class Dialog extends I18nMixin(ThemedMixin(WidgetBase))<DialogProperties>
 		}
 
 		return v('div', {
-			classes: this.theme(css.root)
+			classes: this.theme([css.root, open ? css.open : null])
 		}, open ? [
 			w(GlobalEvent, { key: 'global', document: { keyup: this._onKeyUp } }),
 			this.renderUnderlay(),

--- a/src/dialog/tests/unit/Dialog.ts
+++ b/src/dialog/tests/unit/Dialog.ts
@@ -35,7 +35,7 @@ const expectedCloseButton = function() {
 
 const expected = function(open = false, closeable = false, children: any[] = []) {
 	return v('div', {
-		classes: css.root
+		classes: [css.root, open ? css.open : null]
 	}, open ? [
 		w(GlobalEvent, {
 			key: 'global',
@@ -109,7 +109,7 @@ registerSuite('Dialog', {
 			};
 
 			h.expect(() => v('div', {
-				classes: css.root
+				classes: [css.root, css.open]
 			}, [
 				w(GlobalEvent, {
 					key: 'global',
@@ -163,7 +163,7 @@ registerSuite('Dialog', {
 				title: 'foo'
 			}));
 			h.expect(() => v('div', {
-				classes: css.root
+				classes: [css.root, css.open]
 			}, [
 				w(GlobalEvent, {
 					key: 'global',

--- a/src/theme/dialog.m.css
+++ b/src/theme/dialog.m.css
@@ -19,6 +19,10 @@
 	position: relative;
 }
 
+.open {
+
+}
+
 .close {
 	position: absolute;
 	top: 50%;

--- a/src/theme/dialog.m.css.d.ts
+++ b/src/theme/dialog.m.css.d.ts
@@ -1,6 +1,7 @@
 export const root: string;
 export const main: string;
 export const title: string;
+export const open: string;
 export const close: string;
 export const content: string;
 export const underlayVisible: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds themeable open class to dialog.
Enables use of actual material theme in future.

Resolves #690 
