### PR TITLE
framework #569: Focus meta invalidation change

### DIFF
--- a/src/calendar/CalendarCell.ts
+++ b/src/calendar/CalendarCell.ts
@@ -1,6 +1,6 @@
 import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../meta/Focus';
 import { v } from '@dojo/framework/core/vdom';
 import { DNode } from '@dojo/framework/core/interfaces';
 import * as css from '../theme/calendar.m.css';

--- a/src/calendar/DatePicker.ts
+++ b/src/calendar/DatePicker.ts
@@ -1,6 +1,6 @@
 import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../meta/Focus';
 import { v, w } from '@dojo/framework/core/vdom';
 import { uuid } from '@dojo/framework/core/util';
 import { DNode } from '@dojo/framework/core/interfaces';

--- a/src/checkbox/index.ts
+++ b/src/checkbox/index.ts
@@ -2,7 +2,7 @@ import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { DNode } from '@dojo/framework/core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
 import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../meta/Focus';
 import Label from '../label/index';
 import { formatAriaProperties } from '../common/util';
 import { v, w } from '@dojo/framework/core/vdom';

--- a/src/checkbox/tests/unit/Checkbox.ts
+++ b/src/checkbox/tests/unit/Checkbox.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
 import { v, w } from '@dojo/framework/core/vdom';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../../../meta/Focus';
 import harness from '@dojo/framework/testing/harness';
 
 import Label from '../../../label/index';

--- a/src/combobox/index.ts
+++ b/src/combobox/index.ts
@@ -4,7 +4,7 @@ import { Keys } from '../common/util';
 import { reference } from '@dojo/framework/core/diff';
 import { I18nMixin, I18nProperties } from '@dojo/framework/core/mixins/I18n';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../meta/Focus';
 import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { uuid } from '@dojo/framework/core/util';

--- a/src/combobox/tests/unit/ComboBox.ts
+++ b/src/combobox/tests/unit/ComboBox.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 import * as sinon from 'sinon';
 
 import { v, w } from '@dojo/framework/core/vdom';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../../../meta/Focus';
 import { Keys } from '../../../common/util';
 
 import ComboBox from '../../index';

--- a/src/dialog/example/index.ts
+++ b/src/dialog/example/index.ts
@@ -1,7 +1,7 @@
 import { DNode } from '@dojo/framework/core/interfaces';
 import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { v, w } from '@dojo/framework/core/vdom';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../../meta/Focus';
 import Dialog from '../../dialog/index';
 
 export default class App extends WidgetBase {

--- a/src/dialog/index.ts
+++ b/src/dialog/index.ts
@@ -2,7 +2,7 @@ import { DNode } from '@dojo/framework/core/interfaces';
 import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { I18nMixin, I18nProperties } from '@dojo/framework/core/mixins/I18n';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../meta/Focus';
 import { v, w } from '@dojo/framework/core/vdom';
 import { uuid } from '@dojo/framework/core/util';
 import { formatAriaProperties, Keys } from '../common/util';

--- a/src/dialog/tests/unit/Dialog.ts
+++ b/src/dialog/tests/unit/Dialog.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 import * as sinon from 'sinon';
 
 import { v, w, isWNode } from '@dojo/framework/core/vdom';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../../../meta/Focus';
 
 import Dialog, { DialogProperties } from '../../index';
 import Icon from '../../../icon/index';

--- a/src/listbox/index.ts
+++ b/src/listbox/index.ts
@@ -12,7 +12,7 @@ import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 
 import * as css from '../theme/listbox.m.css';
 import ListboxOption from './ListboxOption';
-import { Focus } from '@dojo/framework/core/meta/Focus';
+import Focus from '../meta/Focus';
 import Resize from '@dojo/framework/core/meta/Resize';
 
 /* Default scroll meta */

--- a/src/listbox/tests/unit/Listbox.ts
+++ b/src/listbox/tests/unit/Listbox.ts
@@ -4,7 +4,7 @@ import * as sinon from 'sinon';
 
 import { DNode } from '@dojo/framework/core/interfaces';
 import { Keys } from '../../../common/util';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../../../meta/Focus';
 import Resize from '@dojo/framework/core/meta/Resize';
 import Dimensions from '@dojo/framework/core/meta/Dimensions';
 import { v, w } from '@dojo/framework/core/vdom';

--- a/src/meta/Focus.ts
+++ b/src/meta/Focus.ts
@@ -1,0 +1,79 @@
+import { Base } from '@dojo/framework/core/meta/Base';
+import global from '@dojo/framework/shim/global';
+import Set from '@dojo/framework/shim/Set';
+
+export interface FocusResults {
+	active: boolean;
+	containsFocus: boolean;
+}
+
+const defaultResults = {
+	active: false,
+	containsFocus: false
+};
+
+export class Focus extends Base {
+	private _nodeset = new Set<Element>();
+
+	private _activeElement: Element | undefined;
+
+	public get(key: string | number): FocusResults {
+		const node = this.getNode(key);
+
+		if (!node) {
+			return { ...defaultResults };
+		}
+
+		this._nodeset.add(node);
+
+		if (!this._activeElement) {
+			this._activeElement = global.document.activeElement;
+			this._createListener();
+		}
+
+		return {
+			active: node === this._activeElement,
+			containsFocus: !!this._activeElement && node.contains(this._activeElement)
+		};
+	}
+
+	public set(key: string | number) {
+		const node = this.getNode(key);
+		node && (node as HTMLElement).focus();
+	}
+
+	private _onFocusChange = () => {
+		if (
+			(this._activeElement && this._nodeset.has(this._activeElement)) ||
+			this._nodeset.has(global.document.activeElement) ||
+			[...this._nodeset].some(
+				(node) =>
+					!!(
+						node.contains(global.document.activeElement) ||
+						(this._activeElement && node.contains(this._activeElement))
+					)
+			)
+		) {
+			this.invalidate();
+		}
+
+		this._activeElement = global.document.activeElement;
+	};
+
+	private _createListener() {
+		global.document.addEventListener('focusin', this._onFocusChange);
+		global.document.addEventListener('focusout', this._onFocusChange);
+		this.own({
+			destroy: () => {
+				this._removeListener();
+			}
+		});
+	}
+
+	private _removeListener() {
+		global.document.removeEventListener('focusin', this._onFocusChange);
+		global.document.removeEventListener('focusout', this._onFocusChange);
+	}
+}
+
+export default Focus;

--- a/src/radio/index.ts
+++ b/src/radio/index.ts
@@ -2,7 +2,7 @@ import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { DNode } from '@dojo/framework/core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
 import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../meta/Focus';
 import Label from '../label/index';
 import { formatAriaProperties } from '../common/util';
 import { v, w } from '@dojo/framework/core/vdom';

--- a/src/radio/tests/unit/Radio.ts
+++ b/src/radio/tests/unit/Radio.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
 import { v, w } from '@dojo/framework/core/vdom';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../../../meta/Focus';
 
 import Label from '../../../label/index';
 import Radio from '../../../radio/index';

--- a/src/range-slider/index.ts
+++ b/src/range-slider/index.ts
@@ -2,7 +2,7 @@ import { uuid } from '@dojo/framework/core/util';
 import { v, w } from '@dojo/framework/core/vdom';
 import { DNode } from '@dojo/framework/core/interfaces';
 import Dimensions from '@dojo/framework/core/meta/Dimensions';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../meta/Focus';
 import { theme, ThemedMixin, ThemedProperties } from '@dojo/framework/core/mixins/Themed';
 import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { formatAriaProperties } from '../common/util';

--- a/src/range-slider/tests/unit/RangeSlider.ts
+++ b/src/range-slider/tests/unit/RangeSlider.ts
@@ -7,7 +7,7 @@ import Label from '../../../label/index';
 import RangeSlider from '../../index';
 import * as css from '../../../theme/range-slider.m.css';
 import * as fixedCss from '../../styles/range-slider.m.css';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../../../meta/Focus';
 import {
 	compareId,
 	compareForId,

--- a/src/select/index.ts
+++ b/src/select/index.ts
@@ -445,8 +445,6 @@ export class Select<T = any> extends ThemedMixin(FocusMixin(WidgetBase))<SelectP
 
 		const focus = this.meta(Focus).get('root');
 
-		console.log(`RENDERED: ${focus.containsFocus}`);
-
 		return v(
 			'div',
 			{

--- a/src/select/index.ts
+++ b/src/select/index.ts
@@ -4,7 +4,7 @@ import { reference } from '@dojo/framework/core/diff';
 import { DNode } from '@dojo/framework/core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
 import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../meta/Focus';
 import { v, w } from '@dojo/framework/core/vdom';
 import { uuid } from '@dojo/framework/core/util';
 import { find } from '@dojo/framework/shim/array';
@@ -444,6 +444,8 @@ export class Select<T = any> extends ThemedMixin(FocusMixin(WidgetBase))<SelectP
 		} = this.properties;
 
 		const focus = this.meta(Focus).get('root');
+
+		console.log(`RENDERED: ${focus.containsFocus}`);
 
 		return v(
 			'div',

--- a/src/select/tests/unit/Select.ts
+++ b/src/select/tests/unit/Select.ts
@@ -4,7 +4,7 @@ const { assert } = intern.getPlugin('chai');
 import * as sinon from 'sinon';
 
 import { v, w } from '@dojo/framework/core/vdom';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../../../meta/Focus';
 import { Keys } from '../../../common/util';
 
 import Icon from '../../../icon/index';

--- a/src/slider/index.ts
+++ b/src/slider/index.ts
@@ -4,7 +4,7 @@ import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import Label from '../label/index';
 import { v, w } from '@dojo/framework/core/vdom';
 import { DNode } from '@dojo/framework/core/interfaces';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../meta/Focus';
 import { uuid } from '@dojo/framework/core/util';
 import { formatAriaProperties } from '../common/util';
 import * as fixedCss from './styles/slider.m.css';

--- a/src/slider/tests/unit/Slider.ts
+++ b/src/slider/tests/unit/Slider.ts
@@ -2,7 +2,7 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 import * as sinon from 'sinon';
 import { v, w } from '@dojo/framework/core/vdom';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../../../meta/Focus';
 
 import Label from '../../../label/index';
 import Slider from '../../index';

--- a/src/text-area/index.ts
+++ b/src/text-area/index.ts
@@ -3,7 +3,7 @@ import { DNode } from '@dojo/framework/core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
 import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { v, w } from '@dojo/framework/core/vdom';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../meta/Focus';
 import Label from '../label/index';
 import { formatAriaProperties } from '../common/util';
 import { uuid } from '@dojo/framework/core/util';

--- a/src/text-area/tests/unit/TextArea.tsx
+++ b/src/text-area/tests/unit/TextArea.tsx
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
 import { v, w, tsx } from '@dojo/framework/core/vdom';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../../../meta/Focus';
 import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
 
 import Label from '../../../label/index';

--- a/src/text-input/index.ts
+++ b/src/text-input/index.ts
@@ -2,7 +2,7 @@ import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { DNode, PropertyChangeRecord } from '@dojo/framework/core/interfaces';
 import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
 import { v, w } from '@dojo/framework/core/vdom';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../meta/Focus';
 import InputValidity from '@dojo/framework/core/meta/InputValidity';
 import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import Label from '../label/index';

--- a/src/text-input/tests/unit/TextInput.tsx
+++ b/src/text-input/tests/unit/TextInput.tsx
@@ -4,7 +4,7 @@ const { assert } = intern.getPlugin('chai');
 import * as sinon from 'sinon';
 
 import { v, w, tsx } from '@dojo/framework/core/vdom';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../../../meta/Focus';
 import InputValidity from '@dojo/framework/core/meta/InputValidity';
 import assertationTemplate from '@dojo/framework/testing/assertionTemplate';
 

--- a/src/time-picker/index.ts
+++ b/src/time-picker/index.ts
@@ -6,7 +6,7 @@ import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import { diffProperty } from '@dojo/framework/core/decorators/diffProperty';
 import { auto } from '@dojo/framework/core/diff';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../meta/Focus';
 import ComboBox from '../combobox/index';
 import { formatAriaProperties } from '../common/util';
 import { TextInputProperties } from '../text-input/index';

--- a/src/time-picker/tests/unit/TimePicker.ts
+++ b/src/time-picker/tests/unit/TimePicker.ts
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import harness from '@dojo/framework/testing/harness';
 import { v, w } from '@dojo/framework/core/vdom';
-import Focus from '@dojo/framework/core/meta/Focus';
+import Focus from '../../../meta/Focus';
 import * as sinon from 'sinon';
 import TimePicker, { getOptions, parseUnits } from '../../index';
 import * as css from '../../../theme/time-picker.m.css';


### PR DESCRIPTION
**Type:** bug

**Description:**

Creates local focus meta copy that only invalidates the calling widget when the node it is interested in gains / loses focus.

Resolves https://github.com/dojo/framework/issues/569
