### PR TITLE
Fix extra rendered calendar header cells in IE 

### DIFF
--- a/src/calendar/index.ts
+++ b/src/calendar/index.ts
@@ -397,19 +397,16 @@ export class Calendar extends I18nMixin(ThemedMixin(WidgetBase))<CalendarPropert
 		const { year, month } = this._getMonthYear();
 
 		// Calendar Weekday array
-		const weekdays = [];
-		for (const weekday in weekdayNames) {
-			weekdays.push(
-				v(
-					'th',
-					{
-						role: 'columnheader',
-						classes: this.theme(css.weekday)
-					},
-					[this.renderWeekdayCell(weekdayNames[weekday])]
-				)
-			);
-		}
+		const weekdays = weekdayNames.map((weekday) =>
+			v(
+				'th',
+				{
+					role: 'columnheader',
+					classes: this.theme(css.weekday)
+				},
+				[this.renderWeekdayCell(weekday)]
+			)
+		);
 
 		return v(
 			'div',


### PR DESCRIPTION
**Type:** bug

Replaces the `for in` loop with a `map`

Resolves #862 
