### PR TITLE
[ISSUE-677] Helpertext on combobox

### DIFF
--- a/src/combobox/example/index.ts
+++ b/src/combobox/example/index.ts
@@ -65,7 +65,10 @@ export default class App extends WidgetBase {
 	private _value7 = '';
 	private _value8 = '';
 	private _value9 = '';
-	private _valid = true;
+	private _valid: { valid: boolean | undefined; message: string } = {
+		valid: true,
+		message: 'Please enter value of state'
+	};
 
 	onChange(value: string, key?: string) {
 		if (!key) {
@@ -179,20 +182,21 @@ export default class App extends WidgetBase {
 					required: true,
 					onChange: (value: string) => {
 						this._value9 = value;
-						this._valid = value.trim().length !== 0;
+						this._valid.valid = value.trim().length !== 0;
 						this.invalidate();
 					},
 					getResultLabel: (result: any) => result.value,
 					onRequestResults,
 					results: this._results,
 					value: this._value9,
-					valid: { valid: this._valid, message: 'Please enter value of state' },
+					valid: this._valid,
 					helperText: 'helper text',
-					onValidate: (valid: boolean | undefined, message: string) => {
-						console.log('onValidate called', valid, message);
-					},
 					inputProperties: {
 						placeholder: 'Enter a value'
+					},
+					onValidate: (valid: boolean | undefined) => {
+						this._valid.valid = valid;
+						this.invalidate();
 					}
 				})
 			]

--- a/src/combobox/example/index.ts
+++ b/src/combobox/example/index.ts
@@ -65,7 +65,7 @@ export default class App extends WidgetBase {
 	private _value7 = '';
 	private _value8 = '';
 	private _value9 = '';
-	private _invalid = false;
+	private _valid = true;
 
 	onChange(value: string, key?: string) {
 		if (!key) {
@@ -89,7 +89,6 @@ export default class App extends WidgetBase {
 
 	render(): DNode {
 		const { onChange, onRequestResults } = this;
-
 		return v(
 			'div',
 			{
@@ -180,14 +179,18 @@ export default class App extends WidgetBase {
 					required: true,
 					onChange: (value: string) => {
 						this._value9 = value;
-						this._invalid = value.trim().length === 0;
+						this._valid = value.trim().length !== 0;
 						this.invalidate();
 					},
 					getResultLabel: (result: any) => result.value,
 					onRequestResults,
 					results: this._results,
 					value: this._value9,
-					invalid: this._invalid,
+					valid: { valid: this._valid, message: 'Please enter value of state' },
+					helperText: 'helper text',
+					onValidate: (valid: boolean | undefined, message: string) => {
+						console.log('onValidate called', valid, message);
+					},
 					inputProperties: {
 						placeholder: 'Enter a value'
 					}

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -58,7 +58,7 @@ export interface ComboBoxProperties extends ThemedProperties, LabeledProperties,
 	helperText?: string;
 	widgetId?: string;
 	inputProperties?: TextInputProperties;
-	valid?: { valid?: boolean; message?: string; } | boolean;
+	valid?: { valid?: boolean; message?: string } | boolean;
 	isResultDisabled?(result: any): boolean;
 	onBlur?(value: string, key?: string | number): void;
 	onChange?(value: string, key?: string | number): void;
@@ -104,7 +104,15 @@ export enum Operation {
 		'results'
 	],
 	attributes: ['widgetId', 'label', 'value'],
-	events: ['onBlur', 'onChange', 'onFocus', 'onMenuChange', 'onRequestResults', 'onResultSelect', 'onValidate']
+	events: [
+		'onBlur',
+		'onChange',
+		'onFocus',
+		'onMenuChange',
+		'onRequestResults',
+		'onResultSelect',
+		'onValidate'
+	]
 })
 export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<ComboBoxProperties> {
 	private _activeIndex = 0;
@@ -293,26 +301,6 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 		this.invalidate();
 	}
 
-	protected getRootClasses(): (string | null)[] {
-		const {
-			clearable
-		} = this.properties;
-
-		const {
-			valid
-		} = this.validity;
-		const focus = this.meta(Focus).get('root');
-
-		return [
-			css.root,
-			this._open ? css.open : null,
-			clearable ? css.clearable : null,
-			focus.containsFocus ? css.focused : null,
-			valid === false ? css.invalid : null,
-			valid === true ? css.valid : null
-		];
-	}
-
 	protected get validity() {
 		const { valid = { valid: undefined, message: undefined } } = this.properties;
 
@@ -467,9 +455,7 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 			classes
 		} = this.properties;
 
-		const {
-			valid
-		} = this.validity;
+		const { valid } = this.validity;
 
 		const { messages } = this.localizeBundle(commonBundle);
 		const focus = this.meta(Focus).get('root');
@@ -481,6 +467,15 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 			this._open = false;
 			this.invalidate();
 		}
+
+		const rootClasses = [
+			css.root,
+			this._open ? css.open : null,
+			clearable ? css.clearable : null,
+			focus.containsFocus ? css.focused : null,
+			valid === false ? css.invalid : null,
+			valid === true ? css.valid : null
+		];
 
 		this._wasOpen = this._open;
 
@@ -524,7 +519,7 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 		return v(
 			'div',
 			{
-				classes: this.theme(this.getRootClasses()),
+				classes: this.theme(rootClasses),
 				key: 'root'
 			},
 			labelAfter ? controls.reverse() : controls

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -31,6 +31,7 @@ import { customElement } from '@dojo/framework/widget-core/decorators/customElem
  * @property getResultLabel     Can be used to get the text label of a result based on the underlying result object
  * @property getResultSelected  Can be used to highlight the selected result. Defaults to checking the result label
  * @property getResultValue     Can be used to define a value returned by onChange when a given result is selected. Defaults to getResultLabel
+ * @property helpertext			Displays text at bottom of widget
  * @property widgetId           Optional id string for the combobox, set on the text input
  * @property inputProperties    TextInput properties to set on the underlying input
  * @property invalid            Determines if this input is valid

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -20,6 +20,7 @@ import { CommonMessages, LabeledProperties } from '../common/interfaces';
 import * as css from '../theme/combobox.m.css';
 import * as baseCss from '../common/styles/base.m.css';
 import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import HelperText from '../helper-text/index';
 
 /**
  * @type ComboBoxProperties
@@ -322,11 +323,10 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 			required,
 			value = '',
 			theme,
-			helperText,
 			onValidate
 		} = this.properties;
 
-		const { valid, message } = this.validity;
+		const { valid } = this.validity;
 
 		return w(TextInput, {
 			...inputProperties,
@@ -338,10 +338,9 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 					: null,
 				autocomplete: 'list'
 			},
-			valid: { valid, message: this._open ? undefined : message },
+			valid,
 			disabled,
 			widgetId,
-			helperText: this._open ? undefined : helperText,
 			focus: this.shouldFocus,
 			onBlur: this._onInputBlur,
 			onFocus: this._onInputFocus,
@@ -449,10 +448,11 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 			labelHidden,
 			results = [],
 			theme,
-			classes
+			classes,
+			helperText
 		} = this.properties;
 
-		const { valid } = this.validity;
+		const { valid, message } = this.validity;
 
 		const { messages } = this.localizeBundle(commonBundle);
 		const focus = this.meta(Focus).get('root');
@@ -510,6 +510,11 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 					this.renderMenuButton(messages)
 				]
 			),
+			!this._open &&
+				w(HelperText, {
+					text: valid ? helperText : message,
+					valid
+				}),
 			menu
 		];
 

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -87,7 +87,6 @@ export enum Operation {
 		'theme',
 		'classes',
 		'extraClasses',
-		'labelAfter',
 		'labelHidden',
 		'clearable',
 		'disabled',
@@ -95,7 +94,6 @@ export enum Operation {
 		'valid',
 		'isResultDisabled',
 		'helperText',
-		'labelAfter',
 		'labelHidden',
 		'openOnFocus',
 		'readOnly',
@@ -448,7 +446,6 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 			required,
 			disabled,
 			labelHidden,
-			labelAfter,
 			results = [],
 			theme,
 			classes
@@ -521,7 +518,7 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 				classes: this.theme(rootClasses),
 				key: 'root'
 			},
-			labelAfter ? controls.reverse() : controls
+			controls
 		);
 	}
 }

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -20,7 +20,6 @@ import { CommonMessages, LabeledProperties } from '../common/interfaces';
 import * as css from '../theme/combobox.m.css';
 import * as baseCss from '../common/styles/base.m.css';
 import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
-import HelperText from '../helper-text';
 
 /**
  * @type ComboBoxProperties

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -111,7 +111,7 @@ const getExpectedControls = function(
 				focus: noop,
 				helperText: helperText || undefined,
 				widgetId: useTestProperties ? 'foo' : '',
-				valid: validity || undefined,
+				valid: validity,
 				readOnly,
 				required,
 				theme: useTestProperties ? {} : undefined,

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -26,6 +26,7 @@ import {
 	MockMetaMixin,
 	stubEvent
 } from '../../../common/tests/support/test-helpers';
+import HelperText from '../../../helper-text';
 
 const harness = createHarness([
 	compareId,
@@ -87,10 +88,11 @@ const getExpectedControls = function(
 	label: boolean,
 	open: boolean,
 	states: States = {},
-	validity?: { valid: boolean | undefined, message: string | undefined},
+	validity: { valid: boolean | undefined; message: string | undefined },
 	helperText?: string
 ) {
 	const { disabled, readOnly, required } = states;
+	const { valid = undefined } = validity;
 	const controlsVdom = v(
 		'div',
 		{
@@ -109,9 +111,8 @@ const getExpectedControls = function(
 				},
 				disabled,
 				focus: noop,
-				helperText: helperText || undefined,
 				widgetId: useTestProperties ? 'foo' : '',
-				valid: validity,
+				valid,
 				readOnly,
 				required,
 				theme: useTestProperties ? {} : undefined,
@@ -121,7 +122,7 @@ const getExpectedControls = function(
 				onFocus: noop,
 				onInput: noop,
 				onKeyDown: noop,
-				onValidate: undefined,
+				onValidate: undefined
 			}),
 			useTestProperties
 				? v(
@@ -216,12 +217,23 @@ const getExpectedVdom = function(
 	label = false,
 	states: States = {},
 	focused = false,
-	validity: { valid: boolean | undefined, message: string | undefined} = {valid: undefined, message: undefined},
+	validity: { valid: boolean | undefined; message: string | undefined } = {
+		valid: undefined,
+		message: undefined
+	},
 	helperText?: string
 ) {
 	const menuVdom = getExpectedMenu(useTestProperties, open);
-	const controlsVdom = getExpectedControls(useTestProperties, label, open, states, validity, helperText);
+	const controlsVdom = getExpectedControls(
+		useTestProperties,
+		label,
+		open,
+		states,
+		validity,
+		helperText
+	);
 	const { disabled, readOnly, required } = states;
+	const { valid, message } = validity;
 
 	return v(
 		'div',
@@ -256,6 +268,11 @@ const getExpectedVdom = function(
 				  )
 				: null,
 			controlsVdom,
+			!open &&
+				w(HelperText, {
+					text: valid ? helperText : message,
+					valid
+				}),
 			menuVdom
 		]
 	);
@@ -605,16 +622,12 @@ registerSuite('ComboBox', {
 					placeholder: 'foo',
 					focus: noop,
 					disabled: undefined,
-					valid: {
-						valid: undefined,
-						message: undefined
-					},
+					valid: undefined,
 					widgetId: '',
 					readOnly: undefined,
 					required: undefined,
 					theme: undefined,
 					classes: undefined,
-					helperText: undefined,
 					value: '',
 					onBlur: noop,
 					onFocus: noop,
@@ -659,17 +672,13 @@ registerSuite('ComboBox', {
 						owns: ''
 					},
 					widgetId: 'foo',
-					valid: {
-						valid: undefined,
-						message: undefined
-					},
+					valid: undefined,
 					focus: noop,
 					disabled: true,
 					readOnly: true,
 					required: true,
 					theme: {},
 					classes: undefined,
-					helperText: undefined,
 					value: 'one',
 					onBlur: noop,
 					onFocus: noop,
@@ -746,15 +755,11 @@ registerSuite('ComboBox', {
 						owns: ''
 					},
 					widgetId: 'foo',
-					valid: {
-						valid: undefined,
-						message: undefined
-					},
+					valid: undefined,
 					focus: noop,
 					disabled: true,
 					readOnly: true,
 					required: true,
-					helperText: undefined,
 					theme: {},
 					value: 'one',
 					onBlur: noop,
@@ -833,49 +838,94 @@ registerSuite('ComboBox', {
 		},
 
 		'renders helpertext'() {
-			const h = harness(() => w(ComboBox, {
-				...testProperties,
-				helperText: helperText
-			}));
-			h.expect(() =>  getExpectedVdom(true, false, true, {}, false, {valid: undefined, message: undefined}, helperText));
+			const h = harness(() =>
+				w(ComboBox, {
+					...testProperties,
+					helperText: helperText
+				})
+			);
+			h.expect(() =>
+				getExpectedVdom(
+					true,
+					false,
+					true,
+					{},
+					false,
+					{ valid: undefined, message: undefined },
+					helperText
+				)
+			);
 		},
 
 		'renders validity correctly'() {
-			let h = harness(() => w(ComboBox, {
-				...testProperties,
-				valid: undefined
-			}));
-			h.expect(() =>  getExpectedVdom(true, false, true, {}, false, {valid: undefined, message: undefined}));
+			let h = harness(() =>
+				w(ComboBox, {
+					...testProperties,
+					valid: undefined
+				})
+			);
+			h.expect(() =>
+				getExpectedVdom(true, false, true, {}, false, {
+					valid: undefined,
+					message: undefined
+				})
+			);
 
-			h = harness(() => w(ComboBox, {
-				...testProperties,
-				valid: true
-			}));
-			h.expect(() =>  getExpectedVdom(true, false, true, {}, false, {valid: true, message: undefined}));
+			h = harness(() =>
+				w(ComboBox, {
+					...testProperties,
+					valid: true
+				})
+			);
+			h.expect(() =>
+				getExpectedVdom(true, false, true, {}, false, { valid: true, message: undefined })
+			);
 
-			h = harness(() => w(ComboBox, {
-				...testProperties,
-				valid: false
-			}));
-			h.expect(() =>  getExpectedVdom(true, false, true, {}, false, {valid: false, message: undefined}));
+			h = harness(() =>
+				w(ComboBox, {
+					...testProperties,
+					valid: false
+				})
+			);
+			h.expect(() =>
+				getExpectedVdom(true, false, true, {}, false, { valid: false, message: undefined })
+			);
 
-			h = harness(() => w(ComboBox, {
-				...testProperties,
-				valid: {valid: true, message: invalidMessage}
-			}));
-			h.expect(() =>  getExpectedVdom(true, false, true, {}, false, {valid: true, message: invalidMessage}));
+			h = harness(() =>
+				w(ComboBox, {
+					...testProperties,
+					valid: { valid: true, message: invalidMessage }
+				})
+			);
+			h.expect(() =>
+				getExpectedVdom(true, false, true, {}, false, {
+					valid: true,
+					message: invalidMessage
+				})
+			);
 
-			h = harness(() => w(ComboBox, {
-				...testProperties,
-				valid: {valid: false, message: invalidMessage}
-			}));
-			h.expect(() =>  getExpectedVdom(true, false, true, {}, false, {valid: false, message: invalidMessage}));
+			h = harness(() =>
+				w(ComboBox, {
+					...testProperties,
+					valid: { valid: false, message: invalidMessage }
+				})
+			);
+			h.expect(() =>
+				getExpectedVdom(true, false, true, {}, false, {
+					valid: false,
+					message: invalidMessage
+				})
+			);
 
-			h = harness(() => w(ComboBox, {
-				...testProperties,
-				valid: {valid: false, message: undefined}
-			}));
-			h.expect(() =>  getExpectedVdom(true, false, true, {}, false, {valid: false, message: undefined}));
+			h = harness(() =>
+				w(ComboBox, {
+					...testProperties,
+					valid: { valid: false, message: undefined }
+				})
+			);
+			h.expect(() =>
+				getExpectedVdom(true, false, true, {}, false, { valid: false, message: undefined })
+			);
 		}
 	}
 });

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -26,7 +26,7 @@ import {
 	MockMetaMixin,
 	stubEvent
 } from '../../../common/tests/support/test-helpers';
-import HelperText from '../../../helper-text';
+import HelperText from '../../../helper-text/index';
 
 const harness = createHarness([
 	compareId,

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -39,7 +39,7 @@ interface TextInputInternalState {
  * @property maxLength      Maximum number of characters allowed in the input
  * @property minLength      Minimum number of characters allowed in the input
  * @property placeholder    Placeholder text
- * @property value           The current value
+ * @property value          The current value
  * @property leading		Renderer for leading icon content
  * @property trailing		Renderer for trailing icon content
  */

--- a/src/theme/combobox.m.css
+++ b/src/theme/combobox.m.css
@@ -29,7 +29,7 @@
 	cursor: pointer;
 	border: none;
 	background: none;
-	top: 50%;
+	top: .5rem;
 	transform: translateY(-50%);
 	padding: 0;
 }

--- a/src/time-picker/index.ts
+++ b/src/time-picker/index.ts
@@ -315,7 +315,7 @@ export class TimePicker extends ThemedMixin(FocusMixin(WidgetBase))<TimePickerPr
 			widgetId,
 			focus: this.shouldFocus,
 			inputProperties,
-			invalid,
+			valid: !invalid,
 			isResultDisabled: isOptionDisabled,
 			label,
 			labelAfter,

--- a/src/time-picker/tests/unit/TimePicker.ts
+++ b/src/time-picker/tests/unit/TimePicker.ts
@@ -39,7 +39,7 @@ const getExpectedCombobox = function(useTestProperties = false, results?: any[])
 		widgetId: useTestProperties ? 'foo' : '',
 		focus: noop,
 		inputProperties: undefined,
-		invalid: useTestProperties ? true : undefined,
+		valid: useTestProperties ? false : true,
 		isResultDisabled: undefined,
 		label: useTestProperties ? 'Some Field' : undefined,
 		labelAfter: undefined,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:** 
- Adds helpertext to combobox widget
- Adds onValidate property to the combobox widget
- Updates valid property to use most recent type interface `{valid: boolean, message: string}` instead of a boolean.

Contributes to #677 
