### PR TITLE
Removes sleep from functional tests

### DIFF
--- a/src/accordion-pane/tests/functional/AccordionPane.ts
+++ b/src/accordion-pane/tests/functional/AccordionPane.ts
@@ -4,21 +4,20 @@ const { assert } = intern.getPlugin('chai');
 import { Remote } from 'intern/lib/executors/Node';
 import { services } from '@theintern/a11y';
 import { uuid } from '@dojo/framework/core/util';
+import * as css from '../../../theme/title-pane.m.css';
 
 const axe = services.axe;
 
 function getPage(remote: Remote) {
 	return remote
 		.get(`http://localhost:9000/dist/dev/src/common/example/?id=${uuid()}#accordion-pane`)
-		.setFindTimeout(5000);
+		.setFindTimeout(5000)
+		.setExecuteAsyncTimeout(750);
 }
-
-const DELAY = 750;
 
 registerSuite('AccordionPane', {
 	'Child panes should open on click'() {
 		return getPage(this.remote)
-			.sleep(DELAY)
 			.findByCssSelector('#pane > div > :first-child')
 			.getSize()
 			.then((size: { height: number }) => {
@@ -27,11 +26,8 @@ registerSuite('AccordionPane', {
 			.findByCssSelector('button')
 			.click()
 			.end()
-			.sleep(DELAY)
-			.getSize()
-			.then((size: { height: number }) => {
-				assert.isAbove(size.height, 50);
-			});
+			.end()
+			.findByCssSelector(`.${css.open}`);
 	},
 
 	'check accessibility'() {

--- a/src/button/tests/functional/Button.ts
+++ b/src/button/tests/functional/Button.ts
@@ -14,8 +14,6 @@ function getPage(remote: Remote) {
 		.setFindTimeout(5000);
 }
 
-const DELAY = 750;
-
 registerSuite('Button', {
 	'button should be visible'() {
 		return getPage(this.remote)
@@ -54,21 +52,11 @@ registerSuite('Button', {
 				assert.isNull(pressed, 'Initial state should be null');
 			})
 			.click()
-			.sleep(DELAY)
 			.end()
-			.findByCssSelector(`#example-4 .${css.root}`)
-			.getAttribute('aria-pressed')
-			.then((pressed: string) => {
-				assert.strictEqual(pressed, 'true');
-			})
+			.findByCssSelector(`#example-4 .${css.root}[aria-pressed="true"]`)
 			.click()
-			.sleep(DELAY)
 			.end()
-			.findByCssSelector(`#example-4 .${css.root}`)
-			.getAttribute('aria-pressed')
-			.then((pressed: string) => {
-				assert.strictEqual(pressed, 'false');
-			})
+			.findByCssSelector(`#example-4 .${css.root}[aria-pressed="false"]`)
 			.end();
 	},
 


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #749 
Removes `sleep` from tests and moves to using `find` instead.
