### PR TITLE
Removing custom element decorators

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -1,5 +1,6 @@
 {
 	"build-widget": {
+		"prefix": "dojo",
 		"widgets": [
 			"src/accordion-pane",
 			"src/button",

--- a/package-lock.json
+++ b/package-lock.json
@@ -100,13 +100,13 @@
       }
     },
     "@dojo/cli-build-widget": {
-      "version": "6.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@dojo/cli-build-widget/-/cli-build-widget-6.0.0-alpha.2.tgz",
-      "integrity": "sha512-Sdx3kpMgNyGk1Cjvx6EsK1/4WV5O4d847zBdvbKyzgR2qo5jO24mJyZOdTTejZPTGp/U1/M+VB8Ef77zZsupjQ==",
+      "version": "6.0.0-alpha.3",
+      "resolved": "https://registry.npmjs.org/@dojo/cli-build-widget/-/cli-build-widget-6.0.0-alpha.3.tgz",
+      "integrity": "sha512-/qlWq1Uk7OVyBPiMbfzg1PNLmjC3ti+3H0lzNNYvHtLbm4XaeksqRwngP/7b4KireWJJYr3UitL3RAmgkB7COA==",
       "dev": true,
       "requires": {
-        "@dojo/framework": "6.0.0-alpha.7",
-        "@dojo/webpack-contrib": "6.0.0-alpha.8",
+        "@dojo/framework": "6.0.0-alpha.18",
+        "@dojo/webpack-contrib": "6.0.0-alpha.12",
         "chalk": "2.4.1",
         "clean-webpack-plugin": "1.0.0",
         "cli-columns": "3.1.2",
@@ -148,9 +148,9 @@
       },
       "dependencies": {
         "@dojo/framework": {
-          "version": "6.0.0-alpha.7",
-          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-6.0.0-alpha.7.tgz",
-          "integrity": "sha512-IuXdT7eAals0jjukBQ6rkwAYF2xSPIJCgn8Dkt6Mqo9Aacm24eAOLRmHVqLHvqG9OzyRHFf9upTjg2NpSHjDVg==",
+          "version": "6.0.0-alpha.18",
+          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-6.0.0-alpha.18.tgz",
+          "integrity": "sha512-2uWoPSgwZzREInTcxipKI8UaELhtxf/O8MvIvtxqNR3bQpbql/yt0yc62woK6yXq/v5t6ZAnQ6pqOiD2wLJohA==",
           "dev": true,
           "requires": {
             "@types/cldrjs": "0.4.20",
@@ -186,9 +186,9 @@
       }
     },
     "@dojo/framework": {
-      "version": "6.0.0-alpha.11",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-6.0.0-alpha.11.tgz",
-      "integrity": "sha512-p/teB09g52XZaeAegXKbWiNw1qFhId1i1QmM1CWFwyE7v787s4AiKCwIjZ7cVj/g52pNjRvgKqReAP4todxe5A==",
+      "version": "6.0.0-alpha.19",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-6.0.0-alpha.19.tgz",
+      "integrity": "sha512-3whYLIEJCyFC4NBxuuvTTVpkNa91QJMFRCTQbAHx4joqHpRopg4+mZLlgQE4vv4L0n0fqKSOsuwjyQIemSlT3Q==",
       "dev": true,
       "requires": {
         "@types/cldrjs": "0.4.20",
@@ -265,12 +265,12 @@
       "dev": true
     },
     "@dojo/webpack-contrib": {
-      "version": "6.0.0-alpha.8",
-      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-6.0.0-alpha.8.tgz",
-      "integrity": "sha512-/eMWQ3BbSTCqHYgtTIYND0Q5cvLSZJgbXckN95gwsM02U5YihPzmyP/SY15JO5E3Kwu0cPt1UosEJipiVnyCVA==",
+      "version": "6.0.0-alpha.12",
+      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-6.0.0-alpha.12.tgz",
+      "integrity": "sha512-c2AH6Sa0IfPiqtSlxNG4nCsO758u56bWpXRVot6FxLfYiblYeYbNhEymN5TaLyONDgV+X9gVw+t6OXPVUmqutw==",
       "dev": true,
       "requires": {
-        "@dojo/framework": "6.0.0-alpha.10",
+        "@dojo/framework": "6.0.0-alpha.18",
         "acorn": "6.1.1",
         "acorn-dynamic-import": "4.0.0",
         "acorn-walk": "6.1.1",
@@ -301,7 +301,7 @@
         "puppeteer": "1.11.0",
         "recast": "0.12.7",
         "source-map": "0.6.1",
-        "ts-loader": "5.3.0",
+        "ts-loader": "5.4.5",
         "ts-node": "^8.0.3",
         "typed-css-modules": "0.3.7",
         "webpack-hot-middleware": "2.24.3",
@@ -310,9 +310,9 @@
       },
       "dependencies": {
         "@dojo/framework": {
-          "version": "6.0.0-alpha.10",
-          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-6.0.0-alpha.10.tgz",
-          "integrity": "sha512-4XWXwxFmb/o8aJCSCVsxWU814Ev2hSodk6Xp9gQrw+kqlzzXjcHxsX0pneZgqMTwkK+mfTKNPnsr2zU0WTzoOg==",
+          "version": "6.0.0-alpha.18",
+          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-6.0.0-alpha.18.tgz",
+          "integrity": "sha512-2uWoPSgwZzREInTcxipKI8UaELhtxf/O8MvIvtxqNR3bQpbql/yt0yc62woK6yXq/v5t6ZAnQ6pqOiD2wLJohA==",
           "dev": true,
           "requires": {
             "@types/cldrjs": "0.4.20",
@@ -474,19 +474,6 @@
             "has-flag": "^2.0.0"
           }
         },
-        "ts-loader": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.3.0.tgz",
-          "integrity": "sha512-lGSNs7szRFj/rK9T1EQuayE3QNLg6izDUxt5jpmq0RG1rU2bapAt7E7uLckLCUPeO1jwxCiet2oRaWovc53UAg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.3.0",
-            "enhanced-resolve": "^4.0.0",
-            "loader-utils": "^1.0.2",
-            "micromatch": "^3.1.4",
-            "semver": "^5.0.1"
-          }
-        },
         "ts-node": {
           "version": "8.3.0",
           "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.3.0.tgz",
@@ -643,9 +630,9 @@
       "dev": true
     },
     "@types/body-parser": {
-      "version": "1.17.0",
-      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.0.tgz",
-      "integrity": "sha512-a2+YeUjPkztKJu5aIF2yArYFQQp8d51wZ7DavSHjFuY1mqVgidGyzEQ41JIVNy82fXj8yPgy2vJmfIywgESW6w==",
+      "version": "1.17.1",
+      "resolved": "https://registry.npmjs.org/@types/body-parser/-/body-parser-1.17.1.tgz",
+      "integrity": "sha512-RoX2EZjMiFMjZh9lmYrwgoP9RTpAjSHiJxdp4oidAQVO02T7HER3xj9UKue5534ULWeqVEkujhWcyvUce+d68w==",
       "dev": true,
       "requires": {
         "@types/connect": "*",
@@ -709,9 +696,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.16.7",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.7.tgz",
-      "integrity": "sha512-847KvL8Q1y3TtFLRTXcVakErLJQgdpFSaq+k043xefz9raEf0C7HalpSY7OW5PyjCnY8P7bPW5t/Co9qqp+USg==",
+      "version": "4.16.9",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.16.9.tgz",
+      "integrity": "sha512-GqpaVWR0DM8FnRUJYKlWgyARoBUAVfRIeVDZQKOttLFp5SmhhF9YFIYeTPwMd/AXfxlP7xVO2dj1fGu0Q+krKQ==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -858,9 +845,9 @@
       "dev": true
     },
     "@types/serve-static": {
-      "version": "1.13.2",
-      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.2.tgz",
-      "integrity": "sha512-/BZ4QRLpH/bNYgZgwhKEh+5AsboDBcUdlBYgzoLX0fpj3Y2gp6EApyOlM3bK53wQS/OE1SrdSYBAbux2D1528Q==",
+      "version": "1.13.3",
+      "resolved": "https://registry.npmjs.org/@types/serve-static/-/serve-static-1.13.3.tgz",
+      "integrity": "sha512-oprSwp094zOglVrXdlo/4bAHtKTAxX6VT8FOZlBKrmyLbNvE1zxZyJ6yikMVtHIvwP45+ZQGJn+FdXGKTozq0g==",
       "dev": true,
       "requires": {
         "@types/express-serve-static-core": "*",
@@ -879,6 +866,12 @@
       "integrity": "sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==",
       "dev": true
     },
+    "@types/source-list-map": {
+      "version": "0.1.2",
+      "resolved": "https://registry.npmjs.org/@types/source-list-map/-/source-list-map-0.1.2.tgz",
+      "integrity": "sha512-K5K+yml8LTo9bWJI/rECfIPrGgxdpeNbj+d53lwN4QjW1MCwlkhUms+gtdzigTeUyBr09+u8BwOIY3MXvHdcsA==",
+      "dev": true
+    },
     "@types/tapable": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@types/tapable/-/tapable-1.0.4.tgz",
@@ -895,16 +888,28 @@
       }
     },
     "@types/webpack": {
-      "version": "4.32.1",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.32.1.tgz",
-      "integrity": "sha512-9n38CBx9uga1FEAdTipnt0EkbKpsCJFh7xJb1LE65FFb/A6OOLFX022vYsGC1IyVCZ/GroNg9u/RMmlDxGcLIw==",
+      "version": "4.39.0",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.39.0.tgz",
+      "integrity": "sha512-8gUiAl6RBI4IoCJVQ9AChp4k2Tcd4ocNei2S83goHKCj8WesBtlqp9/wPd29dArHIGMdHxICwBi8YMm8PD6PEg==",
       "dev": true,
       "requires": {
         "@types/anymatch": "*",
         "@types/node": "*",
         "@types/tapable": "*",
         "@types/uglify-js": "*",
+        "@types/webpack-sources": "*",
         "source-map": "^0.6.0"
+      }
+    },
+    "@types/webpack-sources": {
+      "version": "0.1.5",
+      "resolved": "https://registry.npmjs.org/@types/webpack-sources/-/webpack-sources-0.1.5.tgz",
+      "integrity": "sha512-zfvjpp7jiafSmrzJ2/i3LqOyTYTuJ7u1KOXlKgDlvsj9Rr0x7ZiYu5lZbXwobL7lmsRNtPXlBfmaUD8eU2Hu8w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*",
+        "@types/source-list-map": "*",
+        "source-map": "^0.6.1"
       }
     },
     "@types/ws": {
@@ -2168,9 +2173,9 @@
       "dev": true
     },
     "cacache": {
-      "version": "12.0.2",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.2.tgz",
-      "integrity": "sha512-ifKgxH2CKhJEg6tNdAwziu6Q33EvuG26tYcda6PT3WKisZcYDXsnEdnRv67Po3yCzFfaSoMjGZzJyD2c3DT1dg==",
+      "version": "12.0.3",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
+      "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.5",
@@ -4156,9 +4161,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.230",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.230.tgz",
-      "integrity": "sha512-r0RljY5DZi9RX4v8mjHxJkDWnQe+nsrkGlHtrDF2uvZcvAkw+iglvlQi1794gZhwRtJoDOomMJlDHL2LfXSCZA==",
+      "version": "1.3.236",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.236.tgz",
+      "integrity": "sha512-LWOvuJ80pLO3FtFqTcGuXB0dxdMtzSCkRmbXdY5mHUvXRQGor3sTVmyfU70aD2yF5i+fbHz52ncWr5T3xUYHlA==",
       "dev": true
     },
     "elegant-spinner": {
@@ -5387,7 +5392,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -5408,12 +5414,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -5428,17 +5436,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -5555,7 +5566,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -5567,6 +5579,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -5581,6 +5594,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -5588,12 +5602,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -5612,6 +5628,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -5692,7 +5709,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -5704,6 +5722,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -5789,7 +5808,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -5825,6 +5845,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -5844,6 +5865,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -5887,12 +5909,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },
@@ -6626,9 +6650,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -11745,9 +11769,9 @@
           }
         },
         "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
           "dev": true
         }
       }
@@ -12016,9 +12040,9 @@
       }
     },
     "serialize-javascript": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.7.0.tgz",
-      "integrity": "sha512-ke8UG8ulpFOxO8f8gRYabHQe/ZntKlcig2Mp+8+URDP1D8vJZ0KUt7LYo07q25Z/+JVSgpr/cui9PIp5H6/+nA==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/serialize-javascript/-/serialize-javascript-1.8.0.tgz",
+      "integrity": "sha512-3tHgtF4OzDmeKYj6V9nSyceRS0UJ3C7VqyD2Yj28vC/z2j6jG5FmFGahOKMD9CrglxTm3tETr87jEypaYV8DUg==",
       "dev": true
     },
     "serve": {
@@ -12940,9 +12964,9 @@
       },
       "dependencies": {
         "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
           "dev": true
         }
       }
@@ -13097,9 +13121,9 @@
           }
         },
         "p-limit": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+          "version": "2.2.1",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+          "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
           "dev": true,
           "requires": {
             "p-try": "^2.0.0"
@@ -14732,9 +14756,9 @@
       },
       "dependencies": {
         "uuid": {
-          "version": "3.3.2",
-          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-          "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
+          "version": "3.3.3",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+          "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ==",
           "dev": true
         }
       }

--- a/package.json
+++ b/package.json
@@ -34,8 +34,7 @@
     "build": "npm run clean && npm run build:lib && npm run build:lib:legacy && npm run build:ce",
     "clean": "shx rm -rf dist && shx mkdir dist && shx mkdir dist/umd && shx mkdir dist/esm && shx mkdir dist/dev",
     "release": "run-s \"version:update -- {@}\" build version:reset dojo-package \"dojo-release -- {@}\" --",
-    "uploadCoverage": "codecov --file=coverage/coverage.json",
-    "copy:framework": "cp -R ../framework/dist/release/* node_modules/@dojo/framework/"
+    "uploadCoverage": "codecov --file=coverage/coverage.json"
   },
   "husky": {
     "hooks": {

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
   "devDependencies": {
     "@dojo/cli": "^5.0.0",
     "@dojo/cli-build-widget": "6.0.0-alpha.3",
-    "@dojo/framework": "6.0.0-alpha.18",
+    "@dojo/framework": "6.0.0-alpha.19",
     "@dojo/loader": "^2.0.0",
     "@dojo/scripts": "^4.0.2",
     "@dojo/themes": "^5.0.1",

--- a/package.json
+++ b/package.json
@@ -34,7 +34,8 @@
     "build": "npm run clean && npm run build:lib && npm run build:lib:legacy && npm run build:ce",
     "clean": "shx rm -rf dist && shx mkdir dist && shx mkdir dist/umd && shx mkdir dist/esm && shx mkdir dist/dev",
     "release": "run-s \"version:update -- {@}\" build version:reset dojo-package \"dojo-release -- {@}\" --",
-    "uploadCoverage": "codecov --file=coverage/coverage.json"
+    "uploadCoverage": "codecov --file=coverage/coverage.json",
+    "copy:framework": "cp -R ../framework/dist/release/* node_modules/@dojo/framework/"
   },
   "husky": {
     "hooks": {
@@ -43,8 +44,8 @@
   },
   "devDependencies": {
     "@dojo/cli": "^5.0.0",
-    "@dojo/cli-build-widget": "6.0.0-alpha.2",
-    "@dojo/framework": "6.0.0-alpha.11",
+    "@dojo/cli-build-widget": "6.0.0-alpha.3",
+    "@dojo/framework": "6.0.0-alpha.18",
     "@dojo/loader": "^2.0.0",
     "@dojo/scripts": "^4.0.2",
     "@dojo/themes": "^5.0.1",

--- a/src/accordion-pane/index.ts
+++ b/src/accordion-pane/index.ts
@@ -1,6 +1,5 @@
 import { assign } from '@dojo/framework/shim/object';
 import { DNode, WNode } from '@dojo/framework/core/interfaces';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import { includes } from '@dojo/framework/shim/array';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
 import { v } from '@dojo/framework/core/vdom';
@@ -25,11 +24,6 @@ export interface AccordionPaneProperties extends ThemedProperties {
 }
 
 @theme(css)
-@customElement<AccordionPaneProperties>({
-	tag: 'dojo-accordion-pane',
-	properties: ['openKeys', 'theme', 'extraClasses', 'classes'],
-	events: ['onRequestClose', 'onRequestOpen']
-})
 export class AccordionPane extends ThemedMixin(WidgetBase)<
 	AccordionPaneProperties,
 	WNode<TitlePane>

--- a/src/button/index.ts
+++ b/src/button/index.ts
@@ -11,9 +11,7 @@ import {
 	KeyEventProperties
 } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import Icon from '../icon/index';
-import { CustomElementChildType } from '@dojo/framework/core/registerCustomElement';
 
 export type ButtonType = 'submit' | 'reset' | 'button' | 'menu';
 
@@ -48,27 +46,6 @@ export interface ButtonProperties
 }
 
 @theme(css)
-@customElement<ButtonProperties>({
-	tag: 'dojo-button',
-	childType: CustomElementChildType.TEXT,
-	properties: ['disabled', 'pressed', 'popup', 'theme', 'aria', 'extraClasses', 'classes'],
-	attributes: ['widgetId', 'name', 'type', 'value'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onInput',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart'
-	]
-})
 export class Button extends ThemedMixin(FocusMixin(WidgetBase))<ButtonProperties> {
 	private _onBlur(event: FocusEvent) {
 		this.properties.onBlur && this.properties.onBlur();

--- a/src/calendar/index.ts
+++ b/src/calendar/index.ts
@@ -15,7 +15,6 @@ import Icon from '../icon/index';
 import calendarBundle from './nls/Calendar';
 import * as css from '../theme/calendar.m.css';
 import * as baseCss from '../common/styles/base.m.css';
-import customElement from '@dojo/framework/core/decorators/customElement';
 
 export type CalendarMessages = typeof calendarBundle.messages;
 
@@ -85,23 +84,6 @@ const DEFAULT_WEEKDAYS: ShortLong<typeof commonBundle.messages>[] = [
 ];
 
 @theme(css)
-@customElement<CalendarProperties>({
-	tag: 'dojo-calendar',
-	properties: [
-		'aria',
-		'classes',
-		'selectedDate',
-		'month',
-		'year',
-		'renderMonthLabel',
-		'renderWeekdayCell',
-		'labels',
-		'monthNames',
-		'weekdayNames',
-		'theme'
-	],
-	events: ['onDateSelect', 'onMonthChange', 'onYearChange']
-})
 export class Calendar extends I18nMixin(ThemedMixin(WidgetBase))<CalendarProperties> {
 	private _callDateFocus = false;
 	private _defaultDate = new Date();

--- a/src/card/index.tsx
+++ b/src/card/index.tsx
@@ -4,17 +4,12 @@ import { RenderResult } from '@dojo/framework/core/interfaces';
 import { alwaysRender } from '@dojo/framework/core/decorators/alwaysRender';
 import { ThemedMixin, theme } from '@dojo/framework/core/mixins/Themed';
 import * as css from '../theme/card.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import { DNode } from '@dojo/framework/core/interfaces';
 
 export interface CardProperties {
 	actionsRenderer?(): RenderResult;
 }
 
-@customElement<CardProperties>({
-	tag: 'dojo-card',
-	properties: ['actionsRenderer']
-})
 @theme(css)
 @alwaysRender()
 export class Card extends ThemedMixin(WidgetBase)<CardProperties> {

--- a/src/checkbox/index.ts
+++ b/src/checkbox/index.ts
@@ -16,7 +16,6 @@ import { formatAriaProperties } from '../common/util';
 import { v, w } from '@dojo/framework/core/vdom';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/checkbox.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type CheckboxProperties
@@ -54,37 +53,6 @@ export enum Mode {
 }
 
 @theme(css)
-@customElement<CheckboxProperties>({
-	tag: 'dojo-checkbox',
-	properties: [
-		'required',
-		'invalid',
-		'readOnly',
-		'disabled',
-		'theme',
-		'aria',
-		'extraClasses',
-		'labelAfter',
-		'labelHidden',
-		'checked',
-		'classes'
-	],
-	attributes: ['widgetId', 'label', 'value', 'name', 'mode', 'offLabel', 'onLabel'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart'
-	]
-})
 export class Checkbox extends ThemedMixin(FocusMixin(WidgetBase))<CheckboxProperties> {
 	private _onBlur(event: FocusEvent) {
 		const checkbox = event.target as HTMLInputElement;

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -19,7 +19,6 @@ import { CommonMessages, LabeledProperties } from '../common/interfaces';
 
 import * as css from '../theme/combobox.m.css';
 import * as baseCss from '../common/styles/base.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import HelperText from '../helper-text/index';
 
 /**
@@ -83,36 +82,6 @@ export enum Operation {
 
 @theme(css)
 @diffProperty('results', reference)
-@customElement<ComboBoxProperties>({
-	tag: 'dojo-combo-box',
-	properties: [
-		'theme',
-		'classes',
-		'extraClasses',
-		'labelHidden',
-		'clearable',
-		'disabled',
-		'inputProperties',
-		'valid',
-		'isResultDisabled',
-		'helperText',
-		'labelHidden',
-		'openOnFocus',
-		'readOnly',
-		'required',
-		'results'
-	],
-	attributes: ['widgetId', 'label', 'value'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onFocus',
-		'onMenuChange',
-		'onRequestResults',
-		'onResultSelect',
-		'onValidate'
-	]
-})
 export class ComboBox extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))<ComboBoxProperties> {
 	private _activeIndex = 0;
 	private _ignoreBlur: boolean | undefined;

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -13,7 +13,6 @@ import Icon from '../icon/index';
 import * as fixedCss from './styles/dialog.m.css';
 import * as css from '../theme/dialog.m.css';
 import { GlobalEvent } from '../global-event/index';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * The role of this dialog, used for accessibility
@@ -56,25 +55,6 @@ export interface DialogProperties extends ThemedProperties, CustomAriaProperties
 }
 
 @theme(css)
-@customElement<DialogProperties>({
-	tag: 'dojo-dialog',
-	properties: [
-		'theme',
-		'aria',
-		'extraClasses',
-		'exitAnimation',
-		'enterAnimation',
-		'underlayEnterAnimation',
-		'underlayExitAnimation',
-		'closeable',
-		'modal',
-		'open',
-		'underlay',
-		'classes'
-	],
-	attributes: ['title', 'role', 'closeText'],
-	events: ['onOpen', 'onRequestClose']
-})
 export class Dialog extends I18nMixin(ThemedMixin(WidgetBase))<DialogProperties> {
 	private _titleId = uuid();
 	private _wasOpen: boolean | undefined;

--- a/src/grid/index.ts
+++ b/src/grid/index.ts
@@ -1,7 +1,6 @@
 import WidgetBase from '@dojo/framework/core/WidgetBase';
 import { v, w } from '@dojo/framework/core/vdom';
 import ThemedMixin, { theme, ThemedProperties } from '@dojo/framework/core/mixins/Themed';
-import customElement from '@dojo/framework/core/decorators/customElement';
 import diffProperty from '@dojo/framework/core/decorators/diffProperty';
 import { DNode } from '@dojo/framework/core/interfaces';
 import { reference } from '@dojo/framework/core/diff';
@@ -50,11 +49,6 @@ export interface GridProperties<S> extends ThemedProperties {
 }
 
 @theme(css)
-@customElement<GridProperties<any>>({
-	tag: 'dojo-grid',
-	properties: ['theme', 'classes', 'height', 'fetcher', 'updater', 'columnConfig', 'store'],
-	attributes: ['storeId']
-})
 export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> {
 	private _store = new Store<GridState<S>>();
 	private _handle: any;

--- a/src/icon/index.ts
+++ b/src/icon/index.ts
@@ -6,7 +6,6 @@ import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 import * as css from '../theme/icon.m.css';
 import * as baseCss from '../common/styles/base.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 export type IconType = keyof typeof css;
 
@@ -24,11 +23,6 @@ export interface IconProperties extends ThemedProperties, CustomAriaProperties {
 }
 
 @theme(css)
-@customElement<IconProperties>({
-	tag: 'dojo-icon',
-	properties: ['theme', 'classes', 'aria', 'extraClasses'],
-	attributes: ['type', 'altText']
-})
 export class Icon extends ThemedMixin(WidgetBase)<IconProperties> {
 	protected renderAltText(altText: string): DNode {
 		return v('span', { classes: [baseCss.visuallyHidden] }, [altText]);

--- a/src/label/index.ts
+++ b/src/label/index.ts
@@ -6,7 +6,6 @@ import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 import * as css from '../theme/label.m.css';
 import * as baseCss from '../common/styles/base.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type LabelProperties
@@ -35,24 +34,6 @@ export interface LabelProperties extends ThemedProperties, CustomAriaProperties 
 }
 
 @theme(css)
-@customElement<LabelProperties>({
-	tag: 'dojo-label',
-	properties: [
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'disabled',
-		'focused',
-		'readOnly',
-		'required',
-		'invalid',
-		'hidden',
-		'secondary'
-	],
-	attributes: [],
-	events: []
-})
 export class Label extends ThemedMixin(WidgetBase)<LabelProperties> {
 	protected getRootClasses(): (string | null)[] {
 		const { disabled, focused, invalid, readOnly, required, secondary } = this.properties;

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -15,7 +15,6 @@ import * as css from '../theme/listbox.m.css';
 import ListboxOption from './ListboxOption';
 import { Focus } from '@dojo/framework/core/meta/Focus';
 import Resize from '@dojo/framework/core/meta/Resize';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /* Default scroll meta */
 export class ScrollMeta extends MetaBase {
@@ -65,24 +64,6 @@ export interface ListboxProperties extends ThemedProperties, FocusProperties, Cu
 
 @theme(css)
 @diffProperty('optionData', reference)
-@customElement<ListboxProperties>({
-	tag: 'dojo-listbox',
-	properties: [
-		'theme',
-		'classes',
-		'activeIndex',
-		'multiselect',
-		'tabIndex',
-		'visualFocus',
-		'optionData',
-		'getOptionDisabled',
-		'getOptionId',
-		'getOptionLabel',
-		'getOptionSelected'
-	],
-	attributes: ['widgetId'],
-	events: ['onActiveIndexChange', 'onKeyDown', 'onOptionSelect']
-})
 export class Listbox extends ThemedMixin(FocusMixin(WidgetBase))<ListboxProperties> {
 	private _boundRenderOption = this.renderOption.bind(this);
 	private _idBase = uuid();

--- a/src/outlined-button/index.tsx
+++ b/src/outlined-button/index.tsx
@@ -1,36 +1,13 @@
 import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { ThemedMixin, theme } from '@dojo/framework/core/mixins/Themed';
 import { tsx } from '@dojo/framework/core/vdom';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import Button, { ButtonProperties } from '../button/index';
 import * as css from '../theme/outlined-button.m.css';
-import { CustomElementChildType } from '@dojo/framework/core/registerCustomElement';
 import { DNode } from '@dojo/framework/core/interfaces';
 
 export interface OutlinedButtonProperties extends ButtonProperties {}
 
 @theme(css)
-@customElement<OutlinedButtonProperties>({
-	tag: 'dojo-outlined-button',
-	childType: CustomElementChildType.TEXT,
-	properties: ['disabled', 'pressed', 'popup', 'theme', 'aria', 'extraClasses', 'classes'],
-	attributes: ['widgetId', 'name', 'type', 'value'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onInput',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart'
-	]
-})
 export class OutlinedButton extends ThemedMixin(WidgetBase)<OutlinedButtonProperties> {
 	protected render(): DNode {
 		return (

--- a/src/progress/index.ts
+++ b/src/progress/index.ts
@@ -5,7 +5,6 @@ import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 import { DNode } from '@dojo/framework/core/interfaces';
 import * as css from '../theme/progress.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type ProgressProperties
@@ -29,22 +28,6 @@ export interface ProgressProperties extends ThemedProperties, CustomAriaProperti
 }
 
 @theme(css)
-@customElement<ProgressProperties>({
-	tag: 'dojo-progress',
-	properties: [
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'output',
-		'showOutput',
-		'max',
-		'min',
-		'value'
-	],
-	attributes: ['widgetId'],
-	events: []
-})
 export class Progress extends ThemedMixin(WidgetBase)<ProgressProperties> {
 	private _output(value: number, percent: number) {
 		const { output } = this.properties;

--- a/src/radio/index.ts
+++ b/src/radio/index.ts
@@ -16,7 +16,6 @@ import { formatAriaProperties } from '../common/util';
 import { v, w } from '@dojo/framework/core/vdom';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/radio.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type RadioProperties
@@ -40,37 +39,6 @@ export interface RadioProperties
 }
 
 @theme(css)
-@customElement<RadioProperties>({
-	tag: 'dojo-radio',
-	properties: [
-		'required',
-		'invalid',
-		'readOnly',
-		'disabled',
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'checked',
-		'labelAfter',
-		'labelHidden'
-	],
-	attributes: ['widgetId', 'label', 'value', 'name'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart'
-	]
-})
 export class Radio extends ThemedMixin(FocusMixin(WidgetBase))<RadioProperties> {
 	private _uuid = uuid();
 

--- a/src/raised-button/index.tsx
+++ b/src/raised-button/index.tsx
@@ -1,36 +1,13 @@
 import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { ThemedMixin, theme } from '@dojo/framework/core/mixins/Themed';
 import { tsx } from '@dojo/framework/core/vdom';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import Button, { ButtonProperties } from '../button/index';
 import * as css from '../theme/raised-button.m.css';
-import { CustomElementChildType } from '@dojo/framework/core/registerCustomElement';
 import { DNode } from '@dojo/framework/core/interfaces';
 
 export interface RaisedButtonProperties extends ButtonProperties {}
 
 @theme(css)
-@customElement<RaisedButtonProperties>({
-	tag: 'dojo-raised-button',
-	childType: CustomElementChildType.TEXT,
-	properties: ['disabled', 'pressed', 'popup', 'theme', 'aria', 'extraClasses', 'classes'],
-	attributes: ['widgetId', 'name', 'type', 'value'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onInput',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart'
-	]
-})
 export class RaisedButton extends ThemedMixin(WidgetBase)<RaisedButtonProperties> {
 	protected render(): DNode {
 		return (

--- a/src/range-slider/index.ts
+++ b/src/range-slider/index.ts
@@ -17,7 +17,6 @@ import Label from '../label/index';
 import * as fixedCss from './styles/range-slider.m.css';
 import * as css from '../theme/range-slider.m.css';
 import * as baseCss from '../common/styles/base.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 export interface RangeSliderProperties
 	extends ThemedProperties,
@@ -53,49 +52,6 @@ function extractValue(event: Event): number {
 type MinMaxCallback = (minValue: number, maxValue: number) => void;
 
 @theme(css)
-@customElement<RangeSliderProperties>({
-	tag: 'dojo-range-slider',
-	properties: [
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'disabled',
-		'invalid',
-		'required',
-		'readOnly',
-		'labelAfter',
-		'labelHidden',
-		'max',
-		'min',
-		'output',
-		'outputIsTooltip',
-		'showOutput',
-		'step',
-		'minValue',
-		'maxValue',
-		'minName',
-		'maxName',
-		'minimumLabel',
-		'maximumLabel'
-	],
-	attributes: ['widgetId', 'label', 'name'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onInput',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart'
-	]
-})
 export class RangeSlider extends ThemedMixin(WidgetBase)<RangeSliderProperties> {
 	// id used to associate input with output
 	private _widgetId = uuid();

--- a/src/select/index.ts
+++ b/src/select/index.ts
@@ -15,7 +15,6 @@ import Label from '../label/index';
 import Listbox from '../listbox/index';
 import HelperText from '../helper-text/index';
 import * as css from '../theme/select.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type SelectProperties
@@ -58,30 +57,6 @@ export interface SelectProperties<T = any>
 
 @theme(css)
 @diffProperty('options', reference)
-@customElement<SelectProperties>({
-	tag: 'dojo-select',
-	properties: [
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'options',
-		'useNativeElement',
-		'getOptionDisabled',
-		'getOptionId',
-		'getOptionLabel',
-		'getOptionText',
-		'getOptionSelected',
-		'getOptionValue',
-		'readOnly',
-		'required',
-		'invalid',
-		'disabled',
-		'labelHidden'
-	],
-	attributes: ['widgetId', 'placeholder', 'label', 'value', 'helperText'],
-	events: ['onBlur', 'onChange', 'onFocus']
-})
 export class Select<T = any> extends ThemedMixin(FocusMixin(WidgetBase))<SelectProperties<T>> {
 	private _focusedIndex!: number;
 	private _focusNode = 'trigger';

--- a/src/slide-pane/index.ts
+++ b/src/slide-pane/index.ts
@@ -11,7 +11,6 @@ import commonBundle from '../common/nls/common';
 import Icon from '../icon/index';
 import * as fixedCss from './styles/slide-pane.m.css';
 import * as css from '../theme/slide-pane.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import diffProperty from '@dojo/framework/core/decorators/diffProperty';
 
 /**
@@ -65,12 +64,6 @@ enum Slide {
 }
 
 @theme(css)
-@customElement<SlidePaneProperties>({
-	tag: 'dojo-slide-pane',
-	properties: ['theme', 'aria', 'extraClasses', 'open', 'underlay', 'classes'],
-	attributes: ['align', 'closeText', 'title'],
-	events: ['onOpen', 'onRequestClose']
-})
 export class SlidePane extends I18nMixin(ThemedMixin(WidgetBase))<SlidePaneProperties> {
 	private _initialPosition = 0;
 	private _slide: Slide | undefined;

--- a/src/slider/index.ts
+++ b/src/slider/index.ts
@@ -17,7 +17,6 @@ import {
 import { formatAriaProperties } from '../common/util';
 import * as fixedCss from './styles/slider.m.css';
 import * as css from '../theme/slider.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type SliderProperties
@@ -61,45 +60,6 @@ function extractValue(event: Event): number {
 }
 
 @theme(css)
-@customElement<SliderProperties>({
-	tag: 'dojo-slider',
-	properties: [
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'disabled',
-		'invalid',
-		'required',
-		'readOnly',
-		'labelAfter',
-		'labelHidden',
-		'max',
-		'min',
-		'output',
-		'outputIsTooltip',
-		'showOutput',
-		'step',
-		'vertical',
-		'value'
-	],
-	attributes: ['widgetId', 'label', 'name', 'verticalHeight'],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onInput',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart'
-	]
-})
 export class Slider extends ThemedMixin(FocusMixin(WidgetBase))<SliderProperties> {
 	// id used to associate input with output
 	private _widgetId = uuid();

--- a/src/snackbar/index.tsx
+++ b/src/snackbar/index.tsx
@@ -1,7 +1,6 @@
 import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { DNode, RenderResult } from '@dojo/framework/core/interfaces';
 import { theme, ThemedMixin } from '@dojo/framework/core/mixins/Themed';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import { tsx } from '@dojo/framework/core/vdom';
 import * as css from '../theme/snackbar.m.css';
 
@@ -15,11 +14,6 @@ export interface SnackbarProperties {
 }
 
 @theme(css)
-@customElement<SnackbarProperties>({
-	tag: 'dojo-snackbar',
-	properties: ['messageRenderer', 'actionsRenderer', 'leading', 'open', 'stacked'],
-	attributes: ['type']
-})
 export class Snackbar extends ThemedMixin(WidgetBase)<SnackbarProperties> {
 	protected render(): DNode {
 		const { type, open, leading, stacked, messageRenderer, actionsRenderer } = this.properties;

--- a/src/split-pane/index.ts
+++ b/src/split-pane/index.ts
@@ -9,7 +9,6 @@ import * as css from '../theme/split-pane.m.css';
 import { Dimensions } from '@dojo/framework/core/meta/Dimensions';
 import { Resize, ContentRect } from '@dojo/framework/core/meta/Resize';
 import { GlobalEvent } from '../global-event/index';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * Direction of this SplitPane
@@ -39,12 +38,6 @@ export interface SplitPaneProperties extends ThemedProperties {
 const DEFAULT_SIZE = 100;
 
 @theme(css)
-@customElement<SplitPaneProperties>({
-	tag: 'dojo-split-pane',
-	properties: ['theme', 'classes', 'extraClasses', 'size', 'collapseWidth'],
-	attributes: ['direction'],
-	events: ['onCollapse', 'onResize']
-})
 export class SplitPane extends ThemedMixin(WidgetBase)<SplitPaneProperties> {
 	private _dragging: boolean | undefined;
 	private _lastSize?: number;

--- a/src/tab-controller/index.ts
+++ b/src/tab-controller/index.ts
@@ -11,7 +11,6 @@ import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 
 import * as css from '../theme/tab-controller.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * Enum for tab button alignment
@@ -44,12 +43,6 @@ export interface TabControllerProperties
 }
 
 @theme(css)
-@customElement<TabControllerProperties>({
-	tag: 'dojo-tab-controller',
-	properties: ['theme', 'classes', 'aria', 'extraClasses', 'activeIndex'],
-	attributes: ['alignButtons'],
-	events: ['onRequestTabChange', 'onRequestTabClose']
-})
 export class TabController extends ThemedMixin(FocusMixin(WidgetBase))<
 	TabControllerProperties,
 	WNode<Tab>

--- a/src/tab/index.ts
+++ b/src/tab/index.ts
@@ -6,8 +6,6 @@ import { CustomAriaProperties } from '../common/interfaces';
 import { formatAriaProperties } from '../common/util';
 
 import * as css from '../theme/tab-controller.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
-import { CustomElementChildType } from '@dojo/framework/core/registerCustomElement';
 
 /**
  * @type TabProperties
@@ -32,13 +30,6 @@ export interface TabProperties extends ThemedProperties, CustomAriaProperties {
 }
 
 @theme(css)
-@customElement<TabProperties>({
-	tag: 'dojo-tab',
-	childType: CustomElementChildType.NODE,
-	properties: ['theme', 'classes', 'aria', 'extraClasses', 'closeable', 'disabled', 'show'],
-	attributes: ['key', 'labelledBy', 'widgetId', 'label'],
-	events: []
-})
 export class Tab extends ThemedMixin(WidgetBase)<TabProperties> {
 	render(): DNode {
 		const { aria = {}, widgetId, labelledBy, show = false } = this.properties;

--- a/src/text-area/index.ts
+++ b/src/text-area/index.ts
@@ -14,7 +14,6 @@ import {
 import { formatAriaProperties } from '../common/util';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/text-area.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import HelperText from '../helper-text/index';
 import { InputValidity } from '@dojo/framework/core/meta/InputValidity';
 
@@ -60,48 +59,6 @@ export interface TextareaProperties
 }
 
 @theme(css)
-@customElement<TextareaProperties>({
-	tag: 'dojo-text-area',
-	properties: [
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'columns',
-		'rows',
-		'required',
-		'readOnly',
-		'disabled',
-		'labelHidden'
-	],
-	attributes: [
-		'widgetId',
-		'label',
-		'helperText',
-		'minLength',
-		'maxLength',
-		'name',
-		'placeholder',
-		'value',
-		'wrapText'
-	],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onInput',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart',
-		'onValidate'
-	]
-})
 export class Textarea extends ThemedMixin(FocusMixin(WidgetBase))<TextareaProperties> {
 	private _dirty = false;
 

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -15,7 +15,6 @@ import {
 import { formatAriaProperties } from '../common/util';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/text-input.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import diffProperty from '@dojo/framework/core/decorators/diffProperty';
 import { reference } from '@dojo/framework/core/diff';
 import HelperText from '../helper-text/index';
@@ -99,51 +98,6 @@ function patternDiffer(
 }
 
 @theme(css)
-@customElement<TextInputProperties>({
-	tag: 'dojo-text-input',
-	properties: [
-		'theme',
-		'classes',
-		'aria',
-		'extraClasses',
-		'disabled',
-		'readOnly',
-		'labelHidden',
-		'valid',
-		'leading',
-		'trailing'
-	],
-	attributes: [
-		'widgetId',
-		'label',
-		'placeholder',
-		'helperText',
-		'controls',
-		'type',
-		'minLength',
-		'maxLength',
-		'value',
-		'name',
-		'pattern',
-		'autocomplete'
-	],
-	events: [
-		'onBlur',
-		'onChange',
-		'onClick',
-		'onFocus',
-		'onInput',
-		'onKeyDown',
-		'onKeyPress',
-		'onKeyUp',
-		'onMouseDown',
-		'onMouseUp',
-		'onTouchCancel',
-		'onTouchEnd',
-		'onTouchStart',
-		'onValidate'
-	]
-})
 @diffProperty('pattern', patternDiffer)
 @diffProperty('leading', reference)
 @diffProperty('trailing', reference)

--- a/src/time-picker/index.ts
+++ b/src/time-picker/index.ts
@@ -14,7 +14,6 @@ import { TextInputProperties } from '../text-input/index';
 import Label from '../label/index';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/time-picker.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 interface FocusInputEvent extends FocusEvent {
 	target: HTMLInputElement;
@@ -165,31 +164,6 @@ export function parseUnits(value: string | TimeUnits): TimeUnits {
 }
 
 @theme(css)
-@customElement<TimePickerProperties>({
-	tag: 'dojo-time-picker',
-	properties: [
-		'theme',
-		'classes',
-		'extraClasses',
-		'isOptionDisabled',
-		'getOptionLabel',
-		'autoBlur',
-		'clearable',
-		'inputProperties',
-		'openOnFocus',
-		'options',
-		'useNativeElement',
-		'step',
-		'labelAfter',
-		'labelHidden',
-		'required',
-		'invalid',
-		'readOnly',
-		'disabled'
-	],
-	attributes: ['widgetId', 'label', 'name', 'value', 'start', 'end'],
-	events: ['onBlur', 'onChange', 'onFocus', 'onMenuChange', 'onRequestOptions']
-})
 export class TimePicker extends ThemedMixin(FocusMixin(WidgetBase))<TimePickerProperties> {
 	protected options: TimeUnits[] | null = null;
 

--- a/src/title-pane/index.ts
+++ b/src/title-pane/index.ts
@@ -1,5 +1,5 @@
 import { uuid } from '@dojo/framework/core/util';
-import { DNode } from '@dojo/framework/core/interfaces';
+import { DNode, WidgetProperties } from '@dojo/framework/core/interfaces';
 import { theme, ThemedMixin, ThemedProperties } from '@dojo/framework/core/mixins/Themed';
 import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { v, w } from '@dojo/framework/core/vdom';
@@ -9,7 +9,6 @@ import Icon from '../icon/index';
 import * as fixedCss from './styles/title-pane.m.css';
 import * as css from '../theme/title-pane.m.css';
 import { Dimensions } from '@dojo/framework/core/meta/Dimensions';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 import GlobalEvent from '../global-event/index';
 
 /**
@@ -24,7 +23,7 @@ import GlobalEvent from '../global-event/index';
  * @property open               If true the pane is opened and content is visible
  * @property title              Title to display above the content
  */
-export interface TitlePaneProperties extends ThemedProperties, FocusProperties {
+export interface TitlePaneProperties extends WidgetProperties, ThemedProperties, FocusProperties {
 	closeable?: boolean;
 	headingLevel?: number;
 	onRequestClose?(key: string | number | undefined): void;
@@ -34,12 +33,6 @@ export interface TitlePaneProperties extends ThemedProperties, FocusProperties {
 }
 
 @theme(css)
-@customElement<TitlePaneProperties>({
-	tag: 'dojo-title-pane',
-	properties: ['theme', 'classes', 'extraClasses', 'open', 'closeable', 'headingLevel'],
-	attributes: ['title', 'key'],
-	events: ['onRequestClose', 'onRequestOpen']
-})
 export class TitlePane extends ThemedMixin(FocusMixin(WidgetBase))<TitlePaneProperties> {
 	private _id = uuid();
 	private _open: boolean | undefined;

--- a/src/toolbar/index.ts
+++ b/src/toolbar/index.ts
@@ -11,7 +11,6 @@ import commonBundle from '../common/nls/common';
 import * as fixedCss from './styles/toolbar.m.css';
 import * as css from '../theme/toolbar.m.css';
 import { GlobalEvent } from '../global-event/index';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 export { Align };
 
@@ -32,12 +31,6 @@ export interface ToolbarProperties extends ThemedProperties {
 }
 
 @theme(css)
-@customElement<ToolbarProperties>({
-	tag: 'dojo-toolbar',
-	properties: ['theme', 'classes', 'extraClasses', 'collapseWidth'],
-	attributes: ['key', 'heading'],
-	events: ['onCollapse']
-})
 export class Toolbar extends I18nMixin(ThemedMixin(WidgetBase))<ToolbarProperties> {
 	private _collapsed = false;
 	private _open = false;

--- a/src/tooltip/index.ts
+++ b/src/tooltip/index.ts
@@ -7,7 +7,6 @@ import { formatAriaProperties } from '../common/util';
 
 import * as fixedCss from './styles/tooltip.m.css';
 import * as css from '../theme/tooltip.m.css';
-import { customElement } from '@dojo/framework/core/decorators/customElement';
 
 /**
  * @type TooltipProperties
@@ -36,12 +35,6 @@ const fixedOrientationCss: { [key: string]: any } = fixedCss;
 const orientationCss: { [key: string]: any } = css;
 
 @theme(css)
-@customElement<TooltipProperties>({
-	tag: 'dojo-tooltip',
-	properties: ['theme', 'classes', 'aria', 'extraClasses', 'content', 'open'],
-	attributes: ['orientation'],
-	events: []
-})
 export class Tooltip extends ThemedMixin(WidgetBase)<TooltipProperties> {
 	protected getFixedModifierClasses(): (string | null)[] {
 		const { orientation = Orientation.right } = this.properties;


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Removing custom element decorators!  Custom element info is now auto-detected by framework and the build.

Tested locally with the custom element showcase.
