### PR TITLE
Removing custom element decorators

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -1,9 +1,11 @@
 {
 	"build-widget": {
-		"elements": [
+		"prefix": "dojo",
+		"widgets": [
 			"src/accordion-pane",
 			"src/button",
 			"src/calendar",
+			"src/card",
 			"src/checkbox",
 			"src/combobox",
 			"src/dialog",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,41 @@
 {
   "name": "@dojo/widgets",
-  "version": "6.0.0-alpha.4",
+  "version": "6.0.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.5.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.5.0.tgz",
+      "integrity": "sha512-7dV4eu9gBxoM0dAnj/BCFDW9LFU0zvTrkq0ugM7pnHEgguOEeOz1so2ZghEdzviYzQEED0r4EAgpsBChKy1TRQ==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      },
+      "dependencies": {
+        "js-tokens": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+          "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+          "dev": true
+        }
+      }
+    },
     "@babel/runtime": {
-      "version": "7.4.5",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.4.5.tgz",
-      "integrity": "sha512-TuI4qpWZP6lGOGIuGWtp9sPluqYICmbk8T/1vpSysqJxRPkudh/ofFWyqdcMsDf2s7KvDL4/YHgKyvcS3g9CJQ==",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.5.4.tgz",
+      "integrity": "sha512-Na84uwyImZZc3FKf4aUF1tysApzwf3p2yuFBIyBfbzT5glzKTdvYI4KVW4kcgjrzoGUjC7w3YyCHcJKaRxsr2Q==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -61,19 +89,19 @@
       }
     },
     "@dojo/cli-build-widget": {
-      "version": "6.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@dojo/cli-build-widget/-/cli-build-widget-6.0.0-alpha.1.tgz",
-      "integrity": "sha512-cG2bvyWif/s4G1sxZvqv6voVfoPbm5b1y3yM0FWYQdfnhtPYmrmKPX+z41O5FS+roz5bc19CJ+wkedN4Myjzyg==",
+      "version": "6.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@dojo/cli-build-widget/-/cli-build-widget-6.0.0-alpha.2.tgz",
+      "integrity": "sha512-Sdx3kpMgNyGk1Cjvx6EsK1/4WV5O4d847zBdvbKyzgR2qo5jO24mJyZOdTTejZPTGp/U1/M+VB8Ef77zZsupjQ==",
       "dev": true,
       "requires": {
         "@dojo/framework": "6.0.0-alpha.7",
-        "@dojo/webpack-contrib": "6.0.0-alpha.7",
+        "@dojo/webpack-contrib": "6.0.0-alpha.8",
         "chalk": "2.4.1",
         "clean-webpack-plugin": "1.0.0",
         "cli-columns": "3.1.2",
         "css-loader": "1.0.1",
         "express": "4.16.2",
-        "file-loader": "2.0.0",
+        "file-loader": "^3.0.1",
         "globby": "7.1.1",
         "gzip-size": "4.1.0",
         "html-webpack-plugin": "3.2.0",
@@ -84,7 +112,7 @@
         "loader-utils": "1.1.0",
         "log-symbols": "2.1.0",
         "log-update": "2.3.0",
-        "mini-css-extract-plugin": "0.4.2",
+        "mini-css-extract-plugin": "0.7.0",
         "optimize-css-assets-webpack-plugin": "5.0.1",
         "ora": "1.3.0",
         "pkg-dir": "2.0.0",
@@ -159,12 +187,12 @@
       "dev": true
     },
     "@dojo/webpack-contrib": {
-      "version": "6.0.0-alpha.7",
-      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-6.0.0-alpha.7.tgz",
-      "integrity": "sha512-oAwqkV9gjDhJWOCx1OMC71th6duF5TDw48r+t53gMurrp52rEGrIf9IM3gdRIN87IsNKBBJeG34Puk2atS8Nwg==",
+      "version": "6.0.0-alpha.8",
+      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-6.0.0-alpha.8.tgz",
+      "integrity": "sha512-/eMWQ3BbSTCqHYgtTIYND0Q5cvLSZJgbXckN95gwsM02U5YihPzmyP/SY15JO5E3Kwu0cPt1UosEJipiVnyCVA==",
       "dev": true,
       "requires": {
-        "@dojo/framework": "6.0.0-alpha.7",
+        "@dojo/framework": "6.0.0-alpha.10",
         "acorn": "6.1.1",
         "acorn-dynamic-import": "4.0.0",
         "acorn-walk": "6.1.1",
@@ -203,6 +231,28 @@
         "wrapper-webpack-plugin": "2.0.0"
       },
       "dependencies": {
+        "@dojo/framework": {
+          "version": "6.0.0-alpha.10",
+          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-6.0.0-alpha.10.tgz",
+          "integrity": "sha512-4XWXwxFmb/o8aJCSCVsxWU814Ev2hSodk6Xp9gQrw+kqlzzXjcHxsX0pneZgqMTwkK+mfTKNPnsr2zU0WTzoOg==",
+          "dev": true,
+          "requires": {
+            "@types/cldrjs": "0.4.20",
+            "@types/globalize": "0.0.34",
+            "@webcomponents/webcomponentsjs": "1.1.0",
+            "cldrjs": "0.5.0",
+            "cross-fetch": "3.0.2",
+            "css-select-umd": "1.3.0-rc0",
+            "diff": "3.5.0",
+            "globalize": "1.4.0",
+            "immutable": "3.8.2",
+            "intersection-observer": "0.4.2",
+            "pepjs": "0.4.2",
+            "resize-observer-polyfill": "1.5.0",
+            "tslib": "1.9.3",
+            "web-animations-js": "2.3.1"
+          }
+        },
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -243,12 +293,6 @@
               }
             }
           }
-        },
-        "diff": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
-          "dev": true
         },
         "has-flag": {
           "version": "2.0.0",
@@ -376,6 +420,14 @@
             "make-error": "^1.1.1",
             "source-map-support": "^0.5.6",
             "yn": "^3.0.0"
+          },
+          "dependencies": {
+            "diff": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+              "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+              "dev": true
+            }
           }
         },
         "typed-css-modules": {
@@ -707,9 +759,9 @@
       }
     },
     "@types/lodash": {
-      "version": "4.14.134",
-      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.134.tgz",
-      "integrity": "sha512-2/O0khFUCFeDlbi7sZ7ZFRCcT812fAeOLm7Ev4KbwASkZ575TDrDcY7YyaoHdTOzKcNbfiwLYZqPmoC4wadrsw==",
+      "version": "4.14.136",
+      "resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.136.tgz",
+      "integrity": "sha512-0GJhzBdvsW2RUccNHOBkabI8HZVdOXmXbXhuKlDEd5Vv12P7oAVGfomGp3Ne21o5D/qu1WmthlNKFaoZJJeErA==",
       "dev": true
     },
     "@types/marked": {
@@ -1114,9 +1166,9 @@
       }
     },
     "ajv": {
-      "version": "6.10.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
-      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.1.tgz",
+      "integrity": "sha512-w1YQaVGNC6t2UCPjEawK/vo/dG8OOrVtUmhBT1uJJYxbl5kU2Tj3v6LGqBcsysN1yhuCStJCCA3GqdvKY8sqXQ==",
       "dev": true,
       "requires": {
         "fast-deep-equal": "^2.0.1",
@@ -1132,9 +1184,9 @@
       "dev": true
     },
     "ajv-keywords": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.0.tgz",
-      "integrity": "sha512-aUjdRFISbuFOl0EIZc+9e4FfZp0bDZgAdOOf30bJmw8VM9v84SHyVyxDfbWxpGYbdZD/9XoKxfHVNmxPkhwyGw==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.4.1.tgz",
+      "integrity": "sha512-RO1ibKvd27e6FEShVFfPALuHI3WjSVNeK5FIsmme/LYRNxjKuNj+Dt7bucLa6NdSv3JcVTyMlm9kGR84z1XpaQ==",
       "dev": true
     },
     "align-text": {
@@ -1142,6 +1194,7 @@
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
       "dev": true,
+      "optional": true,
       "requires": {
         "kind-of": "^3.0.2",
         "longest": "^1.0.1",
@@ -1153,6 +1206,7 @@
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
           "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
           "dev": true,
+          "optional": true,
           "requires": {
             "is-buffer": "^1.1.5"
           }
@@ -1274,9 +1328,9 @@
       "dev": true
     },
     "arg": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.0.tgz",
-      "integrity": "sha512-ZWc51jO3qegGkVh8Hwpv636EkbesNV5ZNQPCtRa+0qytRYPEs9IYT9qITY9buezqUH5uqyzlWLcufrzU2rffdg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
+      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
       "dev": true
     },
     "argparse": {
@@ -2097,14 +2151,14 @@
       }
     },
     "browserslist": {
-      "version": "4.6.3",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.3.tgz",
-      "integrity": "sha512-CNBqTCq22RKM8wKJNowcqihHJ4SkI8CGeK7KOR9tPboXUuS5Zk5lQgzzTbs4oxD8x+6HUshZUa2OyNI9lR93bQ==",
+      "version": "4.6.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.6.4.tgz",
+      "integrity": "sha512-ErJT8qGfRt/VWHSr1HeqZzz50DvxHtr1fVL1m5wf20aGrG8e1ce8fpZ2EjZEfs09DDZYSvtRaDlMpWslBf8Low==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30000975",
-        "electron-to-chromium": "^1.3.164",
-        "node-releases": "^1.1.23"
+        "caniuse-lite": "^1.0.30000981",
+        "electron-to-chromium": "^1.3.188",
+        "node-releases": "^1.1.25"
       }
     },
     "buffer": {
@@ -2317,15 +2371,15 @@
       }
     },
     "caniuse-db": {
-      "version": "1.0.30000978",
-      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000978.tgz",
-      "integrity": "sha512-UTzb0WomXxeqhAn3HgygItnkQeiLujN/O4D6hhB4ccSgktBysAbO/duUBJiNsPyxn/DsV8OnIn45jNeuvmUcPQ==",
+      "version": "1.0.30000983",
+      "resolved": "https://registry.npmjs.org/caniuse-db/-/caniuse-db-1.0.30000983.tgz",
+      "integrity": "sha512-LS3aD+ti+fezwo8oN01l5vfZF9/CIN/4pxV5SeakHo5leudiHjE66rVHl+XqoCGw4GpO2u5ab6LOpftTfCN9cw==",
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30000978",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000978.tgz",
-      "integrity": "sha512-H6gK6kxUzG6oAwg/Jal279z8pHw0BzrpZfwo/CA9FFm/vA0l8IhDfkZtepyJNE2Y4V6Dp3P3ubz6czby1/Mgsw==",
+      "version": "1.0.30000983",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000983.tgz",
+      "integrity": "sha512-/llD1bZ6qwNkt41AsvjsmwNOoA4ZB+8iqmf5LVyeSXuBODT/hAMFNVOh84NdUzoiYiSKqo5vQ3ZzeYHSi/olDQ==",
       "dev": true
     },
     "capture-stack-trace": {
@@ -2424,9 +2478,9 @@
       }
     },
     "chownr": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.1.tgz",
-      "integrity": "sha512-j38EvO5+LHX84jlo6h4UzmOwi0UgW61WRyPtJz4qaadK5eY3BTS5TY/S1Stc3Uk2lIM6TPevAlULiEJwie860g==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.2.tgz",
+      "integrity": "sha512-GkfeAQh+QNy3wquu9oIZr6SS5x7wGdSgNQvD10X3r+AZr1Oys22HW8kAmDMvNg2+Dm0TeGaEuO8gFwdBXxwO8A==",
       "dev": true
     },
     "chrome-trace-event": {
@@ -3685,9 +3739,9 @@
       }
     },
     "cssom": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.6.tgz",
-      "integrity": "sha512-DtUeseGk9/GBW0hl0vVPpU22iHL6YB5BUX7ml1hB+GMpo0NX5G4voX3kdWiMSEguFtcW3Vh3djqNF4aIe6ne0A==",
+      "version": "0.3.8",
+      "resolved": "https://registry.npmjs.org/cssom/-/cssom-0.3.8.tgz",
+      "integrity": "sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==",
       "dev": true
     },
     "cssstyle": {
@@ -4211,9 +4265,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.174",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.174.tgz",
-      "integrity": "sha512-OEh3EARo2B07ZRtxB0u9GqWyWmTeNS+diMp5bjw4kqMjgpzqM0w1zUOyErDsyWxTdArbvZ79T/w5n3WsBVHLfA==",
+      "version": "1.3.190",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.190.tgz",
+      "integrity": "sha512-cs9WnTnGBGnYYVFMCtLmr9jXNTOkdp95RLz5VhwzDn7dErg1Lnt9o4d01gEH69XlmRKWUr91Yu1hA+Hi8qW0PA==",
       "dev": true
     },
     "elegant-spinner": {
@@ -4943,9 +4997,9 @@
       }
     },
     "file-loader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-2.0.0.tgz",
-      "integrity": "sha512-YCsBfd1ZGCyonOKLxPiKPdu+8ld9HAaMEvJewzz+b2eTF7uL5Zm/HdBF6FjCrpCMRq25Mi0U1gl4pwn2TlH7hQ==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
+      "integrity": "sha512-4sNIOXgtH/9WZq4NvlfU3Opn5ynUsqBwSLyM+I7UOwdGigTBYfVVQEwe/msZNX/j4pCJTIM14Fsw66Svo1oVrw==",
       "dev": true,
       "requires": {
         "loader-utils": "^1.0.2",
@@ -5493,7 +5547,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5514,12 +5569,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5534,17 +5591,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5661,7 +5721,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5673,6 +5734,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5687,6 +5749,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5694,12 +5757,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5718,6 +5783,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5798,7 +5864,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5810,6 +5877,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5895,7 +5963,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5931,6 +6000,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5950,6 +6020,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5993,12 +6064,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6288,9 +6361,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.1.15",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
-      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.0.tgz",
+      "integrity": "sha512-jpSvDPV4Cq/bgtpndIWbI5hmYxhQGHPC4d4cqBPb4DLniCfhJokdXhwhaDuLBGLQdvvRum/UiX6ECVIPvDXqdg==",
       "dev": true
     },
     "graceful-readlink": {
@@ -7606,12 +7679,12 @@
       "dev": true
     },
     "https-proxy-agent": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.1.tgz",
-      "integrity": "sha512-HPCTS1LW51bcyMYbxUIOO4HEOlQ1/1qRaFWcyxvwaqUS9TY88aoEuHUY33kuAh1YhVVaDQhLZsnPd+XNARWZlQ==",
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-2.2.2.tgz",
+      "integrity": "sha512-c8Ndjc9Bkpfx/vCJueCPy0jlP4ccCCSNDp8xwCZzPjKJUm+B+u9WX2x98Qx4n1PiMNTWo3D7KK5ifNV/yJyRzg==",
       "dev": true,
       "requires": {
-        "agent-base": "^4.1.0",
+        "agent-base": "^4.3.0",
         "debug": "^3.1.0"
       }
     },
@@ -7734,6 +7807,18 @@
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
+        "parse-json": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
+          "integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
+          "dev": true,
+          "requires": {
+            "@babel/code-frame": "^7.0.0",
+            "error-ex": "^1.3.1",
+            "json-parse-better-errors": "^1.0.1",
+            "lines-and-columns": "^1.1.6"
+          }
+        },
         "pkg-dir": {
           "version": "4.2.0",
           "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-4.2.0.tgz",
@@ -7780,15 +7865,15 @@
           }
         },
         "read-pkg": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.1.1.tgz",
-          "integrity": "sha512-dFcTLQi6BZ+aFUaICg7er+/usEoqFdQxiEBsEMNGoipenihtxxtdrQuBXvyANCEI8VuUIVYFgeHGx9sLLvim4w==",
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-5.2.0.tgz",
+          "integrity": "sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==",
           "dev": true,
           "requires": {
             "@types/normalize-package-data": "^2.4.0",
             "normalize-package-data": "^2.5.0",
-            "parse-json": "^4.0.0",
-            "type-fest": "^0.4.1"
+            "parse-json": "^5.0.0",
+            "type-fest": "^0.6.0"
           }
         },
         "slash": {
@@ -9255,6 +9340,12 @@
         "immediate": "~3.0.5"
       }
     },
+    "lines-and-columns": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
+      "integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
+      "dev": true
+    },
     "lint-staged": {
       "version": "8.1.6",
       "resolved": "https://registry.npmjs.org/lint-staged/-/lint-staged-8.1.6.tgz",
@@ -9550,9 +9641,9 @@
       }
     },
     "lodash": {
-      "version": "4.17.11",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
-      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "version": "4.17.14",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.14.tgz",
+      "integrity": "sha512-mmKYbW3GLuJeX+iGP+Y7Gp1AiGHGbXHCOh/jZmrawMmsE7MS4znI3RL2FsjbqOyMayHInjOeykW7PEajUk1/xw==",
       "dev": true
     },
     "lodash._reinterpolate": {
@@ -9568,22 +9659,22 @@
       "dev": true
     },
     "lodash.template": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.4.0.tgz",
-      "integrity": "sha1-5zoDhcg1VZF0bgILmWecaQ5o+6A=",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/lodash.template/-/lodash.template-4.5.0.tgz",
+      "integrity": "sha512-84vYFxIkmidUiFxidA/KjjH9pAycqW+h980j7Fuz5qxRtO9pgB7MDFTdys1N7A5mcucRiDyEq4fusljItR1T/A==",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "~3.0.0",
+        "lodash._reinterpolate": "^3.0.0",
         "lodash.templatesettings": "^4.0.0"
       }
     },
     "lodash.templatesettings": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.1.0.tgz",
-      "integrity": "sha1-K01OlbpEDZFf8IvImeRVNmZxMxY=",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/lodash.templatesettings/-/lodash.templatesettings-4.2.0.tgz",
+      "integrity": "sha512-stgLz+i3Aa9mZgnjr/O+v9ruKZsPsndy7qPZOchbqk2cnTU1ZaldKK+v7m54WoKIyxiuMZTKT2H81F8BeAc3ZQ==",
       "dev": true,
       "requires": {
-        "lodash._reinterpolate": "~3.0.0"
+        "lodash._reinterpolate": "^3.0.0"
       }
     },
     "lodash.uniq": {
@@ -9634,7 +9725,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/longest/-/longest-1.0.1.tgz",
       "integrity": "sha1-MKCy2jj3N3DoKUoNIuZiXtd9AJc=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "loose-envify": {
       "version": "1.4.0",
@@ -9702,22 +9794,39 @@
       }
     },
     "make-fetch-happen": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-4.0.1.tgz",
-      "integrity": "sha512-7R5ivfy9ilRJ1EMKIOziwrns9fGeAD4bAha8EB7BIiBBLHm2KeTUGCrICFt2rbHfzheTLynv50GnNTK1zDTrcQ==",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/make-fetch-happen/-/make-fetch-happen-4.0.2.tgz",
+      "integrity": "sha512-YMJrAjHSb/BordlsDEcVcPyTbiJKkzqMf48N8dAJZT9Zjctrkb6Yg4TY9Sq2AwSIQJFn5qBBKVTYt3vP5FMIHA==",
       "dev": true,
       "requires": {
         "agentkeepalive": "^3.4.1",
-        "cacache": "^11.0.1",
+        "cacache": "^11.3.3",
         "http-cache-semantics": "^3.8.1",
         "http-proxy-agent": "^2.1.0",
         "https-proxy-agent": "^2.2.1",
-        "lru-cache": "^4.1.2",
+        "lru-cache": "^5.1.1",
         "mississippi": "^3.0.0",
         "node-fetch-npm": "^2.0.2",
         "promise-retry": "^1.1.1",
         "socks-proxy-agent": "^4.0.0",
         "ssri": "^6.0.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
       }
     },
     "map-cache": {
@@ -9907,14 +10016,29 @@
       "dev": true
     },
     "mini-css-extract-plugin": {
-      "version": "0.4.2",
-      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.4.2.tgz",
-      "integrity": "sha512-ots7URQH4wccfJq9Ssrzu2+qupbncAce4TmTzunI9CIwlQMp2XI+WNUw6xWF6MMAGAm1cbUVINrSjATaVMyKXg==",
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/mini-css-extract-plugin/-/mini-css-extract-plugin-0.7.0.tgz",
+      "integrity": "sha512-RQIw6+7utTYn8DBGsf/LpRgZCJMpZt+kuawJ/fju0KiOL6nAaTBNmCJwS7HtwSCXfS47gCkmtBFS7HdsquhdxQ==",
       "dev": true,
       "requires": {
         "loader-utils": "^1.1.0",
+        "normalize-url": "1.9.1",
         "schema-utils": "^1.0.0",
         "webpack-sources": "^1.1.0"
+      },
+      "dependencies": {
+        "normalize-url": {
+          "version": "1.9.1",
+          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-1.9.1.tgz",
+          "integrity": "sha1-LMDWazHqIwNkWENuNiDYWVTGbDw=",
+          "dev": true,
+          "requires": {
+            "object-assign": "^4.0.1",
+            "prepend-http": "^1.0.0",
+            "query-string": "^4.1.0",
+            "sort-keys": "^1.0.0"
+          }
+        }
       }
     },
     "minimalistic-assert": {
@@ -10161,9 +10285,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.23",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.23.tgz",
-      "integrity": "sha512-uq1iL79YjfYC0WXoHbC/z28q/9pOl8kSHaXdWmAAc8No+bDwqkZbzIJz55g/MUsPgSGm9LZ7QSUbzTcH5tz47w==",
+      "version": "1.1.25",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.25.tgz",
+      "integrity": "sha512-fI5BXuk83lKEoZDdH3gRhtsNgh05/wZacuXkgbiYkceE7+QIMXOg98n9ZV7mz27B+kFHnqHcUpscZZlGRSmTpQ==",
       "dev": true,
       "requires": {
         "semver": "^5.3.0"
@@ -10236,17 +10360,34 @@
       }
     },
     "npm-registry-fetch": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.9.0.tgz",
-      "integrity": "sha512-srwmt8YhNajAoSAaDWndmZgx89lJwIZ1GWxOuckH4Coek4uHv5S+o/l9FLQe/awA+JwTnj4FJHldxhlXdZEBmw==",
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-3.9.1.tgz",
+      "integrity": "sha512-VQCEZlydXw4AwLROAXWUR7QDfe2Y8Id/vpAgp6TI1/H78a4SiQ1kQrKZALm5/zxM5n4HIi+aYb+idUAV/RuY0Q==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.4",
         "bluebird": "^3.5.1",
         "figgy-pudding": "^3.4.1",
-        "lru-cache": "^4.1.3",
-        "make-fetch-happen": "^4.0.1",
+        "lru-cache": "^5.1.1",
+        "make-fetch-happen": "^4.0.2",
         "npm-package-arg": "^6.1.0"
+      },
+      "dependencies": {
+        "lru-cache": {
+          "version": "5.1.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
+          "integrity": "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==",
+          "dev": true,
+          "requires": {
+            "yallist": "^3.0.2"
+          }
+        },
+        "yallist": {
+          "version": "3.0.3",
+          "resolved": "https://registry.npmjs.org/yallist/-/yallist-3.0.3.tgz",
+          "integrity": "sha512-S+Zk8DEWE6oKpV+vI3qWkaK+jSbIK86pCwe2IF/xwIpQ8jEuxpw9NyaGjmp9+BoJv5FV2piqCDcoCtStppiq2A==",
+          "dev": true
+        }
       }
     },
     "npm-run-path": {
@@ -14394,9 +14535,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.1.33",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.1.33.tgz",
-      "integrity": "sha512-LTDP2uSrsc7XCb5lO7A8BI1qYxRe/8EqlRvMeEl6rsnYAqDOl8xHR+8lSAIVfrNaSAlTPTNOCgNjWcoUL3AZsw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.2.0.tgz",
+      "integrity": "sha512-GEn74ZffufCmkDDLNcl3uuyF/aSD6exEyh1v/ZSdAomB82t6G9hzJVRx0jBmLDW+VfZqks3aScmMw9DszwUalA==",
       "dev": true
     },
     "public-encrypt": {
@@ -15362,9 +15503,9 @@
       "dev": true
     },
     "serve": {
-      "version": "11.0.2",
-      "resolved": "https://registry.npmjs.org/serve/-/serve-11.0.2.tgz",
-      "integrity": "sha512-TjjjwUdPU+STkUyxvZFtkWOTRXdNDNMfot9Z/f97eEeyjPAV69o1TmJrNAlDbvpPu1JEjCoWiGCjkel7kWNF4A==",
+      "version": "11.1.0",
+      "resolved": "https://registry.npmjs.org/serve/-/serve-11.1.0.tgz",
+      "integrity": "sha512-+4wpDtOSS+4ZLyDWMxThutA3iOTawX2+yDovOI8cjOUOmemyvNlHyFAsezBlSgbZKTYChI3tzA1Mh0z6XZ62qA==",
       "dev": true,
       "requires": {
         "@zeit/schemas": "2.6.0",
@@ -15374,7 +15515,7 @@
         "chalk": "2.4.1",
         "clipboardy": "1.2.3",
         "compression": "1.7.3",
-        "serve-handler": "6.0.2",
+        "serve-handler": "6.1.0",
         "update-check": "1.5.2"
       },
       "dependencies": {
@@ -15399,9 +15540,9 @@
       }
     },
     "serve-handler": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.0.2.tgz",
-      "integrity": "sha512-D1zgDpvx9Rgjip6rzY2QBjlZwfr/oiDSg66HipOWkEw1appHn7/mXdVRL6F8+bd1KD117Wch4+4x78OTXQVwDg==",
+      "version": "6.1.0",
+      "resolved": "https://registry.npmjs.org/serve-handler/-/serve-handler-6.1.0.tgz",
+      "integrity": "sha512-63N075Tn3PsFYcu0NVV7tb367UbiW3gnC+/50ohL4oqOhAG6bmbaWqiRcXQgbzqc0ALBjSAzg7VTfa0Qw4E3hA==",
       "dev": true,
       "requires": {
         "bytes": "3.0.0",
@@ -15570,9 +15711,9 @@
       "dev": true
     },
     "simple-git": {
-      "version": "1.116.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.116.0.tgz",
-      "integrity": "sha512-Pbo3tceqMYy0j3U7jzMKabOWcx5+67GdgQUjpK83XUxGhA+1BX93UPvlWNzbCRoFwd7EJTyDSCC2XCoT4NTLYQ==",
+      "version": "1.120.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.120.0.tgz",
+      "integrity": "sha512-caF3eLrUSrL6d5fBVU85bmY0lpbMpbkWze1W2Tg946kN75s/WWvKqpc4Agn3DLHyzXEeiWfv8yPULiCKumuIQg==",
       "dev": true,
       "requires": {
         "debug": "^4.0.1"
@@ -15915,9 +16056,9 @@
       }
     },
     "spdx-license-ids": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.4.tgz",
-      "integrity": "sha512-7j8LYJLeY/Yb6ACbQ7F76qy5jHkp0U6jgBfJsk97bwWlVUnUWsAgpyaCvo17h0/RQGnQ036tVDomiwoI4pDkQA==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.5.tgz",
+      "integrity": "sha512-J+FWzZoynJEXGphVIS+XEh3kFSjZX/1i9gFBaWQcB+/tmpe2qUsSBABpcxqxnAxFdiUFEgAX1bjYGQvIZmoz9Q==",
       "dev": true
     },
     "split-string": {
@@ -16795,9 +16936,9 @@
       "dev": true
     },
     "type-fest": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.4.1.tgz",
-      "integrity": "sha512-IwzA/LSfD2vC1/YDYMv/zHP4rDF1usCwllsDpbolT3D4fUepIO7f9K70jjmUewU/LmGUKJcwcVtDCpnKk4BPMw==",
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.6.0.tgz",
+      "integrity": "sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==",
       "dev": true
     },
     "type-is": {
@@ -18786,9 +18927,9 @@
       "dev": true
     },
     "xtend": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.1.tgz",
-      "integrity": "sha1-pcbVMr5lbiPbgg77lDofBJmNY68=",
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "dev": true
     },
     "y18n": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   },
   "devDependencies": {
     "@dojo/cli": "^5.0.0",
-    "@dojo/cli-build-widget": "6.0.0-alpha.1",
+    "@dojo/cli-build-widget": "6.0.0-alpha.2",
     "@dojo/loader": "^2.0.0",
     "@dojo/themes": "^5.0.1",
     "@theintern/a11y": "~0.2.0",

--- a/src/accordion-pane/index.ts
+++ b/src/accordion-pane/index.ts
@@ -1,6 +1,5 @@
 import { assign } from '@dojo/framework/shim/object';
 import { DNode, WNode } from '@dojo/framework/core/interfaces';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import { includes } from '@dojo/framework/shim/array';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
 import { v } from '@dojo/framework/core/vdom';
@@ -25,11 +24,6 @@ export interface AccordionPaneProperties extends ThemedProperties {
 }
 
 @theme(css)
-@customElement<AccordionPaneProperties>({
-	tag: 'dojo-accordion-pane',
-	properties: ['openKeys', 'theme', 'extraClasses', 'classes'],
-	events: ['onRequestClose', 'onRequestOpen']
-})
 export class AccordionPane extends ThemedMixin(WidgetBase)<
 	AccordionPaneProperties,
 	WNode<TitlePane>

--- a/src/button/index.ts
+++ b/src/button/index.ts
@@ -49,25 +49,7 @@ export interface ButtonProperties
 
 @theme(css)
 @customElement<ButtonProperties>({
-	tag: 'dojo-button',
-	childType: CustomElementChildType.TEXT,
-	properties: ['disabled', 'pressed', 'popup', 'theme', 'aria', 'extraClasses', 'classes'],
-	attributes: ['widgetId', 'name', 'type', 'value'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onInput',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart'
-	]
+	childType: CustomElementChildType.TEXT
 })
 export class Button extends ThemedMixin(FocusMixin(WidgetBase))<ButtonProperties> {
 	private _onBlur(event: FocusEvent) {

--- a/src/calendar/index.ts
+++ b/src/calendar/index.ts
@@ -15,7 +15,6 @@ import Icon from '../icon/index';
 import calendarBundle from './nls/Calendar';
 import * as css from '../theme/calendar.m.css';
 import * as baseCss from '../common/styles/base.m.css';
-import customElement from '@dojo/framework/core/decorators/customElement';
 
 export type CalendarMessages = typeof calendarBundle.messages;
 
@@ -85,23 +84,6 @@ const DEFAULT_WEEKDAYS: ShortLong<typeof commonBundle.messages>[] = [
 ];
 
 @theme(css)
-@customElement<CalendarProperties>({
-	tag: 'dojo-calendar',
-	properties: [
-		'aria',
-		'classes',
-		'selectedDate',
-		'month',
-		'year',
-		'renderMonthLabel',
-		'renderWeekdayCell',
-		'labels',
-		'monthNames',
-		'weekdayNames',
-		'theme'
-	],
-	events: ['onDateSelect', 'onMonthChange', 'onYearChange']
-})
 export class Calendar extends I18nMixin(ThemedMixin(WidgetBase))<CalendarProperties> {
 	private _callDateFocus = false;
 	private _defaultDate = new Date();

--- a/src/card/index.tsx
+++ b/src/card/index.tsx
@@ -4,17 +4,12 @@ import { RenderResult } from '@dojo/framework/core/interfaces';
 import { alwaysRender } from '@dojo/framework/core/decorators/alwaysRender';
 import { ThemedMixin, theme } from '@dojo/framework/core/mixins/Themed';
 import * as css from '../theme/card.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import { DNode } from '@dojo/framework/core/interfaces';
 
 export interface CardProperties {
 	actionsRenderer?(): RenderResult;
 }
 
-@customElement<CardProperties>({
-	tag: 'dojo-card',
-	properties: ['actionsRenderer']
-})
 @theme(css)
 @alwaysRender()
 export class Card extends ThemedMixin(WidgetBase)<CardProperties> {

--- a/src/checkbox/index.ts
+++ b/src/checkbox/index.ts
@@ -16,7 +16,6 @@ import { formatAriaProperties } from '../common/util';
 import { v, w } from '@dojo/framework/core/vdom';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/checkbox.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type CheckboxProperties
@@ -54,37 +53,6 @@ export enum Mode {
 }
 
 @theme(css)
-@customElement<CheckboxProperties>({
-	tag: 'dojo-checkbox',
-	properties: [
-		'required',
-		'invalid',
-		'readOnly',
-		'disabled',
-		'theme',
-		'aria',
-		'extraClasses',
-		'labelAfter',
-		'labelHidden',
-		'checked',
-		'classes'
-	],
-	attributes: ['widgetId', 'label', 'value', 'name', 'mode', 'offLabel', 'onLabel'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart'
-	]
-})
 export class Checkbox extends ThemedMixin(FocusMixin(WidgetBase))<CheckboxProperties> {
 	private _onBlur(event: FocusEvent) {
 		const checkbox = event.target as HTMLInputElement;

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -19,7 +19,6 @@ import { CommonMessages, LabeledProperties } from '../common/interfaces';
 
 import * as css from '../theme/combobox.m.css';
 import * as baseCss from '../common/styles/base.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import HelperText from '../helper-text/index';
 
 /**
@@ -83,36 +82,6 @@ export enum Operation {
 
 @theme(css)
 @diffProperty('results', reference)
-@customElement<ComboBoxProperties>({
-	tag: 'dojo-combo-box',
-	properties: [
-		'theme',
-		'classes',
-		'extraClasses',
-		'labelHidden',
-		'clearable',
-		'disabled',
-		'inputProperties',
-		'valid',
-		'isResultDisabled',
-		'helperText',
-		'labelHidden',
-		'openOnFocus',
-		'readOnly',
-		'required',
-		'results'
-	],
-	attributes: ['widgetId', 'label', 'value'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onFocus',
-		'onMenuChange',
-		'onRequestResults',
-		'onResultSelect',
-		'onValidate'
-	]
-})
 export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<ComboBoxProperties> {
 	private _activeIndex = 0;
 	private _ignoreBlur: boolean | undefined;

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -13,7 +13,6 @@ import Icon from '../icon/index';
 import * as fixedCss from './styles/dialog.m.css';
 import * as css from '../theme/dialog.m.css';
 import { GlobalEvent } from '../global-event/index';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * The role of this dialog, used for accessibility
@@ -56,25 +55,6 @@ export interface DialogProperties extends ThemedProperties, CustomAriaProperties
 }
 
 @theme(css)
-@customElement<DialogProperties>({
-	tag: 'dojo-dialog',
-	properties: [
-		'theme',
-		'aria',
-		'extraClasses',
-		'exitAnimation',
-		'enterAnimation',
-		'underlayEnterAnimation',
-		'underlayExitAnimation',
-		'closeable',
-		'modal',
-		'open',
-		'underlay',
-		'classes'
-	],
-	attributes: ['title', 'role', 'closeText'],
-	events: ['onOpen', 'onRequestClose']
-})
 export class Dialog extends I18nMixin(ThemedMixin(WidgetBase))<DialogProperties> {
 	private _titleId = uuid();
 	private _wasOpen: boolean | undefined;

--- a/src/grid/index.ts
+++ b/src/grid/index.ts
@@ -1,7 +1,6 @@
 import WidgetBase from '@dojo/framework/core/WidgetBase';
 import { v, w } from '@dojo/framework/core/vdom';
 import ThemedMixin, { theme, ThemedProperties } from '@dojo/framework/core/mixins/Themed';
-import customElement from '@dojo/framework/core/decorators/customElement';
 import diffProperty from '@dojo/framework/core/decorators/diffProperty';
 import { DNode } from '@dojo/framework/core/interfaces';
 import { reference } from '@dojo/framework/core/diff';
@@ -49,11 +48,6 @@ export interface GridProperties<S> extends ThemedProperties {
 }
 
 @theme(css)
-@customElement<GridProperties<any>>({
-	tag: 'dojo-grid',
-	properties: ['theme', 'classes', 'height', 'fetcher', 'updater', 'columnConfig', 'store'],
-	attributes: ['storeId']
-})
 export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> {
 	private _store = new Store<GridState<S>>();
 	private _handle: any;

--- a/src/icon/index.ts
+++ b/src/icon/index.ts
@@ -6,7 +6,6 @@ import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 import * as css from '../theme/icon.m.css';
 import * as baseCss from '../common/styles/base.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 export type IconType = keyof typeof css;
 
@@ -24,11 +23,6 @@ export interface IconProperties extends ThemedProperties, CustomAriaProperties {
 }
 
 @theme(css)
-@customElement<IconProperties>({
-	tag: 'dojo-icon',
-	properties: ['theme', 'classes', 'aria', 'extraClasses'],
-	attributes: ['type', 'altText']
-})
 export class Icon extends ThemedMixin(WidgetBase)<IconProperties> {
 	protected renderAltText(altText: string): DNode {
 		return v('span', { classes: [baseCss.visuallyHidden] }, [altText]);

--- a/src/label/index.ts
+++ b/src/label/index.ts
@@ -6,7 +6,6 @@ import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 import * as css from '../theme/label.m.css';
 import * as baseCss from '../common/styles/base.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type LabelProperties
@@ -35,24 +34,6 @@ export interface LabelProperties extends ThemedProperties, CustomAriaProperties 
 }
 
 @theme(css)
-@customElement<LabelProperties>({
-	tag: 'dojo-label',
-	properties: [
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'disabled',
-		'focused',
-		'readOnly',
-		'required',
-		'invalid',
-		'hidden',
-		'secondary'
-	],
-	attributes: [],
-	events: []
-})
 export class Label extends ThemedMixin(WidgetBase)<LabelProperties> {
 	protected getRootClasses(): (string | null)[] {
 		const { disabled, focused, invalid, readOnly, required, secondary } = this.properties;

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -15,7 +15,6 @@ import * as css from '../theme/listbox.m.css';
 import ListboxOption from './ListboxOption';
 import { Focus } from '@dojo/framework/core/meta/Focus';
 import Resize from '@dojo/framework/core/meta/Resize';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /* Default scroll meta */
 export class ScrollMeta extends MetaBase {
@@ -65,24 +64,6 @@ export interface ListboxProperties extends ThemedProperties, FocusProperties, Cu
 
 @theme(css)
 @diffProperty('optionData', reference)
-@customElement<ListboxProperties>({
-	tag: 'dojo-listbox',
-	properties: [
-		'theme',
-		'classes',
-		'activeIndex',
-		'multiselect',
-		'tabIndex',
-		'visualFocus',
-		'optionData',
-		'getOptionDisabled',
-		'getOptionId',
-		'getOptionLabel',
-		'getOptionSelected'
-	],
-	attributes: ['widgetId'],
-	events: ['onActiveIndexChange', 'onKeyDown', 'onOptionSelect']
-})
 export class Listbox extends ThemedMixin(FocusMixin(WidgetBase))<ListboxProperties> {
 	private _boundRenderOption = this.renderOption.bind(this);
 	private _idBase = uuid();

--- a/src/outlined-button/index.tsx
+++ b/src/outlined-button/index.tsx
@@ -11,25 +11,7 @@ export interface OutlinedButtonProperties extends ButtonProperties {}
 
 @theme(css)
 @customElement<OutlinedButtonProperties>({
-	tag: 'dojo-outlined-button',
-	childType: CustomElementChildType.TEXT,
-	properties: ['disabled', 'pressed', 'popup', 'theme', 'aria', 'extraClasses', 'classes'],
-	attributes: ['widgetId', 'name', 'type', 'value'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onInput',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart'
-	]
+	childType: CustomElementChildType.TEXT
 })
 export class OutlinedButton extends ThemedMixin(WidgetBase)<OutlinedButtonProperties> {
 	protected render(): DNode {

--- a/src/progress/index.ts
+++ b/src/progress/index.ts
@@ -5,7 +5,6 @@ import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 import { DNode } from '@dojo/framework/core/interfaces';
 import * as css from '../theme/progress.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type ProgressProperties
@@ -29,22 +28,6 @@ export interface ProgressProperties extends ThemedProperties, CustomAriaProperti
 }
 
 @theme(css)
-@customElement<ProgressProperties>({
-	tag: 'dojo-progress',
-	properties: [
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'output',
-		'showOutput',
-		'max',
-		'min',
-		'value'
-	],
-	attributes: ['widgetId'],
-	events: []
-})
 export class Progress extends ThemedMixin(WidgetBase)<ProgressProperties> {
 	private _output(value: number, percent: number) {
 		const { output } = this.properties;

--- a/src/radio/index.ts
+++ b/src/radio/index.ts
@@ -16,7 +16,6 @@ import { formatAriaProperties } from '../common/util';
 import { v, w } from '@dojo/framework/core/vdom';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/radio.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type RadioProperties
@@ -40,37 +39,6 @@ export interface RadioProperties
 }
 
 @theme(css)
-@customElement<RadioProperties>({
-	tag: 'dojo-radio',
-	properties: [
-		'required',
-		'invalid',
-		'readOnly',
-		'disabled',
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'checked',
-		'labelAfter',
-		'labelHidden'
-	],
-	attributes: ['widgetId', 'label', 'value', 'name'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart'
-	]
-})
 export class Radio extends ThemedMixin(FocusMixin(WidgetBase))<RadioProperties> {
 	private _uuid = uuid();
 

--- a/src/raised-button/index.tsx
+++ b/src/raised-button/index.tsx
@@ -11,25 +11,7 @@ export interface RaisedButtonProperties extends ButtonProperties {}
 
 @theme(css)
 @customElement<RaisedButtonProperties>({
-	tag: 'dojo-raised-button',
-	childType: CustomElementChildType.TEXT,
-	properties: ['disabled', 'pressed', 'popup', 'theme', 'aria', 'extraClasses', 'classes'],
-	attributes: ['widgetId', 'name', 'type', 'value'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onInput',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart'
-	]
+	childType: CustomElementChildType.TEXT
 })
 export class RaisedButton extends ThemedMixin(WidgetBase)<RaisedButtonProperties> {
 	protected render(): DNode {

--- a/src/range-slider/index.ts
+++ b/src/range-slider/index.ts
@@ -17,7 +17,6 @@ import Label from '../label/index';
 import * as fixedCss from './styles/range-slider.m.css';
 import * as css from '../theme/range-slider.m.css';
 import * as baseCss from '../common/styles/base.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 export interface RangeSliderProperties
 	extends ThemedProperties,
@@ -53,49 +52,6 @@ function extractValue(event: Event): number {
 type MinMaxCallback = (minValue: number, maxValue: number) => void;
 
 @theme(css)
-@customElement<RangeSliderProperties>({
-	tag: 'dojo-range-slider',
-	properties: [
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'disabled',
-		'invalid',
-		'required',
-		'readOnly',
-		'labelAfter',
-		'labelHidden',
-		'max',
-		'min',
-		'output',
-		'outputIsTooltip',
-		'showOutput',
-		'step',
-		'minValue',
-		'maxValue',
-		'minName',
-		'maxName',
-		'minimumLabel',
-		'maximumLabel'
-	],
-	attributes: ['widgetId', 'label', 'name'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onInput',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart'
-	]
-})
 export class RangeSlider extends ThemedMixin(WidgetBase)<RangeSliderProperties> {
 	// id used to associate input with output
 	private _widgetId = uuid();

--- a/src/select/index.ts
+++ b/src/select/index.ts
@@ -15,7 +15,6 @@ import Label from '../label/index';
 import Listbox from '../listbox/index';
 import HelperText from '../helper-text/index';
 import * as css from '../theme/select.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type SelectProperties
@@ -58,30 +57,6 @@ export interface SelectProperties
 
 @theme(css)
 @diffProperty('options', reference)
-@customElement<SelectProperties>({
-	tag: 'dojo-select',
-	properties: [
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'options',
-		'useNativeElement',
-		'getOptionDisabled',
-		'getOptionId',
-		'getOptionLabel',
-		'getOptionText',
-		'getOptionSelected',
-		'getOptionValue',
-		'readOnly',
-		'required',
-		'invalid',
-		'disabled',
-		'labelHidden'
-	],
-	attributes: ['widgetId', 'placeholder', 'label', 'value', 'helperText'],
-	events: ['onBlur', 'onChange', 'onFocus']
-})
 export class Select extends ThemedMixin(FocusMixin(WidgetBase))<SelectProperties> {
 	private _focusedIndex!: number;
 	private _focusNode = 'trigger';

--- a/src/slide-pane/index.ts
+++ b/src/slide-pane/index.ts
@@ -11,7 +11,6 @@ import commonBundle from '../common/nls/common';
 import Icon from '../icon/index';
 import * as fixedCss from './styles/slide-pane.m.css';
 import * as css from '../theme/slide-pane.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import diffProperty from '@dojo/framework/core/decorators/diffProperty';
 
 /**
@@ -65,12 +64,6 @@ enum Slide {
 }
 
 @theme(css)
-@customElement<SlidePaneProperties>({
-	tag: 'dojo-slide-pane',
-	properties: ['theme', 'aria', 'extraClasses', 'open', 'underlay', 'classes'],
-	attributes: ['align', 'closeText', 'title'],
-	events: ['onOpen', 'onRequestClose']
-})
 export class SlidePane extends I18nMixin(ThemedMixin(WidgetBase))<SlidePaneProperties> {
 	private _initialPosition = 0;
 	private _slide: Slide | undefined;

--- a/src/slider/index.ts
+++ b/src/slider/index.ts
@@ -17,7 +17,6 @@ import {
 import { formatAriaProperties } from '../common/util';
 import * as fixedCss from './styles/slider.m.css';
 import * as css from '../theme/slider.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type SliderProperties
@@ -61,45 +60,6 @@ function extractValue(event: Event): number {
 }
 
 @theme(css)
-@customElement<SliderProperties>({
-	tag: 'dojo-slider',
-	properties: [
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'disabled',
-		'invalid',
-		'required',
-		'readOnly',
-		'labelAfter',
-		'labelHidden',
-		'max',
-		'min',
-		'output',
-		'outputIsTooltip',
-		'showOutput',
-		'step',
-		'vertical',
-		'value'
-	],
-	attributes: ['widgetId', 'label', 'name', 'verticalHeight'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onInput',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart'
-	]
-})
 export class Slider extends ThemedMixin(FocusMixin(WidgetBase))<SliderProperties> {
 	// id used to associate input with output
 	private _widgetId = uuid();

--- a/src/snackbar/index.tsx
+++ b/src/snackbar/index.tsx
@@ -1,7 +1,6 @@
 import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { DNode, RenderResult } from '@dojo/framework/core/interfaces';
 import { theme, ThemedMixin } from '@dojo/framework/core/mixins/Themed';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import { tsx } from '@dojo/framework/core/vdom';
 import * as css from '../theme/snackbar.m.css';
 
@@ -15,11 +14,6 @@ export interface SnackbarProperties {
 }
 
 @theme(css)
-@customElement<SnackbarProperties>({
-	tag: 'dojo-snackbar',
-	properties: ['actionsRenderer', 'leading', 'open', 'stacked'],
-	attributes: ['message', 'type']
-})
 export class Snackbar extends ThemedMixin(WidgetBase)<SnackbarProperties> {
 	protected render(): DNode {
 		const { type, open, leading, stacked, message, actionsRenderer } = this.properties;

--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -9,7 +9,6 @@ import * as css from '../theme/split-pane.m.css';
 import { Dimensions } from '@dojo/framework/core/meta/Dimensions';
 import { Resize, ContentRect } from '@dojo/framework/core/meta/Resize';
 import { GlobalEvent } from '../global-event/index';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * Direction of this SplitPane
@@ -39,12 +38,6 @@ export interface SplitPaneProperties extends ThemedProperties {
 const DEFAULT_SIZE = 100;
 
 @theme(css)
-@customElement<SplitPaneProperties>({
-	tag: 'dojo-split-pane',
-	properties: ['theme', 'classes', 'extraClasses', 'size', 'collapseWidth'],
-	attributes: ['direction'],
-	events: ['onCollapse', 'onResize']
-})
 export class SplitPane extends ThemedMixin(WidgetBase)<SplitPaneProperties> {
 	private _dragging: boolean | undefined;
 	private _lastSize?: number;

--- a/src/tab-controller/index.ts
+++ b/src/tab-controller/index.ts
@@ -11,7 +11,6 @@ import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 
 import * as css from '../theme/tab-controller.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * Enum for tab button alignment
@@ -44,12 +43,6 @@ export interface TabControllerProperties
 }
 
 @theme(css)
-@customElement<TabControllerProperties>({
-	tag: 'dojo-tab-controller',
-	properties: ['theme', 'classes', 'aria', 'extraClasses', 'activeIndex'],
-	attributes: ['alignButtons'],
-	events: ['onRequestTabChange', 'onRequestTabClose']
-})
 export class TabController extends ThemedMixin(FocusMixin(WidgetBase))<
 	TabControllerProperties,
 	WNode<Tab>

--- a/src/tab/index.ts
+++ b/src/tab/index.ts
@@ -33,11 +33,7 @@ export interface TabProperties extends ThemedProperties, CustomAriaProperties {
 
 @theme(css)
 @customElement<TabProperties>({
-	tag: 'dojo-tab',
-	childType: CustomElementChildType.NODE,
-	properties: ['theme', 'classes', 'aria', 'extraClasses', 'closeable', 'disabled', 'show'],
-	attributes: ['key', 'labelledBy', 'widgetId', 'label'],
-	events: []
+	childType: CustomElementChildType.NODE
 })
 export class Tab extends ThemedMixin(WidgetBase)<TabProperties> {
 	render(): DNode {

--- a/src/text-area/index.ts
+++ b/src/text-area/index.ts
@@ -15,7 +15,6 @@ import {
 import { formatAriaProperties } from '../common/util';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/text-area.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import HelperText from '../helper-text/index';
 
 /**
@@ -53,48 +52,6 @@ export interface TextareaProperties
 }
 
 @theme(css)
-@customElement<TextareaProperties>({
-	tag: 'dojo-text-area',
-	properties: [
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'columns',
-		'rows',
-		'required',
-		'readOnly',
-		'disabled',
-		'invalid',
-		'labelHidden'
-	],
-	attributes: [
-		'widgetId',
-		'label',
-		'helperText',
-		'minLength',
-		'maxLength',
-		'name',
-		'placeholder',
-		'value',
-		'wrapText'
-	],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onInput',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart'
-	]
-})
 export class Textarea extends ThemedMixin(FocusMixin(WidgetBase))<TextareaProperties> {
 	private _onBlur(event: FocusEvent) {
 		this.properties.onBlur && this.properties.onBlur((event.target as HTMLInputElement).value);

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -14,7 +14,6 @@ import {
 import { formatAriaProperties } from '../common/util';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/text-input.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import diffProperty from '@dojo/framework/core/decorators/diffProperty';
 import { reference } from '@dojo/framework/core/diff';
 import InputValidity from '../common/InputValidity';
@@ -101,51 +100,6 @@ function patternDiffer(
 }
 
 @theme(css)
-@customElement<TextInputProperties>({
-	tag: 'dojo-text-input',
-	properties: [
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'disabled',
-		'readOnly',
-		'labelHidden',
-		'valid',
-		'leading',
-		'trailing'
-	],
-	attributes: [
-		'widgetId',
-		'label',
-		'placeholder',
-		'helperText',
-		'controls',
-		'type',
-		'minLength',
-		'maxLength',
-		'value',
-		'name',
-		'pattern',
-		'autocomplete'
-	],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onInput',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart',
-		'onValidate'
-	]
-})
 @diffProperty('pattern', patternDiffer)
 @diffProperty('leading', reference)
 @diffProperty('trailing', reference)

--- a/src/time-picker/index.ts
+++ b/src/time-picker/index.ts
@@ -14,7 +14,6 @@ import { TextInputProperties } from '../text-input/index';
 import Label from '../label/index';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/time-picker.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 interface FocusInputEvent extends FocusEvent {
 	target: HTMLInputElement;
@@ -165,31 +164,6 @@ export function parseUnits(value: string | TimeUnits): TimeUnits {
 }
 
 @theme(css)
-@customElement<TimePickerProperties>({
-	tag: 'dojo-time-picker',
-	properties: [
-		'theme',
-		'classes',
-		'extraClasses',
-		'isOptionDisabled',
-		'getOptionLabel',
-		'autoBlur',
-		'clearable',
-		'inputProperties',
-		'openOnFocus',
-		'options',
-		'useNativeElement',
-		'step',
-		'labelAfter',
-		'labelHidden',
-		'required',
-		'invalid',
-		'readOnly',
-		'disabled'
-	],
-	attributes: ['widgetId', 'label', 'name', 'value', 'start', 'end'],
-	events: ['onBlur', 'onChange', 'onFocus', 'onMenuChange', 'onRequestOptions']
-})
 export class TimePicker extends ThemedMixin(FocusMixin(WidgetBase))<TimePickerProperties> {
 	protected options: TimeUnits[] | null = null;
 

--- a/src/title-pane/index.ts
+++ b/src/title-pane/index.ts
@@ -9,7 +9,6 @@ import Icon from '../icon/index';
 import * as fixedCss from './styles/title-pane.m.css';
 import * as css from '../theme/title-pane.m.css';
 import { Dimensions } from '@dojo/framework/core/meta/Dimensions';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import GlobalEvent from '../global-event/index';
 
 /**
@@ -34,12 +33,6 @@ export interface TitlePaneProperties extends ThemedProperties, FocusProperties {
 }
 
 @theme(css)
-@customElement<TitlePaneProperties>({
-	tag: 'dojo-title-pane',
-	properties: ['theme', 'classes', 'extraClasses', 'open', 'closeable', 'headingLevel'],
-	attributes: ['title', 'key'],
-	events: ['onRequestClose', 'onRequestOpen']
-})
 export class TitlePane extends ThemedMixin(FocusMixin(WidgetBase))<TitlePaneProperties> {
 	private _id = uuid();
 	private _open: boolean | undefined;

--- a/src/toolbar/index.ts
+++ b/src/toolbar/index.ts
@@ -11,7 +11,6 @@ import commonBundle from '../common/nls/common';
 import * as fixedCss from './styles/toolbar.m.css';
 import * as css from '../theme/toolbar.m.css';
 import { GlobalEvent } from '../global-event/index';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 export { Align };
 
@@ -32,12 +31,6 @@ export interface ToolbarProperties extends ThemedProperties {
 }
 
 @theme(css)
-@customElement<ToolbarProperties>({
-	tag: 'dojo-toolbar',
-	properties: ['theme', 'classes', 'extraClasses', 'collapseWidth'],
-	attributes: ['key', 'heading'],
-	events: ['onCollapse']
-})
 export class Toolbar extends I18nMixin(ThemedMixin(WidgetBase))<ToolbarProperties> {
 	private _collapsed = false;
 	private _open = false;

--- a/src/tooltip/index.ts
+++ b/src/tooltip/index.ts
@@ -7,7 +7,6 @@ import { formatAriaProperties } from '../common/util';
 
 import * as fixedCss from './styles/tooltip.m.css';
 import * as css from '../theme/tooltip.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type TooltipProperties
@@ -36,12 +35,6 @@ const fixedOrientationCss: { [key: string]: any } = fixedCss;
 const orientationCss: { [key: string]: any } = css;
 
 @theme(css)
-@customElement<TooltipProperties>({
-	tag: 'dojo-tooltip',
-	properties: ['theme', 'classes', 'aria', 'extraClasses', 'content', 'open'],
-	attributes: ['orientation'],
-	events: []
-})
 export class Tooltip extends ThemedMixin(WidgetBase)<TooltipProperties> {
 	protected getFixedModifierClasses(): (string | null)[] {
 		const { orientation = Orientation.right } = this.properties;


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Removing most of the custom element descriptors now that they can be built automatically.