### PR TITLE
Make card and snackbar themable

### DIFF
--- a/src/card/index.tsx
+++ b/src/card/index.tsx
@@ -22,9 +22,9 @@ export class Card extends ThemedMixin(WidgetBase)<CardProperties> {
 		const { actionsRenderer } = this.properties;
 		const actionsResult = actionsRenderer && actionsRenderer();
 		return (
-			<div key="root" classes={css.root}>
+			<div key="root" classes={this.theme(css.root)}>
 				{this.children}
-				{actionsResult && <div classes={css.actions}>{actionsResult}</div>}
+				{actionsResult && <div classes={this.theme(css.actions)}>{actionsResult}</div>}
 			</div>
 		);
 	}

--- a/src/snackbar/index.tsx
+++ b/src/snackbar/index.tsx
@@ -27,20 +27,20 @@ export class Snackbar extends ThemedMixin(WidgetBase)<SnackbarProperties> {
 		return (
 			<div
 				key="root"
-				classes={[
+				classes={this.theme([
 					css.root,
 					open ? css.open : null,
 					type ? css[type] : null,
 					leading ? css.leading : null,
 					stacked ? css.stacked : null
-				]}
+				])}
 			>
-				<div key="content" classes={css.content}>
-					<div key="label" classes={css.label} role="status" aria-live="polite">
+				<div key="content" classes={this.theme(css.content)}>
+					<div key="label" classes={this.theme(css.label)} role="status" aria-live="polite">
 						{message}
 					</div>
 					{actionsRenderer && (
-						<div key="actions" classes={css.actions}>
+						<div key="actions" classes={this.theme(css.actions)}>
 							{actionsRenderer()}
 						</div>
 					)}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Add `this.theme` to all css classes in `Card` and `Snackbar` widgets so they can actually be themed.
