### PR TITLE
Update combo a11y

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1071,7 +1071,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1083,7 +1082,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -5232,8 +5230,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5254,14 +5251,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5276,20 +5271,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5406,8 +5398,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5419,7 +5410,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5434,7 +5424,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5442,14 +5431,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5468,7 +5455,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5549,8 +5535,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5562,7 +5547,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5648,8 +5632,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5685,7 +5668,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5705,7 +5687,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5749,14 +5730,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -9008,8 +8987,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -376,6 +376,7 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 
 		return v('button', {
 			key: 'clear',
+			'aria-hidden': 'true',
 			classes: this.theme(css.clear),
 			disabled: disabled || readOnly,
 			tabIndex: -1,
@@ -400,7 +401,7 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 
 		return v('button', {
 			key: 'trigger',
-			'aria-controls': this._open ? this._getMenuId() : null,
+			'aria-hidden': 'true',
 			classes: this.theme(css.trigger),
 			disabled: disabled || readOnly,
 			tabIndex: -1,
@@ -489,7 +490,7 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 			v('div', {
 				'aria-expanded': this._open ? 'true' : 'false',
 				'aria-haspopup': 'listbox',
-				'aria-owns': this._open ? this._getMenuId() : '',
+				'aria-owns': this._open ? this._getMenuId() : null,
 				classes: this.theme(css.controls),
 				role: 'combobox'
 			}, [
@@ -502,7 +503,7 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 
 		return v('div', {
 			classes: this.theme(this.getRootClasses()),
-			key: 'root',
+			key: 'root'
 		}, labelAfter ? controls.reverse() : controls);
 	}
 }

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -348,7 +348,7 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 			classes,
 			aria: {
 				activedescendant: this._open ? this._getResultId(results[this._activeIndex], this._activeIndex) : null,
-				controls: this._open ? this._getMenuId() : null
+				autocomplete: 'list'
 			},
 			valid: typeof invalid === 'boolean' ? !invalid : undefined,
 			disabled,
@@ -376,9 +376,9 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 
 		return v('button', {
 			key: 'clear',
-			'aria-controls': this._open ? this._getMenuId() : null,
 			classes: this.theme(css.clear),
 			disabled: disabled || readOnly,
+			tabIndex: -1,
 			type: 'button',
 			onclick: this._onClearClick
 		}, [
@@ -400,6 +400,7 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 
 		return v('button', {
 			key: 'trigger',
+			'aria-controls': this._open ? this._getMenuId() : null,
 			classes: this.theme(css.trigger),
 			disabled: disabled || readOnly,
 			tabIndex: -1,
@@ -486,7 +487,11 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 				forId: widgetId
 			}, [ label ]) : null,
 			v('div', {
-				classes: this.theme(css.controls)
+				'aria-expanded': this._open ? 'true' : 'false',
+				'aria-haspopup': 'listbox',
+				'aria-owns': this._open ? this._getMenuId() : '',
+				classes: this.theme(css.controls),
+				role: 'combobox'
 			}, [
 				this.renderInput(results),
 				clearable ? this.renderClearButton(messages) : null,
@@ -496,12 +501,8 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 		];
 
 		return v('div', {
-			'aria-expanded': this._open ? 'true' : 'false',
-			'aria-haspopup': 'listbox',
-			'aria-required': required ? 'true' : null,
 			classes: this.theme(this.getRootClasses()),
 			key: 'root',
-			role: 'combobox'
 		}, labelAfter ? controls.reverse() : controls);
 	}
 }

--- a/src/combobox/tests/functional/ComboBox.ts
+++ b/src/combobox/tests/functional/ComboBox.ts
@@ -100,20 +100,14 @@ registerSuite('ComboBox', {
 			() => this.remote.pressKeys(keys.TAB);
 
 		return getPage(this.remote)
-			.findByCssSelector(`.${css.trigger}`)
+			.findByCssSelector(`input[type=text]`)
 				.click()
 				.sleep(DELAY)
 				.then(initialTab)
 			.getActiveElement()
-				.getProperty('textContent')
-				.then((text: string) => {
-					assert.strictEqual(text, 'clear Combo:', 'The "clear" button should receive focus.');
-				})
-				.type(keys.TAB)
-			.getActiveElement()
 				.getTagName()
 				.then((tag: string) => {
-					assert.strictEqual(tag.toLowerCase(), 'input', 'The results menu and "open" button should not receive focus.');
+					assert.strictEqual(tag.toLowerCase(), 'input', 'Only the input should be in the tab order');
 				});
 	},
 

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -19,6 +19,7 @@ import {
 	compareWidgetId,
 	compareAria,
 	compareAriaControls,
+	compareAriaOwns,
 	isFocusedComparator,
 	isNotFocusedComparator,
 	noop,
@@ -26,7 +27,7 @@ import {
 	stubEvent
 } from '../../../common/tests/support/test-helpers';
 
-const harness = createHarness([ compareId, compareWidgetId, compareAria, compareAriaControls ]);
+const harness = createHarness([ compareId, compareWidgetId, compareAria, compareAriaControls, compareAriaOwns ]);
 
 const testOptions: any[] = [
 	{
@@ -73,17 +74,20 @@ const compareFocusTrue = {
 	comparator: isFocusedComparator
 };
 
-const getExpectedControls = function(useTestProperties: boolean, label: boolean, states: States = {}) {
+const getExpectedControls = function(useTestProperties: boolean, label: boolean, open: boolean, states: States = {}) {
 	const { disabled, invalid, readOnly, required } = states;
 	const controlsVdom = v('div', {
-		classes: css.controls
+		'aria-expanded': open ? 'true' : 'false',
+		'aria-haspopup': 'listbox',
+		'aria-owns': '',
+		classes: css.controls,
+		role: 'combobox'
 	}, [
 		w(TextInput, {
 			key: 'textinput',
 			aria: {
 				activedescendant: '',
-				controls: '',
-				owns: ''
+				autocomplete: 'list'
 			},
 			disabled,
 			focus: noop,
@@ -100,10 +104,11 @@ const getExpectedControls = function(useTestProperties: boolean, label: boolean,
 			onKeyDown: noop
 		}),
 		useTestProperties ? v('button', {
-			'aria-controls': '',
+			'aria-hidden': 'true',
 			key: 'clear',
 			classes: css.clear,
 			disabled: disabled || readOnly,
+			tabIndex: -1,
 			type: 'button',
 			onclick: noop
 		}, [
@@ -114,6 +119,7 @@ const getExpectedControls = function(useTestProperties: boolean, label: boolean,
 		]) : null,
 		v('button', {
 			key: 'trigger',
+			'aria-hidden': 'true',
 			classes: css.trigger,
 			disabled: disabled || readOnly,
 			tabIndex: -1,
@@ -163,13 +169,10 @@ const getExpectedMenu = function(useTestProperties: boolean, open: boolean, over
 
 const getExpectedVdom = function(useTestProperties = false, open = false, label = false, states: States = {}, focused = false) {
 	const menuVdom = getExpectedMenu(useTestProperties, open);
-	const controlsVdom = getExpectedControls(useTestProperties, label, states);
+	const controlsVdom = getExpectedControls(useTestProperties, label, open, states);
 	const { disabled, invalid, readOnly, required } = states;
 
 	return v('div', {
-		'aria-expanded': open ? 'true' : 'false',
-		'aria-haspopup': 'listbox',
-		'aria-required': null,
 		classes: [
 			css.root,
 			open ? css.open : null,
@@ -178,8 +181,7 @@ const getExpectedVdom = function(useTestProperties = false, open = false, label 
 			null,
 			null
 		],
-		key: 'root',
-		role: 'combobox'
+		key: 'root'
 	}, [
 		label ? w(Label, {
 			key: 'label',
@@ -528,10 +530,11 @@ registerSuite('ComboBox', {
 			}, [ 'foo' ]));
 
 			h.expectPartial('@clear', () => v('button', {
-				'aria-controls': null,
 				key: 'clear',
+				'aria-hidden': 'true',
 				classes: css.clear,
 				disabled: true,
+				tabIndex: -1,
 				type: 'button',
 				onclick: noop
 			}, [
@@ -543,6 +546,7 @@ registerSuite('ComboBox', {
 
 			h.expectPartial('@trigger', () => v('button', {
 				key: 'trigger',
+				'aria-hidden': 'true',
 				classes: css.trigger,
 				disabled: true,
 				tabIndex: -1,

--- a/src/common/tests/support/test-helpers.ts
+++ b/src/common/tests/support/test-helpers.ts
@@ -52,6 +52,12 @@ export const compareAriaLabelledBy = {
 	comparator: isStringComparator
 };
 
+export const compareAriaOwns = {
+	selector: '*',
+	property: 'aria-owns',
+	comparator: isStringComparator
+};
+
 export const compareAriaDescribedBy = {
 	selector: '*',
 	property: 'aria-describedby',

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -209,7 +209,7 @@ export class Listbox extends ThemedMixin(FocusMixin(WidgetBase))<ListboxProperti
 		const disabled = this._getOptionDisabled(option, index);
 		const selected = getOptionSelected ? getOptionSelected(option, index) : false;
 
-		return v('div', { key: this._getOptionId(index) }, [
+		return v('div', { key: this._getOptionId(index), role: 'presentation' }, [
 			w(ListboxOption, {
 				active: activeIndex === index,
 				css: this.getOptionClasses(activeIndex === index, disabled, selected),

--- a/src/listbox/tests/unit/Listbox.ts
+++ b/src/listbox/tests/unit/Listbox.ts
@@ -41,7 +41,7 @@ const testOptions: any[] = [
 ];
 
 const expectedFirstOption = (overrides: Partial<ListboxOptionProperties> = {}) => {
-	return v('div', { key: 'first' }, [
+	return v('div', { key: 'first', role: 'presentation' }, [
 		w(ListboxOption, {
 			active: false,
 			css: [ css.option, css.activeOption, null, null ],
@@ -61,7 +61,7 @@ const expectedFirstOption = (overrides: Partial<ListboxOptionProperties> = {}) =
 };
 
 const expectedSecondOption = (overrides: Partial<ListboxOptionProperties> = {}) => {
-	return v('div', { key: '1' }, [
+	return v('div', { key: '1', role: 'presentation' }, [
 		w(ListboxOption, {
 			active: false,
 			css: [ css.option, null, null, null ],
@@ -81,7 +81,7 @@ const expectedSecondOption = (overrides: Partial<ListboxOptionProperties> = {}) 
 };
 
 const expectedThirdOption = (overrides: Partial<ListboxOptionProperties> = {}) => {
-	return v('div', { key: '2' }, [
+	return v('div', { key: '2', role: 'presentation' }, [
 		w(ListboxOption, {
 			active: false,
 			css: [ css.option, null, null, null ],

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -279,7 +279,8 @@ export class TextInput extends ThemedMixin(FocusMixin(WidgetBase))<TextInputProp
 
 		return v('div', {
 			key: 'root',
-			classes: this.theme(this.getRootClasses())
+			classes: this.theme(this.getRootClasses()),
+			role: 'presentation'
 		}, [
 			label && w(Label, {
 				theme,
@@ -292,7 +293,11 @@ export class TextInput extends ThemedMixin(FocusMixin(WidgetBase))<TextInputProp
 				hidden: labelHidden,
 				forId: widgetId
 			}, [ label ]),
-			v('div', { key: 'inputWrapper', classes: this.theme(css.inputWrapper) }, [
+			v('div', {
+				key: 'inputWrapper',
+				classes: this.theme(css.inputWrapper),
+				role: 'presentation'
+			}, [
 				leading && v('span', { key: 'leading', classes: this.theme(css.leading) }, [ leading() ]),
 				v('input', {
 					...formatAriaProperties(aria),

--- a/src/text-input/tests/unit/TextInput.ts
+++ b/src/text-input/tests/unit/TextInput.ts
@@ -47,6 +47,7 @@ const expected = function({ label = false, inputOverrides = {}, states = {}, foc
 
 	return v('div', {
 		key: 'root',
+		role: 'presentation',
 		classes: [ css.root, disabled ? css.disabled : null, focused ? css.focused : null, valid === false ? css.invalid : null, valid === true ? css.valid : null, readOnly ? css.readonly : null, required ? css.required : null, null, null ]
 	}, [
 		label ? w(Label, {
@@ -60,7 +61,7 @@ const expected = function({ label = false, inputOverrides = {}, states = {}, foc
 			required,
 			forId: ''
 		}, [ 'foo' ]) : null,
-		v('div', { key: 'inputWrapper', classes: css.inputWrapper }, [
+		v('div', { key: 'inputWrapper', role: 'presentation', classes: css.inputWrapper }, [
 			v('input', {
 				key: 'input',
 				classes: css.input,
@@ -102,9 +103,10 @@ const expected = function({ label = false, inputOverrides = {}, states = {}, foc
 const baseTemplate = assertationTemplate(() => {
 	return v('div', {
 		key: 'root',
+		role: 'presentation',
 		classes: [ css.root, null, null, null, null, null, null, null, null ]
 	}, [
-		v('div', { key: 'inputWrapper', classes: css.inputWrapper }, [
+		v('div', { key: 'inputWrapper', role: 'presentation', classes: css.inputWrapper }, [
 			v('input', {
 				key: 'input',
 				classes: css.input,

--- a/src/theme/text-input.m.css.d.ts
+++ b/src/theme/text-input.m.css.d.ts
@@ -10,4 +10,5 @@ export const leading: string;
 export const trailing: string;
 export const hasLeading: string;
 export const hasTrailing: string;
+export const helperText: string;
 export const valid: string;


### PR DESCRIPTION
Hey, remember me? 😉

I've been working on combobox accessibility, so I updated the combo widget with a few things that should make it play nice with more screen reader/browser pairings.

**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/meta/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Improves semantics surfaced by screen readers, particularly when using form navigation shortcuts and in announcing combobox role and expanded/collapsed state when landing on the input. The changes include:

- Using `role="presentation"` on intermediary divs to establish a direct relationship between the combobox and the input
- Remove `aria-controls` as it isn't well used or supported, and the functionality it provides would not be desired in this case, as focus should remain on the input
- Make the clear/trigger buttons hidden from a screen reader, so the input is the only control surfaced when navigating by form field or tabbing. It is already easy to clear and open the combo with a keyboard, so this seems like a better user experience.
- Add aria-autocomplete. This is making an assumption, since it's set to the correct value if the behavior is to filter options in some way based on the typed text.
