### PR TITLE
Fix text-input and text-area validity loop

### DIFF
--- a/src/text-area/index.ts
+++ b/src/text-area/index.ts
@@ -169,11 +169,25 @@ export class Textarea extends ThemedMixin(FocusMixin(WidgetBase))<TextareaProper
 		this.properties.onTouchCancel && this.properties.onTouchCancel();
 	}
 
+	private _callOnValidate(valid: boolean | undefined, message: string) {
+		let { valid: previousValid } = this.properties;
+		let previousMessage: string | undefined;
+
+		if (typeof previousValid === 'object') {
+			previousMessage = previousValid.message;
+			previousValid = previousValid.valid;
+		}
+
+		if (valid !== previousValid || message !== previousMessage) {
+			this.properties.onValidate && this.properties.onValidate(valid, message);
+		}
+	}
+
 	private _validate() {
-		const { customValidator, onValidate, value = '' } = this.properties;
+		const { customValidator, value = '' } = this.properties;
 
 		if (value === '' && !this._dirty) {
-			onValidate && onValidate(undefined, '');
+			this._callOnValidate(undefined, '');
 			return;
 		}
 
@@ -186,7 +200,7 @@ export class Textarea extends ThemedMixin(FocusMixin(WidgetBase))<TextareaProper
 				message = customValid.message || '';
 			}
 		}
-		onValidate && onValidate(valid, message);
+		this._callOnValidate(valid, message);
 	}
 
 	protected get validity() {
@@ -238,11 +252,12 @@ export class Textarea extends ThemedMixin(FocusMixin(WidgetBase))<TextareaProper
 			theme,
 			classes,
 			labelHidden,
-			helperText
+			helperText,
+			onValidate
 		} = this.properties;
 		const focus = this.meta(Focus).get('root');
 
-		this._validate();
+		onValidate && this._validate();
 		const { valid, message } = this.validity;
 
 		const computedHelperText = (valid === false && message) || helperText;

--- a/src/text-area/tests/unit/Textarea.tsx
+++ b/src/text-area/tests/unit/Textarea.tsx
@@ -375,6 +375,29 @@ registerSuite('Textarea', {
 			assert.isTrue(validateSpy.calledWith(true, ''));
 		},
 
+		'onValidate only called when validity or message changed'() {
+			const mockMeta = sinon.stub();
+			let validateSpy = sinon.spy();
+
+			mockMeta.withArgs(InputValidity).returns({
+				get: sinon.stub().returns({ valid: false, message: 'test' })
+			});
+
+			mockMeta.withArgs(Focus).returns({
+				get: () => ({ active: false, containsFocus: false })
+			});
+
+			harness(() =>
+				w(MockMetaMixin(Textarea, mockMeta), {
+					value: 'test value',
+					valid: { valid: false, message: 'test' },
+					onValidate: validateSpy
+				})
+			);
+
+			assert.isFalse(validateSpy.called);
+		},
+
 		'customValidator not called when native validation fails'() {
 			const mockMeta = sinon.stub();
 			let validateSpy = sinon.spy();

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -213,11 +213,25 @@ export class TextInput extends ThemedMixin(FocusMixin(WidgetBase))<TextInputProp
 		this.properties.onTouchCancel && this.properties.onTouchCancel();
 	}
 
+	private _callOnValidate(valid: boolean | undefined, message: string) {
+		let { valid: previousValid } = this.properties;
+		let previousMessage: string | undefined;
+
+		if (typeof previousValid === 'object') {
+			previousMessage = previousValid.message;
+			previousValid = previousValid.valid;
+		}
+
+		if (valid !== previousValid || message !== previousMessage) {
+			this.properties.onValidate && this.properties.onValidate(valid, message);
+		}
+	}
+
 	private _validate() {
-		const { customValidator, onValidate, value = '' } = this.properties;
+		const { customValidator, value = '' } = this.properties;
 		const { dirty = false } = this._state;
 		if (value === '' && !dirty) {
-			onValidate && onValidate(undefined, '');
+			this._callOnValidate(undefined, '');
 			return;
 		}
 
@@ -230,7 +244,8 @@ export class TextInput extends ThemedMixin(FocusMixin(WidgetBase))<TextInputProp
 				message = customValid.message || '';
 			}
 		}
-		onValidate && onValidate(valid, message);
+
+		this._callOnValidate(valid, message);
 	}
 
 	protected get validity() {
@@ -287,10 +302,11 @@ export class TextInput extends ThemedMixin(FocusMixin(WidgetBase))<TextInputProp
 			type = 'text',
 			value,
 			widgetId = this._uuid,
-			helperText
+			helperText,
+			onValidate
 		} = this.properties;
 
-		this._validate();
+		onValidate && this._validate();
 		const { valid, message } = this.validity;
 
 		const focus = this.meta(Focus).get('root');

--- a/src/text-input/tests/unit/TextInput.tsx
+++ b/src/text-input/tests/unit/TextInput.tsx
@@ -441,6 +441,29 @@ registerSuite('TextInput', {
 			assert.isTrue(validateSpy.calledWith(true, ''));
 		},
 
+		'onValidate only called when validity or message changed'() {
+			const mockMeta = sinon.stub();
+			let validateSpy = sinon.spy();
+
+			mockMeta.withArgs(InputValidity).returns({
+				get: sinon.stub().returns({ valid: false, message: 'test' })
+			});
+
+			mockMeta.withArgs(Focus).returns({
+				get: () => ({ active: false, containsFocus: false })
+			});
+
+			harness(() =>
+				w(MockMetaMixin(TextInput, mockMeta), {
+					value: 'test value',
+					valid: { valid: false, message: 'test' },
+					onValidate: validateSpy
+				})
+			);
+
+			assert.isFalse(validateSpy.called);
+		},
+
 		'customValidator not called when native validation fails'() {
 			const mockMeta = sinon.stub();
 			let validateSpy = sinon.spy();


### PR DESCRIPTION
**Type:** bug

`onValidate` was being called on every render and thus causing an infinite loop.
This changes it to be conditionally called when the validity or message changes only.