### PR TITLE
Updating old ARIA describedBy examples

### DIFF
--- a/src/button/README.md
+++ b/src/button/README.md
@@ -11,7 +11,7 @@ Dojo's `Button` widget creates a `<button>` element
 
 ### Accessibility Features
 
-- The basic button provides a strongly typed `type` property, as well as `describedBy` and `disabled`
+- The basic button provides a strongly typed `type` property, as well as `disabled`
 - Setting `pressed` to create a toggle button handles `aria-pressed`
 - Creating a popup button with `popup` sets `aria-haspopup`, `aria-controls`, and `aria-expanded`
 
@@ -27,7 +27,7 @@ w(Button, {
 // Toggle button
 // pressed must be a boolean to correctly set aria-pressed
 w(Button, {
-	describedBy: 'instructions',
+	aria: { describedBy: 'instructions' },
 	pressed: !!this.state.buttonPressed,
 	onClick: (event: MouseEvent) => {
 		this.setState({ buttonPressed: !this.state.buttonPressed });

--- a/src/checkbox/README.md
+++ b/src/checkbox/README.md
@@ -23,7 +23,7 @@ If the `label` property is not used, we recommend creating a separate `label` an
 // Normal usage
 w(Checkbox, {
 	label: 'Sign up for updates',
-	name: 'update-checkbox'
+	name: 'update-checkbox',
 	checked: this.state.checked,
 	value: 'updates',
 	onChange: (event: TypedTargetEvent<HTMLInputElement>) => {
@@ -34,7 +34,7 @@ w(Checkbox, {
 // Toggle mode with description
 w(Checkbox, {
 	checked: this.state.musicChecked,
-	describedBy: 'instructions',
+	aria: { describedBy: 'instructions' },
 	label: 'Play music',
 	mode: Mode.toggle,
 	name: 'music',

--- a/src/radio/README.md
+++ b/src/radio/README.md
@@ -20,9 +20,9 @@ If the `label` property is not used, we recommend creating a separate `label` an
 // Example usage
 w(Radio, {
 	checked: this.state.radioValue === 'radio1-1',
-	describedBy: 'instructions',
+	aria: { describedBy: 'instructions' },
 	label: 'Choice A',
-	name: 'radio1'
+	name: 'radio1',
 	value: 'radio1-1',
 	onChange: (event: TypedTargetEvent<HTMLInputElement>) => {
 		this.setState({ radioValue: event.target.value });
@@ -30,9 +30,9 @@ w(Radio, {
 }),
 w(Radio, {
 	checked: this.state.radioValue === 'radio1-2',
-	describedBy: 'instructions',
+	aria: { describedBy: 'instructions' },
 	label: 'Choice B',
-	name: 'radio1'
+	name: 'radio1',
 	value: 'radio1-2',
 	onChange: (event: TypedTargetEvent<HTMLInputElement>) => {
 		this.setState({ radioValue: event.target.value });

--- a/src/text-area/README.md
+++ b/src/text-area/README.md
@@ -11,7 +11,7 @@ Dojo's `Textarea` widget provides a wrapped native `textarea` input, optionally 
 
 ### Accessibility Features
 
-`Textarea` ensures that the proper attributes (ARIA or otherwise) are set along with classes when properties such as `disabled`, `readOnly`, `invalid`, etc. are used. It provides the property `describedBy` to reference an element with additional descriptive text with `aria-describedby`.
+`Textarea` ensures that the proper attributes (ARIA or otherwise) are set along with classes when properties such as `disabled`, `readOnly`, `invalid`, etc. are used. It also provides an API for custom ARIA implementations of `aria-describedby` and `aria-controls`. It also sets `aria-invalid` when validation fails.
 
 If the `label` property is not used, we recommend creating a separate `label` and pointing it at the input's `widgetId` property.
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Updating old examples that show setting the ARIA `describedBy` with just a `describedBy` property, which is gone now. The new way is to set the `aria` property like `aria: { describedBy: 'instructions' }`.

Resolves #775
