### PR TITLE
Add option to hide helper text

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,4 @@ yarn.lock
 deploy_key
 deploy_key.pub
 package.json.bk
+/.vscode

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -57,6 +57,7 @@ export interface ComboBoxProperties extends ThemedProperties, LabeledProperties,
 	getResultSelected?(result: any): boolean;
 	getResultValue?(result: any): string;
 	helperText?: string;
+	helperTextHidden?: boolean;
 	widgetId?: string;
 	inputProperties?: TextInputProperties;
 	valid?: { valid?: boolean; message?: string } | boolean;
@@ -323,7 +324,8 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 			required,
 			value = '',
 			theme,
-			onValidate
+			onValidate,
+			helperTextHidden
 		} = this.properties;
 
 		const { valid } = this.validity;
@@ -350,7 +352,8 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 			readOnly,
 			required,
 			theme,
-			value
+			value,
+			helperTextHidden
 		});
 	}
 
@@ -449,7 +452,8 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 			results = [],
 			theme,
 			classes,
-			helperText
+			helperText,
+			helperTextHidden = false
 		} = this.properties;
 
 		const { valid, message } = this.validity;
@@ -510,7 +514,8 @@ export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<Com
 					this.renderMenuButton(messages)
 				]
 			),
-			!this._open &&
+			!helperTextHidden &&
+				!this._open &&
 				w(HelperText, {
 					text: valid ? helperText : message,
 					valid

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -101,7 +101,8 @@ export enum Operation {
 		'openOnFocus',
 		'readOnly',
 		'required',
-		'results'
+		'results',
+		'helperTextHidden'
 	],
 	attributes: ['widgetId', 'label', 'value'],
 	events: [

--- a/src/select/index.ts
+++ b/src/select/index.ts
@@ -78,7 +78,8 @@ export interface SelectProperties
 		'required',
 		'invalid',
 		'disabled',
-		'labelHidden'
+		'labelHidden',
+		'helperTextHidden'
 	],
 	attributes: ['widgetId', 'placeholder', 'label', 'value', 'helperText'],
 	events: ['onBlur', 'onChange', 'onFocus']

--- a/src/select/index.ts
+++ b/src/select/index.ts
@@ -45,6 +45,7 @@ export interface SelectProperties
 	getOptionSelected?(option: any, index: number): boolean;
 	getOptionValue?(option: any, index: number): string;
 	helperText?: string;
+	helperTextHidden?: boolean;
 	options?: any[];
 	placeholder?: string;
 	useNativeElement?: boolean;
@@ -419,6 +420,7 @@ export class Select extends ThemedMixin(FocusMixin(WidgetBase))<SelectProperties
 			labelHidden,
 			disabled,
 			helperText,
+			helperTextHidden,
 			widgetId = this._baseId,
 			invalid,
 			readOnly,
@@ -463,7 +465,7 @@ export class Select extends ThemedMixin(FocusMixin(WidgetBase))<SelectProperties
 					  )
 					: null,
 				useNativeElement ? this.renderNativeSelect() : this.renderCustomSelect(),
-				w(HelperText, { theme, text: helperText })
+				!helperTextHidden && w(HelperText, { theme, text: helperText })
 			]
 		);
 	}

--- a/src/select/tests/unit/Select.tsx
+++ b/src/select/tests/unit/Select.tsx
@@ -3,8 +3,9 @@ const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
 
-import { v, w } from '@dojo/framework/core/vdom';
+import { v, w, tsx } from '@dojo/framework/core/vdom';
 import Focus from '@dojo/framework/core/meta/Focus';
+import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
 import { Keys } from '../../../common/util';
 
 import Icon from '../../../icon/index';
@@ -96,6 +97,70 @@ const testStateProperties: Partial<SelectProperties> = {
 	readOnly: true,
 	required: true
 };
+
+const baseNativeAssertion = assertionTemplate(() => (
+	<div key="root" classes={[css.root, null, null, null, null, null, null]}>
+		{nativeSelect()}
+		<HelperText theme={undefined} text={undefined} />
+	</div>
+));
+
+const nativeSelect = () => (
+	<div classes={css.inputWrapper}>
+		<select
+			assertion-key="select"
+			classes={css.input}
+			disabled={undefined}
+			focus={noop}
+			aria-invalid={null}
+			id={compareId as any}
+			name={undefined}
+			readOnly={undefined}
+			aria-readonly={null}
+			required={undefined}
+			value={undefined}
+			onblur={noop}
+			onchange={noop}
+			onfocus={noop}
+		>
+			<option
+				value={testOptions[0].value}
+				id={undefined}
+				disabled={undefined}
+				selected={undefined}
+			>
+				{testOptions[0].label}
+			</option>
+			<option
+				value={testOptions[1].value}
+				id={undefined}
+				disabled={undefined}
+				selected={undefined}
+			>
+				{testOptions[1].label}
+			</option>
+			<option
+				value={testOptions[2].value}
+				id={undefined}
+				disabled={undefined}
+				selected={undefined}
+			>
+				{testOptions[2].label}
+			</option>
+			<option
+				value={testOptions[3].value}
+				id={undefined}
+				disabled={undefined}
+				selected={undefined}
+			>
+				{testOptions[3].label}
+			</option>
+		</select>
+		<span classes={css.arrow}>
+			<Icon type="downIcon" theme={undefined} classes={undefined} />
+		</span>
+	</div>
+);
 
 const expectedNative = function(useTestProperties = false, withStates = false) {
 	const describedBy = useTestProperties ? { 'aria-describedby': 'foo' } : {};
@@ -308,6 +373,20 @@ registerSuite('Select', {
 					})
 				);
 				h.expect(() => expected(expectedNative(), { helperText: 'foo' }));
+			},
+
+			'helperText can be hidden'() {
+				const h = harness(() => (
+					<Select
+						getOptionValue={testProperties.getOptionValue}
+						getOptionLabel={testProperties.getOptionLabel}
+						options={testOptions}
+						useNativeElement={true}
+						helperTextHidden={true}
+					/>
+				));
+
+				h.expect(baseNativeAssertion.setChildren('@root', () => [nativeSelect()]));
 			},
 
 			'custom properties'() {

--- a/src/text-area/index.ts
+++ b/src/text-area/index.ts
@@ -50,6 +50,7 @@ export interface TextareaProperties
 	label?: string;
 	labelHidden?: boolean;
 	helperText?: string;
+	helperTextHidden?: boolean;
 }
 
 @theme(css)
@@ -196,7 +197,8 @@ export class Textarea extends ThemedMixin(FocusMixin(WidgetBase))<TextareaProper
 			theme,
 			classes,
 			labelHidden,
-			helperText
+			helperText,
+			helperTextHidden = false
 		} = this.properties;
 		const focus = this.meta(Focus).get('root');
 
@@ -259,7 +261,7 @@ export class Textarea extends ThemedMixin(FocusMixin(WidgetBase))<TextareaProper
 						ontouchcancel: this._onTouchCancel
 					})
 				]),
-				w(HelperText, { text: helperText })
+				!helperTextHidden && w(HelperText, { text: helperText })
 			]
 		);
 	}

--- a/src/text-area/index.ts
+++ b/src/text-area/index.ts
@@ -67,7 +67,8 @@ export interface TextareaProperties
 		'readOnly',
 		'disabled',
 		'invalid',
-		'labelHidden'
+		'labelHidden',
+		'helperTextHidden'
 	],
 	attributes: [
 		'widgetId',

--- a/src/text-area/tests/unit/Textarea.tsx
+++ b/src/text-area/tests/unit/Textarea.tsx
@@ -2,8 +2,9 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
-import { v, w } from '@dojo/framework/core/vdom';
+import { v, w, tsx } from '@dojo/framework/core/vdom';
 import Focus from '@dojo/framework/core/meta/Focus';
+import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
 
 import Label from '../../../label/index';
 import Textarea from '../../index';
@@ -108,6 +109,50 @@ const expected = function(
 	);
 };
 
+const baseAssertion = assertionTemplate(() => (
+	<div key="root" classes={[css.root, null, null, null, null, null, null]}>
+		{textarea()}
+		<HelperText text="" />
+	</div>
+));
+
+const textarea = () => (
+	<div classes={css.inputWrapper}>
+		<textarea
+			classes={css.input}
+			id=""
+			key="input"
+			cols="20"
+			disabled={undefined}
+			focus={noop}
+			aria-invalid={null}
+			maxlength={null}
+			minlength={null}
+			name={undefined}
+			placeholder={undefined}
+			readOnly={undefined}
+			aria-readonly={null}
+			required={undefined}
+			rows="2"
+			value={undefined}
+			wrap={undefined}
+			onblur={noop}
+			onchange={noop}
+			onclick={noop}
+			onfocus={noop}
+			oninput={noop}
+			onkeydown={noop}
+			onkeypress={noop}
+			onkeyup={noop}
+			onmousedown={noop}
+			onmouseup={noop}
+			ontouchstart={noop}
+			ontouchend={noop}
+			ontouchcancel={noop}
+		/>
+	</div>
+);
+
 registerSuite('Textarea', {
 	tests: {
 		'default properties'() {
@@ -194,6 +239,12 @@ registerSuite('Textarea', {
 		helperText() {
 			const h = harness(() => w(Textarea, { helperText: 'test' }));
 			h.expect(() => expected(false, {}, {}, false, 'test'));
+		},
+
+		'helperText can be hidden'() {
+			const h = harness(() => <Textarea helperTextHidden={true} />);
+
+			h.expect(baseAssertion.setChildren('@root', () => [textarea()]));
 		},
 
 		events() {

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -114,7 +114,8 @@ function patternDiffer(
 		'labelHidden',
 		'valid',
 		'leading',
-		'trailing'
+		'trailing',
+		'helperTextHidden'
 	],
 	attributes: [
 		'widgetId',

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -68,6 +68,7 @@ export interface TextInputProperties
 	maxLength?: number | string;
 	minLength?: number | string;
 	placeholder?: string;
+	helperTextHidden?: boolean;
 	helperText?: string;
 	value?: string;
 	valid?: { valid?: boolean; message?: string } | boolean;
@@ -300,7 +301,8 @@ export class TextInput extends ThemedMixin(FocusMixin(WidgetBase))<TextInputProp
 			type = 'text',
 			value,
 			widgetId = this._uuid,
-			helperText
+			helperText,
+			helperTextHidden = false
 		} = this.properties;
 
 		this._validate();
@@ -384,7 +386,7 @@ export class TextInput extends ThemedMixin(FocusMixin(WidgetBase))<TextInputProp
 							])
 					]
 				),
-				w(HelperText, { text: computedHelperText, valid })
+				!helperTextHidden && w(HelperText, { text: computedHelperText, valid })
 			]
 		);
 	}

--- a/src/text-input/tests/unit/TextInput.tsx
+++ b/src/text-input/tests/unit/TextInput.tsx
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
 
-import { v, w } from '@dojo/framework/core/vdom';
+import { v, w, tsx } from '@dojo/framework/core/vdom';
 import Focus from '@dojo/framework/core/meta/Focus';
 import assertationTemplate from '@dojo/framework/testing/assertionTemplate';
 
@@ -133,53 +133,55 @@ const expected = function({
 	);
 };
 
-const baseTemplate = assertationTemplate(() => {
-	return v(
-		'div',
-		{
-			key: 'root',
-			role: 'presentation',
-			classes: [css.root, null, null, null, null, null, null, null, null]
-		},
-		[
-			v('div', { key: 'inputWrapper', role: 'presentation', classes: css.inputWrapper }, [
-				v('input', {
-					key: 'input',
-					classes: css.input,
-					id: '',
-					disabled: undefined,
-					'aria-invalid': null,
-					autocomplete: undefined,
-					maxlength: null,
-					minlength: null,
-					name: undefined,
-					placeholder: undefined,
-					readOnly: undefined,
-					'aria-readonly': null,
-					required: undefined,
-					type: 'text',
-					value: undefined,
-					focus: noop,
-					pattern: undefined,
-					onblur: noop,
-					onchange: noop,
-					onclick: noop,
-					onfocus: noop,
-					oninput: noop,
-					onkeydown: noop,
-					onkeypress: noop,
-					onkeyup: noop,
-					onmousedown: noop,
-					onmouseup: noop,
-					ontouchstart: noop,
-					ontouchend: noop,
-					ontouchcancel: noop
-				})
-			]),
-			w(HelperText, { text: undefined, valid: undefined })
-		]
+const baseAssertion = assertationTemplate(() => {
+	return (
+		<div
+			key="root"
+			role="presentation"
+			classes={[css.root, null, null, null, null, null, null, null, null]}
+		>
+			{input()}
+			<HelperText text={undefined} valid={undefined} />
+		</div>
 	);
 });
+
+const input = () => (
+	<div key="inputWrapper" role="presentation" classes={css.inputWrapper}>
+		<input
+			key="input"
+			classes={css.input}
+			id=""
+			disabled={undefined}
+			aria-invalid={null}
+			autocomplete={undefined}
+			maxlength={null}
+			minlength={null}
+			name={undefined}
+			placeholder={undefined}
+			readOnly={undefined}
+			aria-readonly={null}
+			required={undefined}
+			type="text"
+			value={undefined}
+			focus={noop}
+			pattern={undefined}
+			onblur={noop}
+			onchange={noop}
+			onclick={noop}
+			onfocus={noop}
+			oninput={noop}
+			onkeydown={noop}
+			onkeypress={noop}
+			onkeyup={noop}
+			onmousedown={noop}
+			onmouseup={noop}
+			ontouchstart={noop}
+			ontouchend={noop}
+			ontouchcancel={noop}
+		/>
+	</div>
+);
 
 registerSuite('TextInput', {
 	tests: {
@@ -398,6 +400,12 @@ registerSuite('TextInput', {
 			h.expect(() => expected({ helperText }));
 		},
 
+		'helperText can be hidden'() {
+			const h = harness(() => <TextInput helperTextHidden={true} />);
+
+			h.expect(baseAssertion.setChildren('@root', () => [input()]));
+		},
+
 		onValidate() {
 			const mockMeta = sinon.stub();
 			let validateSpy = sinon.spy();
@@ -509,7 +517,7 @@ registerSuite('TextInput', {
 
 		'leading property'() {
 			const leading = () => v('span', {}, ['A']);
-			const leadingTemplate = baseTemplate
+			const leadingTemplate = baseAssertion
 				.setProperty('@root', 'classes', [
 					css.root,
 					null,
@@ -521,9 +529,8 @@ registerSuite('TextInput', {
 					css.hasLeading,
 					null
 				])
-				.setChildren('@inputWrapper', [
-					v('span', { key: 'leading', classes: css.leading }, [leading()]),
-					...baseTemplate.getChildren('@inputWrapper')
+				.prepend('@inputWrapper', () => [
+					v('span', { key: 'leading', classes: css.leading }, [leading()])
 				]);
 			const h = harness(() => w(TextInput, { leading }));
 			h.expect(leadingTemplate);
@@ -531,7 +538,7 @@ registerSuite('TextInput', {
 
 		'trailing property'() {
 			const trailing = () => v('span', {}, ['Z']);
-			const trailingTemplate = baseTemplate
+			const trailingTemplate = baseAssertion
 				.setProperty('@root', 'classes', [
 					css.root,
 					null,
@@ -543,8 +550,7 @@ registerSuite('TextInput', {
 					null,
 					css.hasTrailing
 				])
-				.setChildren('@inputWrapper', [
-					...baseTemplate.getChildren('@inputWrapper'),
+				.append('@inputWrapper', () => [
 					v('span', { key: 'trailing', classes: css.trailing }, [trailing()])
 				]);
 			const h = harness(() => w(TextInput, { trailing }));


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Add `helperTextHidden` option (similar to `labelHidden`) that prevents the rendering of the `HelperText` when `true`.

**Use Case**: When application styling does not allow for the extra space needed to display the helper text. Currently the only option to hide it is to override it with some hacky css.