### PR TITLE
Fix broken timepicker test

### DIFF
--- a/src/time-picker/tests/functional/TimePicker.ts
+++ b/src/time-picker/tests/functional/TimePicker.ts
@@ -12,7 +12,7 @@ import * as textinputCss from '../../../theme/text-input.m.css';
 import { uuid } from '@dojo/framework/core/util';
 
 const axe = services.axe;
-const DELAY = 500;
+const DELAY = 1000;
 
 function getPage(remote: Remote, exampleId: string) {
 	return remote
@@ -140,6 +140,7 @@ registerSuite('TimePicker', {
 			.then((isEqual) => {
 				assert.isTrue(isEqual);
 			})
+			.setFindTimeout(DELAY)
 			.findByCssSelector(`.${comboboxCss.dropdown}`)
 			.getSize()
 			.then(({ height }) => {


### PR DESCRIPTION
**Type:** But

The pipeline was having the following error:
```
× chrome 75.0.3770.90 on Linux - TimePicker - disabled menu items cannot be clicked (1.869s)
AssertionError: expected false to be true
  at Command.<anonymous>  <src/time-picker/tests/functional/TimePicker.ts:141:12>
  at runCallback  <node_modules/src/Command.ts:578:36>
  at Command.<anonymous>  <node_modules/src/Command.ts:603:20>
  at <node_modules/@theintern/common/index.js:16:7182>
  at process._tickDomainCallback  <internal/process/next_tick.js:135:7>
  at Command.then  <node_modules/src/Command.ts:599:12>
  at Test.disabled menu items cannot be clicked [as test]  <src/time-picker/tests/functional/TimePicker.ts:140:5>
  at <src/lib/Test.ts:263:52>
  at <node_modules/@theintern/common/index.js:16:7182>
  at process._tickDomainCallback  <internal/process/next_tick.js:135:7>
chrome 75.0.3770.90 on Linux: 2/519 tests failed (4 skipped)
```
The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #???
