### PR TITLE
refactor slide-pane

### DIFF
--- a/src/slide-pane/index.ts
+++ b/src/slide-pane/index.ts
@@ -280,6 +280,7 @@ export class SlidePane extends I18nMixin(ThemedMixin(WidgetBase))<SlidePanePrope
 			closeText = `${messages.close} ${title}`;
 		}
 
+		// This is a side-effect of rendering, it clears the slide styles for the next render.
 		this._slide = undefined;
 
 		return v('div', {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This refactors the slide-pane to avoid a bug that was showing up (accurately) in our functional tests. I narrowed down the issue to some extra complexity in the transform implementation. The refactor includes the following changes:

- Only calculate transform styles one way
- Perform open/close change checking in a diff property rather than in the renderer
- Use a local state to define whether it is sliding in or out (still gets cleared on next render)
- Remove onAttach hook/state that hasn't been needed since a previous change which removed dom manipulation

Resolves #689
