### PR TITLE
Add ability to size SplitPane by its trailing pane

### DIFF
--- a/src/split-pane/README.md
+++ b/src/split-pane/README.md
@@ -83,3 +83,21 @@ w(SplitPane, {
 	})
 ])
 ```
+
+*SplitPane with size applied to the trailing pane*
+```typescript
+import SplitPane, { Direction } from '@dojo/widgets/split-pane';
+import { w } from '@dojo/framework/widget-core/d';
+
+w(SplitPane, {
+	key: 'sizeTrailing',
+	direction: Direction.column,
+	onResize: (size: number) => {
+		this.setState({ size: size });
+	},
+	size: this.state.size
+}, [
+	v('div', ['left: main content']),
+	v('div', ['right: sidebar'])
+])
+```

--- a/src/split-pane/example/index.ts
+++ b/src/split-pane/example/index.ts
@@ -184,37 +184,55 @@ export default class App extends WidgetBase {
 					size: this.state.minSize
 				})
 			]),
-			v('h3', ['Size applies to the second pane (column)']),
+			v('h3', ['Size applies to the trailing pane (column)']),
 			v('div', {
-				id: 'example-second',
+				id: 'example-trailing',
 				styles: containerStyles
 			}, [
 				w(SplitPane, {
-					key: 'secondSize',
+					key: 'trailingSize',
 					direction: Direction.column,
-					sizeAppliesTo: 1,
+					sizeTrailing: true,
 					onResize: (size: number) => {
 						size = size < 100 ? 100 : size;
-						this.setState({ secondSize: size });
+						this.setState({ trailingSize: size });
 					},
-					size: this.state.secondSize
+					size: this.state.trailingSize
 				})
 			]),
-			v('h3', ['Size applies to the second pane (row)']),
+			v('h3', ['Size applies to the trailing pane (row)']),
 			v('div', {
-				id: 'example-secondRow',
+				id: 'example-trailingRow',
 				styles: containerStyles
 			}, [
 				w(SplitPane, {
-					key: 'secondSizeRow',
+					key: 'trailingSizeRow',
 					direction: Direction.row,
-					sizeAppliesTo: 1,
+					sizeTrailing: true,
 					onResize: (size: number) => {
 						size = size < 100 ? 100 : size;
-						this.setState({ secondSizeRow: size });
+						this.setState({ trailingSizeRow: size });
 					},
-					size: this.state.secondSizeRow
+					size: this.state.trailingSizeRow
 				})
+			]),
+			v('h3', ['Size applies to the trailing pane (with collapse)']),
+			v('div', {
+				id: 'example-trailingCollapse',
+				styles: containerStyles
+			}, [
+				w(SplitPane, {
+					key: 'trailingSizeCollapse',
+					sizeTrailing: true,
+					collapseWidth: 400,
+					onResize: (size: number) => {
+						this.setState({ trailingSizeCollapse: size });
+					},
+					size: this.state.trailingSizeCollapse
+				}, [
+					v('div', ['One']),
+					v('div', ['Two'])
+				])
 			])
 		]);
 	}

--- a/src/split-pane/example/index.ts
+++ b/src/split-pane/example/index.ts
@@ -183,6 +183,38 @@ export default class App extends WidgetBase {
 					},
 					size: this.state.minSize
 				})
+			]),
+			v('h3', ['Size applies to the second pane (column)']),
+			v('div', {
+				id: 'example-second',
+				styles: containerStyles
+			}, [
+				w(SplitPane, {
+					key: 'secondSize',
+					direction: Direction.column,
+					sizeAppliesTo: 1,
+					onResize: (size: number) => {
+						size = size < 100 ? 100 : size;
+						this.setState({ secondSize: size });
+					},
+					size: this.state.secondSize
+				})
+			]),
+			v('h3', ['Size applies to the second pane (row)']),
+			v('div', {
+				id: 'example-secondRow',
+				styles: containerStyles
+			}, [
+				w(SplitPane, {
+					key: 'secondSizeRow',
+					direction: Direction.row,
+					sizeAppliesTo: 1,
+					onResize: (size: number) => {
+						size = size < 100 ? 100 : size;
+						this.setState({ secondSizeRow: size });
+					},
+					size: this.state.secondSizeRow
+				})
 			])
 		]);
 	}

--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -28,14 +28,17 @@ export enum Direction {
  * @property direction      Orientation of this SplitPane, can be `row` or `column`
  * @property onResize       Called when the divider is dragged; should be used to update `size`
  * @property size           Size of the primary pane
+ * @property collapseWidth  The pixel width at which the SplitPane should collapse columns
+ * @property onCollapse     Called when the SplitPane is collapsed
+ * @property sizeTrailing   Set to `true` to apply `size` to the trailing pane
  */
 export interface SplitPaneProperties extends ThemedProperties {
 	direction?: Direction;
 	onResize?(size: number): void;
 	size?: number;
-	sizeTrailing?: boolean;
 	collapseWidth?: number;
 	onCollapse?(collapsed: boolean): void;
+	sizeTrailing?: boolean;
 }
 
 const DEFAULT_SIZE = 100;
@@ -180,18 +183,6 @@ export class SplitPane extends ThemedMixin(WidgetBase)<SplitPaneProperties> {
 		const paneStyles: {[key: string]: string} = {};
 		let computedSize = this._collapsed ? 'auto' : `${size}px`;
 		paneStyles[direction === Direction.column ? 'width' : 'height'] = computedSize;
-
-		sizeTrailing && console.log('sizeTrailing =', sizeTrailing, [
-				...this.theme([
-					css.root,
-					this._collapsed ? css.collapsed : null,
-					direction === Direction.row ? css.row : css.column
-				]),
-				fixedCss.rootFixed,
-				direction === Direction.row ? fixedCss.rowFixed : fixedCss.columnFixed,
-				this._collapsed ? fixedCss.collapsedFixed : null,
-				sizeTrailing ? fixedCss.sizeTrailing : null
-			]);
 
 		return v('div', {
 			classes: [

--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -106,12 +106,6 @@ export class SplitPane extends ThemedMixin(WidgetBase)<SplitPaneProperties> {
 
 		const currentPosition = this._getPosition(event);
 		const positionDelta = currentPosition - this._position;
-		/*
-		let newSize = (this._lastSize === undefined ? size : this._lastSize) + currentPosition - this._position;
-		if (sizeAppliesTo === 1) {
-			newSize = (this._lastSize === undefined ? size : this._lastSize) - currentPosition + this._position;
-		}
-		*/
 		let newSize = (this._lastSize === undefined ? size : this._lastSize) +
 			(sizeAppliesTo === 0 ? positionDelta : -positionDelta);
 

--- a/src/split-pane/styles/split-pane.m.css
+++ b/src/split-pane/styles/split-pane.m.css
@@ -27,7 +27,8 @@
 	position: absolute;
 }
 
-.leadingFixed {
+.leadingFixed,
+.sizeTrailing .trailingFixed {
 	flex: 0 0 auto;
 }
 
@@ -55,7 +56,8 @@
 	width: 100%;
 }
 
-.trailingFixed {
+.trailingFixed,
+.sizeTrailing .leadingFixed {
 	flex: 1 1 0%;
 }
 

--- a/src/split-pane/styles/split-pane.m.css.d.ts
+++ b/src/split-pane/styles/split-pane.m.css.d.ts
@@ -2,6 +2,7 @@ export const rootFixed: string;
 export const rowFixed: string;
 export const dividerFixed: string;
 export const leadingFixed: string;
-export const columnFixed: string;
+export const sizeTrailing: string;
 export const trailingFixed: string;
+export const columnFixed: string;
 export const collapsedFixed: string;

--- a/src/split-pane/tests/unit/SplitPane.ts
+++ b/src/split-pane/tests/unit/SplitPane.ts
@@ -39,7 +39,7 @@ registerSuite('SplitPane', {
 		'Should construct SplitPane with passed properties'() {
 			const h = harness(() => w(SplitPane, {}));
 			h.expect(() => v('div', {
-				classes: [ css.root, null, css.column, fixedCss.rootFixed, fixedCss.columnFixed, null ],
+				classes: [ css.root, null, css.column, fixedCss.rootFixed, fixedCss.columnFixed, null, null ],
 				key: 'root'
 			}, [
 				w(GlobalEvent, {
@@ -81,7 +81,7 @@ registerSuite('SplitPane', {
 			]));
 
 			h.expect(() => v('div', {
-				classes: [ css.root, null, css.row, fixedCss.rootFixed, fixedCss.rowFixed, null ],
+				classes: [ css.root, null, css.row, fixedCss.rootFixed, fixedCss.rowFixed, null, null ],
 				key: 'root'
 			}, [
 				w(GlobalEvent, {

--- a/src/split-pane/tests/unit/SplitPane.ts
+++ b/src/split-pane/tests/unit/SplitPane.ts
@@ -112,6 +112,86 @@ registerSuite('SplitPane', {
 			]));
 		},
 
+		'Should apply size to trailing pane when sizeTrailing is true (rows)'() {
+			const h = harness(() => w(SplitPane, {
+				sizeTrailing: true,
+				size: 200
+			}, [ 'first', 'second' ]));
+
+			h.expect(() => v('div', {
+				classes: [ css.root, null, css.column, fixedCss.rootFixed, fixedCss.columnFixed, null, fixedCss.sizeTrailing ],
+				key: 'root'
+			}, [
+				w(GlobalEvent, {
+					key: 'global',
+					window: {
+						mouseup: noop,
+						mousemove: noop,
+						touchmove: noop
+					}
+				}),
+				v('div', {
+					classes: [ css.leading, fixedCss.leadingFixed ],
+					key: 'leading',
+					styles: ''
+				}, [ 'first' ]),
+				v('div', {
+					classes: [ css.divider, fixedCss.dividerFixed ],
+					key: 'divider',
+					onmousedown: noop,
+					ontouchend: noop,
+					ontouchstart: noop
+				}),
+				v('div', {
+					classes: [ css.trailing, fixedCss.trailingFixed ],
+					key: 'trailing',
+					styles: { width: '200px' }
+				}, [ 'second' ])
+			]));
+		},
+
+		'Should apply size to trailing pane when sizeTrailing is true (columns)'() {
+			const h = harness(() => w(SplitPane, {
+				direction: Direction.column,
+				onResize: noop,
+				size: 200
+			}, [
+				'abc',
+				'def'
+			]));
+
+			h.expect(() => v('div', {
+				classes: [ css.root, null, css.column, fixedCss.rootFixed, fixedCss.columnFixed, null, null ],
+				key: 'root'
+			}, [
+				w(GlobalEvent, {
+					key: 'global',
+					window: {
+						mouseup: noop,
+						mousemove: noop,
+						touchmove: noop
+					}
+				}),
+				v('div', {
+					classes: [ css.leading, fixedCss.leadingFixed ],
+					key: 'leading',
+					styles: { width: '200px' }
+				}, [ 'abc' ]),
+				v('div', {
+					classes: [ css.divider, fixedCss.dividerFixed ],
+					key: 'divider',
+					onmousedown: noop,
+					ontouchend: noop,
+					ontouchstart: noop
+				}),
+				v('div', {
+					classes: [ css.trailing, fixedCss.trailingFixed ],
+					key: 'trailing',
+					styles: ''
+				}, [ 'def' ])
+			]));
+		},
+
 		'Pane should not be a negative size'() {
 			let setSize;
 			const mockMeta = stub();

--- a/src/split-pane/tests/unit/SplitPane.ts
+++ b/src/split-pane/tests/unit/SplitPane.ts
@@ -64,7 +64,8 @@ registerSuite('SplitPane', {
 				}),
 				v('div', {
 					classes: [ css.trailing, fixedCss.trailingFixed ],
-					key: 'trailing'
+					key: 'trailing',
+					styles: ''
 				}, [])
 			]));
 		},
@@ -105,7 +106,8 @@ registerSuite('SplitPane', {
 				}),
 				v('div', {
 					classes: [ css.trailing, fixedCss.trailingFixed ],
-					key: 'trailing'
+					key: 'trailing',
+					styles: ''
 				}, [ 'def' ])
 			]));
 		},


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Add the ability to have `size` apply to the second pane in a `SplitPane`. This PR does it by adding a property named `sizeAppliesTo` that can be `0` (first pane, default) or `1` (second pane). Sample:

```ts
w(SplitPane, {
	key: 'secondSizeRow',
	direction: Direction.column,
	sizeAppliesTo: 1,
	onResize: (size: number) => {
		this.setState({ secondSizeRow: size });
	},
	size: this.state.secondSizeRow
})
```

Notes:
- If `sizeAppliesTo = 1`, the leading/trailing CSS classes are swapped (i.e. the second pane is considered the leading pane). If this could cause any issues, then new CSS classes should be added instead.
- I realize the name `sizeAppliesTo` may not be the best. Open to any suggestions.

Resolves #698 
