### PR TITLE
Rename numberInput config entry

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ To test locally in node run:
 
 The Dojo widget examples application is located in `src/examples`.
 
-To add a new example, create a directory that matches the directory name of the widget e.g. `src/examples/src/widgets/text-input`. Each widget _must_ have an example called `Basic.tsx` and an entry in the `src/examples/src/config.ts` keyed by the name of the widget directory. The widget example should import widgets from `@dojo/widgets` and not via a relative import.
+To add a new example, create a directory that matches the directory name of the widget e.g. `src/examples/src/widgets/text-input`. Each widget _must_ have an example called `Basic.tsx` and an entry in the `src/examples/src/config.ts` keyed by the name of the widget directory. The widget example should import widgets from `@dojo/widgets` and not via a relative import. It is very important that the config entry name (ie. `text-input`) matches the folder name / css file name of the widget otherwise the doc build will fail.
 
 ```js
 {

--- a/src/examples/src/config.ts
+++ b/src/examples/src/config.ts
@@ -354,7 +354,7 @@ export const config: Config = {
 			}
 		}
 	},
-	numberInput: {
+	'number-input': {
 		overview: {
 			example: {
 				module: BasicNumberInput,


### PR DESCRIPTION
**Type:** bug 

Previous naming of `NumberInput` config entry in the example app broke our doc generation.
The standard is to use hyphenated naming as per the folder name / css file name.