### PR TITLE
Add date type to text-input

### DIFF
--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -20,7 +20,15 @@ import { reference } from '@dojo/framework/core/diff';
 import InputValidity from '../common/InputValidity';
 import HelperText from '../helper-text/index';
 
-export type TextInputType = 'text' | 'email' | 'number' | 'password' | 'search' | 'tel' | 'url';
+export type TextInputType =
+	| 'text'
+	| 'email'
+	| 'number'
+	| 'password'
+	| 'search'
+	| 'tel'
+	| 'url'
+	| 'date';
 
 interface TextInputInternalState {
 	previousValue?: string;


### PR DESCRIPTION
**Type:** feature

This add's `date` as a `type` option on the text-input widget allowing it to use the native date picker.