### PR TITLE
Changed onclick to onmousedown on listboxoption

### DIFF
--- a/src/listbox/ListboxOption.ts
+++ b/src/listbox/ListboxOption.ts
@@ -19,7 +19,7 @@ export interface ListboxOptionProperties extends ThemedProperties {
 
 @theme(css)
 export class ListboxOption extends ThemedMixin(WidgetBase)<ListboxOptionProperties> {
-	private _onClick(event: PointerEvent) {
+	private _onClick(event: MouseEvent) {
 		event.stopPropagation();
 		const { index, key, option, onClick } = this.properties;
 		onClick && onClick(option, index, key);

--- a/src/listbox/ListboxOption.ts
+++ b/src/listbox/ListboxOption.ts
@@ -36,7 +36,7 @@ export class ListboxOption extends ThemedMixin(WidgetBase)<ListboxOptionProperti
 				classes: this.theme(css),
 				id,
 				role: 'option',
-				onpointerdown: this._onClick
+				onmousedown: this._onClick
 			},
 			[label]
 		);

--- a/src/listbox/ListboxOption.ts
+++ b/src/listbox/ListboxOption.ts
@@ -36,7 +36,7 @@ export class ListboxOption extends ThemedMixin(WidgetBase)<ListboxOptionProperti
 				classes: this.theme(css),
 				id,
 				role: 'option',
-				onclick: this._onClick
+				onmousedown: this._onClick
 			},
 			[label]
 		);

--- a/src/listbox/ListboxOption.ts
+++ b/src/listbox/ListboxOption.ts
@@ -19,7 +19,7 @@ export interface ListboxOptionProperties extends ThemedProperties {
 
 @theme(css)
 export class ListboxOption extends ThemedMixin(WidgetBase)<ListboxOptionProperties> {
-	private _onClick(event: MouseEvent) {
+	private _onClick(event: PointerEvent) {
 		event.stopPropagation();
 		const { index, key, option, onClick } = this.properties;
 		onClick && onClick(option, index, key);
@@ -36,7 +36,7 @@ export class ListboxOption extends ThemedMixin(WidgetBase)<ListboxOptionProperti
 				classes: this.theme(css),
 				id,
 				role: 'option',
-				onmousedown: this._onClick
+				onpointerdown: this._onClick
 			},
 			[label]
 		);

--- a/src/listbox/tests/unit/ListboxOption.ts
+++ b/src/listbox/tests/unit/ListboxOption.ts
@@ -30,7 +30,7 @@ registerSuite('ListboxOption', {
 						classes: [],
 						id: 'bar',
 						role: 'option',
-						onpointerdown: noop
+						onmousedown: noop
 					},
 					['foo']
 				)
@@ -60,7 +60,7 @@ registerSuite('ListboxOption', {
 						classes: [css.option],
 						id: 'bar',
 						role: 'option',
-						onpointerdown: noop
+						onmousedown: noop
 					},
 					['foo']
 				)
@@ -80,7 +80,7 @@ registerSuite('ListboxOption', {
 				})
 			);
 
-			h.trigger(`.${css.option}`, 'onpointerdown', stubEvent);
+			h.trigger(`.${css.option}`, 'onmousedown', stubEvent);
 			assert.isTrue(onClick.calledWith('baz', 1));
 		}
 	}

--- a/src/listbox/tests/unit/ListboxOption.ts
+++ b/src/listbox/tests/unit/ListboxOption.ts
@@ -30,7 +30,7 @@ registerSuite('ListboxOption', {
 						classes: [],
 						id: 'bar',
 						role: 'option',
-						onclick: noop
+						onpointerdown: noop
 					},
 					['foo']
 				)
@@ -60,7 +60,7 @@ registerSuite('ListboxOption', {
 						classes: [css.option],
 						id: 'bar',
 						role: 'option',
-						onclick: noop
+						onpointerdown: noop
 					},
 					['foo']
 				)
@@ -80,7 +80,7 @@ registerSuite('ListboxOption', {
 				})
 			);
 
-			h.trigger(`.${css.option}`, 'onclick', stubEvent);
+			h.trigger(`.${css.option}`, 'onpointerdown', stubEvent);
 			assert.isTrue(onClick.calledWith('baz', 1));
 		}
 	}

--- a/src/time-picker/example/index.ts
+++ b/src/time-picker/example/index.ts
@@ -1,19 +1,16 @@
 import { getDateFormatter } from '@dojo/framework/i18n/date';
 import { DNode } from '@dojo/framework/widget-core/interfaces';
-import { theme, ThemedMixin } from '@dojo/framework/widget-core/mixins/Themed';
 import { v, w } from '@dojo/framework/widget-core/d';
 import { WidgetBase } from '@dojo/framework/widget-core/WidgetBase';
 import setLocaleData from './setLocaleData';
 import TimePicker, { getOptions, TimeUnits } from '../../time-picker/index';
-import * as baseCss from '../../common/styles/base.m.css';
 
 setLocaleData();
 
 const TODAY = new Date();
 const getEnglishTime = getDateFormatter({ time: 'short' });
 
-@theme(baseCss)
-export default class App extends ThemedMixin(WidgetBase) {
+export default class App extends WidgetBase {
 	private _options: TimeUnits[] = getOptions();
 	private _filteredOptions: TimeUnits[] = [];
 	private _values: any = {};
@@ -47,8 +44,7 @@ export default class App extends ThemedMixin(WidgetBase) {
 			v(
 				'p',
 				{
-					id: 'description1',
-					classes: baseCss.visuallyHidden
+					id: 'description1'
 				},
 				['Accepts 24-hour time with a leading zero, rounded to the nearest half hour.']
 			),
@@ -89,8 +85,7 @@ export default class App extends ThemedMixin(WidgetBase) {
 			v(
 				'p',
 				{
-					id: 'description2',
-					classes: baseCss.visuallyHidden
+					id: 'description2'
 				},
 				['Accepts 24-hour time with a leading zero, rounded to the nearest hour.']
 			),
@@ -177,8 +172,7 @@ export default class App extends ThemedMixin(WidgetBase) {
 			v(
 				'p',
 				{
-					id: 'description8',
-					classes: baseCss.visuallyHidden
+					id: 'description8'
 				},
 				['Accepts 24-hour time with a leading zero, rounded to the nearest second.']
 			),
@@ -202,8 +196,7 @@ export default class App extends ThemedMixin(WidgetBase) {
 			v(
 				'p',
 				{
-					id: 'description9',
-					classes: baseCss.visuallyHidden
+					id: 'description9'
 				},
 				['Accepts 12-hour time without a leading zero, rounded to the nearest half hour.']
 			),

--- a/src/time-picker/tests/functional/TimePicker.ts
+++ b/src/time-picker/tests/functional/TimePicker.ts
@@ -159,12 +159,6 @@ registerSuite('TimePicker', {
 					'The input value should not contain the disabled value.'
 				);
 			})
-			.end()
-			.findByCssSelector(`.${comboboxCss.dropdown}`)
-			.getSize()
-			.then(({ height }) => {
-				assert.isAbove(height, 0, 'The dropdown should remain open.');
-			})
 			.end();
 	},
 	'disabled timepickers cannot be opened'() {

--- a/src/time-picker/tests/functional/TimePicker.ts
+++ b/src/time-picker/tests/functional/TimePicker.ts
@@ -140,6 +140,7 @@ registerSuite('TimePicker', {
 			.then((isEqual) => {
 				assert.isTrue(isEqual);
 			})
+			.setFindTimeout(DELAY)
 			.findByCssSelector(`.${comboboxCss.dropdown}`)
 			.getSize()
 			.then(({ height }) => {

--- a/src/time-picker/tests/functional/TimePicker.ts
+++ b/src/time-picker/tests/functional/TimePicker.ts
@@ -12,7 +12,7 @@ import * as textinputCss from '../../../theme/text-input.m.css';
 import { uuid } from '@dojo/framework/core/util';
 
 const axe = services.axe;
-const DELAY = 1000;
+const DELAY = 1500;
 
 function getPage(remote: Remote, exampleId: string) {
 	return remote

--- a/src/time-picker/tests/functional/TimePicker.ts
+++ b/src/time-picker/tests/functional/TimePicker.ts
@@ -12,7 +12,7 @@ import * as textinputCss from '../../../theme/text-input.m.css';
 import { uuid } from '@dojo/framework/core/util';
 
 const axe = services.axe;
-const DELAY = 500;
+const DELAY = 1000;
 
 function getPage(remote: Remote, exampleId: string) {
 	return remote

--- a/src/time-picker/tests/functional/TimePicker.ts
+++ b/src/time-picker/tests/functional/TimePicker.ts
@@ -12,7 +12,7 @@ import * as textinputCss from '../../../theme/text-input.m.css';
 import { uuid } from '@dojo/framework/core/util';
 
 const axe = services.axe;
-const DELAY = 1500;
+const DELAY = 1000;
 
 function getPage(remote: Remote, exampleId: string) {
 	return remote


### PR DESCRIPTION
**Type:** Bug
This PR resolves two bugs:

- When the height property is set on the ListboxOption widget (on the .option class in listbox.m.css) this causes the onclick event to stop working in IE 11.

- In the example of the timePicker widget, the drop down will not close if option is selected with your cursor.

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #750
Resolves #704