### PR TITLE
670 - Toolbar children: set horizontal and vertical layout

### DIFF
--- a/src/common/example/example.css
+++ b/src/common/example/example.css
@@ -25,6 +25,7 @@
 @import '../../theme/time-picker.m.css';
 @import '../../title-pane/styles/title-pane.m.css';
 @import '../../toolbar/styles/toolbar.m.css';
+@import '../../theme/toolbar.m.css';
 @import '../../theme/title-pane.m.css';
 @import '../../theme/accordion-pane.m.css';
 @import '../../tooltip/styles/tooltip.m.css';

--- a/src/theme/toolbar.m.css
+++ b/src/theme/toolbar.m.css
@@ -3,10 +3,8 @@
 	flex-direction: row;
 }
 
-.collapsed {
-	& .actions {
-		flex-direction: column;
-	}
+.collapsed .actions {
+	flex-direction: column;
 }
 
 .menuButton { }

--- a/src/theme/toolbar.m.css
+++ b/src/theme/toolbar.m.css
@@ -1,4 +1,8 @@
-.actions { }
+.actions {
+	display: flex;
+	flex-direction: row;
+}
+
 .collapsed { }
 .menuButton { }
 .root { }

--- a/src/theme/toolbar.m.css
+++ b/src/theme/toolbar.m.css
@@ -3,12 +3,12 @@
 	flex-direction: row;
 }
 
-.slidePaneActions {
-	display: flex;
-	flex-direction: column;
+.collapsed {
+	& .actions {
+		flex-direction: column;
+	}
 }
 
-.collapsed { }
 .menuButton { }
 .root { }
 .title { }

--- a/src/theme/toolbar.m.css
+++ b/src/theme/toolbar.m.css
@@ -3,6 +3,11 @@
 	flex-direction: row;
 }
 
+.slidePaneActions {
+	display: flex;
+	flex-direction: column;
+}
+
 .collapsed { }
 .menuButton { }
 .root { }

--- a/src/theme/toolbar.m.css.d.ts
+++ b/src/theme/toolbar.m.css.d.ts
@@ -1,4 +1,5 @@
 export const actions: string;
+export const slidePaneActions: string;
 export const collapsed: string;
 export const menuButton: string;
 export const root: string;

--- a/src/theme/toolbar.m.css.d.ts
+++ b/src/theme/toolbar.m.css.d.ts
@@ -1,5 +1,4 @@
 export const actions: string;
-export const slidePaneActions: string;
 export const collapsed: string;
 export const menuButton: string;
 export const root: string;

--- a/src/toolbar/index.ts
+++ b/src/toolbar/index.ts
@@ -82,7 +82,7 @@ export class Toolbar extends I18nMixin(ThemedMixin(WidgetBase))<ToolbarPropertie
 			heading
 		} = this.properties;
 		const actions = v('div', {
-			classes: this.theme(this._collapsed ? css.slidePaneActions : css.actions),
+			classes: this.theme(css.actions),
 			key: 'menu'
 		}, this.children);
 

--- a/src/toolbar/index.ts
+++ b/src/toolbar/index.ts
@@ -81,6 +81,10 @@ export class Toolbar extends I18nMixin(ThemedMixin(WidgetBase))<ToolbarPropertie
 			classes,
 			heading
 		} = this.properties;
+		const actions = v('div', {
+			classes: this.theme(this._collapsed ? css.slidePaneActions : css.actions),
+			key: 'menu'
+		}, this.children);
 
 		return this._collapsed ? w(SlidePane, {
 			align: Align.right,
@@ -91,10 +95,7 @@ export class Toolbar extends I18nMixin(ThemedMixin(WidgetBase))<ToolbarPropertie
 			theme,
 			classes,
 			title: heading
-		}, this.children) : v('div', {
-			classes: this.theme(css.actions),
-			key: 'menu'
-		}, this.children);
+		}, [ actions ]) : actions;
 	}
 
 	protected renderButton(): DNode {

--- a/src/toolbar/tests/unit/Toolbar.ts
+++ b/src/toolbar/tests/unit/Toolbar.ts
@@ -117,7 +117,7 @@ registerSuite('Toolbar', {
 				title: 'foo'
 			}, [
 				v('div', {
-					classes: css.slidePaneActions,
+					classes: css.actions,
 					key: 'menu'
 				}, [
 				'test'

--- a/src/toolbar/tests/unit/Toolbar.ts
+++ b/src/toolbar/tests/unit/Toolbar.ts
@@ -116,7 +116,12 @@ registerSuite('Toolbar', {
 				classes: undefined,
 				title: 'foo'
 			}, [
+				v('div', {
+					classes: css.slidePaneActions,
+					key: 'menu'
+				}, [
 				'test'
+				])
 			]);
 
 			const buttonVDom = v('button', {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit tests are updated in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Toolbar: add CSS classes and rules to lay out children using `flex-direction: row` for the toolbar and `flex-direction: column` for the slide pane.

Resolves #670 
