### PR TITLE
Remove the widget examples! text from the landing page

### DIFF
--- a/src/examples/src/App.tsx
+++ b/src/examples/src/App.tsx
@@ -45,12 +45,6 @@ export default factory(function App({ properties, middleware: { block } }) {
 			<Menu widgetNames={widgets} />
 			<main classes={[css.main]}>
 				<Outlet
-					id="landing"
-					renderer={() => {
-						return <div>Widget Examples!</div>;
-					}}
-				/>
-				<Outlet
 					id="example"
 					renderer={({ params }) => {
 						const { widget: widgetName, example: exampleName } = params;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**
Removing the text and outlet from the landing page until someone comes up with an actual useful thing to present there
