### PR TITLE
enable noUnusedLocals and clean up violations

### DIFF
--- a/src/button/example/index.ts
+++ b/src/button/example/index.ts
@@ -1,5 +1,4 @@
 import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import renderer from '@dojo/framework/widget-core/vdom';
 import { w, v } from '@dojo/framework/widget-core/d';
 import Button from '../../button/index';
 

--- a/src/calendar/DatePicker.ts
+++ b/src/calendar/DatePicker.ts
@@ -342,8 +342,6 @@ export class DatePicker extends ThemedMixin(WidgetBase)<DatePickerProperties> {
 	protected render(): DNode {
 		const { labelId = `${this._idBase}_label`, labels, month, year } = this.properties;
 
-		const { first: minYear, last: maxYear } = this._getYearRange();
-
 		return v(
 			'div',
 			{

--- a/src/calendar/example/index.ts
+++ b/src/calendar/example/index.ts
@@ -1,5 +1,4 @@
 import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import renderer from '@dojo/framework/widget-core/vdom';
 import { v, w } from '@dojo/framework/widget-core/d';
 import Calendar from '../../calendar/index';
 

--- a/src/calendar/index.ts
+++ b/src/calendar/index.ts
@@ -122,7 +122,7 @@ export class Calendar extends I18nMixin(ThemedMixin(WidgetBase))<CalendarPropert
 	}
 
 	private _getMonthYear() {
-		const { month, selectedDate = this._defaultDate, year, minDate, maxDate } = this.properties;
+		const { month, selectedDate = this._defaultDate, year } = this.properties;
 
 		return {
 			month: typeof month === 'number' ? month : selectedDate.getMonth(),

--- a/src/calendar/tests/unit/Calendar.ts
+++ b/src/calendar/tests/unit/Calendar.ts
@@ -20,7 +20,6 @@ import {
 	stubEvent
 } from '../../../common/tests/support/test-helpers';
 import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
-import { register } from '@dojo/framework/widget-core/registerCustomElement';
 
 const testDate = new Date('June 5 2017');
 const harness = createHarness([compareId, compareLabelId, compareAriaLabelledBy]);

--- a/src/calendar/tests/unit/DatePicker.ts
+++ b/src/calendar/tests/unit/DatePicker.ts
@@ -317,10 +317,6 @@ const expected = function(monthOpen = false, yearOpen = false, options: Expected
 	);
 };
 
-interface TestEventInit extends EventInit {
-	which: number;
-}
-
 registerSuite('Calendar DatePicker', {
 	tests: {
 		'Popup should render with default properties'() {

--- a/src/calendar/tests/unit/date-utils.ts
+++ b/src/calendar/tests/unit/date-utils.ts
@@ -1,7 +1,7 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
-import { monthInMin, monthInMax } from '../../date-utils';
+import { monthInMin } from '../../date-utils';
 
 registerSuite('Calendar date utils', {
 	tests: {

--- a/src/combobox/tests/functional/ComboBox.ts
+++ b/src/combobox/tests/functional/ComboBox.ts
@@ -19,17 +19,9 @@ function getPage(remote: Remote) {
 
 registerSuite('ComboBox', {
 	'the results menu should be visible'() {
-		let inputWidth: number;
-
 		return getPage(this.remote)
 			.findByCssSelector(`.${css.trigger}`)
 			.click()
-			.end()
-			.findByCssSelector(`.${css.controls} input`)
-			.getSize()
-			.then(({ width }) => {
-				inputWidth = width;
-			})
 			.end()
 			.sleep(DELAY)
 			.findByCssSelector(`.${css.dropdown}`)

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -173,7 +173,6 @@ export class Dialog extends I18nMixin(ThemedMixin(WidgetBase))<DialogProperties>
 			closeText,
 			enterAnimation = this.theme(css.enter),
 			exitAnimation = this.theme(css.exit),
-			modal,
 			open = false,
 			role = 'dialog',
 			title = '',

--- a/src/dialog/tests/unit/Dialog.ts
+++ b/src/dialog/tests/unit/Dialog.ts
@@ -507,7 +507,7 @@ registerSuite('Dialog', {
 					get: mockFocusGet,
 					set: mockFocusSet
 				});
-				const h = harness(() => w(MockMetaMixin(Dialog, mockMeta), { open: true }));
+				harness(() => w(MockMetaMixin(Dialog, mockMeta), { open: true }));
 				assert.isTrue(mockFocusSet.calledOnce, 'focus set when dialog is opened');
 			},
 
@@ -522,7 +522,7 @@ registerSuite('Dialog', {
 					get: mockFocusGet,
 					set: mockFocusSet
 				});
-				const h = harness(() => w(MockMetaMixin(Dialog, mockMeta), { open: true }));
+				harness(() => w(MockMetaMixin(Dialog, mockMeta), { open: true }));
 				assert.isFalse(mockFocusSet.called, 'focus not set when dialog is already focused');
 			},
 

--- a/src/grid/Body.ts
+++ b/src/grid/Body.ts
@@ -158,12 +158,10 @@ export default class Body<S> extends ThemedMixin(WidgetBase)<BodyProperties<S>> 
 			placeholderRowRenderer = defaultPlaceholderRowRenderer,
 			totalRows = 0,
 			pageSize,
-			columnConfig,
 			height
 		} = this.properties;
 
 		if (!this._rowHeight) {
-			const hasFilters = columnConfig.some((config) => !!config.filterable);
 			const firstRow = placeholderRowRenderer(0);
 			const dimensions = offscreen(firstRow);
 			this._rowHeight = dimensions.height;

--- a/src/grid/Cell.ts
+++ b/src/grid/Cell.ts
@@ -82,7 +82,7 @@ export default class Cell extends ThemedMixin(FocusMixin(WidgetBase))<CellProper
 	}
 
 	protected render(): DNode {
-		let { editable, rawValue, value, theme, classes } = this.properties;
+		let { editable, rawValue, theme, classes } = this.properties;
 
 		return v('div', { role: 'cell', classes: [this.theme(css.root), fixedCss.rootFixed] }, [
 			this._editing

--- a/src/grid/Header.ts
+++ b/src/grid/Header.ts
@@ -1,7 +1,7 @@
 import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
 import { v, w } from '@dojo/framework/widget-core/d';
 import ThemedMixin, { theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { ColumnConfig, FilterOptions, SortOptions } from './interfaces';
+import { ColumnConfig, SortOptions } from './interfaces';
 import { DNode } from '@dojo/framework/widget-core/interfaces';
 import TextInput from '../text-input/index';
 import Icon from '../icon/index';
@@ -94,12 +94,9 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 	protected render(): DNode {
 		const {
 			columnConfig,
-			sorter,
 			sort,
 			filterer,
 			filter = {},
-			theme,
-			classes,
 			sortRenderer = this._sortRenderer,
 			filterRenderer = this._filterRenderer
 		} = this.properties;

--- a/src/grid/index.ts
+++ b/src/grid/index.ts
@@ -134,7 +134,6 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 		const meta = this._store.get(this._store.path(storeId, 'meta')) || defaultGridMeta;
 		const pages = this._store.get(this._store.path(storeId, 'data', 'pages')) || {};
 		const hasFilters = columnConfig.some((config) => !!config.filterable);
-		const containerDimensions = this.meta(Dimensions).get('root');
 		const bodyHeight = this._getBodyHeight();
 		this.meta(Resize).get('root');
 

--- a/src/grid/processes.ts
+++ b/src/grid/processes.ts
@@ -152,7 +152,6 @@ const filterCommand = commandFactory<FilterCommandPayload>(
 			return [];
 		}
 
-		const filters = get(path(id, 'meta', 'filter'));
 		if (filterOptions !== get(path(id, 'meta', 'currentFilter'))) {
 			throw new Error();
 		}

--- a/src/helper-text/index.ts
+++ b/src/helper-text/index.ts
@@ -1,5 +1,4 @@
 import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { I18nMixin } from '@dojo/framework/widget-core/mixins/I18n';
 import { theme, ThemedMixin } from '@dojo/framework/widget-core/mixins/Themed';
 import * as css from '../theme/helper-text.m.css';
 import { v } from '@dojo/framework/widget-core/d';

--- a/src/helper-text/tests/unit/HelperText.ts
+++ b/src/helper-text/tests/unit/HelperText.ts
@@ -1,5 +1,4 @@
 const { registerSuite } = intern.getInterface('object');
-const { assert } = intern.getPlugin('chai');
 
 import { v, w } from '@dojo/framework/widget-core/d';
 import assertationTemplate from '@dojo/framework/testing/assertionTemplate';

--- a/src/label/index.ts
+++ b/src/label/index.ts
@@ -1,4 +1,3 @@
-import { uuid } from '@dojo/framework/core/util';
 import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
 import { DNode } from '@dojo/framework/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';

--- a/src/listbox/tests/unit/Listbox.ts
+++ b/src/listbox/tests/unit/Listbox.ts
@@ -33,10 +33,6 @@ const compareAriaActiveDescendant = {
 
 const harness = createHarness([compareId, compareAriaActiveDescendant]);
 
-interface TestEventInit extends EventInit {
-	which: number;
-}
-
 const testOptions: any[] = [
 	{
 		label: 'One',

--- a/src/select/tests/unit/Select.ts
+++ b/src/select/tests/unit/Select.ts
@@ -38,10 +38,6 @@ const compareTriggerFocused = {
 	comparator: isFocusedComparator
 };
 
-interface TestEventInit extends EventInit {
-	which: number;
-}
-
 interface States {
 	invalid?: boolean;
 	disabled?: boolean;

--- a/src/slide-pane/index.ts
+++ b/src/slide-pane/index.ts
@@ -85,7 +85,7 @@ export class SlidePane extends I18nMixin(ThemedMixin(WidgetBase))<SlidePanePrope
 	}
 
 	@diffProperty('open')
-	private _onOpenChange(
+	protected _onOpenChange(
 		oldProperties: Partial<SlidePaneProperties>,
 		newProperties: Partial<SlidePaneProperties>
 	) {
@@ -148,7 +148,7 @@ export class SlidePane extends I18nMixin(ThemedMixin(WidgetBase))<SlidePanePrope
 		}
 		this._hasMoved = true;
 
-		const { align = Align.left, width = DEFAULT_WIDTH } = this.properties;
+		const { width = DEFAULT_WIDTH } = this.properties;
 
 		const delta = this._getDelta(event, 'touchmove');
 
@@ -257,15 +257,7 @@ export class SlidePane extends I18nMixin(ThemedMixin(WidgetBase))<SlidePanePrope
 	}
 
 	protected render(): DNode {
-		let {
-			aria = {},
-			closeText,
-			onOpen,
-			open = false,
-			title = '',
-			theme,
-			classes
-		} = this.properties;
+		let { aria = {}, closeText, open = false, title = '', theme, classes } = this.properties;
 
 		const contentStyles = this.getStyles();
 		const contentClasses = this.getModifierClasses();

--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -2,7 +2,6 @@ import { DNode } from '@dojo/framework/widget-core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
 import { v, w } from '@dojo/framework/widget-core/d';
 import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { auto } from '@dojo/framework/widget-core/diff';
 import { diffProperty } from '@dojo/framework/widget-core/decorators/diffProperty';
 
 import * as fixedCss from './styles/split-pane.m.css';
@@ -56,7 +55,7 @@ export class SplitPane extends ThemedMixin(WidgetBase)<SplitPaneProperties> {
 
 	@diffProperty('collapseWidth')
 	@diffProperty('direction')
-	private collapseWidthDiff(
+	protected collapseWidthDiff(
 		oldProperties: SplitPaneProperties,
 		{ collapseWidth, direction, onCollapse }: SplitPaneProperties
 	) {

--- a/src/split-pane/tests/functional/SplitPane.ts
+++ b/src/split-pane/tests/functional/SplitPane.ts
@@ -229,10 +229,6 @@ registerSuite('SplitPane', {
 		let command: Command<Element | void> = getPage(this).findByCssSelector(
 			`#example-max .${css.root}`
 		);
-		let containerWidth = 0;
-		command = command.getSize().then(({ width }) => {
-			containerWidth = width;
-		});
 		command = testResizes(
 			command,
 			[{ x: 10, y: 0 }, { x: -9999, y: 0 }, { x: 10, y: 0 }],

--- a/src/split-pane/tests/unit/SplitPane.ts
+++ b/src/split-pane/tests/unit/SplitPane.ts
@@ -290,7 +290,7 @@ registerSuite('SplitPane', {
 				get: mockDimensionsGet
 			});
 
-			const h = harness(() =>
+			harness(() =>
 				w(MockMetaMixin(SplitPane, mockMeta), { onCollapse, direction: Direction.row })
 			);
 			assert.isTrue(onCollapse.calledWith(false));

--- a/src/tab-controller/TabButton.ts
+++ b/src/tab-controller/TabButton.ts
@@ -2,7 +2,6 @@ import { DNode } from '@dojo/framework/widget-core/interfaces';
 import { I18nMixin } from '@dojo/framework/widget-core/mixins/I18n';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
 import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
 import { v } from '@dojo/framework/widget-core/d';
 import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
 import commonBundle from '../common/nls/common';

--- a/src/tab-controller/example/index.ts
+++ b/src/tab-controller/example/index.ts
@@ -6,8 +6,6 @@ import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
 import Tab from '../../tab/index';
 import TabController, { Align } from '../../tab-controller/index';
 
-let refresh: Promise<any>;
-
 function refreshData() {
 	return new Promise((resolve, reject) => {
 		setTimeout(resolve, 1500);
@@ -90,7 +88,7 @@ export default class App extends WidgetBase {
 									activeIndex: 2,
 									loading: true
 								});
-								refresh = refreshData().then(() => {
+								refreshData().then(() => {
 									this.setState({ loading: false });
 								});
 							} else {

--- a/src/tab-controller/tests/unit/TabButton.ts
+++ b/src/tab-controller/tests/unit/TabButton.ts
@@ -12,10 +12,6 @@ import TabButton, { TabButtonProperties } from '../../TabButton';
 import * as css from '../../../theme/tab-controller.m.css';
 import { noop, stubEvent } from '../../../common/tests/support/test-helpers';
 
-interface KeyboardEventInit extends EventInit {
-	which: number;
-}
-
 const props = function(props = {}) {
 	return assign(
 		{

--- a/src/text-input/example/index.ts
+++ b/src/text-input/example/index.ts
@@ -6,7 +6,6 @@ export default class App extends WidgetBase {
 	private _value1: string | undefined;
 	private _value2: string | undefined;
 	private _value3: string | undefined;
-	private _value4: string | undefined;
 	private _value5: string | undefined;
 	private _value6: string | undefined;
 	private _value6Valid: boolean | { valid?: boolean; message?: string };

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -7,7 +7,6 @@ import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/
 import Label from '../label/index';
 import {
 	CustomAriaProperties,
-	InputProperties,
 	PointerEventProperties,
 	KeyEventProperties,
 	InputEventProperties

--- a/src/text-input/tests/unit/TextInput.ts
+++ b/src/text-input/tests/unit/TextInput.ts
@@ -8,7 +8,7 @@ import Focus from '@dojo/framework/widget-core/meta/Focus';
 import assertationTemplate from '@dojo/framework/testing/assertionTemplate';
 
 import Label from '../../../label/index';
-import TextInput, { TextInputProperties } from '../../index';
+import TextInput from '../../index';
 import InputValidity from '../../../common/InputValidity';
 import * as css from '../../../theme/text-input.m.css';
 import {

--- a/src/title-pane/tests/unit/TitlePane.ts
+++ b/src/title-pane/tests/unit/TitlePane.ts
@@ -1,6 +1,5 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
-import * as sinon from 'sinon';
 
 import { v, w, isWNode } from '@dojo/framework/widget-core/d';
 import Icon from '../../../icon/index';
@@ -18,10 +17,6 @@ import {
 import { GlobalEvent } from '../../../global-event/index';
 
 const harness = createHarness([compareId, compareAriaLabelledBy, compareAriaControls]);
-
-interface TestEventInit extends EventInit {
-	keyCode: number;
-}
 
 class StubMeta {
 	// dimensions .get()

--- a/src/toolbar/index.ts
+++ b/src/toolbar/index.ts
@@ -8,7 +8,6 @@ import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
 import Icon from '../icon/index';
 import SlidePane, { Align } from '../slide-pane/index';
 import commonBundle from '../common/nls/common';
-import { CommonMessages } from '../common/interfaces';
 import * as fixedCss from './styles/toolbar.m.css';
 import * as css from '../theme/toolbar.m.css';
 import { GlobalEvent } from '../global-event/index';

--- a/src/toolbar/tests/unit/Toolbar.ts
+++ b/src/toolbar/tests/unit/Toolbar.ts
@@ -1,5 +1,4 @@
 const { registerSuite } = intern.getInterface('object');
-const { assert } = intern.getPlugin('chai');
 
 import { Dimensions } from '@dojo/framework/widget-core/meta/Dimensions';
 import { v, w, isWNode } from '@dojo/framework/widget-core/d';

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,6 +16,7 @@
 		],
 		"module": "umd",
 		"moduleResolution": "node",
+		"noUnusedLocals": true,
 		"importHelpers": true,
 		"downlevelIteration": true,
 		"outDir": "_build/",


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This enables `noUnusedLocals` in tsconfig.json and fixes the violations throughout the project, cleaning up some unnecessary imports, some unnecessary looping, and some unused variables. It also enables the feature going forward so your editor will alert the user to unused variables in the future.

Resolves #725 