### PR TITLE
[WIP] Switch onChange and onInput to onValue

### DIFF
--- a/src/button/index.ts
+++ b/src/button/index.ts
@@ -55,7 +55,6 @@ export interface ButtonProperties
 	attributes: ['widgetId', 'name', 'type', 'value'],
 	events: [
 		'onBlur',
-		'onChange',
 		'onClick',
 		'onFocus',
 		'onInput',

--- a/src/calendar/README.md
+++ b/src/calendar/README.md
@@ -36,7 +36,7 @@ w(Calendar, {
 	year: this.state.year,
 	onMonthChange: (month: number) => { this.setState({ 'month': month }); },
 	onYearChange: (year: number) => { this.setState({ 'year': year }); },
-	onDateSelect: (date: Date) => {
+	onValue: (date: Date) => {
 		this.setState({ 'selectedDate': date });
 	}
 })
@@ -71,7 +71,7 @@ w(Calendar, {
 	},
 	onMonthChange: (month: number) => { this.setState({ 'month': month }); },
 	onYearChange: (year: number) => { this.setState({ 'year': year }); },
-	onDateSelect: (date: Date) => {
+	onValue: (date: Date) => {
 		this.setState({ 'selectedDate': date });
 	}
 })

--- a/src/calendar/example/index.ts
+++ b/src/calendar/example/index.ts
@@ -30,7 +30,7 @@ export default class App extends WidgetBase {
 					this._year = year;
 					this.invalidate();
 				},
-				onDateSelect: (date: Date) => {
+				onValue: (date: Date) => {
 					this._selectedDate = date;
 					this.invalidate();
 				}

--- a/src/calendar/index.ts
+++ b/src/calendar/index.ts
@@ -36,7 +36,7 @@ export type CalendarMessages = typeof calendarBundle.messages;
  * @property renderWeekdayCell Format the weekday column headers
  * @property onMonthChange     Function called when the month changes
  * @property onYearChange      Function called when the year changes
- * @property onDateSelect      Function called when the user selects a date
+ * @property onValue      Function called when the user selects a date or changes the year/month
  */
 export interface CalendarProperties extends ThemedProperties, CustomAriaProperties {
 	labels?: CalendarMessages;
@@ -51,7 +51,7 @@ export interface CalendarProperties extends ThemedProperties, CustomAriaProperti
 	renderWeekdayCell?(day: { short: string; long: string }): DNode;
 	onMonthChange?(month: number): void;
 	onYearChange?(year: number): void;
-	onDateSelect?(date: Date): void;
+	onValue?(date: Date): void;
 }
 
 interface ShortLong<T> {
@@ -100,7 +100,7 @@ const DEFAULT_WEEKDAYS: ShortLong<typeof commonBundle.messages>[] = [
 		'weekdayNames',
 		'theme'
 	],
-	events: ['onDateSelect', 'onMonthChange', 'onYearChange']
+	events: ['onValue', 'onMonthChange', 'onYearChange']
 })
 export class Calendar extends I18nMixin(ThemedMixin(WidgetBase))<CalendarProperties> {
 	private _callDateFocus = false;
@@ -158,7 +158,7 @@ export class Calendar extends I18nMixin(ThemedMixin(WidgetBase))<CalendarPropert
 	}
 
 	private _onDateClick(date: number, disabled: boolean) {
-		const { onDateSelect } = this.properties;
+		const { onValue } = this.properties;
 		let { month, year } = this._getMonthYear();
 
 		if (disabled) {
@@ -166,7 +166,7 @@ export class Calendar extends I18nMixin(ThemedMixin(WidgetBase))<CalendarPropert
 			this._callDateFocus = true;
 		}
 		this._focusedDay = date;
-		onDateSelect && onDateSelect(new Date(year, month, date));
+		onValue && onValue(new Date(year, month, date));
 	}
 
 	private _onDateFocusCalled() {
@@ -203,36 +203,40 @@ export class Calendar extends I18nMixin(ThemedMixin(WidgetBase))<CalendarPropert
 				break;
 			case Keys.Enter:
 			case Keys.Space:
-				const { onDateSelect } = this.properties;
-				onDateSelect && onDateSelect(new Date(year, month, this._focusedDay));
+				const { onValue } = this.properties;
+				onValue && onValue(new Date(year, month, this._focusedDay));
 		}
 	}
 
 	private _onMonthDecrement() {
 		const { month, year } = this._getMonthYear();
-		const { onMonthChange, onYearChange } = this.properties;
+		const { onValue, onMonthChange, onYearChange } = this.properties;
 
 		if (month === 0) {
 			onMonthChange && onMonthChange(11);
 			onYearChange && onYearChange(year - 1);
+			onValue && onValue(new Date(year - 1, 11));
 			return { month: 11, year: year - 1 };
 		}
 
 		onMonthChange && onMonthChange(month - 1);
+		onValue && onValue(new Date(year, month - 1));
 		return { month: month - 1, year: year };
 	}
 
 	private _onMonthIncrement() {
 		const { month, year } = this._getMonthYear();
-		const { onMonthChange, onYearChange } = this.properties;
+		const { onValue, onMonthChange, onYearChange } = this.properties;
 
 		if (month === 11) {
 			onMonthChange && onMonthChange(0);
 			onYearChange && onYearChange(year + 1);
+			onValue && onValue(new Date(year + 1, month));
 			return { month: 0, year: year + 1 };
 		}
 
 		onMonthChange && onMonthChange(month + 1);
+		onValue && onValue(new Date(year, month + 1));
 		return { month: month + 1, year: year };
 	}
 

--- a/src/calendar/tests/unit/Calendar.ts
+++ b/src/calendar/tests/unit/Calendar.ts
@@ -406,7 +406,7 @@ registerSuite('Calendar', {
 				w(Calendar, {
 					month: testDate.getMonth(),
 					year: testDate.getFullYear(),
-					onDateSelect: (date: Date) => {
+					onValue: (date: Date) => {
 						selectedDate = date;
 					}
 				})
@@ -435,7 +435,7 @@ registerSuite('Calendar', {
 				onMonthChange: (month: number) => {
 					currentMonth = month;
 				},
-				onDateSelect: (date: Date) => {
+				onValue: (date: Date) => {
 					selectedDate = date;
 				}
 			};
@@ -458,7 +458,7 @@ registerSuite('Calendar', {
 				w(Calendar, {
 					month: testDate.getMonth(),
 					year: testDate.getFullYear(),
-					onDateSelect: (date: Date) => {
+					onValue: (date: Date) => {
 						selectedDate = date;
 					}
 				})
@@ -818,7 +818,7 @@ registerSuite('Calendar with min-max', {
 					year: testDate.getFullYear(),
 					minDate: minDateInMonth,
 					maxDate: maxDateInMonth,
-					onDateSelect: (date: Date) => {
+					onValue: (date: Date) => {
 						selectedDate = date.toDateString();
 					}
 				})

--- a/src/checkbox/README.md
+++ b/src/checkbox/README.md
@@ -26,7 +26,7 @@ w(Checkbox, {
 	name: 'update-checkbox'
 	checked: this.state.checked,
 	value: 'updates',
-	onChange: (event: TypedTargetEvent<HTMLInputElement>) => {
+	onValue: (event: TypedTargetEvent<HTMLInputElement>) => {
 		this.setState({ checked: event.target.checked });
 	},
 });
@@ -40,7 +40,7 @@ w(Checkbox, {
 	name: 'music',
 	onLabel: 'On',
 	offLabel: 'Off',
-	onChange: (event: TypedTargetEvent<HTMLInputElement>) => {
+	onValue: (event: TypedTargetEvent<HTMLInputElement>) => {
 		this.setState({ musicChecked: event.target.checked });
 	}
 }),

--- a/src/checkbox/example/index.ts
+++ b/src/checkbox/example/index.ts
@@ -11,7 +11,7 @@ export default class App extends WidgetBase {
 		c5: true
 	};
 
-	onChange(value: string, checked: boolean) {
+	onValue(checked: boolean, value: string) {
 		this._checkboxStates[value] = checked;
 		this.invalidate();
 	}
@@ -31,7 +31,7 @@ export default class App extends WidgetBase {
 						checked: c1,
 						label: 'Sample checkbox that starts checked',
 						value: 'c1',
-						onChange: this.onChange
+						onValue: this.onValue
 					})
 				]),
 
@@ -42,7 +42,7 @@ export default class App extends WidgetBase {
 						label: 'Sample disabled checkbox',
 						disabled: true,
 						value: 'c2',
-						onChange: this.onChange
+						onValue: this.onValue
 					})
 				]),
 
@@ -53,7 +53,7 @@ export default class App extends WidgetBase {
 						label: 'Required checkbox',
 						required: true,
 						value: 'c3',
-						onChange: this.onChange
+						onValue: this.onValue
 					})
 				]),
 
@@ -64,7 +64,7 @@ export default class App extends WidgetBase {
 						label: 'Checkbox in "toggle" mode',
 						mode: Mode.toggle,
 						value: 'c4',
-						onChange: this.onChange
+						onValue: this.onValue
 					})
 				]),
 
@@ -78,7 +78,7 @@ export default class App extends WidgetBase {
 						mode: Mode.toggle,
 						disabled: true,
 						value: 'c5',
-						onChange: this.onChange
+						onValue: this.onValue
 					})
 				])
 			])

--- a/src/checkbox/index.ts
+++ b/src/checkbox/index.ts
@@ -27,7 +27,8 @@ import { customElement } from '@dojo/framework/widget-core/decorators/customElem
  * @property mode           The type of user interface to show for this Checkbox
  * @property offLabel       Label to show in the "off" positin of a toggle
  * @property onLabel        Label to show in the "on" positin of a toggle
- * @property value           The current value
+ * @property onValue        Function called when the user toggles the checkbox
+ * @property value          The current value
  */
 export interface CheckboxProperties
 	extends ThemedProperties,
@@ -42,6 +43,7 @@ export interface CheckboxProperties
 	mode?: Mode;
 	offLabel?: DNode;
 	onLabel?: DNode;
+	onValue?: (checked: boolean, value: string) => void;
 	value?: string;
 }
 
@@ -72,7 +74,6 @@ export enum Mode {
 	attributes: ['widgetId', 'label', 'value', 'name', 'mode', 'offLabel', 'onLabel'],
 	events: [
 		'onBlur',
-		'onChange',
 		'onClick',
 		'onFocus',
 		'onKeyDown',
@@ -82,7 +83,8 @@ export enum Mode {
 		'onMouseUp',
 		'onTouchCancel',
 		'onTouchEnd',
-		'onTouchStart'
+		'onTouchStart',
+		'onValue'
 	]
 })
 export class Checkbox extends ThemedMixin(FocusMixin(WidgetBase))<CheckboxProperties> {
@@ -90,10 +92,10 @@ export class Checkbox extends ThemedMixin(FocusMixin(WidgetBase))<CheckboxProper
 		const checkbox = event.target as HTMLInputElement;
 		this.properties.onBlur && this.properties.onBlur(checkbox.value, checkbox.checked);
 	}
-	private _onChange(event: Event) {
+	private _onValue(event: Event) {
 		event.stopPropagation();
 		const checkbox = event.target as HTMLInputElement;
-		this.properties.onChange && this.properties.onChange(checkbox.value, checkbox.checked);
+		this.properties.onValue && this.properties.onValue(checkbox.checked, checkbox.value);
 	}
 	private _onClick(event: MouseEvent) {
 		event.stopPropagation();
@@ -216,7 +218,7 @@ export class Checkbox extends ThemedMixin(FocusMixin(WidgetBase))<CheckboxProper
 					type: 'checkbox',
 					value,
 					onblur: this._onBlur,
-					onchange: this._onChange,
+					onchange: this._onValue,
 					onclick: this._onClick,
 					onfocus: this._onFocus,
 					onmousedown: this._onMouseDown,

--- a/src/checkbox/tests/unit/Checkbox.ts
+++ b/src/checkbox/tests/unit/Checkbox.ts
@@ -458,7 +458,7 @@ registerSuite('Checkbox', {
 
 		events() {
 			const onBlur = sinon.stub();
-			const onChange = sinon.stub();
+			const onValue = sinon.stub();
 			const onClick = sinon.stub();
 			const onFocus = sinon.stub();
 			const onMouseDown = sinon.stub();
@@ -470,7 +470,7 @@ registerSuite('Checkbox', {
 			const h = harness(() =>
 				w(Checkbox, {
 					onBlur,
-					onChange,
+					onValue,
 					onClick,
 					onFocus,
 					onMouseDown,
@@ -484,7 +484,7 @@ registerSuite('Checkbox', {
 			h.trigger('input', 'onblur', stubEvent);
 			assert.isTrue(onBlur.called, 'onBlur called');
 			h.trigger('input', 'onchange', stubEvent);
-			assert.isTrue(onChange.called, 'onChange called');
+			assert.isTrue(onValue.called, 'onValue called');
 			h.trigger('input', 'onclick', stubEvent);
 			assert.isTrue(onClick.called, 'onClick called');
 			h.trigger('input', 'onfocus', stubEvent);

--- a/src/combobox/example/index.ts
+++ b/src/combobox/example/index.ts
@@ -67,7 +67,7 @@ export default class App extends WidgetBase {
 	private _value9 = '';
 	private _invalid = false;
 
-	onChange(value: string, key?: string) {
+	onValue(value: string, key?: string) {
 		if (!key) {
 			return;
 		}
@@ -88,7 +88,7 @@ export default class App extends WidgetBase {
 	}
 
 	render(): DNode {
-		const { onChange, onRequestResults } = this;
+		const { onValue, onRequestResults } = this;
 
 		return v(
 			'div',
@@ -102,7 +102,7 @@ export default class App extends WidgetBase {
 					key: '2',
 					label: 'Combo:',
 					clearable: true,
-					onChange,
+					onValue: onValue,
 					getResultLabel: (result: any) => result.value,
 					onRequestResults,
 					results: this._results,
@@ -116,7 +116,7 @@ export default class App extends WidgetBase {
 					key: '1',
 					label: 'Combo:',
 					openOnFocus: true,
-					onChange,
+					onValue: onValue,
 					getResultLabel: (result: any) => result.value,
 					onRequestResults,
 					results: this._results,
@@ -129,7 +129,7 @@ export default class App extends WidgetBase {
 				w(ComboBox, {
 					key: '5',
 					label: 'Combo:',
-					onChange,
+					onValue: onValue,
 					getResultLabel: (result: any) => result.value,
 					onRequestResults,
 					results: this._results,
@@ -147,7 +147,7 @@ export default class App extends WidgetBase {
 					inputProperties: {
 						placeholder: 'Enter a value'
 					},
-					onChange,
+					onValue: onValue,
 					onRequestResults,
 					value: this._value6
 				}),
@@ -159,14 +159,14 @@ export default class App extends WidgetBase {
 					inputProperties: {
 						placeholder: 'Enter a value'
 					},
-					onChange,
+					onValue: onValue,
 					onRequestResults,
 					value: this._value7
 				}),
 				v('h3', ['Label']),
 				w(ComboBox, {
 					key: '8',
-					onChange,
+					onValue: onValue,
 					getResultLabel: (result: any) => result.value,
 					onRequestResults,
 					results: this._results,
@@ -178,7 +178,7 @@ export default class App extends WidgetBase {
 					key: '9',
 					label: 'Combo:',
 					required: true,
-					onChange: (value: string) => {
+					onValue: (value: string) => {
 						this._value9 = value;
 						this._invalid = value.trim().length === 0;
 						this.invalidate();

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -30,14 +30,14 @@ import { customElement } from '@dojo/framework/widget-core/decorators/customElem
  * @property disabled           Prevents user interaction and styles content accordingly
  * @property getResultLabel     Can be used to get the text label of a result based on the underlying result object
  * @property getResultSelected  Can be used to highlight the selected result. Defaults to checking the result label
- * @property getResultValue     Can be used to define a value returned by onChange when a given result is selected. Defaults to getResultLabel
+ * @property getResultValue     Can be used to define a value returned by onValue when a given result is selected. Defaults to getResultLabel
  * @property widgetId           Optional id string for the combobox, set on the text input
  * @property inputProperties    TextInput properties to set on the underlying input
  * @property invalid            Determines if this input is valid
  * @property isResultDisabled   Used to determine if an item should be disabled
  * @property label              Label to show for this input
  * @property onBlur             Called when the input is blurred
- * @property onChange           Called when the value changes
+ * @property onValue            Called when the value changes
  * @property onFocus            Called when the input is focused
  * @property onMenuChange       Called when menu visibility changes
  * @property onRequestResults   Called when results are shown; should be used to set `results`
@@ -59,7 +59,7 @@ export interface ComboBoxProperties extends ThemedProperties, LabeledProperties,
 	invalid?: boolean;
 	isResultDisabled?(result: any): boolean;
 	onBlur?(value: string, key?: string | number): void;
-	onChange?(value: string, key?: string | number): void;
+	onValue?(value: string, key?: string | number): void;
 	onFocus?(value: string, key?: string | number): void;
 	onMenuChange?(open: boolean, key?: string | number): void;
 	onRequestResults?(key?: string | number): void;
@@ -100,7 +100,7 @@ export enum Operation {
 		'results'
 	],
 	attributes: ['widgetId', 'label', 'value'],
-	events: ['onBlur', 'onChange', 'onFocus', 'onMenuChange', 'onRequestResults', 'onResultSelect']
+	events: ['onBlur', 'onValue', 'onFocus', 'onMenuChange', 'onRequestResults', 'onResultSelect']
 })
 export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<ComboBoxProperties> {
 	private _activeIndex = 0;
@@ -155,17 +155,17 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 
 	private _onClearClick(event: MouseEvent) {
 		event.stopPropagation();
-		const { key, onChange } = this.properties;
+		const { key, onValue: onValue } = this.properties;
 
 		this.focus();
 		this.invalidate();
-		onChange && onChange('', key);
+		onValue && onValue('', key);
 	}
 
 	private _onInput(value: string) {
-		const { key, disabled, readOnly, onChange } = this.properties;
+		const { key, disabled, readOnly, onValue } = this.properties;
 
-		onChange && onChange(value, key);
+		onValue && onValue(value, key);
 		!disabled && !readOnly && this._openMenu();
 	}
 
@@ -265,12 +265,12 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 	}
 
 	private _selectIndex(index: number) {
-		const { key, onChange, onResultSelect, results = [] } = this.properties;
+		const { key, onValue: onValue, onResultSelect, results = [] } = this.properties;
 
 		this.focus();
 		this._closeMenu();
 		onResultSelect && onResultSelect(results[index], key);
-		onChange && onChange(this._getResultValue(results[index]), key);
+		onValue && onValue(this._getResultValue(results[index]), key);
 	}
 
 	private _moveActiveIndex(operation: Operation) {

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -293,7 +293,7 @@ registerSuite('ComboBox', {
 		},
 
 		'menu opens on input'() {
-			const onChange = sinon.stub();
+			const onValue = sinon.stub();
 			const onRequestResults = sinon.stub();
 			const onResultSelect = sinon.stub();
 			const onMenuChange = sinon.stub();
@@ -302,7 +302,7 @@ registerSuite('ComboBox', {
 					w(ComboBox, {
 						...testProperties,
 						label: undefined,
-						onChange,
+						onValue: onValue,
 						onRequestResults,
 						onResultSelect,
 						onMenuChange
@@ -313,7 +313,7 @@ registerSuite('ComboBox', {
 			h.trigger('@textinput', 'onInput', 'foo');
 			h.expectPartial('@dropdown', () => getExpectedMenu(true, true));
 
-			assert.isTrue(onChange.calledWith('foo'), 'onChange callback called with input value');
+			assert.isTrue(onValue.calledWith('foo'), 'onValue callback called with input value');
 			assert.isTrue(onRequestResults.calledOnce, 'onRequestResults callback called');
 			assert.isFalse(onResultSelect.called, 'onResultSelect is not called on input');
 			assert.isTrue(onMenuChange.calledOnce, 'onMenuChange called when menu is opened');
@@ -363,13 +363,13 @@ registerSuite('ComboBox', {
 		},
 
 		'menu closes on result selection'() {
-			const onChange = sinon.stub();
+			const onValue = sinon.stub();
 			const onResultSelect = sinon.stub();
 			const h = harness(
 				() =>
 					w(ComboBox, {
 						...testProperties,
-						onChange,
+						onValue,
 						onResultSelect
 					}),
 				[compareFocusTrue]
@@ -378,8 +378,8 @@ registerSuite('ComboBox', {
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
 			h.trigger('@listbox', 'onOptionSelect', testOptions[1], 1);
 			assert.isTrue(
-				onChange.calledWith('Two'),
-				'onChange callback called with label of second option'
+				onValue.calledWith('Two'),
+				'onValue callback called with label of second option'
 			);
 			assert.isTrue(
 				onResultSelect.calledWith(testOptions[1]),
@@ -453,13 +453,13 @@ registerSuite('ComboBox', {
 		},
 
 		'enter and space select option'() {
-			const onChange = sinon.stub();
+			const onValue = sinon.stub();
 			const onResultSelect = sinon.stub();
 			const h = harness(
 				() =>
 					w(ComboBox, {
 						...testProperties,
-						onChange,
+						onValue,
 						onResultSelect
 					}),
 				[compareFocusTrue]
@@ -468,8 +468,8 @@ registerSuite('ComboBox', {
 			h.trigger('@textinput', 'onKeyDown', Keys.Enter, () => {});
 
 			assert.isTrue(
-				onChange.calledWith('One'),
-				'enter triggers onChange callback called with label of first option'
+				onValue.calledWith('One'),
+				'enter triggers onValue callback called with label of first option'
 			);
 			assert.isTrue(
 				onResultSelect.calledWith(testOptions[0]),
@@ -479,20 +479,20 @@ registerSuite('ComboBox', {
 
 			h.trigger('@textinput', 'onKeyDown', Keys.Enter, () => {});
 			assert.isFalse(
-				onChange.calledTwice,
-				'enter does not trigger onChange when menu is closed'
+				onValue.calledTwice,
+				'enter does not trigger onValue when menu is closed'
 			);
 			assert.isFalse(
 				onResultSelect.calledTwice,
 				'enter does not trigger onResultSelect when menu is closed'
 			);
-			onChange.reset();
+			onValue.reset();
 
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
 			h.trigger('@textinput', 'onKeyDown', Keys.Space, () => {});
 			assert.isTrue(
-				onChange.calledWith('One'),
-				'space triggers onChange callback called with label of first option'
+				onValue.calledWith('One'),
+				'space triggers onValue callback called with label of first option'
 			);
 			assert.isTrue(
 				onResultSelect.calledWith(testOptions[0]),
@@ -502,14 +502,14 @@ registerSuite('ComboBox', {
 		},
 
 		'disabled options are not selected'() {
-			const onChange = sinon.stub();
+			const onValue = sinon.stub();
 			const onResultSelect = sinon.stub();
 			const preventDefault = sinon.stub();
 			const h = harness(() =>
 				w(ComboBox, {
 					...testProperties,
 					isResultDisabled: (result: any) => !!result.disabled,
-					onChange,
+					onValue: onValue,
 					onResultSelect
 				})
 			);
@@ -517,7 +517,7 @@ registerSuite('ComboBox', {
 			h.trigger('@textinput', 'onKeyDown', Keys.Up, preventDefault);
 			h.trigger('@textinput', 'onKeyDown', Keys.Enter, preventDefault);
 
-			assert.isFalse(onChange.called, 'onChange not called for disabled option');
+			assert.isFalse(onValue.called, 'onValue not called for disabled option');
 			assert.isFalse(onResultSelect.called, 'onResultSelect not called for disabled option');
 			h.expectPartial('@dropdown', () =>
 				getExpectedMenu(true, true, {
@@ -528,25 +528,25 @@ registerSuite('ComboBox', {
 			);
 		},
 
-		'keyboard does not trigger onChange with no results'() {
-			const onChange = sinon.stub();
+		'keyboard does not trigger onValue with no results'() {
+			const onValue = sinon.stub();
 			const preventDefault = sinon.stub();
-			const h = harness(() => w(ComboBox, { onChange }));
+			const h = harness(() => w(ComboBox, { onValue: onValue }));
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
 			h.expect(() => getExpectedVdom(false, true, false, {}));
 
 			h.trigger('@textinput', 'onKeyDown', Keys.Down, preventDefault);
 			h.trigger('@textinput', 'onKeyDown', Keys.Enter, preventDefault);
 
-			assert.isFalse(onChange.called, 'onChange not called for no results');
+			assert.isFalse(onValue.called, 'onValue not called for no results');
 		},
 
-		'onChange uses custom getResultValue'() {
-			const onChange = sinon.stub();
+		'onValue uses custom getResultValue'() {
+			const onValue = sinon.stub();
 			const h = harness(() =>
 				w(ComboBox, {
 					...testProperties,
-					onChange,
+					onValue,
 					getResultValue: (result: any) => result.value
 				})
 			);
@@ -554,25 +554,25 @@ registerSuite('ComboBox', {
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
 			h.trigger('@listbox', 'onOptionSelect', testOptions[1], 1);
 			assert.isTrue(
-				onChange.calledWith('two'),
-				'onChange callback called with value of second option'
+				onValue.calledWith('two'),
+				'onValue callback called with value of second option'
 			);
 		},
 
 		'clear button clears input'() {
-			const onChange = sinon.stub();
+			const onValue = sinon.stub();
 			const onResultSelect = sinon.stub();
 			const h = harness(() =>
 				w(ComboBox, {
 					...testProperties,
-					onChange,
+					onValue,
 					onResultSelect
 				})
 			);
 			h.trigger(`.${css.clear}`, 'onclick', stubEvent);
 			assert.isTrue(
-				onChange.calledWith(''),
-				'clear button calls onChange with an empty string'
+				onValue.calledWith(''),
+				'clear button calls onValue with an empty string'
 			);
 			assert.isFalse(onResultSelect.called, 'clear button does not call onResultSelect');
 		},

--- a/src/common/example/index.ts
+++ b/src/common/example/index.ts
@@ -56,7 +56,7 @@ export default class App extends WidgetBase {
 		return v('div', { id: 'module-select' }, [
 			v('h2', ['Select a module to view']),
 			w(Select, {
-				onChange: this._onModuleChange,
+				onValue: this._onModuleChange,
 				useNativeElement: true,
 				label: 'Select a module to view',
 				options: modules,

--- a/src/radio/README.md
+++ b/src/radio/README.md
@@ -24,8 +24,8 @@ w(Radio, {
 	label: 'Choice A',
 	name: 'radio1'
 	value: 'radio1-1',
-	onChange: (event: TypedTargetEvent<HTMLInputElement>) => {
-		this.setState({ radioValue: event.target.value });
+	onValue: (value: string) => {
+		this.setState({ radioValue: value });
 	},
 }),
 w(Radio, {
@@ -34,8 +34,8 @@ w(Radio, {
 	label: 'Choice B',
 	name: 'radio1'
 	value: 'radio1-2',
-	onChange: (event: TypedTargetEvent<HTMLInputElement>) => {
-		this.setState({ radioValue: event.target.value });
+	onValue: (value: string) => {
+		this.setState({ radioValue: value });
 	},
 }),
 v('p', {

--- a/src/radio/example/index.ts
+++ b/src/radio/example/index.ts
@@ -5,7 +5,7 @@ import Radio from '../../radio/index';
 export default class App extends WidgetBase {
 	private _inputValue: string | undefined;
 
-	onChange(value: string) {
+	onValue(checked: boolean, value: string) {
 		this._inputValue = value;
 		this.invalidate();
 	}
@@ -25,7 +25,7 @@ export default class App extends WidgetBase {
 					value: 'first',
 					label: 'First option',
 					name: 'sample-radios',
-					onChange: this.onChange
+					onValue: this.onValue
 				}),
 				w(Radio, {
 					key: 'r2',
@@ -33,7 +33,7 @@ export default class App extends WidgetBase {
 					value: 'second',
 					label: 'Second option',
 					name: 'sample-radios',
-					onChange: this.onChange
+					onValue: this.onValue
 				}),
 				w(Radio, {
 					key: 'r3',
@@ -41,7 +41,7 @@ export default class App extends WidgetBase {
 					value: 'third',
 					label: 'Third option',
 					name: 'sample-radios',
-					onChange: this.onChange
+					onValue: this.onValue
 				})
 			]),
 			v('fieldset', { id: 'example-2' }, [

--- a/src/radio/index.ts
+++ b/src/radio/index.ts
@@ -24,6 +24,7 @@ import { customElement } from '@dojo/framework/widget-core/decorators/customElem
  * Properties that can be set on a Radio component
  *
  * @property checked          Checked/unchecked property of the radio
+ * @property onValue          Called when the value changes
  * @property value           The current value
  */
 export interface RadioProperties
@@ -36,6 +37,7 @@ export interface RadioProperties
 		CustomAriaProperties,
 		CheckboxRadioEventProperties {
 	checked?: boolean;
+	onValue?: (checked: boolean, value: string) => void;
 	value?: string;
 }
 
@@ -58,7 +60,6 @@ export interface RadioProperties
 	attributes: ['widgetId', 'label', 'value', 'name'],
 	events: [
 		'onBlur',
-		'onChange',
 		'onClick',
 		'onFocus',
 		'onKeyDown',
@@ -68,7 +69,8 @@ export interface RadioProperties
 		'onMouseUp',
 		'onTouchCancel',
 		'onTouchEnd',
-		'onTouchStart'
+		'onTouchStart',
+		'onValue'
 	]
 })
 export class Radio extends ThemedMixin(FocusMixin(WidgetBase))<RadioProperties> {
@@ -78,10 +80,11 @@ export class Radio extends ThemedMixin(FocusMixin(WidgetBase))<RadioProperties> 
 		const radio = event.target as HTMLInputElement;
 		this.properties.onBlur && this.properties.onBlur(radio.value, radio.checked);
 	}
-	private _onChange(event: Event) {
+	private _onValue(event: Event) {
+		const { onValue } = this.properties;
 		event.stopPropagation();
 		const radio = event.target as HTMLInputElement;
-		this.properties.onChange && this.properties.onChange(radio.value, radio.checked);
+		onValue && onValue(radio.checked, radio.value);
 	}
 	private _onClick(event: MouseEvent) {
 		event.stopPropagation();
@@ -165,7 +168,7 @@ export class Radio extends ThemedMixin(FocusMixin(WidgetBase))<RadioProperties> 
 					type: 'radio',
 					value,
 					onblur: this._onBlur,
-					onchange: this._onChange,
+					onchange: this._onValue,
 					onclick: this._onClick,
 					onfocus: this._onFocus,
 					onmousedown: this._onMouseDown,

--- a/src/radio/tests/unit/Radio.ts
+++ b/src/radio/tests/unit/Radio.ts
@@ -217,7 +217,7 @@ registerSuite('Radio', {
 
 		events() {
 			const onBlur = sinon.stub();
-			const onChange = sinon.stub();
+			const onValue = sinon.stub();
 			const onClick = sinon.stub();
 			const onFocus = sinon.stub();
 			const onMouseDown = sinon.stub();
@@ -229,7 +229,7 @@ registerSuite('Radio', {
 			const h = harness(() =>
 				w(Radio, {
 					onBlur,
-					onChange,
+					onValue,
 					onClick,
 					onFocus,
 					onMouseDown,
@@ -242,7 +242,7 @@ registerSuite('Radio', {
 			h.trigger('input', 'onblur', stubEvent);
 			assert.isTrue(onBlur.called, 'onBlur called');
 			h.trigger('input', 'onchange', stubEvent);
-			assert.isTrue(onChange.called, 'onChange called');
+			assert.isTrue(onValue.called, 'onValue called');
 			h.trigger('input', 'onclick', stubEvent);
 			assert.isTrue(onClick.called, 'onClick called');
 			h.trigger('input', 'onfocus', stubEvent);

--- a/src/range-slider/README.md
+++ b/src/range-slider/README.md
@@ -27,7 +27,7 @@ w(RangeSlider, {
 	step: 1,
 	minValue: this.state.min,
     maxValue: this.state.max,
-	onInput: (min: number, max: number) => {
+	onValue: (min: number, max: number) => {
 		this.setState({ min, max });
 	},
 });

--- a/src/range-slider/example/index.ts
+++ b/src/range-slider/example/index.ts
@@ -44,12 +44,7 @@ export default class App extends WidgetBase {
 				max: 50,
 				minValue: this._state.value1Min,
 				maxValue: this._state.value1Max,
-				onInput: (min: number, max: number) => {
-					this._state.value1Min = min;
-					this._state.value1Max = max;
-					this.invalidate();
-				},
-				onChange: (min: number, max: number) => {
+				onValue: (min: number, max: number) => {
 					this._state.value1Min = min;
 					this._state.value1Max = max;
 					this.invalidate();
@@ -66,8 +61,7 @@ export default class App extends WidgetBase {
 					max: 100,
 					minValue: this._state.exampleMin,
 					maxValue: this._state.exampleMax,
-					onInput: this._onRangeSliderInput,
-					onChange: this._onRangeSliderInput,
+					onValue: this._onRangeSliderInput,
 					showOutput: true,
 					output(minValue: number, maxValue: number) {
 						return `${minValue}, ${maxValue}`;
@@ -83,8 +77,7 @@ export default class App extends WidgetBase {
 				step: 20,
 				minValue: this._state.range1Min,
 				maxValue: this._state.range1Max,
-				onInput: this._onRange2SliderInput,
-				onChange: this._onRange2SliderInput,
+				onValue: this._onRange2SliderInput,
 				showOutput: true,
 				outputIsTooltip: true,
 				output(minValue: number, maxValue: number) {
@@ -94,12 +87,7 @@ export default class App extends WidgetBase {
 			v('h3', {}, ['Events']),
 			w(RangeSlider, {
 				key: 'eventExample',
-				onInput: (min: number, max: number) => {
-					this._state.eventMin = min;
-					this._state.eventMax = max;
-					this.invalidate();
-				},
-				onChange: (min: number, max: number) => {
+				onValue: (min: number, max: number) => {
 					this._state.eventMin = min;
 					this._state.eventMax = max;
 					this.invalidate();
@@ -128,12 +116,7 @@ export default class App extends WidgetBase {
 				disabled: true,
 				minValue: this._state.disabledMin,
 				maxValue: this._state.disabledMax,
-				onChange: (min: number, max: number) => {
-					this._state.disabledMin = min;
-					this._state.disabledMax = max;
-					this.invalidate();
-				},
-				onInput: (min: number, max: number) => {
+				onValue: (min: number, max: number) => {
 					this._state.disabledMin = min;
 					this._state.disabledMax = max;
 					this.invalidate();
@@ -146,12 +129,7 @@ export default class App extends WidgetBase {
 				maxValue: this._state.requiredMax,
 				required: true,
 				name: 'required',
-				onChange: (min: number, max: number) => {
-					this._state.requiredMin = min;
-					this._state.requiredMax = max;
-					this.invalidate();
-				},
-				onInput: (min: number, max: number) => {
+				onValue: (min: number, max: number) => {
 					this._state.requiredMin = min;
 					this._state.requiredMax = max;
 					this.invalidate();

--- a/src/range-slider/index.ts
+++ b/src/range-slider/index.ts
@@ -39,8 +39,7 @@ export interface RangeSliderProperties
 	minimumLabel?: string;
 	maximumLabel?: string;
 	onClick?(minValue: number, maxValue: number): void;
-	onInput?(minValue: number, maxValue: number): void;
-	onChange?(minValue: number, maxValue: number): void;
+	onValue?(minValue: number, maxValue: number): void;
 	onBlur?(value?: string | number | boolean): void;
 	onFocus?(value?: string | number | boolean): void;
 }
@@ -82,10 +81,8 @@ type MinMaxCallback = (minValue: number, maxValue: number) => void;
 	attributes: ['widgetId', 'label', 'name'],
 	events: [
 		'onBlur',
-		'onChange',
 		'onClick',
 		'onFocus',
-		'onInput',
 		'onKeyDown',
 		'onKeyPress',
 		'onKeyUp',
@@ -93,7 +90,8 @@ type MinMaxCallback = (minValue: number, maxValue: number) => void;
 		'onMouseUp',
 		'onTouchCancel',
 		'onTouchEnd',
-		'onTouchStart'
+		'onTouchStart',
+		'onValue'
 	]
 })
 export class RangeSlider extends ThemedMixin(WidgetBase)<RangeSliderProperties> {
@@ -247,11 +245,11 @@ export class RangeSlider extends ThemedMixin(WidgetBase)<RangeSliderProperties> 
 			),
 			onchange: prepareCallback(
 				(prop, e1, e2) => this._genericChangeCallback(prop, e1, e2),
-				this.properties.onChange
+				this.properties.onValue
 			),
 			oninput: prepareCallback(
 				(prop, e1, e2) => this._genericChangeCallback(prop, e1, e2),
-				this.properties.onInput
+				this.properties.onValue
 			),
 			onkeydown: this._onKeyDown,
 			onkeypress: this._onKeyPress,

--- a/src/range-slider/tests/unit/RangeSlider.ts
+++ b/src/range-slider/tests/unit/RangeSlider.ts
@@ -372,12 +372,12 @@ registerSuite('RangeSlider', {
 			);
 		},
 		events: {
-			onChange() {
-				const onChange = sinon.stub();
+			onValue() {
+				const onValue = sinon.stub();
 
 				const h = harness(() =>
 					w(RangeSlider, {
-						onChange
+						onValue: onValue
 					})
 				);
 
@@ -388,7 +388,7 @@ registerSuite('RangeSlider', {
 					}
 				});
 
-				assert(onChange.calledWith(25, 100));
+				assert(onValue.calledWith(25, 100));
 
 				h.trigger('@slider2', 'onchange', {
 					stopPropagation: sinon.stub(),
@@ -397,16 +397,9 @@ registerSuite('RangeSlider', {
 					}
 				});
 
-				assert(onChange.calledWith(0, 50));
-			},
-			onInput() {
-				const onInput = sinon.stub();
+				assert(onValue.calledWith(0, 50));
 
-				const h = harness(() =>
-					w(RangeSlider, {
-						onInput
-					})
-				);
+				onValue.reset()
 
 				h.trigger('@slider1', 'oninput', {
 					stopPropagation: sinon.stub(),
@@ -415,7 +408,7 @@ registerSuite('RangeSlider', {
 					}
 				});
 
-				assert(onInput.calledWith(25, 100));
+				assert(onValue.calledWith(25, 100));
 
 				h.trigger('@slider2', 'oninput', {
 					stopPropagation: sinon.stub(),
@@ -424,7 +417,7 @@ registerSuite('RangeSlider', {
 					}
 				});
 
-				assert(onInput.calledWith(0, 50));
+				assert(onValue.calledWith(0, 50));
 			},
 
 			onBlur() {

--- a/src/select/README.md
+++ b/src/select/README.md
@@ -64,6 +64,11 @@ w(Select, {
 	onChange: (option: OptionData) => {
 		value = option.value;
 	}
+	// The wrapped select also participates in the onValue protocol.
+	// This is commented out because it's equivalent to the previous onChange handler.
+	//     onValue: (option: string) => {
+    //         value = option;
+	//     }
 });
 ```
 
@@ -79,7 +84,7 @@ w(Select, {
 	label: 'Option label defaults to option data',
 	options,
 	value,
-	onChange: (option: string) => {
+	onValue: (option: string) => {
 		value = option;
 	}
 });
@@ -101,7 +106,7 @@ w(Select, {
 	options,
 	placeholder: 'Choose one',
 	value,
-	onChange: (option: string) => {
+	onValue: (option: string) => {
 		value = option;
 	}
 });

--- a/src/select/example/index.ts
+++ b/src/select/example/index.ts
@@ -71,8 +71,8 @@ export default class App extends WidgetBase {
 				options: this._selectOptions,
 				useNativeElement: true,
 				value: this._value1,
-				onChange: (option: any) => {
-					this._value1 = option.value;
+				onValue: (val: string) => {
+					this._value1 = val;
 					this.invalidate();
 				}
 			}),
@@ -98,8 +98,8 @@ export default class App extends WidgetBase {
 				options: this._evenMoreSelectOptions,
 				placeholder: 'Choose a cat',
 				value: this._value3,
-				onChange: (option: any) => {
-					this._value3 = option;
+				onValue: (val: string) => {
+					this._value3 = val;
 					this.invalidate();
 				}
 			}),
@@ -112,8 +112,8 @@ export default class App extends WidgetBase {
 				options: this._selectOptions,
 				useNativeElement: true,
 				value: this._value1,
-				onChange: (option: any) => {
-					this._value1 = option.value;
+				onValue: (val: string) => {
+					this._value1 = val;
 					this.invalidate();
 				},
 				helperText: 'pick a value'
@@ -124,8 +124,8 @@ export default class App extends WidgetBase {
 				label: 'Custom select box with helper text',
 				options: this._moreSelectOptions,
 				value: this._value2,
-				onChange: (option: any) => {
-					this._value2 = option.value;
+				onValue: (val: string) => {
+					this._value2 = val;
 					this.invalidate();
 				},
 				helperText: 'pick a value'

--- a/src/select/index.ts
+++ b/src/select/index.ts
@@ -50,6 +50,7 @@ export interface SelectProperties
 	useNativeElement?: boolean;
 	onBlur?(key?: string | number): void;
 	onChange?(option: any, key?: string | number): void;
+	onValue?(option: string): void;
 	onFocus?(key?: string | number): void;
 	value?: string;
 	labelHidden?: boolean;
@@ -80,7 +81,7 @@ export interface SelectProperties
 		'labelHidden'
 	],
 	attributes: ['widgetId', 'placeholder', 'label', 'value', 'helperText'],
-	events: ['onBlur', 'onChange', 'onFocus']
+	events: ['onBlur', 'onChange', 'onFocus', 'onValue']
 })
 export class Select extends ThemedMixin(FocusMixin(WidgetBase))<SelectProperties> {
 	private _focusedIndex: number;
@@ -140,13 +141,14 @@ export class Select extends ThemedMixin(FocusMixin(WidgetBase))<SelectProperties
 
 	// native select events
 	private _onNativeChange(event: Event) {
-		const { key, getOptionValue, options = [], onChange } = this.properties;
+		const { key, getOptionValue, options = [], onChange, onValue } = this.properties;
 		event.stopPropagation();
 		const value = (<HTMLInputElement>event.target).value;
 		const option = find(options, (option: any, index: number) =>
 			getOptionValue ? getOptionValue(option, index) === value : option === value
 		);
 		option && onChange && onChange(option, key);
+		option && onValue && onValue(option.value);
 	}
 
 	// custom select events
@@ -191,12 +193,13 @@ export class Select extends ThemedMixin(FocusMixin(WidgetBase))<SelectProperties
 	}
 
 	private _onTriggerKeyDown(event: KeyboardEvent) {
-		const { key, options = [], onChange } = this.properties;
+		const { key, options = [], onChange, onValue } = this.properties;
 		event.stopPropagation();
 		const index = this._getSelectedIndexOnInput(event);
 		if (index !== undefined) {
 			this._focusedIndex = index;
 			onChange && onChange(options[index], key);
+			onValue && onValue(options[index].value);
 			this.invalidate();
 		}
 		if (event.which === Keys.Down) {
@@ -293,7 +296,8 @@ export class Select extends ThemedMixin(FocusMixin(WidgetBase))<SelectProperties
 			options = [],
 			theme,
 			classes,
-			onChange
+			onChange,
+			onValue
 		} = this.properties;
 
 		if (this._focusedIndex === undefined) {
@@ -341,6 +345,7 @@ export class Select extends ThemedMixin(FocusMixin(WidgetBase))<SelectProperties
 							},
 							onOptionSelect: (option: any) => {
 								onChange && onChange(option, key);
+								onValue && onValue(option.value);
 								this._closeSelect();
 								this.focus();
 							},

--- a/src/select/tests/unit/Select.ts
+++ b/src/select/tests/unit/Select.ts
@@ -411,7 +411,7 @@ registerSuite('Select', {
 				assert.isTrue(onFocus.calledWith('foo'), 'onFocus called with foo key');
 				h.trigger('select', 'onchange', { ...stubEvent, target: { value: 'one' } });
 				assert.isTrue(
-					onChange.calledWith(testOptions[0], 'foo'),
+					onChange.calledWith(testOptions[0].label, 'foo'),
 					'onChange called with foo key'
 				);
 			}
@@ -501,13 +501,13 @@ registerSuite('Select', {
 			},
 
 			'select options'() {
-				const onChange = sinon.stub();
+				const onValue = sinon.stub();
 
 				const h = harness(() =>
 					w(Select, {
 						...testProperties,
 						options: testOptions,
-						onChange
+						onValue
 					})
 				);
 
@@ -515,7 +515,7 @@ registerSuite('Select', {
 				h.expect(() => expected(expectedSingle(true, false, true, '')));
 				h.trigger('@listbox', 'onOptionSelect', testOptions[2]);
 				h.expect(() => expected(expectedSingle(true)));
-				assert.isTrue(onChange.calledOnce, 'onChange handler called when option selected');
+				assert.isTrue(onValue.calledOnce, 'onValue handler called when option selected');
 
 				// open widget a second time
 				h.trigger('@trigger', 'onclick', stubEvent);

--- a/src/slider/README.md
+++ b/src/slider/README.md
@@ -24,8 +24,8 @@ w(Slider, {
 	max: 100,
 	step: 1,
 	value: this.state.sliderValue,
-	onInput: (event: TypedTargetEvent<HTMLInputElement>) => {
-		this.setState({ sliderValue: parseFloat(event.target.value) });
+	onChange: (value: number) => {
+		this.setState({ sliderValue: value });
 	},
 });
 
@@ -43,8 +43,8 @@ w(Slider, {
 	},
 	step: 1,
 	value: this.state.tribbleValue,
-	onInput: (event: TypedTargetEvent<HTMLInputElement>) => {
-		this.setState({ tribbleValue: parseFloat(event.target.value) });
+	onChange: (value: string) => {
+		this.setState({ tribbleValue: value });
 	}
 });
 
@@ -56,8 +56,7 @@ w(Slider, {
 	value: verticalValue,
 	vertical: true,
 	invalid: verticalInvalid,
-	onInput: (event: TypedTargetEvent<HTMLInputElement>) => {
-		const value = parseFloat(event.target.value);
+	onChange: (value: string) => {
 		this.setState({
 			verticalValue: value,
 			verticalInvalid: value > 50 ? true : false

--- a/src/slider/index.ts
+++ b/src/slider/index.ts
@@ -52,6 +52,7 @@ export interface SliderProperties
 	verticalHeight?: string;
 	value?: number;
 	onClick?(value: number): void;
+	onValue?(value: number): void;
 	inputStyles?: Partial<CSSStyleDeclaration>;
 }
 
@@ -86,10 +87,8 @@ function extractValue(event: Event): number {
 	attributes: ['widgetId', 'label', 'name', 'verticalHeight'],
 	events: [
 		'onBlur',
-		'onChange',
 		'onClick',
 		'onFocus',
-		'onInput',
 		'onKeyDown',
 		'onKeyPress',
 		'onKeyUp',
@@ -97,7 +96,8 @@ function extractValue(event: Event): number {
 		'onMouseUp',
 		'onTouchCancel',
 		'onTouchEnd',
-		'onTouchStart'
+		'onTouchStart',
+		'onValue'
 	]
 })
 export class Slider extends ThemedMixin(FocusMixin(WidgetBase))<SliderProperties> {
@@ -107,10 +107,6 @@ export class Slider extends ThemedMixin(FocusMixin(WidgetBase))<SliderProperties
 	private _onBlur(event: FocusEvent) {
 		this.properties.onBlur && this.properties.onBlur(extractValue(event));
 	}
-	private _onChange(event: Event) {
-		event.stopPropagation();
-		this.properties.onChange && this.properties.onChange(extractValue(event));
-	}
 	private _onClick(event: MouseEvent) {
 		event.stopPropagation();
 		this.properties.onClick && this.properties.onClick(extractValue(event));
@@ -118,9 +114,9 @@ export class Slider extends ThemedMixin(FocusMixin(WidgetBase))<SliderProperties
 	private _onFocus(event: FocusEvent) {
 		this.properties.onFocus && this.properties.onFocus(extractValue(event));
 	}
-	private _onInput(event: Event) {
+	private _onValue(event: Event) {
 		event.stopPropagation();
-		this.properties.onInput && this.properties.onInput(extractValue(event));
+		this.properties.onValue && this.properties.onValue(extractValue(event));
 	}
 	private _onKeyDown(event: KeyboardEvent) {
 		event.stopPropagation();
@@ -285,10 +281,10 @@ export class Slider extends ThemedMixin(FocusMixin(WidgetBase))<SliderProperties
 					type: 'range',
 					value: `${value}`,
 					onblur: this._onBlur,
-					onchange: this._onChange,
+					onchange: this._onValue,
 					onclick: this._onClick,
 					onfocus: this._onFocus,
-					oninput: this._onInput,
+					oninput: this._onValue,
 					onkeydown: this._onKeyDown,
 					onkeypress: this._onKeyPress,
 					onkeyup: this._onKeyUp,

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -833,10 +833,8 @@ registerSuite('Slider', {
 
 		events() {
 			const onBlur = sinon.stub();
-			const onChange = sinon.stub();
 			const onClick = sinon.stub();
 			const onFocus = sinon.stub();
-			const onInput = sinon.stub();
 			const onKeyDown = sinon.stub();
 			const onKeyPress = sinon.stub();
 			const onKeyUp = sinon.stub();
@@ -845,14 +843,13 @@ registerSuite('Slider', {
 			const onTouchStart = sinon.stub();
 			const onTouchEnd = sinon.stub();
 			const onTouchCancel = sinon.stub();
+			const onValue = sinon.stub();
 
 			const h = harness(() =>
 				w(Slider, {
 					onBlur,
-					onChange,
 					onClick,
 					onFocus,
-					onInput,
 					onKeyDown,
 					onKeyPress,
 					onKeyUp,
@@ -860,7 +857,8 @@ registerSuite('Slider', {
 					onMouseUp,
 					onTouchStart,
 					onTouchEnd,
-					onTouchCancel
+					onTouchCancel,
+					onValue
 				})
 			);
 
@@ -868,7 +866,7 @@ registerSuite('Slider', {
 			assert.isTrue(onBlur.called, 'onBlur called');
 
 			h.trigger('@input', 'onchange', stubEvent);
-			assert.isTrue(onChange.called, 'onChange called');
+			assert.isTrue(onValue.called, 'onValue called on change');
 
 			h.trigger('@input', 'onclick', stubEvent);
 			assert.isTrue(onClick.called, 'onClick called');
@@ -876,8 +874,9 @@ registerSuite('Slider', {
 			h.trigger('@input', 'onfocus', stubEvent);
 			assert.isTrue(onFocus.called, 'onFocus called');
 
+			onValue.reset()
 			h.trigger('@input', 'oninput', stubEvent);
-			assert.isTrue(onInput.called, 'onInput called');
+			assert.isTrue(onValue.called, 'onValue called on input');
 
 			h.trigger('@input', 'onkeydown', stubEvent);
 			assert.isTrue(onKeyDown.called, 'onKeyDown called');

--- a/src/text-area/README.md
+++ b/src/text-area/README.md
@@ -22,8 +22,8 @@ If the `label` property is not used, we recommend creating a separate `label` an
 w(Textarea, {
 	label: 'Your Message',
 	value: this.state.textareaValue,
-	onChange: (event: TypedTargetEvent<HTMLInputElement>) => {
-		this.setState({ textareaValue: event.target.value });
+	onValue: (value: string) => {
+		this.setState({ textareaValue: value });
 	},
 });
 
@@ -42,8 +42,8 @@ w(Textarea, {
 	required: true,
 	value: this.state.message,
 	wrapText: 'hard',
-	onChange: (event: TypedTargetEvent<HTMLInputElement>) => {
-		this.setState({ message: event.target.value });
+	onValue: (value: string) => {
+		this.setState({ message: value });
 		this.setState({ messageValid: this._validatePassword() });
 	}
 }),

--- a/src/text-area/index.ts
+++ b/src/text-area/index.ts
@@ -47,6 +47,7 @@ export interface TextareaProperties
 	placeholder?: string;
 	value?: string;
 	onClick?(value: string): void;
+	onValue?(value: string): void;
 	label?: string;
 	labelHidden?: boolean;
 	helperText?: string;
@@ -81,10 +82,8 @@ export interface TextareaProperties
 	],
 	events: [
 		'onBlur',
-		'onChange',
 		'onClick',
 		'onFocus',
-		'onInput',
 		'onKeyDown',
 		'onKeyPress',
 		'onKeyUp',
@@ -92,17 +91,18 @@ export interface TextareaProperties
 		'onMouseUp',
 		'onTouchCancel',
 		'onTouchEnd',
-		'onTouchStart'
+		'onTouchStart',
+		'onValue'
 	]
 })
 export class Textarea extends ThemedMixin(FocusMixin(WidgetBase))<TextareaProperties> {
 	private _onBlur(event: FocusEvent) {
 		this.properties.onBlur && this.properties.onBlur((event.target as HTMLInputElement).value);
 	}
-	private _onChange(event: Event) {
+	private _onValue(event: Event) {
 		event.stopPropagation();
-		this.properties.onChange &&
-			this.properties.onChange((event.target as HTMLInputElement).value);
+		this.properties.onValue &&
+			this.properties.onValue((event.target as HTMLInputElement).value);
 	}
 	private _onClick(event: MouseEvent) {
 		event.stopPropagation();
@@ -112,11 +112,6 @@ export class Textarea extends ThemedMixin(FocusMixin(WidgetBase))<TextareaProper
 	private _onFocus(event: FocusEvent) {
 		this.properties.onFocus &&
 			this.properties.onFocus((event.target as HTMLInputElement).value);
-	}
-	private _onInput(event: Event) {
-		event.stopPropagation();
-		this.properties.onInput &&
-			this.properties.onInput((event.target as HTMLInputElement).value);
 	}
 	private _onKeyDown(event: KeyboardEvent) {
 		event.stopPropagation();
@@ -245,10 +240,10 @@ export class Textarea extends ThemedMixin(FocusMixin(WidgetBase))<TextareaProper
 						value,
 						wrap: wrapText,
 						onblur: this._onBlur,
-						onchange: this._onChange,
+						onchange: this._onValue,
 						onclick: this._onClick,
 						onfocus: this._onFocus,
-						oninput: this._onInput,
+						oninput: this._onValue,
 						onkeydown: this._onKeyDown,
 						onkeypress: this._onKeyPress,
 						onkeyup: this._onKeyUp,

--- a/src/text-area/tests/unit/Textarea.ts
+++ b/src/text-area/tests/unit/Textarea.ts
@@ -198,10 +198,8 @@ registerSuite('Textarea', {
 
 		events() {
 			const onBlur = sinon.stub();
-			const onChange = sinon.stub();
 			const onClick = sinon.stub();
 			const onFocus = sinon.stub();
-			const onInput = sinon.stub();
 			const onKeyDown = sinon.stub();
 			const onKeyPress = sinon.stub();
 			const onKeyUp = sinon.stub();
@@ -210,14 +208,13 @@ registerSuite('Textarea', {
 			const onTouchStart = sinon.stub();
 			const onTouchEnd = sinon.stub();
 			const onTouchCancel = sinon.stub();
+			const onValue = sinon.stub();
 
 			const h = harness(() =>
 				w(Textarea, {
 					onBlur,
-					onChange,
 					onClick,
 					onFocus,
-					onInput,
 					onKeyDown,
 					onKeyPress,
 					onKeyUp,
@@ -225,20 +222,22 @@ registerSuite('Textarea', {
 					onMouseUp,
 					onTouchStart,
 					onTouchEnd,
-					onTouchCancel
+					onTouchCancel,
+					onValue
 				})
 			);
 
 			h.trigger('@input', 'onblur', stubEvent);
 			assert.isTrue(onBlur.called, 'onBlur called');
 			h.trigger('@input', 'onchange', stubEvent);
-			assert.isTrue(onChange.called, 'onChange called');
+			assert.isTrue(onValue.called, 'onValue called for change');
 			h.trigger('@input', 'onclick', stubEvent);
 			assert.isTrue(onClick.called, 'onClick called');
 			h.trigger('@input', 'onfocus', stubEvent);
 			assert.isTrue(onFocus.called, 'onFocus called');
 			h.trigger('@input', 'oninput', stubEvent);
-			assert.isTrue(onInput.called, 'onInput called');
+			onValue.reset()
+			assert.isTrue(onValue.called, 'onValue called for input');
 			h.trigger('@input', 'onkeydown', stubEvent);
 			assert.isTrue(onKeyDown.called, 'onKeyDown called');
 			h.trigger('@input', 'onkeypress', stubEvent);

--- a/src/text-input/example/index.ts
+++ b/src/text-input/example/index.ts
@@ -26,7 +26,7 @@ export default class App extends WidgetBase {
 						type: 'text',
 						placeholder: 'Hello, World',
 						value: this._value1,
-						onChange: (value: string) => {
+						onValue: (value: string) => {
 							this._value1 = value;
 							this.invalidate();
 						}
@@ -40,7 +40,7 @@ export default class App extends WidgetBase {
 						label: 'Email (required)',
 						required: true,
 						value: this._value2,
-						onChange: (value: string) => {
+						onValue: (value: string) => {
 							this._value2 = value;
 							this.invalidate();
 						}
@@ -55,7 +55,7 @@ export default class App extends WidgetBase {
 						label: 'Try listening to me!',
 						labelHidden: true,
 						value: this._value3,
-						onChange: (value: string) => {
+						onValue: (value: string) => {
 							this._value3 = value;
 							this.invalidate();
 						}
@@ -80,7 +80,7 @@ export default class App extends WidgetBase {
 						label: 'input with helper text',
 						value: this._value5,
 						helperText: 'helper text',
-						onInput: (value: string) => {
+						onValue: (value: string) => {
 							this._value5 = value;
 							this.invalidate();
 						}
@@ -101,7 +101,7 @@ export default class App extends WidgetBase {
 							this.invalidate();
 						},
 						pattern: 'foo|bar',
-						onInput: (value: string) => {
+						onValue: (value: string) => {
 							this._value6 = value;
 							this.invalidate();
 						}

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -68,6 +68,7 @@ export interface TextInputProperties
 	autocomplete?: boolean | string;
 	onClick?(value: string): void;
 	onValidate?: (valid: boolean | undefined, message: string) => void;
+	onValue?: (value: string) => void;
 	leading?: () => DNode;
 	trailing?: () => DNode;
 	labelHidden?: boolean;
@@ -123,10 +124,8 @@ function patternDiffer(
 	],
 	events: [
 		'onBlur',
-		'onChange',
 		'onClick',
 		'onFocus',
-		'onInput',
 		'onKeyDown',
 		'onKeyPress',
 		'onKeyUp',
@@ -145,10 +144,10 @@ export class TextInput extends ThemedMixin(FocusMixin(WidgetBase))<TextInputProp
 	private _onBlur(event: FocusEvent) {
 		this.properties.onBlur && this.properties.onBlur((event.target as HTMLInputElement).value);
 	}
-	private _onChange(event: Event) {
+	private _onValue(event: Event) {
 		event.stopPropagation();
-		this.properties.onChange &&
-			this.properties.onChange((event.target as HTMLInputElement).value);
+		this.properties.onValue &&
+			this.properties.onValue((event.target as HTMLInputElement).value);
 	}
 	private _onClick(event: MouseEvent) {
 		event.stopPropagation();
@@ -158,11 +157,6 @@ export class TextInput extends ThemedMixin(FocusMixin(WidgetBase))<TextInputProp
 	private _onFocus(event: FocusEvent) {
 		this.properties.onFocus &&
 			this.properties.onFocus((event.target as HTMLInputElement).value);
-	}
-	private _onInput(event: Event) {
-		event.stopPropagation();
-		this.properties.onInput &&
-			this.properties.onInput((event.target as HTMLInputElement).value);
 	}
 	private _onKeyDown(event: KeyboardEvent) {
 		event.stopPropagation();
@@ -357,10 +351,10 @@ export class TextInput extends ThemedMixin(FocusMixin(WidgetBase))<TextInputProp
 							type,
 							value,
 							onblur: this._onBlur,
-							onchange: this._onChange,
+							onchange: this._onValue,
 							onclick: this._onClick,
 							onfocus: this._onFocus,
-							oninput: this._onInput,
+							oninput: this._onValue,
 							onkeydown: this._onKeyDown,
 							onkeypress: this._onKeyPress,
 							onkeyup: this._onKeyUp,

--- a/src/text-input/tests/unit/TextInput.ts
+++ b/src/text-input/tests/unit/TextInput.ts
@@ -553,10 +553,9 @@ registerSuite('TextInput', {
 
 		events() {
 			const onBlur = sinon.stub();
-			const onChange = sinon.stub();
+			const onValue = sinon.stub();
 			const onClick = sinon.stub();
 			const onFocus = sinon.stub();
-			const onInput = sinon.stub();
 			const onKeyDown = sinon.stub();
 			const onKeyPress = sinon.stub();
 			const onKeyUp = sinon.stub();
@@ -569,10 +568,9 @@ registerSuite('TextInput', {
 			const h = harness(() =>
 				w(TextInput, {
 					onBlur,
-					onChange,
+					onValue,
 					onClick,
 					onFocus,
-					onInput,
 					onKeyDown,
 					onKeyPress,
 					onKeyUp,
@@ -587,13 +585,14 @@ registerSuite('TextInput', {
 			h.trigger('@input', 'onblur', stubEvent);
 			assert.isTrue(onBlur.called, 'onBlur called');
 			h.trigger('@input', 'onchange', stubEvent);
-			assert.isTrue(onChange.called, 'onChange called');
+			assert.isTrue(onValue.called, 'onValue called');
 			h.trigger('@input', 'onclick', stubEvent);
 			assert.isTrue(onClick.called, 'onClick called');
 			h.trigger('@input', 'onfocus', stubEvent);
 			assert.isTrue(onFocus.called, 'onFocus called');
+			onValue.reset();
 			h.trigger('@input', 'oninput', stubEvent);
-			assert.isTrue(onInput.called, 'onInput called');
+			assert.isTrue(onValue.called, 'onValue called for input event');
 			h.trigger('@input', 'onkeydown', stubEvent);
 			assert.isTrue(onKeyDown.called, 'onKeyDown called');
 			h.trigger('@input', 'onkeypress', stubEvent);

--- a/src/time-picker/index.ts
+++ b/src/time-picker/index.ts
@@ -321,7 +321,7 @@ export class TimePicker extends ThemedMixin(FocusMixin(WidgetBase))<TimePickerPr
 			labelAfter,
 			labelHidden,
 			onBlur: this._onBlur,
-			onChange: this._onChange,
+			onValue: this._onChange,
 			onFocus: this._onFocus,
 			onMenuChange: this._onMenuChange,
 			onRequestResults: this._onRequestOptions.bind(this),

--- a/src/time-picker/tests/unit/TimePicker.ts
+++ b/src/time-picker/tests/unit/TimePicker.ts
@@ -45,7 +45,7 @@ const getExpectedCombobox = function(useTestProperties = false, results?: any[])
 		labelAfter: undefined,
 		labelHidden: undefined,
 		onBlur: noop,
-		onChange: noop,
+		onValue: noop,
 		onFocus: noop,
 		onMenuChange: noop,
 		onRequestResults: noop,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [X] There is a related issue ( #724 )
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [X] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This is an in-progress branch for collapsing `onInput`, `onChange`, and the custom-widget specific update events into a single `onValue` with the goal of simplifying state update code and allowing better generic handling at the form level.

Incomplete:

* I was working through the components incrementally and haven't yet changed the definitions in `interfaces.d.ts` so the components have individual `onValue` definitions that must be removed when that happens.
* Select has a more complicated interaction here than other widgets. As a result, I was hoping to keep `onChange` as an escape hatch for handling an entire option object and building `onValue` alongside it. I'm missing one of the interactions and as a result a unit test is failing.
* What's here is mostly a mechanical translation from `onChange` and friends. I think there should be some additional API changes to further the goal of generic form handling. In particular I think the first argument should *always* be the value and the second *always* the name. This means that the range slider's onValue callback should take a `[low, high]` array instead of two separate arguments and changes to the radio and checkbox versions. The last two are most problematic because they have both `checked` and `value`. We can pass `checked` as the third argument easily enough but I'm not sure if the first argument should be `undefined` if not checked or the empty string.

Resolves #???
