### PR TITLE
Fix examples/docs build on windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2910,6 +2910,12 @@
       "integrity": "sha512-/F3t/Yo8LEdRSEPCmI15fLu5vepVh9UCg/9inJXF5AAfW7xRRJkbaM2ut52iRMQMnGCLQouLbFdbOA+VEFOIsg==",
       "dev": true
     },
+    "canonical-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/canonical-path/-/canonical-path-1.0.0.tgz",
+      "integrity": "sha512-feylzsbDxi1gPZ1IjystzIQZagYYLvfKrSuygUCgf7z6x790VEzze5QEkdSV1U58RA7Hi0+v6fv4K54atOzATg==",
+      "dev": true
+    },
     "capture-stack-trace": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/capture-stack-trace/-/capture-stack-trace-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -60,6 +60,7 @@
     "@types/jsdom": "2.0.*",
     "@types/node": "~9.6.5",
     "@types/sinon": "^4.1.3",
+    "canonical-path": "^1.0.0",
     "codecov": "3.5.0",
     "cpx": "1.5.0",
     "cross-spawn": "6.0.5",

--- a/src/examples/src/glob-examples.block.ts
+++ b/src/examples/src/glob-examples.block.ts
@@ -1,5 +1,5 @@
 import * as glob from 'glob';
-import * as path from 'path';
+import * as path from 'canonical-path';
 
 export default function() {
 	const files = glob.sync(path.join(__dirname, 'widgets/**/*'), { nodir: true });

--- a/src/examples/src/properties.block.ts
+++ b/src/examples/src/properties.block.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'canonical-path';
 import { Project, InterfaceDeclaration, MethodSignature, PropertySignature } from 'ts-morph';
 
 function getPropertyInterfaceName(value: string) {

--- a/src/examples/src/readme.block.ts
+++ b/src/examples/src/readme.block.ts
@@ -1,6 +1,6 @@
 import globExamples from './glob-examples.block';
 import * as fs from 'fs';
-import * as path from 'path';
+import * as path from 'canonical-path';
 const unified = require('unified');
 const remarkParse = require('remark-parse');
 const remark2rehype = require('remark-rehype');

--- a/src/examples/src/theme.block.ts
+++ b/src/examples/src/theme.block.ts
@@ -1,4 +1,4 @@
-import * as path from 'path';
+import * as path from 'canonical-path';
 import { Project } from 'ts-morph';
 
 interface ThemeInterface {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Cannot build examples/docs on windows due to the difference in path separators. Switching to use `canonical-path` over `path` resolves this issue.