### PR TITLE
Upgrade to Dojo 6.0.0 Alpha

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -779,9 +779,9 @@
       }
     },
     "@types/webpack": {
-      "version": "4.4.32",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.4.32.tgz",
-      "integrity": "sha512-mNARoaSJTzbiHxtZbf9NULFilu2frqD+g9Iyl9V2jPYJWXi+AC3Hz8lQWPZ5LLtgUm7iF4SDDMB/1bPrbRQgFw==",
+      "version": "4.4.33",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.4.33.tgz",
+      "integrity": "sha512-MU5Lokm30QHF9Wn0+yq/hnToPlEBRQVa72mgn1/W8OpJu63aRDKy0aEdMI+pCk8F6zwQJfSFaVzx1JN1MLXx8A==",
       "dev": true,
       "requires": {
         "@types/anymatch": "*",
@@ -2063,13 +2063,13 @@
       }
     },
     "browserslist": {
-      "version": "4.6.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.2.tgz",
-      "integrity": "sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==",
+      "version": "4.6.3",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.3.tgz",
+      "integrity": "sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000974",
-        "electron-to-chromium": "^1.3.150",
+        "caniuse-lite": "^1.0.30000975",
+        "electron-to-chromium": "^1.3.164",
         "node-releases": "^1.1.23"
       }
     },
@@ -2149,22 +2149,22 @@
       "dev": true
     },
     "cacache": {
-      "version": "11.3.2",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.2.tgz",
-      "integrity": "sha512-E0zP4EPGDOaT2chM08Als91eYnf8Z+eH1awwwVsngUmgppfM5jjJ8l3z5vO5p5w/I3LsiXawb1sW0VY65pQABg==",
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-11.3.3.tgz",
+      "integrity": "sha512-p8WcneCytvzPxhDvYp31PD039vi77I12W+/KfR9S8AZbaiARFBCpsPJS+9uhWfeBfeAtW7o/4vt3MUqLkbY6nA==",
       "dev": true,
       "requires": {
-        "bluebird": "^3.5.3",
+        "bluebird": "^3.5.5",
         "chownr": "^1.1.1",
         "figgy-pudding": "^3.5.1",
-        "glob": "^7.1.3",
+        "glob": "^7.1.4",
         "graceful-fs": "^4.1.15",
         "lru-cache": "^5.1.1",
         "mississippi": "^3.0.0",
         "mkdirp": "^0.5.1",
         "move-concurrently": "^1.0.1",
         "promise-inflight": "^1.0.1",
-        "rimraf": "^2.6.2",
+        "rimraf": "^2.6.3",
         "ssri": "^6.0.1",
         "unique-filename": "^1.1.1",
         "y18n": "^4.0.0"
@@ -2275,15 +2275,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000974",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000974.tgz",
-      "integrity": "sha512-zeXkn1hbjMvXdadcyUELZnGu7OjlW3HK0956DWczM7ZJqGV4jFaPi8CidB8QiAj5xl5O9I+f7j9F0AFmXmGTpg==",
+      "version": "1.0.30000976",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000976.tgz",
+      "integrity": "sha512-QvzPHBh2cYmilQAiiamun3ooHRGKFKtVwLzzx0RG7avjpj7Gii89Yzs92EKeHNqbAA2rlcFXg4GzP/tC68OGuw==",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000974",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz",
-      "integrity": "sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==",
+      "version": "1.0.30000976",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000976.tgz",
+      "integrity": "sha512-tleNB1IwPRqZiod6nUNum63xQCMN96BUO2JTeiwuRM7p9d616EHsMBjBWJMudX39qCaPuWY8KEWzMZq7A9XQMQ==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -4149,9 +4149,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.159",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.159.tgz",
-      "integrity": "sha512-bhiEr8/A97GUBcUzNb9MFNhzQOjakbKmEKBEAa6UMY45zG2e8PM63LOgAPXEJE9bQiaQH6nOdYiYf8X821tZjQ==",
+      "version": "1.3.172",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.172.tgz",
+      "integrity": "sha512-bHgFvYeHBiQNNuY/WvoX37zLosPgMbR8nKU1r4mylHptLvuMMny/KG/L28DTIlcoOCJjMAhEimy3DHDgDayPbg==",
       "dev": true
     },
     "elegant-spinner": {
@@ -7490,6 +7490,12 @@
         "statuses": ">= 1.4.0 < 2"
       },
       "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        },
         "statuses": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
@@ -7670,12 +7676,13 @@
           },
           "dependencies": {
             "find-up": {
-              "version": "4.0.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.0.0.tgz",
-              "integrity": "sha512-zoH7ZWPkRdgwYCDVoQTzqjG8JSPANhtvLhh4KVUHyKnaUJJrNeFmWIkTcNuJmR3GLMEmGYEf2S2bjgx26JTF+Q==",
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
               "dev": true,
               "requires": {
-                "locate-path": "^5.0.0"
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
               }
             },
             "locate-path": {
@@ -7695,6 +7702,12 @@
               "requires": {
                 "p-limit": "^2.2.0"
               }
+            },
+            "path-exists": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
+              "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+              "dev": true
             }
           }
         },
@@ -7864,9 +7877,9 @@
       }
     },
     "inherits": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
-      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
       "dev": true
     },
     "ini": {
@@ -14188,9 +14201,9 @@
       "dev": true
     },
     "process-nextick-args": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.0.tgz",
-      "integrity": "sha512-MtEC1TqN0EU5nephaJ4rAtThHtC86dNN9qCuEhtshvpVBkAW5ZO7BASN9REnF9eoXGcRub+pFuKEpOHE+HbEMw==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
       "dev": true
     },
     "progress": {
@@ -14276,9 +14289,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.32",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
-      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
+      "version": "1.1.33",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz",
+      "integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw==",
       "dev": true
     },
     "public-encrypt": {
@@ -14479,6 +14492,12 @@
           "version": "0.4.19",
           "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.19.tgz",
           "integrity": "sha512-oTZqweIP51xaGPI4uPa56/Pri/480R+mo7SeU+YETByQNhDG55ycFyNLIgta9vXhILrxXDmF7ZGhqZIcuN0gJQ==",
+          "dev": true
+        },
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
           "dev": true
         },
         "setprototypeof": {
@@ -14942,9 +14961,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.11.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
-      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -15238,9 +15257,9 @@
       "dev": true
     },
     "serve": {
-      "version": "11.0.1",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-11.0.1.tgz",
-      "integrity": "sha512-kmcR5jOumMcmoDVJk7izj2Gnz+ql4K3Xq1g0l4XX598lLYvbXgfS1oeTgckPVGzsk0MU/dBPHiolRgH0fI7c5g==",
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-11.0.2.tgz",
+      "integrity": "sha512-TjjjwUdPU+STkUyxvZFtkWOTRXdNDNMfot9Z/f97eEeyjPAV69o1TmJrNAlDbvpPu1JEjCoWiGCjkel7kWNF4A==",
       "dev": true,
       "requires": {
         "@zeit/schemas": "2.6.0",
@@ -15250,7 +15269,7 @@
         "chalk": "2.4.1",
         "clipboardy": "1.2.3",
         "compression": "1.7.3",
-        "serve-handler": "6.0.1",
+        "serve-handler": "6.0.2",
         "update-check": "1.5.2"
       },
       "dependencies": {
@@ -15269,9 +15288,9 @@
       }
     },
     "serve-handler": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.0.1.tgz",
-      "integrity": "sha512-k/im4Fbx96d8VcrJDjrsagNd9Vq18tVYRDDe90rpNO8Mr76KJF/zES5tBZdlLEbhBXjOs36m9Wl+hRCiDnYfmA==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.0.2.tgz",
+      "integrity": "sha512-D1zgDpvx9Rgjip6rzY2QBjlZwfr/oiDSg66HipOWkEw1appHn7/mXdVRL6F8+bd1KD117Wch4+4x78OTXQVwDg==",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
@@ -15440,9 +15459,9 @@
       "dev": true
     },
     "simple-git": {
-      "version": "1.113.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.113.0.tgz",
-      "integrity": "sha512-i9WVsrK2u0G/cASI9nh7voxOk9mhanWY9eGtWBDSYql6m49Yk5/Fan6uZsDr/xmzv8n+eQ8ahKCoEr8cvU3h+g==",
+      "version": "1.116.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.116.0.tgz",
+      "integrity": "sha512-Pbo3tceqMYy0j3U7jzMKabOWcx5+67GdgQUjpK83XUxGhA+1BX93UPvlWNzbCRoFwd7EJTyDSCC2XCoT4NTLYQ==",
       "dev": true,
       "requires": {
         "debug": "^4.0.1"
@@ -17740,6 +17759,14 @@
       "dev": true,
       "requires": {
         "inherits": "2.0.3"
+      },
+      "dependencies": {
+        "inherits": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+          "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+          "dev": true
+        }
       }
     },
     "util-deprecate": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -453,9 +453,9 @@
       }
     },
     "@theintern/leadfoot": {
-      "version": "2.2.10",
-      "resolved": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.2.10.tgz",
-      "integrity": "sha512-2CzsEhLebDM6XDjyCG+M8h4stHt1pGcOWc3Ezcst9r4ewCxeu9DKvspB1XH3FtlsUBDRUZbk2XA050wAUBIi5Q==",
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.2.12.tgz",
+      "integrity": "sha512-S6GvDXEVVOUG0YduPcfYF5FKWWvMM9CDNKGPU6uUc/hUHEWLVNO4c8K5KLsi1x91fSUvFGcdl8gnUhWcs51x0w==",
       "dev": true,
       "requires": {
         "@theintern/common": "~0.1.3",
@@ -548,9 +548,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.6",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.6.tgz",
-      "integrity": "sha512-8wr3CA/EMybyb6/V8qvTRKiNkPmgUA26uA9XWD6hlA0yFDuqi4r2L0C2B0U2HAYltJamoYJszlkaWM31vrKsHg==",
+      "version": "4.16.7",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
+      "integrity": "sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -676,9 +676,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.133",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.133.tgz",
-      "integrity": "sha512-/3JqnvPnY58GLzG3Y7fpphOhATV1DDZ/Ak3DQufjlRK5E4u+s0CfClfNFtAGBabw+jDGtRFbOZe+Z02ZMWCBNQ==",
+      "version": "4.14.134",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.134.tgz",
+      "integrity": "sha512-2/O0khFUCFeDlbi7sZ7ZFRCcT812fAeOLm7Ev4KbwASkZ575TDrDcY7YyaoHdTOzKcNbfiwLYZqPmoC4wadrsw==",
       "dev": true
     },
     "@types/marked": {
@@ -1062,9 +1062,9 @@
       }
     },
     "agent-base": {
-      "version": "4.2.1",
-      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
-      "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.3.0.tgz",
+      "integrity": "sha512-salcGninV0nPrwpGNn4VTXBb1SOuXQBiqbrNXoeizJsHrsL6ERFM2Ne3JUSBWRE6aeNJI2ROP/WEEIDUiDe3cg==",
       "dev": true,
       "requires": {
         "es6-promisify": "^5.0.0"
@@ -2063,14 +2063,14 @@
       }
     },
     "browserslist": {
-      "version": "4.6.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
-      "integrity": "sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.2.tgz",
+      "integrity": "sha512-2neU/V0giQy9h3XMPwLhEY3+Ao0uHSwHvU8Q1Ea6AgLVL1sXbX3dzPrJ8NWe5Hi4PoTkCYXOtVR9rfRLI0J/8Q==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000971",
-        "electron-to-chromium": "^1.3.137",
-        "node-releases": "^1.1.21"
+        "caniuse-lite": "^1.0.30000974",
+        "electron-to-chromium": "^1.3.150",
+        "node-releases": "^1.1.23"
       }
     },
     "buffer": {
@@ -2275,15 +2275,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000973",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000973.tgz",
-      "integrity": "sha512-leylQOpbgiYSm4G3NT8kq/KkKhKHlOLIBugpr6QsmjrYWgIR+S/iTDjM/5uM6FVqJg4YiD0en3P1udVvnRmrWA==",
+      "version": "1.0.30000974",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000974.tgz",
+      "integrity": "sha512-zeXkn1hbjMvXdadcyUELZnGu7OjlW3HK0956DWczM7ZJqGV4jFaPi8CidB8QiAj5xl5O9I+f7j9F0AFmXmGTpg==",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000973",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000973.tgz",
-      "integrity": "sha512-/F3t/Yo8LEdRSEPCmI15fLu5vepVh9UCg/9inJXF5AAfW7xRRJkbaM2ut52iRMQMnGCLQouLbFdbOA+VEFOIsg==",
+      "version": "1.0.30000974",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000974.tgz",
+      "integrity": "sha512-xc3rkNS/Zc3CmpMKuczWEdY2sZgx09BkAxfvkxlAEBTqcMHeL8QnPqhKse+5sRTi3nrw2pJwToD2WvKn1Uhvww==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -3653,12 +3653,13 @@
       "dev": true
     },
     "d": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
-      "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/d/-/d-1.0.1.tgz",
+      "integrity": "sha512-m62ShEObQ39CfralilEQRjH6oAMtNCV1xJyEx5LpRYUVN+EviphDgUc/F3hnYbADmkiNs67Y+3ylmlG7Lnu+FA==",
       "dev": true,
       "requires": {
-        "es5-ext": "^0.10.9"
+        "es5-ext": "^0.10.50",
+        "type": "^1.0.1"
       }
     },
     "dashdash": {
@@ -4148,9 +4149,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.144",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.144.tgz",
-      "integrity": "sha512-jNRFJpfNrYm5uJ4x0q9oYMOfbL0JPOlkNli8GS/5zEmCjnE5jAtoCo4BYajHiqSPqEeAjtTdItL4p7EZw+jSfg==",
+      "version": "1.3.159",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.159.tgz",
+      "integrity": "sha512-bhiEr8/A97GUBcUzNb9MFNhzQOjakbKmEKBEAa6UMY45zG2e8PM63LOgAPXEJE9bQiaQH6nOdYiYf8X821tZjQ==",
       "dev": true
     },
     "elegant-spinner": {
@@ -4309,9 +4310,9 @@
       "dev": true
     },
     "es6-promise": {
-      "version": "4.2.6",
-      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.6.tgz",
-      "integrity": "sha512-aRVgGdnmW2OiySVPUC9e6m+plolMAJKjZnQlCwNSuK5yQ0JN61DZSO1X1Ufd1foqWRAlig0rhduTCHe7sVtK5Q==",
+      "version": "4.2.8",
+      "resolved": "https://registry.npmjs.org/es6-promise/-/es6-promise-4.2.8.tgz",
+      "integrity": "sha512-HJDGx5daxeIvxdBxvG2cb9g4tEvwIk3i8+nhX0yGrYmZUzbkdg8QbDevheDB8gd0//uPj4c1EQua8Q+MViT0/w==",
       "dev": true
     },
     "es6-promisify": {
@@ -7498,9 +7499,9 @@
       }
     },
     "http-parser-js": {
-      "version": "0.5.0",
-      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.5.0.tgz",
-      "integrity": "sha512-cZdEF7r4gfRIq7ezX9J0T+kQmJNOub71dWbgAXVHDct80TKP4MCETtZQ31xyv38UwgzkWPYF/Xc0ge55dW9Z9w==",
+      "version": "0.4.10",
+      "resolved": "https://registry.npmjs.org/http-parser-js/-/http-parser-js-0.4.10.tgz",
+      "integrity": "sha1-ksnBN0w1CF912zWexWzCV8u5P6Q=",
       "dev": true
     },
     "http-proxy-agent": {
@@ -7850,12 +7851,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/indexes-of/-/indexes-of-1.0.1.tgz",
       "integrity": "sha1-8w9xbI4r00bHtn0985FVZqfAVgc=",
-      "dev": true
-    },
-    "indexof": {
-      "version": "0.0.1",
-      "resolved": "https://registry.npmjs.org/indexof/-/indexof-0.0.1.tgz",
-      "integrity": "sha1-gtwzbSMrkGIXnQWrMpOmYFn9Q10=",
       "dev": true
     },
     "inflight": {
@@ -9138,9 +9133,9 @@
       }
     },
     "libnpmsearch": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.0.tgz",
-      "integrity": "sha512-vd+JWbTGzOSfiOc+72MU6y7WqmBXn49egCCrIXp27iE/88bX8EpG64ST1blWQI1bSMUr9l1AKPMVsqa2tS5KWA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/libnpmsearch/-/libnpmsearch-2.0.1.tgz",
+      "integrity": "sha512-K0yXyut9MHHCAH+DOiglQCpmBKPZXSUu76+BE2maSEfQN15OwNaA/Aiioe9lRFlVFOr7WcuJCY+VSl+gLi9NTA==",
       "dev": true,
       "requires": {
         "figgy-pudding": "^3.5.1",
@@ -9909,9 +9904,9 @@
       }
     },
     "ms": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+      "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
     },
     "multimatch": {
@@ -10018,9 +10013,9 @@
       }
     },
     "node-libs-browser": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.0.tgz",
-      "integrity": "sha512-5MQunG/oyOaBdttrL40dA7bUfPORLRWMUJLQtMg7nluxUvk5XwnLdL9twQHFAjRx/y7mIMkLKT9++qPbbk6BZA==",
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.2.1.tgz",
+      "integrity": "sha512-h/zcD8H9kaDZ9ALUWwlBUDo6TKF8a7qBSCSEGfjTVIYeqsioSKaAX+BN7NgiMGp6iSIXZ3PxgCu8KS3b71YK5Q==",
       "dev": true,
       "requires": {
         "assert": "^1.1.1",
@@ -10033,7 +10028,7 @@
         "events": "^3.0.0",
         "https-browserify": "^1.0.0",
         "os-browserify": "^0.3.0",
-        "path-browserify": "0.0.0",
+        "path-browserify": "0.0.1",
         "process": "^0.11.10",
         "punycode": "^1.2.4",
         "querystring-es3": "^0.2.0",
@@ -10045,7 +10040,7 @@
         "tty-browserify": "0.0.0",
         "url": "^0.11.0",
         "util": "^0.11.0",
-        "vm-browserify": "0.0.4"
+        "vm-browserify": "^1.0.1"
       },
       "dependencies": {
         "punycode": {
@@ -10057,9 +10052,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.22",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.22.tgz",
-      "integrity": "sha512-O6XpteBuntW1j86mw6LlovBIwTe+sO2+7vi9avQffNeIW4upgnaCVm6xrBWH+KATz7mNNRNNeEpuWB7dT6Cr3w==",
+      "version": "1.1.23",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.23.tgz",
+      "integrity": "sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -10678,9 +10673,9 @@
       "dev": true
     },
     "path-browserify": {
-      "version": "0.0.0",
-      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.0.tgz",
-      "integrity": "sha1-oLhwcpquIUAFt9UDLsLLuw+0RRo=",
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-0.0.1.tgz",
+      "integrity": "sha512-BapA40NHICOS+USX9SN4tyhq+A2RrN/Ws5F0Z5aMHDp98Fl86lX8Oti8B7uN93L4Ifv4fHOEA+pQw87gmMO/lQ==",
       "dev": true
     },
     "path-dirname": {
@@ -12976,27 +12971,13 @@
       }
     },
     "postcss-load-config": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.0.0.tgz",
-      "integrity": "sha512-V5JBLzw406BB8UIfsAWSK2KSwIJ5yoEIVFb4gVkXci0QdKgA24jLmHZ/ghe/GgX0lJ0/D1uUK1ejhzEY94MChQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-load-config/-/postcss-load-config-2.1.0.tgz",
+      "integrity": "sha512-4pV3JJVPLd5+RueiVVB+gFOAa7GWc25XQcMp86Zexzke69mKf6Nx9LRcQywdz7yZI9n1udOxmLuAwTBypypF8Q==",
       "dev": true,
       "requires": {
-        "cosmiconfig": "^4.0.0",
+        "cosmiconfig": "^5.0.0",
         "import-cwd": "^2.0.0"
-      },
-      "dependencies": {
-        "cosmiconfig": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-4.0.0.tgz",
-          "integrity": "sha512-6e5vDdrXZD+t5v0L8CrurPeybg4Fmf+FCSYxXKYVAqLUtyCSbuyqE059d0kDthTNRzKVjL7QMgNpEUlsoYH3iQ==",
-          "dev": true,
-          "requires": {
-            "is-directory": "^0.3.1",
-            "js-yaml": "^3.9.0",
-            "parse-json": "^4.0.0",
-            "require-from-string": "^2.0.1"
-          }
-        }
       }
     },
     "postcss-loader": {
@@ -14379,9 +14360,9 @@
           }
         },
         "mime": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
-          "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==",
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
           "dev": true
         }
       }
@@ -14948,12 +14929,6 @@
       "integrity": "sha1-jGStX9MNqxyXbiNE/+f3kqam30I=",
       "dev": true
     },
-    "require-from-string": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
-      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
-      "dev": true
-    },
     "require-main-filename": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/require-main-filename/-/require-main-filename-1.0.1.tgz",
@@ -14967,9 +14942,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.11.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
-      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
+      "version": "1.11.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.0.tgz",
+      "integrity": "sha512-WL2pBDjqT6pGUNSUzMw00o4T7If+z4H2x3Gz893WoUQ5KW8Vr9txp00ykiP16VBaZF5+j/OcXJHZ9+PCvdiDKw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -15686,6 +15661,17 @@
       "requires": {
         "agent-base": "~4.2.1",
         "socks": "~2.3.2"
+      },
+      "dependencies": {
+        "agent-base": {
+          "version": "4.2.1",
+          "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-4.2.1.tgz",
+          "integrity": "sha512-JVwXMr9nHYTUXsBFKUqhJwvlcYU/blreOEUkhNR2eXZIvwd+c+o5V4MgDPKWnMS/56awN3TRzIP+KoPn+roQtg==",
+          "dev": true,
+          "requires": {
+            "es6-promisify": "^5.0.0"
+          }
+        }
       }
     },
     "sort-keys": {
@@ -16105,9 +16091,9 @@
       "dev": true
     },
     "symbol-tree": {
-      "version": "3.2.2",
-      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.2.tgz",
-      "integrity": "sha1-rifbOPZgp64uHDt9G8KQgZuFGeY=",
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
       "dev": true
     },
     "synchronous-promise": {
@@ -16643,6 +16629,12 @@
       "version": "0.14.5",
       "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
       "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+      "dev": true
+    },
+    "type": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/type/-/type-1.0.1.tgz",
+      "integrity": "sha512-MAM5dBMJCJNKs9E7JXo4CXRAansRfG0nlJxW7Wf6GZzSOvH31zClSaHdIMWLehe/EGMBkqeC55rrkaOr5Oo7Nw==",
       "dev": true
     },
     "type-check": {
@@ -17544,9 +17536,9 @@
       }
     },
     "unique-slug": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.1.tgz",
-      "integrity": "sha512-n9cU6+gITaVu7VGj1Z8feKMmfAjEAQGhwD9fE3zvpRRa0wEIx8ODYkVGfSc94M2OX00tUFV8wH3zYbm1I8mxFg==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/unique-slug/-/unique-slug-2.0.2.tgz",
+      "integrity": "sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==",
       "dev": true,
       "requires": {
         "imurmurhash": "^0.1.4"
@@ -17842,13 +17834,10 @@
       "dev": true
     },
     "vm-browserify": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
-      "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true,
-      "requires": {
-        "indexof": "0.0.1"
-      }
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-1.1.0.tgz",
+      "integrity": "sha512-iq+S7vZJE60yejDYM0ek6zg308+UZsdtPExWP9VZoCFCz1zkJoXFnAX7aZfd/ZwrkidzdUZL0C/ryW+JwAiIGw==",
+      "dev": true
     },
     "watchpack": {
       "version": "1.6.0",
@@ -17945,9 +17934,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.3",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
-          "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==",
+          "version": "2.4.4",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.4.tgz",
+          "integrity": "sha512-LRxmNwziLPT828z+4YkNzloCFC2YM4wrB99k+AV5ZbEyfGNWfG8SO1FUXLmLDBSo89NrJZ4DIWeLjy1CHGhMGA==",
           "dev": true
         }
       }
@@ -18016,12 +18005,13 @@
       }
     },
     "websocket-driver": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
-      "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.3.tgz",
+      "integrity": "sha512-bpxWlvbbB459Mlipc5GBzzZwhoZgGEZLuqPaR0INBGnPAY1vdBX6hPnoFXiw+3yWxDuHyQjO2oXTMyS8A5haFg==",
       "dev": true,
       "requires": {
-        "http-parser-js": ">=0.4.0",
+        "http-parser-js": ">=0.4.0 <0.4.11",
+        "safe-buffer": ">=5.1.0",
         "websocket-extensions": ">=0.1.1"
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -779,9 +779,9 @@
       }
     },
     "@types/webpack": {
-      "version": "4.4.33",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.4.33.tgz",
-      "integrity": "sha512-MU5Lokm30QHF9Wn0+yq/hnToPlEBRQVa72mgn1/W8OpJu63aRDKy0aEdMI+pCk8F6zwQJfSFaVzx1JN1MLXx8A==",
+      "version": "4.4.34",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.4.34.tgz",
+      "integrity": "sha512-GnEBgjHsfO1M7DIQ0dAupSofcmDItE3Zsu3reK8SQpl/6N0rtUQxUmQzVFAS5ou/FGjsYKjXAWfItLZ0kNFTfQ==",
       "dev": true,
       "requires": {
         "@types/anymatch": "*",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,9 +5,9 @@
   "requires": true,
   "dependencies": {
     "@babel/runtime": {
-      "version": "7.4.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.4.tgz",
-      "integrity": "sha512-w0+uT71b6Yi7i5SE0co4NioIpSYS6lLiXvCzWzGSKvpK5vdQtCbICHMj+gbAKAOtxiV6HsVh/MBdaF9EQ6faSg==",
+      "version": "7.4.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
+      "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -50,6 +50,14 @@
         "tslib": "1.8.1",
         "update-notifier": "2.5.0",
         "yargs": "10.1.2"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+          "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
+          "dev": true
+        }
       }
     },
     "@dojo/cli-build-widget": {
@@ -134,6 +142,14 @@
         "tslib": "1.8.1",
         "web-animations-js": "2.3.1",
         "whatwg-fetch": "3.0.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.8.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
+          "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw=",
+          "dev": true
+        }
       }
     },
     "@dojo/loader": {
@@ -413,20 +429,12 @@
       "requires": {
         "axios": "~0.18.0",
         "tslib": "~1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-          "dev": true
-        }
       }
     },
     "@theintern/digdug": {
-      "version": "2.2.3",
-      "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.2.3.tgz",
-      "integrity": "sha512-K3udP/hLAI/0snTBo92FGC6TQnqZ247bADYzTm4SzfprL64Y71cQ46z6s/ORZscbx19d0TXyjKWvBUlraEBQOA==",
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/@theintern/digdug/-/digdug-2.2.4.tgz",
+      "integrity": "sha512-hVsQ9YFFW8F675ITnNsCfrIMTOYf4JdhceHKx8O40r4xZImXPBnTGYHGh6djBV68ULxxv1dWyCI+1xa/dTjWdg==",
       "dev": true,
       "requires": {
         "@theintern/common": "~0.1.3",
@@ -441,32 +449,18 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-5.5.1.tgz",
           "integrity": "sha512-PqpAxfrEhlSUWge8dwIp4tZnQ25DIOthpiaHNIthsjEFQD6EvqUKUDM7L8O2rShkFccYo1VjJR0coWfNkCubRw==",
           "dev": true
-        },
-        "tslib": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-          "dev": true
         }
       }
     },
     "@theintern/leadfoot": {
-      "version": "2.2.9",
-      "resolved": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.2.9.tgz",
-      "integrity": "sha512-Jwxz0/nVDJpz6b1HfXoPs0O6rcv0mNyvgIynx0zYUvSL7d7kuJEA8JBDhmYtc31Bji5yTjep+FBuEH3ul94Kcg==",
+      "version": "2.2.10",
+      "resolved": "https://registry.npmjs.org/@theintern/leadfoot/-/leadfoot-2.2.10.tgz",
+      "integrity": "sha512-2CzsEhLebDM6XDjyCG+M8h4stHt1pGcOWc3Ezcst9r4ewCxeu9DKvspB1XH3FtlsUBDRUZbk2XA050wAUBIi5Q==",
       "dev": true,
       "requires": {
         "@theintern/common": "~0.1.3",
         "jszip": "~3.1.5",
         "tslib": "~1.9.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-          "dev": true
-        }
       }
     },
     "@types/anymatch": {
@@ -554,9 +548,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.4",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.4.tgz",
-      "integrity": "sha512-x/8h6FHm14rPWnW2HP5likD/rsqJ3t/77OWx2PLxym0hXbeBWQmcPyHmwX+CtCQpjIfgrUdEoDFcLPwPZWiqzQ==",
+      "version": "4.16.6",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.6.tgz",
+      "integrity": "sha512-8wr3CA/EMybyb6/V8qvTRKiNkPmgUA26uA9XWD6hlA0yFDuqi4r2L0C2B0U2HAYltJamoYJszlkaWM31vrKsHg==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -682,9 +676,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.123",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.123.tgz",
-      "integrity": "sha512-pQvPkc4Nltyx7G1Ww45OjVqUsJP4UsZm+GWJpigXgkikZqJgRm4c48g027o6tdgubWHwFRF15iFd+Y4Pmqv6+Q==",
+      "version": "4.14.133",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.133.tgz",
+      "integrity": "sha512-/3JqnvPnY58GLzG3Y7fpphOhATV1DDZ/Ak3DQufjlRK5E4u+s0CfClfNFtAGBabw+jDGtRFbOZe+Z02ZMWCBNQ==",
       "dev": true
     },
     "@types/marked": {
@@ -715,9 +709,9 @@
       }
     },
     "@types/node": {
-      "version": "9.6.48",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.48.tgz",
-      "integrity": "sha512-velR2CyDrHC1WFheHr5Jm25mdCMs0BXJRp6u0zf8PF9yeOy4Xff5sJeusWS7xOmhAoezlSq8LJ0+9M5H7YkTdw==",
+      "version": "9.6.49",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-9.6.49.tgz",
+      "integrity": "sha512-YY0Okyn4QXC4ugJI+Kng5iWjK8A6eIHiQVaGIhJkyn0YL6Iqo0E0tBC8BuhvYcBK87vykBijM5FtMnCqaa5anA==",
       "dev": true
     },
     "@types/normalize-package-data": {
@@ -785,9 +779,9 @@
       }
     },
     "@types/webpack": {
-      "version": "4.4.29",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.4.29.tgz",
-      "integrity": "sha512-8KVp+cNy9OPYsa4jU6vWsBemn5ixJ0Durh95Cw/YpEKm5ks2ODhdXc4FG3Xc46KIbPrJolwY7mSZFNn1aU3hKg==",
+      "version": "4.4.32",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.4.32.tgz",
+      "integrity": "sha512-mNARoaSJTzbiHxtZbf9NULFilu2frqD+g9Iyl9V2jPYJWXi+AC3Hz8lQWPZ5LLtgUm7iF4SDDMB/1bPrbRQgFw==",
       "dev": true,
       "requires": {
         "@types/anymatch": "*",
@@ -1114,7 +1108,6 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
-      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1126,7 +1119,6 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
-          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -1376,11 +1368,12 @@
       }
     },
     "assert": {
-      "version": "1.4.1",
-      "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
-      "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/assert/-/assert-1.5.0.tgz",
+      "integrity": "sha512-EDsgawzwoun2CZkCgtxJbv392v4nbk9XDD06zI+kQYoBM/3RBWLlEyJARDOmhAAosBjWACEkKL6S+lIZtcAubA==",
       "dev": true,
       "requires": {
+        "object-assign": "^4.1.1",
         "util": "0.10.3"
       },
       "dependencies": {
@@ -1511,13 +1504,21 @@
       "dev": true
     },
     "axios": {
-      "version": "0.18.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
-      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "version": "0.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+      "integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
       "dev": true,
       "requires": {
-        "follow-redirects": "^1.3.0",
-        "is-buffer": "^1.1.5"
+        "follow-redirects": "1.5.10",
+        "is-buffer": "^2.0.2"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.3",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.3.tgz",
+          "integrity": "sha512-U15Q7MXTuZlrbymiz95PJpZxu8IlipAp4dtS3wOdgPXx3mqBnslrWU14kxfHB+Py/+2PVKSr37dMAgM2A4uArw==",
+          "dev": true
+        }
       }
     },
     "babel-code-frame": {
@@ -1836,9 +1837,9 @@
       }
     },
     "bluebird": {
-      "version": "3.5.4",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.4.tgz",
-      "integrity": "sha512-FG+nFEZChJrbQ9tIccIfZJBz3J7mLrAhxakAbnrJWn8d7aKOC+LWifa0G+p4ZqKp4y13T7juYvdhq9NzKdsrjw==",
+      "version": "3.5.5",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.5.5.tgz",
+      "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
       "dev": true
     },
     "bn.js": {
@@ -2062,14 +2063,14 @@
       }
     },
     "browserslist": {
-      "version": "4.5.6",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.5.6.tgz",
-      "integrity": "sha512-o/hPOtbU9oX507lIqon+UvPYqpx3mHc8cV3QemSBTXwkG8gSQSK6UKvXcE/DcleU3+A59XTUHyCvZ5qGy8xVAg==",
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.1.tgz",
+      "integrity": "sha512-1MC18ooMPRG2UuVFJTHFIAkk6mpByJfxCrnUyvSlu/hyQSFHMrlhM02SzNuCV+quTP4CKmqtOMAIjrifrpBJXQ==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000963",
-        "electron-to-chromium": "^1.3.127",
-        "node-releases": "^1.1.17"
+        "caniuse-lite": "^1.0.30000971",
+        "electron-to-chromium": "^1.3.137",
+        "node-releases": "^1.1.21"
       }
     },
     "buffer": {
@@ -2274,15 +2275,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000966",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000966.tgz",
-      "integrity": "sha512-PDXDry9EACH5Ld4s1JZMKR9BOnhO5qX/2Saqq9SeQhOSJbauFDwUzSefVyDuXN3trnR9MOicR9apPKcb1sihEA==",
+      "version": "1.0.30000973",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000973.tgz",
+      "integrity": "sha512-leylQOpbgiYSm4G3NT8kq/KkKhKHlOLIBugpr6QsmjrYWgIR+S/iTDjM/5uM6FVqJg4YiD0en3P1udVvnRmrWA==",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000966",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000966.tgz",
-      "integrity": "sha512-qqLQ/uYrpZmFhPY96VuBkMEo8NhVFBZ9y/Bh+KnvGzGJ5I8hvpIaWlF2pw5gqe4PLAL+ZjsPgMOvoXSpX21Keg==",
+      "version": "1.0.30000973",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000973.tgz",
+      "integrity": "sha512-/F3t/Yo8LEdRSEPCmI15fLu5vepVh9UCg/9inJXF5AAfW7xRRJkbaM2ut52iRMQMnGCLQouLbFdbOA+VEFOIsg==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -2361,9 +2362,9 @@
       "dev": true
     },
     "chokidar": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.5.tgz",
-      "integrity": "sha512-i0TprVWp+Kj4WRPtInjexJ8Q+BqTE909VpH8xVhXrJkoc5QC8VO9TryGOqTr+2hljzc1sC62t22h5tZePodM/A==",
+      "version": "2.1.6",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-2.1.6.tgz",
+      "integrity": "sha512-V2jUo67OKkc6ySiRpJrjlpJKl9kDuG+Xb8VgsGzb+aEouhgS1D0weyPU4lEzdAcsCAvrih2J2BqyXqHWvVLw5g==",
       "dev": true,
       "requires": {
         "anymatch": "^2.0.0",
@@ -2387,20 +2388,12 @@
       "dev": true
     },
     "chrome-trace-event": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.0.tgz",
-      "integrity": "sha512-xDbVgyfDTT2piup/h8dK/y4QZfJRSa73bw1WZ8b4XM1o7fsFubUVGYcE+1ANtOzJJELGpYoG2961z0Z6OAld9A==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/chrome-trace-event/-/chrome-trace-event-1.0.2.tgz",
+      "integrity": "sha512-9e/zx1jw7B4CO+c/RXoCsfg/x1AfUBioy4owYH0bJprEYAx5hRFLRhWBqHAG57D0ZM4H7vxbP7bPe0VwhQRYDQ==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-          "dev": true
-        }
       }
     },
     "ci-info": {
@@ -2726,9 +2719,9 @@
       }
     },
     "color": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/color/-/color-3.1.1.tgz",
-      "integrity": "sha512-PvUltIXRjehRKPSy89VnDWFKY58xyhTLyxIg21vwQBI6qLwZNPmC8k3C1uytIgFKEpOIzN4y32iPm8231zFHIg==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/color/-/color-3.1.2.tgz",
+      "integrity": "sha512-vXTJhHebByxZn3lDvDJYw4lR5+uB3vuoHsuYA5AKuxRVn5wzzIfQKGLBmgdVRHKTJYeK5rvJcHnrd0Li49CFpg==",
       "dev": true,
       "requires": {
         "color-convert": "^1.9.1",
@@ -2800,9 +2793,9 @@
       "dev": true
     },
     "combined-stream": {
-      "version": "1.0.7",
-      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.7.tgz",
-      "integrity": "sha512-brWl9y6vOB1xYPZcpZde3N9zDByXTosAeMDo4p1wzo6UMOX4vumB+TP1RZ76sfE6Md68Q0NJSrE/gbezd4Ul+w==",
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
       "dev": true,
       "requires": {
         "delayed-stream": "~1.0.0"
@@ -3088,9 +3081,9 @@
       }
     },
     "core-js": {
-      "version": "2.6.5",
-      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.5.tgz",
-      "integrity": "sha512-klh/kDpwX8hryYL14M9w/xei6vrv6sE8gTHDG7/T/+SEovB/G4ejwcfE/CBzO6Edsu+OETZMZ3wcX/EjUkrl5A==",
+      "version": "2.6.9",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.6.9.tgz",
+      "integrity": "sha512-HOpZf6eXmnl7la+cUdMnLvUxKNqLUzJvgIziQ0DiF3JwSImNphIqdGqzj6hIKyX04MmV0poclQ7+wjWvxQyR2A==",
       "dev": true
     },
     "core-util-is": {
@@ -3100,14 +3093,14 @@
       "dev": true
     },
     "cosmiconfig": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.0.tgz",
-      "integrity": "sha512-nxt+Nfc3JAqf4WIWd0jXLjTJZmsPLrA9DDc4nRw2KFJQJK7DNooqSXrNI7tzLG50CF8axczly5UV929tBmh/7g==",
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-5.2.1.tgz",
+      "integrity": "sha512-H65gsXo1SKjf8zmrJ67eJk8aIRKV5ff2D4uKZIBZShbhGSpEmsQOPW/SKMKYhSTrqR7ufy6RP69rPogdaPh/kA==",
       "dev": true,
       "requires": {
         "import-fresh": "^2.0.0",
         "is-directory": "^0.3.1",
-        "js-yaml": "^3.13.0",
+        "js-yaml": "^3.13.1",
         "parse-json": "^4.0.0"
       }
     },
@@ -4155,9 +4148,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.130",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.130.tgz",
-      "integrity": "sha512-UY2DI+gsnqGtQJqO8wXN0DnpJY+29FwJafACj0h18ZShn5besKnrRq6+lXWUbKzdxw92QQcnTqRLgNByOKXcUg==",
+      "version": "1.3.144",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.144.tgz",
+      "integrity": "sha512-jNRFJpfNrYm5uJ4x0q9oYMOfbL0JPOlkNli8GS/5zEmCjnE5jAtoCo4BYajHiqSPqEeAjtTdItL4p7EZw+jSfg==",
       "dev": true
     },
     "elegant-spinner": {
@@ -5290,23 +5283,12 @@
       "dev": true
     },
     "follow-redirects": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.7.0.tgz",
-      "integrity": "sha512-m/pZQy4Gj287eNy94nivy5wchN3Kp+Q5WgUPNy5lJSZ3sgkVKSYV/ZChMAQVIgx1SqfZ2zBZtPA2YlXIWxxJOQ==",
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
       "dev": true,
       "requires": {
-        "debug": "^3.2.6"
-      },
-      "dependencies": {
-        "debug": {
-          "version": "3.2.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-          "dev": true,
-          "requires": {
-            "ms": "^2.1.1"
-          }
-        }
+        "debug": "=3.1.0"
       }
     },
     "for-in": {
@@ -5442,8 +5424,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5464,14 +5445,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5486,20 +5465,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5616,8 +5592,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5629,7 +5604,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5644,7 +5618,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5652,14 +5625,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5678,7 +5649,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5759,8 +5729,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5772,7 +5741,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5858,8 +5826,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5895,7 +5862,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5915,7 +5881,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5959,14 +5924,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -6102,9 +6065,9 @@
       }
     },
     "glob": {
-      "version": "7.1.3",
-      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
-      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
+      "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
       "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
@@ -7322,9 +7285,9 @@
       "dev": true
     },
     "highlight.js": {
-      "version": "9.15.6",
-      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.6.tgz",
-      "integrity": "sha512-zozTAWM1D6sozHo8kqhfYgsac+B+q0PmsjXeyDrYIHHcBN0zTVT66+s2GW1GZv7DbyaROdLXKdabwS/WqPyIdQ==",
+      "version": "9.15.8",
+      "resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.15.8.tgz",
+      "integrity": "sha512-RrapkKQWwE+wKdF73VsOa2RQdIoO3mxwJ4P8mhbI6KYJUraUHRKM5w5zQQKXNk0xNL4UVRdulV9SBJcmzJNzVA==",
       "dev": true
     },
     "hmac-drbg": {
@@ -7496,9 +7459,9 @@
       },
       "dependencies": {
         "readable-stream": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.3.0.tgz",
-          "integrity": "sha512-EsI+s3k3XsW+fU8fQACLN59ky34AZ14LoeVZpYwmZvldCFo0r0gnelwF2TcMjLor/BTL5aDJVBMkss0dthToPw==",
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.4.0.tgz",
+          "integrity": "sha512-jItXPLmrSR8jmTRmRWJXCnGJsfy85mB3Wd/uINMXA65yrnFo0cPClFIUWzo2najVNSl+mx7/4W8ttlLWJe99pQ==",
           "dev": true,
           "requires": {
             "inherits": "^2.0.3",
@@ -7697,12 +7660,41 @@
           "dev": true
         },
         "pkg-dir": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.1.0.tgz",
-          "integrity": "sha512-55k9QN4saZ8q518lE6EFgYiu95u3BWkSajCifhdQjvLvmr8IpnRbhI+UGpWJQfa0KzDguHeeWT1ccO1PmkOi3A==",
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
+          "integrity": "sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==",
           "dev": true,
           "requires": {
-            "find-up": "^3.0.0"
+            "find-up": "^4.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.0.0.tgz",
+              "integrity": "sha512-zoH7ZWPkRdgwYCDVoQTzqjG8JSPANhtvLhh4KVUHyKnaUJJrNeFmWIkTcNuJmR3GLMEmGYEf2S2bjgx26JTF+Q==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^5.0.0"
+              }
+            },
+            "locate-path": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
+              "integrity": "sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==",
+              "dev": true,
+              "requires": {
+                "p-locate": "^4.1.0"
+              }
+            },
+            "p-locate": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-4.1.0.tgz",
+              "integrity": "sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==",
+              "dev": true,
+              "requires": {
+                "p-limit": "^2.2.0"
+              }
+            }
           }
         },
         "read-pkg": {
@@ -8153,12 +8145,6 @@
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.5.0.tgz",
           "integrity": "sha1-Fhx9rBd2Wf2YEfQ3cfqZOBR4Yow=",
-          "dev": true
-        },
-        "tslib": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
           "dev": true
         },
         "ws": {
@@ -9550,8 +9536,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -9948,9 +9933,9 @@
       "dev": true
     },
     "nan": {
-      "version": "2.13.2",
-      "resolved": "https://registry.npmjs.org/nan/-/nan-2.13.2.tgz",
-      "integrity": "sha512-TghvYc72wlMGMVMluVo9WRJc0mB8KxxF/gZ4YYFy7V2ZQX9l7rgbPg7vjS9mt6U5HXODVFVI2bOduCzwOMv/lw==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.0.tgz",
+      "integrity": "sha512-INOFj37C7k3AfaNTtX8RhsTw7qRy7eLET14cROi9+5HAVbbHuIWUHEauBv5qT4Av2tWasiTY1Jw6puUNqRJXQg==",
       "dev": true,
       "optional": true
     },
@@ -9986,9 +9971,9 @@
       "dev": true
     },
     "neo-async": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.0.tgz",
-      "integrity": "sha512-MFh0d/Wa7vkKO3Y3LlacqAEeHK0mckVqzDieUKTT+KGxi+zIpeVsFxymkIiRpbpDziHc290Xr9A1O4Om7otoRA==",
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
+      "integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
       "dev": true
     },
     "next-tick": {
@@ -10072,9 +10057,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.17",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.17.tgz",
-      "integrity": "sha512-/SCjetyta1m7YXLgtACZGDYJdCSIBAWorDWkGCGZlydP2Ll7J48l7j/JxNYZ+xsgSPbWfdulVS/aY+GdjUsQ7Q==",
+      "version": "1.1.22",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.22.tgz",
+      "integrity": "sha512-O6XpteBuntW1j86mw6LlovBIwTe+sO2+7vi9avQffNeIW4upgnaCVm6xrBWH+KATz7mNNRNNeEpuWB7dT6Cr3w==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -14310,9 +14295,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.31",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.31.tgz",
-      "integrity": "sha512-/6pt4+C+T+wZUieKR620OpzN/LlnNKuWjy1iFLQ/UG35JqHlR/89MP1d96dUfkf6Dne3TuLQzOYEYshJ+Hx8mw==",
+      "version": "1.1.32",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.32.tgz",
+      "integrity": "sha512-MHACAkHpihU/REGGPLj4sEfc/XKW2bheigvHO1dUqjaKigMp1C8+WLQYRGgeKFMsw5PMfegZcaN8IDXK/cD0+g==",
       "dev": true
     },
     "public-encrypt": {
@@ -14394,9 +14379,9 @@
           }
         },
         "mime": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
-          "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
+          "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==",
           "dev": true
         }
       }
@@ -14474,9 +14459,9 @@
       }
     },
     "range-parser": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
-      "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.1.tgz",
+      "integrity": "sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==",
       "dev": true
     },
     "raw-body": {
@@ -14982,9 +14967,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.10.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.10.1.tgz",
-      "integrity": "sha512-KuIe4mf++td/eFb6wkaPbMDnP6kObCaEtIDuHOUED6MNUo4K670KZUHuuvYPZDxNF0WVLw49n06M2m2dXphEzA==",
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.11.1.tgz",
+      "integrity": "sha512-vIpgF6wfuJOZI7KKKSP+HmiKggadPQAdsp5HiC1mvqnfp0gF1vdwgBWZIdrVft9pgqoMFQN+R7BSWZiBxx+BBw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -15134,20 +15119,12 @@
       }
     },
     "rxjs": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.1.tgz",
-      "integrity": "sha512-y0j31WJc83wPu31vS1VlAFW5JGrnGC+j+TtGAa1fRQphy48+fDYiDmX8tjGloToEsMkxnouOg/1IzXGKkJnZMg==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.5.2.tgz",
+      "integrity": "sha512-HUb7j3kvb7p7eCUHE3FqjoDsC1xfZQ4AHFWfTKSpZ+sAhhz5X1WX0ZuUqWbzB2QhSLp3DoLUG+hMdEDKqWo2Zg==",
       "dev": true,
       "requires": {
         "tslib": "^1.9.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.9.3",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
-          "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
-          "dev": true
-        }
       }
     },
     "safe-buffer": {
@@ -15286,9 +15263,9 @@
       "dev": true
     },
     "serve": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-11.0.0.tgz",
-      "integrity": "sha512-Gnyyp3JAtRUo0dRH1/YWPKbnaXHfzQBiVh9+qSUi6tyVcVA8twUP2c+GnOwsoe9Ss7dfOHJUTSA4fdWP//Y4gQ==",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-11.0.1.tgz",
+      "integrity": "sha512-kmcR5jOumMcmoDVJk7izj2Gnz+ql4K3Xq1g0l4XX598lLYvbXgfS1oeTgckPVGzsk0MU/dBPHiolRgH0fI7c5g==",
       "dev": true,
       "requires": {
         "@zeit/schemas": "2.6.0",
@@ -15298,7 +15275,7 @@
         "chalk": "2.4.1",
         "clipboardy": "1.2.3",
         "compression": "1.7.3",
-        "serve-handler": "6.0.0",
+        "serve-handler": "6.0.1",
         "update-check": "1.5.2"
       },
       "dependencies": {
@@ -15317,9 +15294,9 @@
       }
     },
     "serve-handler": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.0.0.tgz",
-      "integrity": "sha512-2/e0+N1abV1HAN+YN8uCOPi1B0bIYaR6kRcSfzezRwszak5Yzr6QhT34XJk2Bw89rhXenqwLNJb4NnF2/krnGQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.0.1.tgz",
+      "integrity": "sha512-k/im4Fbx96d8VcrJDjrsagNd9Vq18tVYRDDe90rpNO8Mr76KJF/zES5tBZdlLEbhBXjOs36m9Wl+hRCiDnYfmA==",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
@@ -15351,6 +15328,12 @@
           "version": "2.2.1",
           "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-2.2.1.tgz",
           "integrity": "sha512-gu9bD6Ta5bwGrrU8muHzVOBFFREpp2iRkVfhBJahwJ6p6Xw20SjT0MxLnwkjOibQmGSYhiUnf2FLe7k+jcFmGQ==",
+          "dev": true
+        },
+        "range-parser": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/range-parser/-/range-parser-1.2.0.tgz",
+          "integrity": "sha1-9JvmtIeJTdxA3MlKMi9hEJLgDV4=",
           "dev": true
         }
       }
@@ -15482,9 +15465,9 @@
       "dev": true
     },
     "simple-git": {
-      "version": "1.110.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.110.0.tgz",
-      "integrity": "sha512-UYY0rQkknk0P5eb+KW+03F4TevZ9ou0H+LoGaj7iiVgpnZH4wdj/HTViy/1tNNkmIPcmtxuBqXWiYt2YwlRKOQ==",
+      "version": "1.113.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.113.0.tgz",
+      "integrity": "sha512-i9WVsrK2u0G/cASI9nh7voxOk9mhanWY9eGtWBDSYql6m49Yk5/Fan6uZsDr/xmzv8n+eQ8ahKCoEr8cvU3h+g==",
       "dev": true,
       "requires": {
         "debug": "^4.0.1"
@@ -16128,9 +16111,9 @@
       "dev": true
     },
     "synchronous-promise": {
-      "version": "2.0.7",
-      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.7.tgz",
-      "integrity": "sha512-16GbgwTmFMYFyQMLvtQjvNWh30dsFe1cAW5Fg1wm5+dg84L9Pe36mftsIRU95/W2YsISxsz/xq4VB23sqpgb/A==",
+      "version": "2.0.9",
+      "resolved": "https://registry.npmjs.org/synchronous-promise/-/synchronous-promise-2.0.9.tgz",
+      "integrity": "sha512-LO95GIW16x69LuND1nuuwM4pjgFGupg7pZ/4lU86AmchPKrhk0o2tpMU2unXRrqo81iAFe1YJ0nAGEVwsrZAgg==",
       "dev": true
     },
     "tapable": {
@@ -16596,9 +16579,9 @@
       }
     },
     "tslib": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.8.1.tgz",
-      "integrity": "sha1-aUavLR1lGnsYY7Ux1uWvpBqkTqw="
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ=="
     },
     "tslint": {
       "version": "5.8.0",
@@ -17156,9 +17139,9 @@
       "dev": true
     },
     "typescript": {
-      "version": "2.6.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.6.2.tgz",
-      "integrity": "sha1-PFtv1/beCRQmkCfwPAlGdY92c6Q=",
+      "version": "3.4.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.5.tgz",
+      "integrity": "sha512-YycBxUb49UUhdNMU5aJ7z5Ej2XGmaIBL0x34vZ82fn3hGvD+bgrMrVDpatgz2f7YxUMJxMkbWxJZeAvDxVe7Vw==",
       "dev": true
     },
     "typings-core": {
@@ -17264,6 +17247,12 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/string-template/-/string-template-1.0.0.tgz",
           "integrity": "sha1-np8iM9wA8hhxjsN5oopWc+zKi5Y=",
+          "dev": true
+        },
+        "typescript": {
+          "version": "2.9.2",
+          "resolved": "https://registry.npmjs.org/typescript/-/typescript-2.9.2.tgz",
+          "integrity": "sha512-Gr4p6nFNaoufRIY4NMdpQRNmgxVIGMs4Fcu/ujdYk3nAZqk7supzBE9idmvfZIlH/Cuj//dvi+019qEue9lV0w==",
           "dev": true
         },
         "write-file-atomic": {
@@ -17796,9 +17785,9 @@
       "dev": true
     },
     "v8flags": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.2.tgz",
-      "integrity": "sha512-MtivA7GF24yMPte9Rp/BWGCYQNaUj86zeYxV/x2RRJMKagImbbv3u8iJC57lNhWLPcGLJmHcHmFWkNsplbbLWw==",
+      "version": "3.1.3",
+      "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-3.1.3.tgz",
+      "integrity": "sha512-amh9CCg3ZxkzQ48Mhcb8iX7xpAfYJgePHxWMQCBWECpOSqJUXgY26ncA61UTV0BkPqfhcy6mzwCIoP4ygxpW8w==",
       "dev": true,
       "requires": {
         "homedir-polyfill": "^1.0.1"
@@ -17830,9 +17819,9 @@
       "dev": true
     },
     "vendors": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.2.tgz",
-      "integrity": "sha512-w/hry/368nO21AN9QljsaIhb9ZiZtZARoVH5f3CsFbawdLdayCgKRPup7CggujvySMxx0I91NOyxdVENohprLQ==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/vendors/-/vendors-1.0.3.tgz",
+      "integrity": "sha512-fOi47nsJP5Wqefa43kyWSg80qF+Q3XA6MUkgi7Hp1HQaKDQW4cQrK2D0P7mmbFtsV1N89am55Yru/nyEwRubcw==",
       "dev": true
     },
     "verror": {
@@ -17956,9 +17945,9 @@
       },
       "dependencies": {
         "mime": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.2.tgz",
-          "integrity": "sha512-zJBfZDkwRu+j3Pdd2aHsR5GfH2jIWhmL1ZzBoc+X+3JEti2hbArWcyJ+1laC1D2/U/W1a/+Cegj0/OnEU2ybjg==",
+          "version": "2.4.3",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-2.4.3.tgz",
+          "integrity": "sha512-QgrPRJfE+riq5TPZMcHZOtm8c6K/yYrMbKIoRfapfiGLxS8OTeIfRhUGW5LU7MlRa52KOAGCfUNruqLrIBvWZw==",
           "dev": true
         }
       }
@@ -18358,9 +18347,9 @@
       "dev": true
     },
     "write-file-atomic": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.2.tgz",
-      "integrity": "sha512-s0b6vB3xIVRLWywa6X9TOMA7k9zio0TMOsl9ZnDkliA/cfJlpHXAscj0gbHVJiTdIuAYpIyqS5GW91fqm6gG5g==",
+      "version": "2.4.3",
+      "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.4.3.tgz",
+      "integrity": "sha512-GaETH5wwsX+GcnzhPgKcKjJ6M2Cq3/iZp1WyY/X1CSqrW+jVNM9Y7D8EC2sM4ZG/V8wZlSniJnCKWPmBYAucRQ==",
       "dev": true,
       "requires": {
         "graceful-fs": "^4.1.11",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     }
   },
   "peerDependencies": {
-    "@dojo/framework": "^5.0.0"
+    "@dojo/framework": "6.0.0-alpha.2"
   },
   "devDependencies": {
     "@dojo/cli": "^5.0.0",
@@ -58,10 +58,10 @@
     "shx": "^0.2.2",
     "sinon": "^1.17.6",
     "ts-node": "^3.3.0",
-    "typescript": "~2.6.1"
+    "typescript": "~3.4.5"
   },
   "dependencies": {
-    "tslib": "~1.8.1"
+    "tslib": "~1.9.1"
   },
   "lint-staged": {
     "*.{ts,tsx}": [

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     }
   },
   "peerDependencies": {
-    "@dojo/framework": "6.0.0-alpha.3"
+    "@dojo/framework": "6.0.0-alpha.4"
   },
   "devDependencies": {
     "@dojo/cli": "^5.0.0",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     }
   },
   "peerDependencies": {
-    "@dojo/framework": "6.0.0-alpha.2"
+    "@dojo/framework": "6.0.0-alpha.3"
   },
   "devDependencies": {
     "@dojo/cli": "^5.0.0",

--- a/src/accordion-pane/README.md
+++ b/src/accordion-pane/README.md
@@ -26,7 +26,7 @@ The following CSS classes are used to style the `AccordionPane` widget and shoul
 ```typescript
 import AccordionPane from '@dojo/widgets/accordion-pane';
 import TitlePane from '@dojo/widgets/title-pane';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(AccordionPane, {
 	onRequestOpen: (key: string) => {

--- a/src/accordion-pane/example/index.ts
+++ b/src/accordion-pane/example/index.ts
@@ -1,6 +1,6 @@
 import { Set } from '@dojo/framework/shim/Set';
-import { w, v } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { w, v } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { from } from '@dojo/framework/shim/array';
 
 import AccordionPane from '../../accordion-pane/index';

--- a/src/accordion-pane/index.ts
+++ b/src/accordion-pane/index.ts
@@ -1,10 +1,10 @@
 import { assign } from '@dojo/framework/shim/object';
-import { DNode, WNode } from '@dojo/framework/widget-core/interfaces';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { DNode, WNode } from '@dojo/framework/core/interfaces';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 import { includes } from '@dojo/framework/shim/array';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { v } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { v } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 
 import TitlePane from '../title-pane/index';
 import * as css from '../theme/accordion-pane.m.css';

--- a/src/accordion-pane/tests/unit/AccordionPane.ts
+++ b/src/accordion-pane/tests/unit/AccordionPane.ts
@@ -1,7 +1,7 @@
 const { assert } = intern.getPlugin('chai');
 const { registerSuite } = intern.getInterface('object');
 
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 import * as sinon from 'sinon';
 import harness from '@dojo/framework/testing/harness';
 

--- a/src/button/example/index.ts
+++ b/src/button/example/index.ts
@@ -1,5 +1,5 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { w, v } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { w, v } from '@dojo/framework/core/vdom';
 import Button from '../../button/index';
 
 export default class App extends WidgetBase {

--- a/src/button/index.ts
+++ b/src/button/index.ts
@@ -1,8 +1,8 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
 import * as css from '../theme/button.m.css';
 import {
 	CustomAriaProperties,
@@ -11,9 +11,9 @@ import {
 	KeyEventProperties
 } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 import Icon from '../icon/index';
-import { CustomElementChildType } from '@dojo/framework/widget-core/registerCustomElement';
+import { CustomElementChildType } from '@dojo/framework/core/registerCustomElement';
 
 export type ButtonType = 'submit' | 'reset' | 'button' | 'menu';
 

--- a/src/button/tests/unit/Button.ts
+++ b/src/button/tests/unit/Button.ts
@@ -2,7 +2,7 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 
 import Button from '../../index';
 import Icon from '../../../icon/index';

--- a/src/calendar/CalendarCell.ts
+++ b/src/calendar/CalendarCell.ts
@@ -1,8 +1,8 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
-import { v } from '@dojo/framework/widget-core/d';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import Focus from '@dojo/framework/core/meta/Focus';
+import { v } from '@dojo/framework/core/vdom';
+import { DNode } from '@dojo/framework/core/interfaces';
 import * as css from '../theme/calendar.m.css';
 
 /**

--- a/src/calendar/DatePicker.ts
+++ b/src/calendar/DatePicker.ts
@@ -1,9 +1,9 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import Focus from '@dojo/framework/core/meta/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
 import { uuid } from '@dojo/framework/core/util';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { DNode } from '@dojo/framework/core/interfaces';
 import calendarBundle from './nls/Calendar';
 import { Keys } from '../common/util';
 import { monthInMin, monthInMax } from './date-utils';

--- a/src/calendar/example/index.ts
+++ b/src/calendar/example/index.ts
@@ -1,5 +1,5 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
 import Calendar from '../../calendar/index';
 
 export default class App extends WidgetBase {

--- a/src/calendar/index.ts
+++ b/src/calendar/index.ts
@@ -1,8 +1,8 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { I18nMixin } from '@dojo/framework/widget-core/mixins/I18n';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { I18nMixin } from '@dojo/framework/core/mixins/I18n';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { v, w } from '@dojo/framework/core/vdom';
+import { DNode } from '@dojo/framework/core/interfaces';
 import { uuid } from '@dojo/framework/core/util';
 import commonBundle from '../common/nls/common';
 import { CommonMessages } from '../common/interfaces';
@@ -15,7 +15,7 @@ import Icon from '../icon/index';
 import calendarBundle from './nls/Calendar';
 import * as css from '../theme/calendar.m.css';
 import * as baseCss from '../common/styles/base.m.css';
-import customElement from '@dojo/framework/widget-core/decorators/customElement';
+import customElement from '@dojo/framework/core/decorators/customElement';
 
 export type CalendarMessages = typeof calendarBundle.messages;
 

--- a/src/calendar/tests/unit/Calendar.ts
+++ b/src/calendar/tests/unit/Calendar.ts
@@ -1,7 +1,7 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 import { Keys } from '../../../common/util';
 
 import { DEFAULT_LABELS, DEFAULT_MONTHS, DEFAULT_WEEKDAYS } from '../support/defaults';

--- a/src/calendar/tests/unit/CalendarCell.ts
+++ b/src/calendar/tests/unit/CalendarCell.ts
@@ -2,7 +2,7 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 
 import CalendarCell from '../../CalendarCell';
 import * as css from '../../../theme/calendar.m.css';

--- a/src/calendar/tests/unit/DatePicker.ts
+++ b/src/calendar/tests/unit/DatePicker.ts
@@ -2,7 +2,7 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 import { Keys } from '../../../common/util';
 
 import { DEFAULT_LABELS, DEFAULT_MONTHS } from '../support/defaults';

--- a/src/card/example/index.tsx
+++ b/src/card/example/index.tsx
@@ -1,6 +1,6 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { tsx } from '@dojo/framework/widget-core/tsx';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { tsx } from '@dojo/framework/core/vdom';
+import { DNode } from '@dojo/framework/core/interfaces';
 import Card from '../index';
 import * as cardCss from './../../theme/card.m.css';
 import Button from '../../button/index';

--- a/src/card/index.tsx
+++ b/src/card/index.tsx
@@ -1,11 +1,11 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { tsx } from '@dojo/framework/widget-core/tsx';
-import { RenderResult } from '@dojo/framework/widget-core/interfaces';
-import { alwaysRender } from '@dojo/framework/widget-core/decorators/alwaysRender';
-import { ThemedMixin, theme } from '@dojo/framework/widget-core/mixins/Themed';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { tsx } from '@dojo/framework/core/vdom';
+import { RenderResult } from '@dojo/framework/core/interfaces';
+import { alwaysRender } from '@dojo/framework/core/decorators/alwaysRender';
+import { ThemedMixin, theme } from '@dojo/framework/core/mixins/Themed';
 import * as css from '../theme/card.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
+import { DNode } from '@dojo/framework/core/interfaces';
 
 export interface CardProperties {
 	actionsRenderer?(): RenderResult;

--- a/src/card/tests/unit/Card.tsx
+++ b/src/card/tests/unit/Card.tsx
@@ -1,7 +1,7 @@
 const { describe, it } = intern.getInterface('bdd');
 import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
 import harness from '@dojo/framework/testing/harness';
-import { tsx } from '@dojo/framework/widget-core/tsx';
+import { tsx } from '@dojo/framework/core/vdom';
 import Card from '../../index';
 import Button from '../../../button/index';
 import * as css from '../../../theme/card.m.css';

--- a/src/checkbox/example/index.ts
+++ b/src/checkbox/example/index.ts
@@ -1,5 +1,5 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
 import Checkbox, { Mode } from '../../checkbox/index';
 
 export default class App extends WidgetBase {

--- a/src/checkbox/index.ts
+++ b/src/checkbox/index.ts
@@ -1,8 +1,8 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
+import Focus from '@dojo/framework/core/meta/Focus';
 import Label from '../label/index';
 import {
 	CustomAriaProperties,
@@ -13,10 +13,10 @@ import {
 	PointerEventProperties
 } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/checkbox.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type CheckboxProperties

--- a/src/checkbox/tests/unit/Checkbox.ts
+++ b/src/checkbox/tests/unit/Checkbox.ts
@@ -2,8 +2,8 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
-import { v, w } from '@dojo/framework/widget-core/d';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
+import Focus from '@dojo/framework/core/meta/Focus';
 import harness from '@dojo/framework/testing/harness';
 
 import Label from '../../../label/index';

--- a/src/combobox/README.md
+++ b/src/combobox/README.md
@@ -41,7 +41,7 @@ The `ComboBox` makes no assumptions about the format of its underlying data. A f
 *Basic Example*
 ```typescript
 import ComboBox from '@dojo/widgets/combobox';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(ComboBox, {
 	results: ['foo', 'bar', 'baz'],
@@ -53,7 +53,7 @@ w(ComboBox, {
 *Filtered results*
 ```typescript
 import ComboBox from '@dojo/widgets/combobox';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 const data = ['foo', 'bar', 'baz'];
 
@@ -79,7 +79,7 @@ w(ComboBox, {
 *Custom Data Format / Provider*
 ```typescript
 import ComboBox from '@dojo/widgets/combobox';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 // A fictional store for example purposes only; this can be any data provider
 import MyAwesomeStore from 'some/amazing/package';
 
@@ -100,7 +100,7 @@ w(ComboBox, {
 *Validation*
 ```typescript
 import ComboBox from '@dojo/widgets/combobox';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(ComboBox, {
 	results: ['foo', 'bar', 'baz'],
@@ -117,7 +117,7 @@ w(ComboBox, {
 *Custom formatted option*
 ```typescript
 import ComboBox from '@dojo/widgets/combobox';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 
 w(ComboBox, {
 	getResultLabel: (result: string) => v('span', { style: 'color: blue' }, [ result ]),

--- a/src/combobox/example/index.ts
+++ b/src/combobox/example/index.ts
@@ -1,6 +1,6 @@
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { v, w } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import ComboBox from '../../combobox/index';
 
 const data = [

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -1,14 +1,14 @@
-import { diffProperty } from '@dojo/framework/widget-core/decorators/diffProperty';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { diffProperty } from '@dojo/framework/core/decorators/diffProperty';
+import { DNode } from '@dojo/framework/core/interfaces';
 import { Keys } from '../common/util';
-import { reference } from '@dojo/framework/widget-core/diff';
-import { I18nMixin } from '@dojo/framework/widget-core/mixins/I18n';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
-import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { reference } from '@dojo/framework/core/diff';
+import { I18nMixin } from '@dojo/framework/core/mixins/I18n';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import Focus from '@dojo/framework/core/meta/Focus';
+import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { uuid } from '@dojo/framework/core/util';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 
 import Icon from '../icon/index';
 import Label from '../label/index';
@@ -19,7 +19,7 @@ import { CommonMessages, LabeledProperties } from '../common/interfaces';
 
 import * as css from '../theme/combobox.m.css';
 import * as baseCss from '../common/styles/base.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 import HelperText from '../helper-text/index';
 
 /**

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -2,8 +2,8 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import * as sinon from 'sinon';
 
-import { v, w } from '@dojo/framework/widget-core/d';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
+import Focus from '@dojo/framework/core/meta/Focus';
 import { Keys } from '../../../common/util';
 
 import ComboBox from '../../index';

--- a/src/common/InputValidity.ts
+++ b/src/common/InputValidity.ts
@@ -1,6 +1,6 @@
 // NOTE: This module will be deleted in favor of
 // https://github.com/dojo/framework/pull/264
-import Base from '@dojo/framework/widget-core/meta/Base';
+import Base from '@dojo/framework/core/meta/Base';
 
 export class InputValidity extends Base {
 	get(key: string | number, value: string) {

--- a/src/common/example/index.ts
+++ b/src/common/example/index.ts
@@ -1,11 +1,11 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import renderer from '@dojo/framework/widget-core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import renderer from '@dojo/framework/core/vdom';
 import Select from '../../select/index';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { watch } from '@dojo/framework/widget-core/decorators/watch';
+import { v, w } from '@dojo/framework/core/vdom';
+import { watch } from '@dojo/framework/core/decorators/watch';
 import Outlet from '@dojo/framework/routing/Outlet';
 import { registerRouterInjector } from '@dojo/framework/routing/RouterInjector';
-import Registry from '@dojo/framework/widget-core/Registry';
+import Registry from '@dojo/framework/core/Registry';
 import Router from '@dojo/framework/routing/Router';
 import dojoTheme from '../../../node_modules/@dojo/themes/dojo/index';
 import { registerThemeInjector } from '@dojo/framework/widget-core/mixins/Themed';

--- a/src/common/example/index.ts
+++ b/src/common/example/index.ts
@@ -8,7 +8,7 @@ import { registerRouterInjector } from '@dojo/framework/routing/RouterInjector';
 import Registry from '@dojo/framework/core/Registry';
 import Router from '@dojo/framework/routing/Router';
 import dojoTheme from '../../../node_modules/@dojo/themes/dojo/index';
-import { registerThemeInjector } from '@dojo/framework/widget-core/mixins/Themed';
+import { registerThemeInjector } from '@dojo/framework/core/mixins/Themed';
 import Radio from '../../radio/index';
 
 const modules = [

--- a/src/common/tests/support/test-helpers.ts
+++ b/src/common/tests/support/test-helpers.ts
@@ -1,13 +1,12 @@
 import {
 	WNode,
-	WidgetBaseInterface,
 	Constructor,
 	MetaBase,
 	WidgetMetaConstructor
-} from '@dojo/framework/widget-core/interfaces';
+} from '@dojo/framework/core/interfaces';
 import { CustomComparator, harness } from '@dojo/framework/testing/harness';
 import { SinonStub } from 'sinon';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 
 export const noop: any = () => {};
 
@@ -78,10 +77,7 @@ export const compareLabelId = {
 };
 
 export const createHarness = (globalCompares: CustomComparator[]) => {
-	return (
-		renderFunction: () => WNode<WidgetBaseInterface>,
-		compares: CustomComparator[] = []
-	) => {
+	return (renderFunction: () => WNode, compares: CustomComparator[] = []) => {
 		return harness(renderFunction, [...globalCompares, ...compares]);
 	};
 };

--- a/src/dialog/README.md
+++ b/src/dialog/README.md
@@ -32,7 +32,7 @@ The following CSS classes are used to style the `Dialog` widget and should be pr
 *Basic Example*
 ```typescript
 import Dialog from '@dojo/widgets/dialog';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(Dialog, {
 	title: 'My Dialog',
@@ -44,7 +44,7 @@ w(Dialog, {
 *Modal with underlay*
 ```typescript
 import Dialog from '@dojo/widgets/dialog';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(Dialog, {
 	title: 'My Dialog',
@@ -58,7 +58,7 @@ w(Dialog, {
 *Custom animations*
 ```typescript
 import Dialog from '@dojo/widgets/dialog';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(Dialog, {
 	title: 'My Dialog',
@@ -72,7 +72,7 @@ w(Dialog, {
 *Dialog that can't be closed*
 ```typescript
 import Dialog from '@dojo/widgets/dialog';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(Dialog, {
 	title: 'My Dialog',

--- a/src/dialog/example/index.ts
+++ b/src/dialog/example/index.ts
@@ -1,7 +1,7 @@
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
+import Focus from '@dojo/framework/core/meta/Focus';
 import Dialog from '../../dialog/index';
 
 export default class App extends WidgetBase {

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -1,9 +1,9 @@
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { I18nMixin } from '@dojo/framework/widget-core/mixins/I18n';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { I18nMixin } from '@dojo/framework/core/mixins/I18n';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import Focus from '@dojo/framework/core/meta/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
 import { uuid } from '@dojo/framework/core/util';
 import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties, Keys } from '../common/util';
@@ -13,7 +13,7 @@ import Icon from '../icon/index';
 import * as fixedCss from './styles/dialog.m.css';
 import * as css from '../theme/dialog.m.css';
 import { GlobalEvent } from '../global-event/index';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * The role of this dialog, used for accessibility

--- a/src/dialog/tests/unit/Dialog.ts
+++ b/src/dialog/tests/unit/Dialog.ts
@@ -2,8 +2,8 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import * as sinon from 'sinon';
 
-import { v, w, isWNode } from '@dojo/framework/widget-core/d';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { v, w, isWNode } from '@dojo/framework/core/vdom';
+import Focus from '@dojo/framework/core/meta/Focus';
 
 import Dialog, { DialogProperties } from '../../index';
 import Icon from '../../../icon/index';
@@ -399,17 +399,6 @@ registerSuite('Dialog', {
 			assert.isTrue(
 				onRequestClose.calledOnce,
 				'onRequestClose handler called when close button is clicked'
-			);
-
-			properties = {
-				closeable: false,
-				open: true,
-				onRequestClose
-			};
-			h.trigger(`.${css.close}`, 'onclick', stubEvent);
-			assert.isTrue(
-				onRequestClose.calledOnce,
-				'onRequestClose handler not called when closeable is false'
 			);
 		},
 

--- a/src/global-event/index.ts
+++ b/src/global-event/index.ts
@@ -1,8 +1,8 @@
 import global from '@dojo/framework/shim/global';
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { diffProperty } from '@dojo/framework/widget-core/decorators/diffProperty';
-import { shallow } from '@dojo/framework/widget-core/diff';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { diffProperty } from '@dojo/framework/core/decorators/diffProperty';
+import { shallow } from '@dojo/framework/core/diff';
 
 export interface ListenerObject {
 	[index: string]: (event?: any) => void;

--- a/src/global-event/tests/unit/GlobalEvent.ts
+++ b/src/global-event/tests/unit/GlobalEvent.ts
@@ -5,7 +5,7 @@ import { stub, SinonStub } from 'sinon';
 import global from '@dojo/framework/shim/global';
 import { GlobalEvent } from './../../index';
 import { harness } from '@dojo/framework/testing/harness';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 let windowAddEventlistenerStub: SinonStub;
 let documentAddEventlistenerStub: SinonStub;

--- a/src/grid/Body.ts
+++ b/src/grid/Body.ts
@@ -1,9 +1,9 @@
 import global from '@dojo/framework/shim/global';
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
-import ThemedMixin, { theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { DNode, VNodeProperties } from '@dojo/framework/widget-core/interfaces';
-import renderer from '@dojo/framework/widget-core/vdom';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
+import ThemedMixin, { theme } from '@dojo/framework/core/mixins/Themed';
+import { DNode, VNodeProperties } from '@dojo/framework/core/interfaces';
+import renderer from '@dojo/framework/core/vdom';
 
 import { GridPages, ColumnConfig } from './interfaces';
 import PlaceholderRow from './PlaceholderRow';
@@ -11,8 +11,8 @@ import Row from './Row';
 
 import * as fixedCss from './styles/body.m.css';
 import * as css from '../theme/grid-body.m.css';
-import { diffProperty } from '@dojo/framework/widget-core/decorators/diffProperty';
-import { auto, reference } from '@dojo/framework/widget-core/diff';
+import { diffProperty } from '@dojo/framework/core/decorators/diffProperty';
+import { auto, reference } from '@dojo/framework/core/diff';
 
 export interface BodyProperties<S> {
 	totalRows?: number;
@@ -54,9 +54,9 @@ const defaultPlaceholderRowRenderer = (index: number) => {
 @theme(css)
 @diffProperty('pages', reference)
 export default class Body<S> extends ThemedMixin(WidgetBase)<BodyProperties<S>> {
-	private _rowHeight: number;
-	private _rowsInView: number;
-	private _renderPageSize: number;
+	private _rowHeight!: number;
+	private _rowsInView!: number;
+	private _renderPageSize!: number;
 	private _start = 0;
 	private _end = 100;
 	private _resetScroll = false;

--- a/src/grid/Cell.ts
+++ b/src/grid/Cell.ts
@@ -1,8 +1,8 @@
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
-import ThemedMixin, { theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
+import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
+import ThemedMixin, { theme } from '@dojo/framework/core/mixins/Themed';
+import { DNode } from '@dojo/framework/core/interfaces';
 import { uuid } from '@dojo/framework/core/util';
 import { Keys } from '../common/util';
 import TextInput from '../text-input/index';
@@ -23,7 +23,7 @@ export interface CellProperties extends FocusProperties {
 export default class Cell extends ThemedMixin(FocusMixin(WidgetBase))<CellProperties> {
 	private _editing = false;
 	private _editingValue = '';
-	private _focusKey: string;
+	private _focusKey!: string;
 	private _idBase = uuid();
 
 	private _callFocus(key: string) {

--- a/src/grid/Footer.ts
+++ b/src/grid/Footer.ts
@@ -1,7 +1,7 @@
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
-import { v } from '@dojo/framework/widget-core/d';
-import ThemedMixin, { theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import { v } from '@dojo/framework/core/vdom';
+import ThemedMixin, { theme } from '@dojo/framework/core/mixins/Themed';
+import { DNode } from '@dojo/framework/core/interfaces';
 
 import * as css from '../theme/grid-footer.m.css';
 

--- a/src/grid/Header.ts
+++ b/src/grid/Header.ts
@@ -1,8 +1,8 @@
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
-import ThemedMixin, { theme } from '@dojo/framework/widget-core/mixins/Themed';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
+import ThemedMixin, { theme } from '@dojo/framework/core/mixins/Themed';
 import { ColumnConfig, SortOptions } from './interfaces';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { DNode } from '@dojo/framework/core/interfaces';
 import TextInput from '../text-input/index';
 import Icon from '../icon/index';
 

--- a/src/grid/PlaceholderRow.ts
+++ b/src/grid/PlaceholderRow.ts
@@ -1,7 +1,7 @@
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
-import { v } from '@dojo/framework/widget-core/d';
-import ThemedMixin, { theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import { v } from '@dojo/framework/core/vdom';
+import ThemedMixin, { theme } from '@dojo/framework/core/mixins/Themed';
+import { DNode } from '@dojo/framework/core/interfaces';
 import * as css from '../theme/grid-placeholder-row.m.css';
 
 @theme(css)

--- a/src/grid/README.md
+++ b/src/grid/README.md
@@ -12,8 +12,8 @@ A reactive lightweight, customizable grid widget built with Dojo.
 
 ```ts
 import global from "@dojo/framework/shim/global";
-import renderer from '@dojo/framework/widget-core/vdom';
-import { w } from '@dojo/framework/widget-core/d';
+import renderer from '@dojo/framework/core/vdom';
+import { w } from '@dojo/framework/core/vdom';
 import { createFetcher } from '@dojo/widgets/grid/utils';
 import Grid from '@dojo/widgets/grid';
 

--- a/src/grid/Row.ts
+++ b/src/grid/Row.ts
@@ -1,7 +1,7 @@
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import ThemedMixin, { theme } from '@dojo/framework/widget-core/mixins/Themed';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
+import { DNode } from '@dojo/framework/core/interfaces';
+import ThemedMixin, { theme } from '@dojo/framework/core/mixins/Themed';
 
 import { ColumnConfig } from './interfaces';
 import Cell from './Cell';

--- a/src/grid/example/index.ts
+++ b/src/grid/example/index.ts
@@ -1,5 +1,5 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
 import Grid from '../../grid/index';
 import { createFetcher } from '../../grid/utils';
 import mockData from './mockData';

--- a/src/grid/index.ts
+++ b/src/grid/index.ts
@@ -1,13 +1,13 @@
-import WidgetBase from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
-import ThemedMixin, { theme, ThemedProperties } from '@dojo/framework/widget-core/mixins/Themed';
-import customElement from '@dojo/framework/widget-core/decorators/customElement';
-import diffProperty from '@dojo/framework/widget-core/decorators/diffProperty';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { reference } from '@dojo/framework/widget-core/diff';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
+import ThemedMixin, { theme, ThemedProperties } from '@dojo/framework/core/mixins/Themed';
+import customElement from '@dojo/framework/core/decorators/customElement';
+import diffProperty from '@dojo/framework/core/decorators/diffProperty';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { reference } from '@dojo/framework/core/diff';
 import { Store } from '@dojo/framework/stores/Store';
-import Dimensions from '@dojo/framework/widget-core/meta/Dimensions';
-import Resize from '@dojo/framework/widget-core/meta/Resize';
+import Dimensions from '@dojo/framework/core/meta/Dimensions';
+import Resize from '@dojo/framework/core/meta/Resize';
 
 import { Fetcher, ColumnConfig, GridState, Updater } from './interfaces';
 import {

--- a/src/grid/interfaces.d.ts
+++ b/src/grid/interfaces.d.ts
@@ -1,4 +1,4 @@
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { DNode } from '@dojo/framework/core/interfaces';
 
 export interface FetcherMeta {
 	total: number;

--- a/src/grid/tests/unit/Body.ts
+++ b/src/grid/tests/unit/Body.ts
@@ -1,7 +1,7 @@
 const { describe, it, afterEach, beforeEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 import global from '@dojo/framework/shim/global';
 
 import * as fixedCss from '../../styles/body.m.css';

--- a/src/grid/tests/unit/Cell.ts
+++ b/src/grid/tests/unit/Cell.ts
@@ -5,7 +5,7 @@ import Button from '../../../button/index';
 import Icon from '../../../icon/index';
 import { Keys } from '../../../common/util';
 
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 import { stub } from 'sinon';
 import {
 	compareId,

--- a/src/grid/tests/unit/Footer.ts
+++ b/src/grid/tests/unit/Footer.ts
@@ -1,7 +1,7 @@
 const { describe, it } = intern.getInterface('bdd');
 
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 
 import * as css from '../../../theme/grid-footer.m.css';
 import Footer from '../../Footer';

--- a/src/grid/tests/unit/Grid.ts
+++ b/src/grid/tests/unit/Grid.ts
@@ -2,9 +2,9 @@ const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/widget-core/d';
-import Dimensions from '@dojo/framework/widget-core/meta/Dimensions';
-import Resize from '@dojo/framework/widget-core/meta/Resize';
+import { v, w } from '@dojo/framework/core/vdom';
+import Dimensions from '@dojo/framework/core/meta/Dimensions';
+import Resize from '@dojo/framework/core/meta/Resize';
 import { Store } from '@dojo/framework/stores/Store';
 import { OperationType } from '@dojo/framework/stores/state/Patch';
 import { Pointer } from '@dojo/framework/stores/state/Pointer';

--- a/src/grid/tests/unit/Header.ts
+++ b/src/grid/tests/unit/Header.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import { stub } from 'sinon';
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 import TextInput from '../../../text-input/index';
 import Icon from '../../../icon/index';
 

--- a/src/grid/tests/unit/Row.ts
+++ b/src/grid/tests/unit/Row.ts
@@ -1,7 +1,7 @@
 const { describe, it } = intern.getInterface('bdd');
 
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 import Row from '../../Row';
 
 import * as fixedCss from './../../styles/row.m.css';

--- a/src/helper-text/index.ts
+++ b/src/helper-text/index.ts
@@ -1,8 +1,8 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { theme, ThemedMixin } from '@dojo/framework/widget-core/mixins/Themed';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { theme, ThemedMixin } from '@dojo/framework/core/mixins/Themed';
 import * as css from '../theme/helper-text.m.css';
-import { v } from '@dojo/framework/widget-core/d';
-import { VNode } from '@dojo/framework/widget-core/interfaces';
+import { v } from '@dojo/framework/core/vdom';
+import { VNode } from '@dojo/framework/core/interfaces';
 
 export interface HelperTextProperties {
 	text?: string;

--- a/src/helper-text/tests/unit/HelperText.ts
+++ b/src/helper-text/tests/unit/HelperText.ts
@@ -1,6 +1,6 @@
 const { registerSuite } = intern.getInterface('object');
 
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 import assertationTemplate from '@dojo/framework/testing/assertionTemplate';
 import * as css from '../../../theme/helper-text.m.css';
 import HelperText from '../../index';

--- a/src/icon/README.md
+++ b/src/icon/README.md
@@ -8,7 +8,7 @@ Dojo's `Icon` widget renders an icon.
 *Basic Example*
 ```typescript
 import Icon from '@dojo/widgets/icon';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(Icon, { type: 'downIcon', });
 ```
@@ -20,7 +20,7 @@ text for screen readers can be provided via the `altText` property.
 *Custom aria attributes Example*
 ```typescript
 import Icon from '@dojo/widgets/icon';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(Icon, {
 	type: 'downIcon',
@@ -35,7 +35,7 @@ w(Icon, {
 *Example with altText*
 ```typescript
 import Icon from '@dojo/widgets/icon';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(Icon, {
 	type: 'downIcon',

--- a/src/icon/example/index.ts
+++ b/src/icon/example/index.ts
@@ -1,5 +1,5 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
 import Icon from '../index';
 
 export default class App extends WidgetBase {

--- a/src/icon/index.ts
+++ b/src/icon/index.ts
@@ -1,12 +1,12 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { v } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { v } from '@dojo/framework/core/vdom';
 import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 import * as css from '../theme/icon.m.css';
 import * as baseCss from '../common/styles/base.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 export type IconType = keyof typeof css;
 

--- a/src/icon/tests/unit/Icon.ts
+++ b/src/icon/tests/unit/Icon.ts
@@ -1,6 +1,6 @@
 const { registerSuite } = intern.getInterface('object');
 
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 
 import Icon from '../../index';
 import * as css from '../../../theme/icon.m.css';

--- a/src/label/example/index.ts
+++ b/src/label/example/index.ts
@@ -1,5 +1,5 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
 import Label from '../../label/index';
 
 export default class App extends WidgetBase {

--- a/src/label/index.ts
+++ b/src/label/index.ts
@@ -1,12 +1,12 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { v } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { v } from '@dojo/framework/core/vdom';
 import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 import * as css from '../theme/label.m.css';
 import * as baseCss from '../common/styles/base.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type LabelProperties

--- a/src/label/tests/unit/Label.ts
+++ b/src/label/tests/unit/Label.ts
@@ -1,7 +1,7 @@
 const { registerSuite } = intern.getInterface('object');
 
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 
 import Label from '../../index';
 import * as css from '../../../theme/label.m.css';

--- a/src/listbox/ListboxOption.ts
+++ b/src/listbox/ListboxOption.ts
@@ -1,7 +1,7 @@
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { v } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { v } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 
 import * as css from '../theme/listbox.m.css';
 

--- a/src/listbox/README.md
+++ b/src/listbox/README.md
@@ -33,7 +33,7 @@ Option text is handled through the `getOptionLabel` property. Localization is ha
 *Basic Listbox*
 ```typescript
 import Listbox from '@dojo/widgets/listbox';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 interface OptionData {
 	disabled: boolean;
@@ -70,7 +70,7 @@ w(Listbox, {
 *Multi-select Listbox*
 ```typescript
 import Listbox from '@dojo/widgets/listbox';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 interface OptionData {
 	disabled: boolean;

--- a/src/listbox/example/index.ts
+++ b/src/listbox/example/index.ts
@@ -1,5 +1,5 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
 import Listbox from '../../listbox/index';
 
 interface CustomOption {

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -1,21 +1,21 @@
-import { reference } from '@dojo/framework/widget-core/diff';
-import { diffProperty } from '@dojo/framework/widget-core/decorators/diffProperty';
-import Dimensions from '@dojo/framework/widget-core/meta/Dimensions';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { reference } from '@dojo/framework/core/diff';
+import { diffProperty } from '@dojo/framework/core/decorators/diffProperty';
+import Dimensions from '@dojo/framework/core/meta/Dimensions';
+import { DNode } from '@dojo/framework/core/interfaces';
 import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties, Keys } from '../common/util';
-import MetaBase from '@dojo/framework/widget-core/meta/Base';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
+import MetaBase from '@dojo/framework/core/meta/Base';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { uuid } from '@dojo/framework/core/util';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 
 import * as css from '../theme/listbox.m.css';
 import ListboxOption from './ListboxOption';
-import { Focus } from '@dojo/framework/widget-core/meta/Focus';
-import Resize from '@dojo/framework/widget-core/meta/Resize';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { Focus } from '@dojo/framework/core/meta/Focus';
+import Resize from '@dojo/framework/core/meta/Resize';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /* Default scroll meta */
 export class ScrollMeta extends MetaBase {

--- a/src/listbox/tests/unit/Listbox.ts
+++ b/src/listbox/tests/unit/Listbox.ts
@@ -2,12 +2,12 @@ const { assert } = intern.getPlugin('chai');
 const { registerSuite } = intern.getInterface('object');
 import * as sinon from 'sinon';
 
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { DNode } from '@dojo/framework/core/interfaces';
 import { Keys } from '../../../common/util';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
-import Resize from '@dojo/framework/widget-core/meta/Resize';
-import Dimensions from '@dojo/framework/widget-core/meta/Dimensions';
-import { v, w } from '@dojo/framework/widget-core/d';
+import Focus from '@dojo/framework/core/meta/Focus';
+import Resize from '@dojo/framework/core/meta/Resize';
+import Dimensions from '@dojo/framework/core/meta/Dimensions';
+import { v, w } from '@dojo/framework/core/vdom';
 
 import Listbox from '../../index';
 import ListboxOption, { ListboxOptionProperties } from '../../ListboxOption';

--- a/src/listbox/tests/unit/ListboxOption.ts
+++ b/src/listbox/tests/unit/ListboxOption.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 import * as sinon from 'sinon';
 
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 
 import ListboxOption from '../../ListboxOption';
 import * as css from '../../../theme/listbox.m.css';

--- a/src/outlined-button/example/index.ts
+++ b/src/outlined-button/example/index.ts
@@ -1,5 +1,5 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { w, v } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { w, v } from '@dojo/framework/core/vdom';
 import OutlinedButton from '../../outlined-button/index';
 
 export default class App extends WidgetBase {

--- a/src/outlined-button/index.tsx
+++ b/src/outlined-button/index.tsx
@@ -1,11 +1,11 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { ThemedMixin, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { tsx } from '@dojo/framework/widget-core/tsx';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { ThemedMixin, theme } from '@dojo/framework/core/mixins/Themed';
+import { tsx } from '@dojo/framework/core/vdom';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 import Button, { ButtonProperties } from '../button/index';
 import * as css from '../theme/outlined-button.m.css';
-import { CustomElementChildType } from '@dojo/framework/widget-core/registerCustomElement';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { CustomElementChildType } from '@dojo/framework/core/registerCustomElement';
+import { DNode } from '@dojo/framework/core/interfaces';
 
 export interface OutlinedButtonProperties extends ButtonProperties {}
 

--- a/src/outlined-button/tests/unit/OutlinedButton.tsx
+++ b/src/outlined-button/tests/unit/OutlinedButton.tsx
@@ -2,7 +2,7 @@ import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
 
 const { registerSuite } = intern.getInterface('object');
 
-import { tsx } from '@dojo/framework/widget-core/tsx';
+import { tsx } from '@dojo/framework/core/vdom';
 import harness from '@dojo/framework/testing/harness';
 
 import OutlinedButton from '../../index';

--- a/src/progress/example/index.ts
+++ b/src/progress/example/index.ts
@@ -1,5 +1,5 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
 import Progress from '../../progress/index';
 
 const customOutputMax = 750;

--- a/src/progress/index.ts
+++ b/src/progress/index.ts
@@ -1,11 +1,11 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { v } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { v } from '@dojo/framework/core/vdom';
 import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { DNode } from '@dojo/framework/core/interfaces';
 import * as css from '../theme/progress.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type ProgressProperties

--- a/src/progress/tests/unit/Progress.ts
+++ b/src/progress/tests/unit/Progress.ts
@@ -1,5 +1,5 @@
 const { describe, it } = intern.getInterface('bdd');
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 import harness from '@dojo/framework/testing/harness';
 import Progress from '../../index';
 import * as css from '../../../theme/progress.m.css';

--- a/src/radio/example/index.ts
+++ b/src/radio/example/index.ts
@@ -1,5 +1,5 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
 import Radio from '../../radio/index';
 
 export default class App extends WidgetBase {

--- a/src/radio/index.ts
+++ b/src/radio/index.ts
@@ -1,8 +1,8 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
+import Focus from '@dojo/framework/core/meta/Focus';
 import Label from '../label/index';
 import {
 	CustomAriaProperties,
@@ -13,10 +13,10 @@ import {
 	PointerEventProperties
 } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/radio.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type RadioProperties

--- a/src/radio/tests/unit/Radio.ts
+++ b/src/radio/tests/unit/Radio.ts
@@ -2,8 +2,8 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
-import { v, w } from '@dojo/framework/widget-core/d';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
+import Focus from '@dojo/framework/core/meta/Focus';
 
 import Label from '../../../label/index';
 import Radio from '../../../radio/index';

--- a/src/raised-button/example/index.tsx
+++ b/src/raised-button/example/index.tsx
@@ -1,7 +1,7 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { tsx } from '@dojo/framework/widget-core/tsx';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { tsx } from '@dojo/framework/core/vdom';
 import RaisedButton from '../../raised-button/index';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { DNode } from '@dojo/framework/core/interfaces';
 
 export default class App extends WidgetBase {
 	private _buttonPressed: boolean | undefined;

--- a/src/raised-button/index.tsx
+++ b/src/raised-button/index.tsx
@@ -1,11 +1,11 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { ThemedMixin, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { tsx } from '@dojo/framework/widget-core/tsx';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { ThemedMixin, theme } from '@dojo/framework/core/mixins/Themed';
+import { tsx } from '@dojo/framework/core/vdom';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 import Button, { ButtonProperties } from '../button/index';
 import * as css from '../theme/raised-button.m.css';
-import { CustomElementChildType } from '@dojo/framework/widget-core/registerCustomElement';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { CustomElementChildType } from '@dojo/framework/core/registerCustomElement';
+import { DNode } from '@dojo/framework/core/interfaces';
 
 export interface RaisedButtonProperties extends ButtonProperties {}
 

--- a/src/raised-button/tests/unit/RaisedButton.tsx
+++ b/src/raised-button/tests/unit/RaisedButton.tsx
@@ -4,7 +4,7 @@ import harness from '@dojo/framework/testing/harness';
 
 import { RaisedButton } from '../../index';
 import * as css from '../../../theme/raised-button.m.css';
-import { tsx } from '@dojo/framework/widget-core/tsx';
+import { tsx } from '@dojo/framework/core/vdom';
 import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
 import Button from '../../../button/index';
 

--- a/src/range-slider/example/index.ts
+++ b/src/range-slider/example/index.ts
@@ -1,6 +1,6 @@
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { v, w } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import RangeSlider from '../index';
 
 export default class App extends WidgetBase {

--- a/src/range-slider/index.ts
+++ b/src/range-slider/index.ts
@@ -1,10 +1,10 @@
 import { uuid } from '@dojo/framework/core/util';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import Dimensions from '@dojo/framework/widget-core/meta/Dimensions';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
-import { theme, ThemedMixin, ThemedProperties } from '@dojo/framework/widget-core/mixins/Themed';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
+import { DNode } from '@dojo/framework/core/interfaces';
+import Dimensions from '@dojo/framework/core/meta/Dimensions';
+import Focus from '@dojo/framework/core/meta/Focus';
+import { theme, ThemedMixin, ThemedProperties } from '@dojo/framework/core/mixins/Themed';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import {
 	CustomAriaProperties,
 	InputProperties,
@@ -17,7 +17,7 @@ import Label from '../label/index';
 import * as fixedCss from './styles/range-slider.m.css';
 import * as css from '../theme/range-slider.m.css';
 import * as baseCss from '../common/styles/base.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 export interface RangeSliderProperties
 	extends ThemedProperties,

--- a/src/range-slider/tests/unit/RangeSlider.ts
+++ b/src/range-slider/tests/unit/RangeSlider.ts
@@ -1,13 +1,13 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import * as sinon from 'sinon';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 
 import Label from '../../../label/index';
 import RangeSlider from '../../index';
 import * as css from '../../../theme/range-slider.m.css';
 import * as fixedCss from '../../styles/range-slider.m.css';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import Focus from '@dojo/framework/core/meta/Focus';
 import {
 	compareId,
 	compareForId,
@@ -18,7 +18,7 @@ import {
 	compareWidgetId,
 	compareAriaLabelledBy
 } from '../../../common/tests/support/test-helpers';
-import Dimensions from '@dojo/framework/widget-core/meta/Dimensions';
+import Dimensions from '@dojo/framework/core/meta/Dimensions';
 
 const compareFor = {
 	selector: '*',

--- a/src/select/README.md
+++ b/src/select/README.md
@@ -42,7 +42,7 @@ Option text is handled through the `getOptionLabel` property. Localization is ha
 *Wrapped Native Select*
 ```typescript
 import Select from '@dojo/widgets/select';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 interface OptionData {
 	disabled: boolean;
@@ -70,7 +70,7 @@ w(Select, {
 *Custom select using default option calculations*
 ```typescript
 import Select from '@dojo/widgets/select';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 const options = ['foo', 'bar', 'baz'];
 let value: string;
@@ -88,7 +88,7 @@ w(Select, {
 *Custom select with formatted option text and placeholder*
 ```typescript
 import Select from '@dojo/widgets/select';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 const options = ['foo', 'bar', 'baz'];
 let value: string;

--- a/src/select/example/index.ts
+++ b/src/select/example/index.ts
@@ -1,5 +1,5 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
 import Select, { SelectProperties } from '../../select/index';
 
 export default class App extends WidgetBase {

--- a/src/select/index.ts
+++ b/src/select/index.ts
@@ -1,11 +1,11 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { diffProperty } from '@dojo/framework/widget-core/decorators/diffProperty';
-import { reference } from '@dojo/framework/widget-core/diff';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { diffProperty } from '@dojo/framework/core/decorators/diffProperty';
+import { reference } from '@dojo/framework/core/diff';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
+import Focus from '@dojo/framework/core/meta/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
 import { uuid } from '@dojo/framework/core/util';
 import { find } from '@dojo/framework/shim/array';
 import { formatAriaProperties, Keys } from '../common/util';
@@ -15,7 +15,7 @@ import Label from '../label/index';
 import Listbox from '../listbox/index';
 import HelperText from '../helper-text/index';
 import * as css from '../theme/select.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type SelectProperties
@@ -83,7 +83,7 @@ export interface SelectProperties
 	events: ['onBlur', 'onChange', 'onFocus']
 })
 export class Select extends ThemedMixin(FocusMixin(WidgetBase))<SelectProperties> {
-	private _focusedIndex: number;
+	private _focusedIndex!: number;
 	private _focusNode = 'trigger';
 	private _ignoreBlur = false;
 	private _open = false;

--- a/src/select/tests/unit/Select.ts
+++ b/src/select/tests/unit/Select.ts
@@ -3,8 +3,8 @@ const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
 
-import { v, w } from '@dojo/framework/widget-core/d';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
+import Focus from '@dojo/framework/core/meta/Focus';
 import { Keys } from '../../../common/util';
 
 import Icon from '../../../icon/index';

--- a/src/slide-pane/README.md
+++ b/src/slide-pane/README.md
@@ -13,7 +13,7 @@ Dojo's `SlidePane` widget provides a component capable of moving content into or
 
 *Basic Example*
 ```typescript
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 import SlidePane from '@dojo/widgets/slide-pane';
 
 w(SlidePane, {
@@ -25,7 +25,7 @@ w(SlidePane, {
 
 *Right-aligned*
 ```typescript
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 import SlidePane, { Align } from '@dojo/widgets/slide-pane';
 
 w(SlidePane, {

--- a/src/slide-pane/example/index.ts
+++ b/src/slide-pane/example/index.ts
@@ -1,6 +1,6 @@
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { v, w } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import SlidePane, { Align } from '../../slide-pane/index';
 
 export default class App extends WidgetBase {

--- a/src/slide-pane/index.ts
+++ b/src/slide-pane/index.ts
@@ -1,9 +1,9 @@
 import { uuid } from '@dojo/framework/core/util';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { I18nMixin } from '@dojo/framework/widget-core/mixins/I18n';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { I18nMixin } from '@dojo/framework/core/mixins/I18n';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { v, w } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 import * as animations from '../common/styles/animations.m.css';
@@ -11,8 +11,8 @@ import commonBundle from '../common/nls/common';
 import Icon from '../icon/index';
 import * as fixedCss from './styles/slide-pane.m.css';
 import * as css from '../theme/slide-pane.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
-import diffProperty from '@dojo/framework/widget-core/decorators/diffProperty';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
+import diffProperty from '@dojo/framework/core/decorators/diffProperty';
 
 /**
  * Enum for left / right alignment
@@ -195,7 +195,7 @@ export class SlidePane extends I18nMixin(ThemedMixin(WidgetBase))<SlidePanePrope
 		);
 	}
 
-	protected getStyles(): { [index: string]: string | null } {
+	protected getStyles(): { [index: string]: string | undefined } {
 		const { align = Align.left, width = DEFAULT_WIDTH } = this.properties;
 
 		let translate = '';
@@ -209,9 +209,9 @@ export class SlidePane extends I18nMixin(ThemedMixin(WidgetBase))<SlidePanePrope
 		}
 
 		return {
-			transform: translate ? `translate${translateAxis}(${translate}%)` : null,
-			width: this.plane === Plane.x ? `${width}px` : null,
-			height: this.plane === Plane.y ? `${width}px` : null
+			transform: translate ? `translate${translateAxis}(${translate}%)` : undefined,
+			width: this.plane === Plane.x ? `${width}px` : undefined,
+			height: this.plane === Plane.y ? `${width}px` : undefined
 		};
 	}
 

--- a/src/slide-pane/tests/unit/SlidePane.ts
+++ b/src/slide-pane/tests/unit/SlidePane.ts
@@ -1,7 +1,7 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 
 import SlidePane, { Align, SlidePaneProperties } from '../../index';
 import * as css from '../../../theme/slide-pane.m.css';
@@ -54,9 +54,9 @@ const closedTemplate = assertionTemplate(() =>
 					],
 					transitionend: noop,
 					styles: {
-						transform: null,
+						transform: undefined,
 						width: '320px',
-						height: null
+						height: undefined
 					}
 				},
 				[
@@ -182,9 +182,9 @@ registerSuite('SlidePane', {
 									],
 									transitionend: noop,
 									styles: {
-										transform: null,
+										transform: undefined,
 										width: '320px',
-										height: null
+										height: undefined
 									}
 								},
 								[
@@ -274,9 +274,9 @@ registerSuite('SlidePane', {
 								],
 								transitionend: noop,
 								styles: {
-									transform: null,
+									transform: undefined,
 									width: '320px',
-									height: null
+									height: undefined
 								}
 							},
 							[
@@ -328,9 +328,9 @@ registerSuite('SlidePane', {
 								],
 								transitionend: noop,
 								styles: {
-									transform: null,
+									transform: undefined,
 									width: '320px',
-									height: null
+									height: undefined
 								}
 							},
 							[
@@ -656,9 +656,9 @@ registerSuite('SlidePane', {
 								],
 								transitionend: noop,
 								styles: {
-									transform: null,
+									transform: undefined,
 									width: '320px',
-									height: null
+									height: undefined
 								}
 							},
 							[
@@ -719,7 +719,7 @@ registerSuite('SlidePane', {
 				openTemplate.setProperty('@content', 'styles', {
 					transform: 'translateX(-46.875%)',
 					width: '320px',
-					height: null
+					height: undefined
 				})
 			);
 
@@ -788,7 +788,7 @@ registerSuite('SlidePane', {
 					.setProperty('@content', 'styles', {
 						transform: 'translateX(31.25%)',
 						width: '320px',
-						height: null
+						height: undefined
 					})
 			);
 

--- a/src/slider/example/index.ts
+++ b/src/slider/example/index.ts
@@ -1,5 +1,5 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
 import Slider from '../../slider/index';
 
 export default class App extends WidgetBase {

--- a/src/slider/index.ts
+++ b/src/slider/index.ts
@@ -1,10 +1,10 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import Label from '../label/index';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
+import { DNode } from '@dojo/framework/core/interfaces';
+import Focus from '@dojo/framework/core/meta/Focus';
 import { uuid } from '@dojo/framework/core/util';
 import {
 	CustomAriaProperties,
@@ -17,7 +17,7 @@ import {
 import { formatAriaProperties } from '../common/util';
 import * as fixedCss from './styles/slider.m.css';
 import * as css from '../theme/slider.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type SliderProperties

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -1,8 +1,8 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import * as sinon from 'sinon';
-import { v, w } from '@dojo/framework/widget-core/d';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
+import Focus from '@dojo/framework/core/meta/Focus';
 
 import Label from '../../../label/index';
 import Slider from '../../index';

--- a/src/snackbar/example/index.tsx
+++ b/src/snackbar/example/index.tsx
@@ -1,7 +1,7 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { tsx } from '@dojo/framework/widget-core/tsx';
-import watch from '@dojo/framework/widget-core/decorators/watch';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { tsx } from '@dojo/framework/core/vdom';
+import watch from '@dojo/framework/core/decorators/watch';
 import Snackbar from '../index';
 import Button from '../../button/index';
 

--- a/src/snackbar/index.tsx
+++ b/src/snackbar/index.tsx
@@ -1,8 +1,8 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { DNode, RenderResult } from '@dojo/framework/widget-core/interfaces';
-import { theme, ThemedMixin } from '@dojo/framework/widget-core/mixins/Themed';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
-import { tsx } from '@dojo/framework/widget-core/tsx';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { DNode, RenderResult } from '@dojo/framework/core/interfaces';
+import { theme, ThemedMixin } from '@dojo/framework/core/mixins/Themed';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
+import { tsx } from '@dojo/framework/core/vdom';
 import * as css from '../theme/snackbar.m.css';
 
 export interface SnackbarProperties {

--- a/src/snackbar/tests/unit/Snackbar.tsx
+++ b/src/snackbar/tests/unit/Snackbar.tsx
@@ -2,7 +2,7 @@ const { describe, it } = intern.getInterface('bdd');
 
 import assertationTemplate from '@dojo/framework/testing/assertionTemplate';
 import harness from '@dojo/framework/testing/harness';
-import { tsx } from '@dojo/framework/widget-core/tsx';
+import { tsx } from '@dojo/framework/core/vdom';
 import Snackbar from '../../index';
 import * as css from '../../../theme/snackbar.m.css';
 import Button from '../../../button/index';

--- a/src/split-pane/README.md
+++ b/src/split-pane/README.md
@@ -25,7 +25,7 @@ The following CSS classes are used to style the `SplitPane` widget and should be
 *Basic Row Example*
 ```typescript
 import SplitPane, { Direction } from '@dojo/widgets/split-pane';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(SplitPane, {
 	key: 'splitpane1',
@@ -43,7 +43,7 @@ w(SplitPane, {
 *Column example that collapses at 600px*
 ```typescript
 import SplitPane, { Direction } from '@dojo/widgets/split-pane';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(SplitPane, {
 	key: 'splitpane2',
@@ -62,7 +62,7 @@ w(SplitPane, {
 *Nested SplitPanes*
 ```typescript
 import SplitPane, { Direction } from '@dojo/widgets/split-pane';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(SplitPane, {
 	key: 'nested',

--- a/src/split-pane/example/index.ts
+++ b/src/split-pane/example/index.ts
@@ -1,8 +1,8 @@
 import { deepAssign } from '@dojo/framework/core/util';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { Dimensions } from '@dojo/framework/widget-core/meta/Dimensions';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
+import { Dimensions } from '@dojo/framework/core/meta/Dimensions';
 import SplitPane, { Direction } from '../../split-pane/index';
 import GlobalEvent from '../../global-event/index';
 

--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -1,15 +1,15 @@
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { diffProperty } from '@dojo/framework/widget-core/decorators/diffProperty';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { v, w } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { diffProperty } from '@dojo/framework/core/decorators/diffProperty';
 
 import * as fixedCss from './styles/split-pane.m.css';
 import * as css from '../theme/split-pane.m.css';
-import { Dimensions } from '@dojo/framework/widget-core/meta/Dimensions';
-import { Resize, ContentRect } from '@dojo/framework/widget-core/meta/Resize';
+import { Dimensions } from '@dojo/framework/core/meta/Dimensions';
+import { Resize, ContentRect } from '@dojo/framework/core/meta/Resize';
 import { GlobalEvent } from '../global-event/index';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * Direction of this SplitPane

--- a/src/split-pane/tests/unit/SplitPane.ts
+++ b/src/split-pane/tests/unit/SplitPane.ts
@@ -2,15 +2,15 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import { stub } from 'sinon';
 
-import { v, w, isWNode } from '@dojo/framework/widget-core/d';
+import { v, w, isWNode } from '@dojo/framework/core/vdom';
 import harness from '@dojo/framework/testing/harness';
 
 import * as css from '../../../theme/split-pane.m.css';
 import * as fixedCss from '../../styles/split-pane.m.css';
 import SplitPane, { Direction } from '../../index';
 import { GlobalEvent } from '../../../global-event/index';
-import { Dimensions } from '@dojo/framework/widget-core/meta/Dimensions';
-import { Resize } from '@dojo/framework/widget-core/meta/Resize';
+import { Dimensions } from '@dojo/framework/core/meta/Dimensions';
+import { Resize } from '@dojo/framework/core/meta/Resize';
 import { noop, MockMetaMixin, stubEvent } from '../../../common/tests/support/test-helpers';
 
 function createVNodeSelector(type: 'window' | 'document', name: string) {

--- a/src/tab-controller/README.md
+++ b/src/tab-controller/README.md
@@ -32,7 +32,7 @@ Beyond complete keyboard accessibility, `TabController` ensures that all appropr
 ```typescript
 import TabController from '@dojo/widgets/tab-controller';
 import Tab from '@dojo/widgets/tab';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(TabController, {
 	activeIndex: this.state.activeIndex,
@@ -54,7 +54,7 @@ w(TabController, {
 ```typescript
 import TabController from '@dojo/widgets/tab-controller';
 import Tab from '@dojo/widgets/tab';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(TabController, {
 	activeIndex: this.state.activeIndex,
@@ -79,7 +79,7 @@ w(TabController, {
 ```typescript
 import TabController, { Align } from '@dojo/widgets/tab-controller';
 import Tab from '@dojo/widgets/tab';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(TabController, {
 	activeIndex: this.state.activeIndex,

--- a/src/tab-controller/TabButton.ts
+++ b/src/tab-controller/TabButton.ts
@@ -1,9 +1,9 @@
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { I18nMixin } from '@dojo/framework/widget-core/mixins/I18n';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
-import { v } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { I18nMixin } from '@dojo/framework/core/mixins/I18n';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
+import { v } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import commonBundle from '../common/nls/common';
 import { CommonMessages } from '../common/interfaces';
 import { Keys } from '../common/util';

--- a/src/tab-controller/example/index.ts
+++ b/src/tab-controller/example/index.ts
@@ -1,8 +1,8 @@
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { DNode } from '@dojo/framework/core/interfaces';
 import { includes } from '@dojo/framework/shim/array';
 import { deepAssign } from '@dojo/framework/core/util';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import Tab from '../../tab/index';
 import TabController, { Align } from '../../tab-controller/index';
 

--- a/src/tab-controller/index.ts
+++ b/src/tab-controller/index.ts
@@ -1,17 +1,17 @@
 import { assign } from '@dojo/framework/shim/object';
-import { DNode, WNode } from '@dojo/framework/widget-core/interfaces';
+import { DNode, WNode } from '@dojo/framework/core/interfaces';
 import Tab, { TabProperties } from '../tab/index';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import TabButton from './TabButton';
 import { uuid } from '@dojo/framework/core/util';
 import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 
 import * as css from '../theme/tab-controller.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * Enum for tab button alignment

--- a/src/tab-controller/tests/unit/TabButton.ts
+++ b/src/tab-controller/tests/unit/TabButton.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
 
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 import harness from '@dojo/framework/testing/harness';
 import { Keys } from '../../../common/util';
 import { assign } from '@dojo/framework/shim/object';

--- a/src/tab-controller/tests/unit/TabController.ts
+++ b/src/tab-controller/tests/unit/TabController.ts
@@ -3,8 +3,8 @@ const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
 
-import { v, w } from '@dojo/framework/widget-core/d';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
+import { v, w } from '@dojo/framework/core/vdom';
+import { DNode } from '@dojo/framework/core/interfaces';
 
 import TabController, { Align } from '../../index';
 import TabButton from '../../TabButton';

--- a/src/tab/index.ts
+++ b/src/tab/index.ts
@@ -1,13 +1,13 @@
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { v } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { v } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 
 import * as css from '../theme/tab-controller.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
-import { CustomElementChildType } from '@dojo/framework/widget-core/registerCustomElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
+import { CustomElementChildType } from '@dojo/framework/core/registerCustomElement';
 
 /**
  * @type TabProperties

--- a/src/tab/tests/unit/Tab.ts
+++ b/src/tab/tests/unit/Tab.ts
@@ -1,7 +1,7 @@
 const { registerSuite } = intern.getInterface('object');
 
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 
 import Tab from '../../index';
 import * as css from '../../../theme/tab-controller.m.css';

--- a/src/text-area/example/index.ts
+++ b/src/text-area/example/index.ts
@@ -1,5 +1,5 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
 import Textarea from '../../text-area/index';
 
 export default class App extends WidgetBase {

--- a/src/text-area/index.ts
+++ b/src/text-area/index.ts
@@ -1,9 +1,9 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
-import { v, w } from '@dojo/framework/widget-core/d';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
+import Focus from '@dojo/framework/core/meta/Focus';
 import Label from '../label/index';
 import {
 	CustomAriaProperties,
@@ -15,7 +15,7 @@ import {
 import { formatAriaProperties } from '../common/util';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/text-area.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 import HelperText from '../helper-text/index';
 
 /**

--- a/src/text-area/tests/unit/Textarea.ts
+++ b/src/text-area/tests/unit/Textarea.ts
@@ -2,8 +2,8 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
-import { v, w } from '@dojo/framework/widget-core/d';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
+import Focus from '@dojo/framework/core/meta/Focus';
 
 import Label from '../../../label/index';
 import Textarea from '../../index';

--- a/src/text-input/example/index.ts
+++ b/src/text-input/example/index.ts
@@ -1,5 +1,5 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { v, w } from '@dojo/framework/widget-core/d';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
 import TextInput from '../../text-input/index';
 
 export default class App extends WidgetBase {
@@ -8,7 +8,7 @@ export default class App extends WidgetBase {
 	private _value3: string | undefined;
 	private _value5: string | undefined;
 	private _value6: string | undefined;
-	private _value6Valid: boolean | { valid?: boolean; message?: string };
+	private _value6Valid!: boolean | { valid?: boolean; message?: string };
 
 	render() {
 		return v(

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -1,9 +1,9 @@
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { DNode, PropertyChangeRecord } from '@dojo/framework/widget-core/interfaces';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { v, w } from '@dojo/framework/widget-core/d';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
-import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { DNode, PropertyChangeRecord } from '@dojo/framework/core/interfaces';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { v, w } from '@dojo/framework/core/vdom';
+import Focus from '@dojo/framework/core/meta/Focus';
+import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import Label from '../label/index';
 import {
 	CustomAriaProperties,
@@ -14,9 +14,9 @@ import {
 import { formatAriaProperties } from '../common/util';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/text-input.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
-import diffProperty from '@dojo/framework/widget-core/decorators/diffProperty';
-import { reference } from '@dojo/framework/widget-core/diff';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
+import diffProperty from '@dojo/framework/core/decorators/diffProperty';
+import { reference } from '@dojo/framework/core/diff';
 import InputValidity from '../common/InputValidity';
 import HelperText from '../helper-text/index';
 

--- a/src/text-input/tests/unit/TextInput.ts
+++ b/src/text-input/tests/unit/TextInput.ts
@@ -3,8 +3,8 @@ const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
 
-import { v, w } from '@dojo/framework/widget-core/d';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
+import Focus from '@dojo/framework/core/meta/Focus';
 import assertationTemplate from '@dojo/framework/testing/assertionTemplate';
 
 import Label from '../../../label/index';

--- a/src/time-picker/README.md
+++ b/src/time-picker/README.md
@@ -53,7 +53,7 @@ By default, all options are formatted in 24-hour standard time (`HHmmss`, or `HH
 
 ```typescript
 import { getDateFormatter } from '@dojo/framework/i18n/date';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 import TimePicker, { TimeUnits } from '@dojo/widgets/time-picker';
 
 const getShorTime = getDateFormatter({ time: 'short' });
@@ -72,7 +72,7 @@ w(TimePicker, {
 ## Example Usage
 
 ```typescript
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 import TimePicker from '@dojo/widgets/time-picker';
 
 // Custom (Non-Native) TimePicker

--- a/src/time-picker/example/index.ts
+++ b/src/time-picker/example/index.ts
@@ -1,7 +1,7 @@
 import { getDateFormatter } from '@dojo/framework/i18n/date';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { v, w } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import setLocaleData from './setLocaleData';
 import TimePicker, { getOptions, TimeUnits } from '../../time-picker/index';
 

--- a/src/time-picker/index.ts
+++ b/src/time-picker/index.ts
@@ -1,12 +1,12 @@
 import { padStart } from '@dojo/framework/shim/string';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import ThemedMixin, { theme, ThemedProperties } from '@dojo/framework/widget-core/mixins/Themed';
-import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
-import { diffProperty } from '@dojo/framework/widget-core/decorators/diffProperty';
-import { auto } from '@dojo/framework/widget-core/diff';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
+import { DNode } from '@dojo/framework/core/interfaces';
+import ThemedMixin, { theme, ThemedProperties } from '@dojo/framework/core/mixins/Themed';
+import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
+import { diffProperty } from '@dojo/framework/core/decorators/diffProperty';
+import { auto } from '@dojo/framework/core/diff';
+import Focus from '@dojo/framework/core/meta/Focus';
 import ComboBox from '../combobox/index';
 import { LabeledProperties, InputProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
@@ -14,7 +14,7 @@ import { TextInputProperties } from '../text-input/index';
 import Label from '../label/index';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/time-picker.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 interface FocusInputEvent extends FocusEvent {
 	target: HTMLInputElement;

--- a/src/time-picker/tests/unit/TimePicker.ts
+++ b/src/time-picker/tests/unit/TimePicker.ts
@@ -2,8 +2,8 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/widget-core/d';
-import Focus from '@dojo/framework/widget-core/meta/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
+import Focus from '@dojo/framework/core/meta/Focus';
 import * as sinon from 'sinon';
 import TimePicker, { getOptions, parseUnits } from '../../index';
 import * as css from '../../../theme/time-picker.m.css';

--- a/src/title-pane/README.md
+++ b/src/title-pane/README.md
@@ -36,7 +36,7 @@ The following CSS classes are used to style the `TitlePane` widget and should be
 *Basic Example*
 ```typescript
 import TitlePane from '@dojo/widgets/title-pane';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(Titlepane, {
 	title: 'My Pane',
@@ -50,7 +50,7 @@ w(Titlepane, {
 *Basic Example*
 ```typescript
 import TitlePane from '@dojo/widgets/title-pane';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(Titlepane, {
 	title: 'My Pane',

--- a/src/title-pane/example/index.ts
+++ b/src/title-pane/example/index.ts
@@ -1,5 +1,5 @@
-import { v, w } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { v, w } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 
 import TitlePane from '../../title-pane/index';
 

--- a/src/title-pane/index.ts
+++ b/src/title-pane/index.ts
@@ -1,15 +1,15 @@
 import { uuid } from '@dojo/framework/core/util';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { theme, ThemedMixin, ThemedProperties } from '@dojo/framework/widget-core/mixins/Themed';
-import { FocusMixin, FocusProperties } from '@dojo/framework/widget-core/mixins/Focus';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { theme, ThemedMixin, ThemedProperties } from '@dojo/framework/core/mixins/Themed';
+import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
+import { v, w } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 
 import Icon from '../icon/index';
 import * as fixedCss from './styles/title-pane.m.css';
 import * as css from '../theme/title-pane.m.css';
-import { Dimensions } from '@dojo/framework/widget-core/meta/Dimensions';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { Dimensions } from '@dojo/framework/core/meta/Dimensions';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 import GlobalEvent from '../global-event/index';
 
 /**

--- a/src/title-pane/tests/unit/TitlePane.ts
+++ b/src/title-pane/tests/unit/TitlePane.ts
@@ -1,7 +1,7 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
-import { v, w, isWNode } from '@dojo/framework/widget-core/d';
+import { v, w, isWNode } from '@dojo/framework/core/vdom';
 import Icon from '../../../icon/index';
 import TitlePane, { TitlePaneProperties } from '../../index';
 import * as css from '../../../theme/title-pane.m.css';

--- a/src/toolbar/README.md
+++ b/src/toolbar/README.md
@@ -25,7 +25,7 @@ The following CSS classes are used to style the `Toolbar` widget and should be p
 *Basic Example*
 ```typescript
 import Toolbar from '@dojo/widgets/toolbar';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(Toolbar, {
 	heading: 'My Site',
@@ -40,7 +40,7 @@ w(Toolbar, {
 *Fixed position Example*
 ```typescript
 import Toolbar from '@dojo/widgets/toolbar';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 // wrap toolbar in a fixed element
 v('div', { styles: { position: fixed, top: 0 } }, [

--- a/src/toolbar/example/index.ts
+++ b/src/toolbar/example/index.ts
@@ -1,5 +1,5 @@
-import { w, v } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { w, v } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 
 import Toolbar from '../../toolbar/index';
 

--- a/src/toolbar/index.ts
+++ b/src/toolbar/index.ts
@@ -1,9 +1,9 @@
-import { Dimensions } from '@dojo/framework/widget-core/meta/Dimensions';
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { I18nMixin } from '@dojo/framework/widget-core/mixins/I18n';
-import { ThemedMixin, theme, ThemedProperties } from '@dojo/framework/widget-core/mixins/Themed';
-import { v, w } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { Dimensions } from '@dojo/framework/core/meta/Dimensions';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { I18nMixin } from '@dojo/framework/core/mixins/I18n';
+import { ThemedMixin, theme, ThemedProperties } from '@dojo/framework/core/mixins/Themed';
+import { v, w } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 
 import Icon from '../icon/index';
 import SlidePane, { Align } from '../slide-pane/index';
@@ -11,7 +11,7 @@ import commonBundle from '../common/nls/common';
 import * as fixedCss from './styles/toolbar.m.css';
 import * as css from '../theme/toolbar.m.css';
 import { GlobalEvent } from '../global-event/index';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 export { Align };
 

--- a/src/toolbar/tests/unit/Toolbar.ts
+++ b/src/toolbar/tests/unit/Toolbar.ts
@@ -1,7 +1,7 @@
 const { registerSuite } = intern.getInterface('object');
 
-import { Dimensions } from '@dojo/framework/widget-core/meta/Dimensions';
-import { v, w, isWNode } from '@dojo/framework/widget-core/d';
+import { Dimensions } from '@dojo/framework/core/meta/Dimensions';
+import { v, w, isWNode } from '@dojo/framework/core/vdom';
 import harness from '@dojo/framework/testing/harness';
 import { stub } from 'sinon';
 

--- a/src/tooltip/README.md
+++ b/src/tooltip/README.md
@@ -25,7 +25,7 @@ The following CSS classes are used to style the `Tooltip` widget and should be p
 ```typescript
 import TextInput from '@dojo/widgets/text-input';
 import Tooltip from '@dojo/widgets/tooltip';
-import { w } from '@dojo/framework/widget-core/d';
+import { w } from '@dojo/framework/core/vdom';
 
 w(Tooltip, {
 	key: 'foo',

--- a/src/tooltip/example/index.ts
+++ b/src/tooltip/example/index.ts
@@ -1,6 +1,6 @@
 import { Set } from '@dojo/framework/shim/Set';
-import { w, v } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { w, v } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 
 import Button from '../../button/index';
 import TextInput from '../../text-input/index';

--- a/src/tooltip/index.ts
+++ b/src/tooltip/index.ts
@@ -1,13 +1,13 @@
-import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/widget-core/mixins/Themed';
-import { v } from '@dojo/framework/widget-core/d';
-import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { v } from '@dojo/framework/core/vdom';
+import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 
 import * as fixedCss from './styles/tooltip.m.css';
 import * as css from '../theme/tooltip.m.css';
-import { customElement } from '@dojo/framework/widget-core/decorators/customElement';
+import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type TooltipProperties

--- a/src/tooltip/tests/unit/Tooltip.ts
+++ b/src/tooltip/tests/unit/Tooltip.ts
@@ -1,6 +1,6 @@
 const { registerSuite } = intern.getInterface('object');
 
-import { v, w } from '@dojo/framework/widget-core/d';
+import { v, w } from '@dojo/framework/core/vdom';
 import harness from '@dojo/framework/testing/harness';
 
 import Tooltip, { Orientation } from '../../index';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Upgrades `@dojo/widgets` to use the 6.0.0-alpha.2 version of `@dojo/framework`. Includes a mandatory upgrade to the minimum supported version of TypeScript, `v3.4.5`.

* Updates import references to `widget-core` to `core`
* Updates the module from `d.ts` to `vdom.ts` for `tsx`, `w` and `v`.
