### PR TITLE
Added dojo theme option for examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,8 @@ Not all widgets include these extension points, and some have additional overrid
 We appreciate your interest!  Please see the [Dojo Meta Repository](https://github.com/dojo/meta#readme) for the
 Contributing Guidelines and Style Guide.
 
+Note that all changes to widgets should work with the [dojo theme](https://github.com/dojo/themes/). To test this start the example page (instructions at [Installation](#installation) section) and select the dojo option at the top of the page.
+
 ### Installation
 
 To start working with this package, clone the repository and run `npm install`.

--- a/package-lock.json
+++ b/package-lock.json
@@ -142,6 +142,12 @@
       "integrity": "sha512-Mdx+DRRb2OJKXtz1gfTh9EQNk0WEqF482i9UQsHj0gdKpAlSBvRMXb8wjZEVDLFGcsa9hXRpq0xuE6QOe/EiFQ==",
       "dev": true
     },
+    "@dojo/themes": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/@dojo/themes/-/themes-5.0.1.tgz",
+      "integrity": "sha512-Ph/mQ3FZAV+ioVVrc/f3Sq4dOKFJ4cDMYYXI+CJbdOOpoRc9ydgOyONaAOBI5o56VJHnO5CrvFp6cLt83O3GnQ==",
+      "dev": true
+    },
     "@dojo/webpack-contrib": {
       "version": "5.0.3",
       "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-5.0.3.tgz",

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "@dojo/cli": "^5.0.0",
     "@dojo/cli-build-widget": "^5.0.0",
     "@dojo/loader": "^2.0.0",
+    "@dojo/themes": "^5.0.1",
     "@theintern/a11y": "~0.2.0",
     "@types/execa": "^0.8.1",
     "@types/glob": "5.0.*",

--- a/src/calendar/tests/functional/Calendar.ts
+++ b/src/calendar/tests/functional/Calendar.ts
@@ -132,7 +132,7 @@ registerSuite('Calendar', {
 		}
 
 		return openMonthPicker(this.remote)
-			.findByCssSelector('input[type=radio]')
+			.findByCssSelector(`.${css.monthRadioInput}`)
 			.click()
 			.sleep(DELAY)
 			.end()

--- a/src/common/example/index.html
+++ b/src/common/example/index.html
@@ -18,6 +18,7 @@
 <body>
 	<script src="../../../node_modules/@dojo/framework/shim/util/amd.js"></script>
 	<script src="../../../node_modules/@dojo/loader/loader.js"></script>
+	<link rel="stylesheet" href="../../../node_modules/@dojo/themes/dojo/index.css">
 	<link rel="stylesheet" href="./example.css">
 	<script>
 		require.config(shimAmdDependencies({

--- a/src/common/example/index.ts
+++ b/src/common/example/index.ts
@@ -7,6 +7,9 @@ import Outlet from '@dojo/framework/routing/Outlet';
 import { registerRouterInjector } from '@dojo/framework/routing/RouterInjector';
 import Registry from '@dojo/framework/widget-core/Registry';
 import Router from '@dojo/framework/routing/Router';
+import dojo from '../../../node_modules/@dojo/themes/dojo/index';
+import { registerThemeInjector } from '@dojo/framework/widget-core/mixins/Themed';
+import Radio from '../../radio/index';
 
 const modules = [
 	'',
@@ -39,12 +42,26 @@ const modules = [
 	'tooltip'
 ];
 
+interface ThemeOption {
+	value: any;
+	label: string;
+}
+
+let themes: ThemeOption[] = [
+	{ label: 'dojo', value: dojo },
+	{ label: 'vanilla', value: undefined }
+];
+
 const registry = new Registry();
 registerRouterInjector([{ path: '{module}', outlet: 'module' }], registry);
+const themeInjector = registerThemeInjector(dojo, registry);
 
 export default class App extends WidgetBase {
 	@watch()
 	private _module = '';
+
+	@watch()
+	private _theme = themes[0].label;
 
 	private _onModuleChange(module: string) {
 		const item = this.registry.getInjector<Router>('router')!;
@@ -56,8 +73,31 @@ export default class App extends WidgetBase {
 		return import('src/' + this._module + '/example/index');
 	};
 
+	private _onThemeChange(label: string) {
+		const [theme] = themes.filter((theme: ThemeOption) => theme.label === label);
+		if (theme) {
+			themeInjector.set(theme.value);
+			this._theme = theme.label;
+		}
+	}
+
 	render() {
 		return v('div', { id: 'module-select' }, [
+			v('fieldset', [
+				v('legend', {}, ['Select Theme']),
+				v(
+					'div',
+					themes.map((theme, index) => {
+						return w(Radio, {
+							key: theme.label.concat(index.toString()),
+							checked: this._theme === theme.label,
+							value: theme.label,
+							label: theme.label,
+							onChange: this._onThemeChange
+						});
+					})
+				)
+			]),
 			v('h2', ['Select a module to view']),
 			w(Select, {
 				onChange: this._onModuleChange,

--- a/src/common/example/index.ts
+++ b/src/common/example/index.ts
@@ -54,7 +54,7 @@ let themes: ThemeOption[] = [
 
 const registry = new Registry();
 registerRouterInjector([{ path: '{module}', outlet: 'module' }], registry);
-const themeInjector = registerThemeInjector(dojoTheme, registry);
+const themeInjector = registerThemeInjector(undefined, registry);
 
 export default class App extends WidgetBase {
 	@watch()
@@ -82,7 +82,7 @@ export default class App extends WidgetBase {
 	}
 
 	render() {
-		return v('div', { id: 'module-select' }, [
+		return v('div', [
 			v('fieldset', [
 				v('legend', {}, ['Select Theme']),
 				v(
@@ -98,26 +98,28 @@ export default class App extends WidgetBase {
 					})
 				)
 			]),
-			v('h2', ['Select a module to view']),
-			w(Select, {
-				onChange: this._onModuleChange,
-				useNativeElement: true,
-				label: 'Select a module to view',
-				options: modules,
-				value: this._module,
-				getOptionValue: (module: any) => module,
-				getOptionLabel: (module: any) => module
-			}),
-			w(Outlet, {
-				id: 'module',
-				renderer: (matchDetail: any) => {
-					this._module = matchDetail.params.module;
-					return w(
-						{ label: this._module, registryItem: this._renderItem },
-						{ key: this._module }
-					);
-				}
-			})
+			v('div', { id: 'module-select' }, [
+				v('h2', ['Select a module to view']),
+				w(Select, {
+					onChange: this._onModuleChange,
+					useNativeElement: true,
+					label: 'Select a module to view',
+					options: modules,
+					value: this._module,
+					getOptionValue: (module: any) => module,
+					getOptionLabel: (module: any) => module
+				}),
+				w(Outlet, {
+					id: 'module',
+					renderer: (matchDetail: any) => {
+						this._module = matchDetail.params.module;
+						return w(
+							{ label: this._module, registryItem: this._renderItem },
+							{ key: this._module }
+						);
+					}
+				})
+			])
 		]);
 	}
 }

--- a/src/common/example/index.ts
+++ b/src/common/example/index.ts
@@ -7,7 +7,7 @@ import Outlet from '@dojo/framework/routing/Outlet';
 import { registerRouterInjector } from '@dojo/framework/routing/RouterInjector';
 import Registry from '@dojo/framework/widget-core/Registry';
 import Router from '@dojo/framework/routing/Router';
-import dojo from '../../../node_modules/@dojo/themes/dojo/index';
+import dojoTheme from '../../../node_modules/@dojo/themes/dojo/index';
 import { registerThemeInjector } from '@dojo/framework/widget-core/mixins/Themed';
 import Radio from '../../radio/index';
 
@@ -48,13 +48,13 @@ interface ThemeOption {
 }
 
 let themes: ThemeOption[] = [
-	{ label: 'dojo', value: dojo },
-	{ label: 'vanilla', value: undefined }
+	{ label: 'dojoTheme', value: dojoTheme },
+	{ label: 'none', value: undefined }
 ];
 
 const registry = new Registry();
 registerRouterInjector([{ path: '{module}', outlet: 'module' }], registry);
-const themeInjector = registerThemeInjector(dojo, registry);
+const themeInjector = registerThemeInjector(dojoTheme, registry);
 
 export default class App extends WidgetBase {
 	@watch()

--- a/src/common/example/index.ts
+++ b/src/common/example/index.ts
@@ -48,8 +48,8 @@ interface ThemeOption {
 }
 
 let themes: ThemeOption[] = [
-	{ label: 'dojoTheme', value: dojoTheme },
-	{ label: 'none', value: undefined }
+	{ label: 'none', value: undefined },
+	{ label: 'dojoTheme', value: dojoTheme }
 ];
 
 const registry = new Registry();

--- a/src/common/example/index.ts
+++ b/src/common/example/index.ts
@@ -49,7 +49,7 @@ interface ThemeOption {
 
 let themes: ThemeOption[] = [
 	{ label: 'none', value: undefined },
-	{ label: 'dojoTheme', value: dojoTheme }
+	{ label: 'dojo', value: dojoTheme }
 ];
 
 const registry = new Registry();

--- a/src/time-picker/tests/functional/TimePicker.ts
+++ b/src/time-picker/tests/functional/TimePicker.ts
@@ -12,7 +12,7 @@ import * as textinputCss from '../../../theme/text-input.m.css';
 import { uuid } from '@dojo/framework/core/util';
 
 const axe = services.axe;
-const DELAY = 300;
+const DELAY = 500;
 
 function getPage(remote: Remote, exampleId: string) {
 	return remote


### PR DESCRIPTION
**Type:** Feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Dojo widgets in this repo should be compatible with the dojo theme at https://github.com/dojo/themes/. However in the dev environment there was no easy way to test this. This PR adds the ability to test compatibility with the dojo theme easily by toggling radio buttons at the top of the page. Two themes are included:
- dojo
- vanilla (no styling)

Resolves #739 

**Screenshot:**
<img width="1631" alt="Screen Shot 2019-06-07 at 4 16 39 PM" src="https://user-images.githubusercontent.com/3914018/59138057-ab378c00-893f-11e9-9597-43fc0eb4deaf.png">

