### PR TITLE
Added watch command for ts file changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,19 +212,15 @@ To test against browsers with a local selenium server run:
 
 Each Dojo widget includes functioning example code so you can view the widget. To view individual widget example:
 
-1. Run `npm run build:test` in your terminal
-2. Run `npm run examples`
+1. To build the project run `npm run build:test`.
+2. To start the server run `npm run examples`
 2. Open the newly built project at `http://localhost:5000/_build/common/example/` in your web browser
 3. By default, no widget is selected, open the dropdown to select a widget
 4. Observe the page reloads and the selected widget displays
 
 #### Watching widget example code
 
-Running `npm run build` each time you wish to view a small change can be tedious, instead to have your files watched run:
-
-```
-tsc -w
-```
+Running `npm run build` each time you wish to view a small change can be tedious, instead to have your typescript files watched run: `npm run build:watch`. In another terminal run `npm run examples` to start the server. Note that this will not watch for changes to `.css` files.
 
 With that command, TypeScript watches for changes and recompiles when necessary.
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "build:lib:legacy": "dojo build widget -t lib -l && shx cp -r output/dist dist/umd/src",
     "build:test": "dojo build widget -t lib -l && shx cp -r output/dist dist/dev/src && tsc && npm run copy:test && node scripts/umd",
     "build": "npm run clean && npm run build:lib && npm run build:lib:legacy && npm run build:ce",
+    "build:watch": "npm run clean && npm run build:test && tsc -w",
     "clean": "shx rm -rf dist && shx mkdir dist && shx mkdir dist/umd && shx mkdir dist/esm && shx mkdir dist/dev",
     "release": "run-s \"version:update -- {@}\" build version:reset dojo-package \"dojo-release -- {@}\" --",
     "uploadCoverage": "codecov --file=coverage/coverage.json"


### PR DESCRIPTION
**Type:** Feature

The dojo widgets project does not have a build watch option which makes it hard when developing/working on widgets.

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description of code changes:**
- Added `build:watch` command to package.json that will start to watch for files changes to any typescript files.
- Updated readme.md

Resolves #764
