### PR TITLE
Support customizing the first day of calendar week

### DIFF
--- a/src/calendar/index.ts
+++ b/src/calendar/index.ts
@@ -26,8 +26,6 @@ export enum FirstDayOfWeek {
 	saturday = 6
 }
 
-FirstDayOfWeek.sunday;
-
 export interface CalendarProperties extends ThemedProperties, I18nProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
@@ -260,17 +258,8 @@ export class Calendar extends I18nMixin(ThemedMixin(WidgetBase))<CalendarPropert
 		const initialWeekday =
 			currentMonthStartDay - firstDayOfWeek < 0
 				? currentMonthStartDay - firstDayOfWeek + 7
-				: currentMonthStartDay - firstDayOfWeek; // 7 + currentMonthStartDay - firstDayOfWeek;
+				: currentMonthStartDay - firstDayOfWeek;
 		const todayString = new Date().toDateString();
-
-		console.log(
-			'firstDayOfWeek',
-			firstDayOfWeek,
-			'currentMonthStartDay',
-			currentMonthStartDay,
-			'initialWeekday',
-			initialWeekday
-		);
 
 		let dayIndex = 0;
 		let isCurrentMonth = currentMonthStartDay === firstDayOfWeek;

--- a/src/calendar/tests/unit/Calendar.spec.ts
+++ b/src/calendar/tests/unit/Calendar.spec.ts
@@ -663,7 +663,6 @@ registerSuite('Calendar', {
 const minDateInMonth = new Date('June 3, 2017');
 const maxDateInMonth = new Date('June 29, 2017');
 
-let dateIndex = 28;
 const baseMinMaxTemplate = baseTemplate
 	.setProperty('@date-picker', 'minDate', minDateInMonth)
 	.setProperty('@date-picker', 'maxDate', maxDateInMonth)
@@ -678,26 +677,129 @@ const baseMinMaxTemplate = baseTemplate
 	])
 	.setProperty('@date-4', 'focusable', false)
 	.setProperty('@date-6', 'focusable', true)
-	.replaceChildren('tbody tr:nth-child(5)', () => [
-		expectedDateCell(dateIndex++, 25, true, false),
-		expectedDateCell(dateIndex++, 26, true, false),
-		expectedDateCell(dateIndex++, 27, true, false),
-		expectedDateCell(dateIndex++, 28, true, false),
-		expectedDateCell(dateIndex++, 29, true, false),
-		expectedDateCell(dateIndex++, 30, true, true),
-		expectedDateCell(dateIndex++, 1, false, true)
-	])
-	.replaceChildren('tbody tr:last-child', () => [
-		expectedDateCell(dateIndex++, 2, false, true),
-		expectedDateCell(dateIndex++, 3, false, true),
-		expectedDateCell(dateIndex++, 4, false, true),
-		expectedDateCell(dateIndex++, 5, false, true),
-		expectedDateCell(dateIndex++, 6, false, true),
-		expectedDateCell(dateIndex++, 7, false, true),
-		expectedDateCell(dateIndex++, 8, false, true)
-	])
+	.replaceChildren('tbody tr:nth-child(5)', () => {
+		let dateIndex = 28;
+		return [
+			expectedDateCell(dateIndex++, 25, true, false),
+			expectedDateCell(dateIndex++, 26, true, false),
+			expectedDateCell(dateIndex++, 27, true, false),
+			expectedDateCell(dateIndex++, 28, true, false),
+			expectedDateCell(dateIndex++, 29, true, false),
+			expectedDateCell(dateIndex++, 30, true, true),
+			expectedDateCell(dateIndex++, 1, false, true)
+		];
+	})
+	.replaceChildren('tbody tr:last-child', () => {
+		let dateIndex = 35;
+		return [
+			expectedDateCell(dateIndex++, 2, false, true),
+			expectedDateCell(dateIndex++, 3, false, true),
+			expectedDateCell(dateIndex++, 4, false, true),
+			expectedDateCell(dateIndex++, 5, false, true),
+			expectedDateCell(dateIndex++, 6, false, true),
+			expectedDateCell(dateIndex++, 7, false, true),
+			expectedDateCell(dateIndex++, 8, false, true)
+		];
+	})
 	.setProperty('~previousMonth', 'disabled', true)
 	.setProperty('~nextMonth', 'disabled', true);
+
+registerSuite('Custom first day of week', {
+	tests: {
+		'render the correct first day of week'() {
+			const h = harness(() =>
+				w(Calendar, {
+					month: testDate.getMonth(),
+					year: testDate.getFullYear(),
+					firstDayOfWeek: 2
+				})
+			);
+			const firstDayOfWeekTemplate = baseTemplate
+				.replaceChildren('thead', () => {
+					let dayOrder = [2, 3, 4, 5, 6, 0, 1];
+					return [
+						v(
+							'tr',
+							dayOrder.map((order) =>
+								v(
+									'th',
+									{
+										role: 'columnheader',
+										classes: css.weekday
+									},
+									[
+										v('abbr', { title: DEFAULT_WEEKDAYS[order].long }, [
+											DEFAULT_WEEKDAYS[order].short
+										])
+									]
+								)
+							)
+						)
+					];
+				})
+				.replaceChildren('tbody', () => {
+					let dateIndex = 0;
+					return [
+						v('tr', [
+							expectedDateCell(dateIndex++, 30, false),
+							expectedDateCell(dateIndex++, 31, false),
+							expectedDateCell(dateIndex++, 1, true),
+							expectedDateCell(dateIndex++, 2, true),
+							expectedDateCell(dateIndex++, 3, true),
+							expectedDateCell(dateIndex++, 4, true),
+							expectedDateCell(dateIndex++, 5, true)
+						]),
+						v('tr', [
+							expectedDateCell(dateIndex++, 6, true),
+							expectedDateCell(dateIndex++, 7, true),
+							expectedDateCell(dateIndex++, 8, true),
+							expectedDateCell(dateIndex++, 9, true),
+							expectedDateCell(dateIndex++, 10, true),
+							expectedDateCell(dateIndex++, 11, true),
+							expectedDateCell(dateIndex++, 12, true)
+						]),
+						v('tr', [
+							expectedDateCell(dateIndex++, 13, true),
+							expectedDateCell(dateIndex++, 14, true),
+							expectedDateCell(dateIndex++, 15, true),
+							expectedDateCell(dateIndex++, 16, true),
+							expectedDateCell(dateIndex++, 17, true),
+							expectedDateCell(dateIndex++, 18, true),
+							expectedDateCell(dateIndex++, 19, true)
+						]),
+						v('tr', [
+							expectedDateCell(dateIndex++, 20, true),
+							expectedDateCell(dateIndex++, 21, true),
+							expectedDateCell(dateIndex++, 22, true),
+							expectedDateCell(dateIndex++, 23, true),
+							expectedDateCell(dateIndex++, 24, true),
+							expectedDateCell(dateIndex++, 25, true),
+							expectedDateCell(dateIndex++, 26, true)
+						]),
+						v('tr', [
+							expectedDateCell(dateIndex++, 27, true),
+							expectedDateCell(dateIndex++, 28, true),
+							expectedDateCell(dateIndex++, 29, true),
+							expectedDateCell(dateIndex++, 30, true),
+							expectedDateCell(dateIndex++, 1, false),
+							expectedDateCell(dateIndex++, 2, false),
+							expectedDateCell(dateIndex++, 3, false)
+						]),
+						v('tr', [
+							expectedDateCell(dateIndex++, 4, false),
+							expectedDateCell(dateIndex++, 5, false),
+							expectedDateCell(dateIndex++, 6, false),
+							expectedDateCell(dateIndex++, 7, false),
+							expectedDateCell(dateIndex++, 8, false),
+							expectedDateCell(dateIndex++, 9, false),
+							expectedDateCell(dateIndex++, 10, false)
+						])
+					];
+				});
+			h.expect(firstDayOfWeekTemplate);
+		}
+	}
+});
 
 registerSuite('Calendar with min-max', {
 	tests: {
@@ -768,29 +870,34 @@ registerSuite('Calendar with min-max', {
 			// Change to next month so 29th cell is invalid
 			calendarProperties.month = testDate.getMonth();
 
-			dateIndex = 28;
 			h.expect(
 				baseTemplate
 					.setProperty('@date-picker', 'maxDate', maxDate)
 					.setProperty('@date-4', 'focusable', false)
-					.replaceChildren('tbody tr:nth-child(5)', () => [
-						expectedDateCell(dateIndex++, 25, true, true),
-						expectedDateCell(dateIndex++, 26, true, true),
-						expectedDateCell(dateIndex++, 27, true, true),
-						expectedDateCell(dateIndex++, 28, true, true),
-						expectedDateCell(dateIndex++, 29, true, true),
-						expectedDateCell(dateIndex++, 30, true, true),
-						expectedDateCell(dateIndex++, 1, false, true)
-					])
-					.replaceChildren('tbody tr:last-child', () => [
-						expectedDateCell(dateIndex++, 2, false, true),
-						expectedDateCell(dateIndex++, 3, false, true),
-						expectedDateCell(dateIndex++, 4, false, true),
-						expectedDateCell(dateIndex++, 5, false, true),
-						expectedDateCell(dateIndex++, 6, false, true),
-						expectedDateCell(dateIndex++, 7, false, true),
-						expectedDateCell(dateIndex++, 8, false, true)
-					])
+					.replaceChildren('tbody tr:nth-child(5)', () => {
+						let dateIndex = 28;
+						return [
+							expectedDateCell(dateIndex++, 25, true, true),
+							expectedDateCell(dateIndex++, 26, true, true),
+							expectedDateCell(dateIndex++, 27, true, true),
+							expectedDateCell(dateIndex++, 28, true, true),
+							expectedDateCell(dateIndex++, 29, true, true),
+							expectedDateCell(dateIndex++, 30, true, true),
+							expectedDateCell(dateIndex++, 1, false, true)
+						];
+					})
+					.replaceChildren('tbody tr:last-child', () => {
+						let dateIndex = 35;
+						return [
+							expectedDateCell(dateIndex++, 2, false, true),
+							expectedDateCell(dateIndex++, 3, false, true),
+							expectedDateCell(dateIndex++, 4, false, true),
+							expectedDateCell(dateIndex++, 5, false, true),
+							expectedDateCell(dateIndex++, 6, false, true),
+							expectedDateCell(dateIndex++, 7, false, true),
+							expectedDateCell(dateIndex++, 8, false, true)
+						];
+					})
 					.setProperty('@date-27', 'focusable', true)
 					.setProperty('@date-27', 'callFocus', true)
 					.setProperty('~nextMonth', 'disabled', true)

--- a/src/examples/src/config.ts
+++ b/src/examples/src/config.ts
@@ -1,6 +1,7 @@
 import BasicAccordionPane from './widgets/accordion-pane/Basic';
 import BasicButton from './widgets/button/Basic';
 import BasicCalendar from './widgets/calendar/Basic';
+import FirstDayOfWeekCalendar from './widgets/calendar/CustomFirstWeekDay';
 import BasicCard from './widgets/card/Basic';
 import BasicCheckbox from './widgets/checkbox/Basic';
 import BasicCombobox from './widgets/combobox/Basic';
@@ -231,7 +232,14 @@ export const config: Config = {
 				module: BasicCalendar,
 				filename: 'Basic'
 			}
-		}
+		},
+		examples: [
+			{
+				title: 'Custom First Day of Week',
+				module: FirstDayOfWeekCalendar,
+				filename: 'CustomFirstWeekDay'
+			}
+		]
 	},
 	checkbox: {
 		filename: 'index',

--- a/src/examples/src/widgets/calendar/Basic.tsx
+++ b/src/examples/src/widgets/calendar/Basic.tsx
@@ -1,8 +1,28 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
+import icache from '@dojo/framework/core/middleware/icache';
 import Calendar from '@dojo/widgets/calendar';
 
-const factory = create();
+const factory = create({ icache });
 
-export default factory(function Basic() {
-	return <Calendar />;
+export default factory(function Basic({ middleware: { icache } }) {
+	const date = icache.getOrSet('date', new Date());
+	const month = icache.getOrSet('month', date.getMonth());
+	const year = icache.getOrSet('year', date.getFullYear());
+
+	return (
+		<Calendar
+			selectedDate={date}
+			year={year}
+			month={month}
+			onMonthChange={(month) => {
+				icache.set('month', month);
+			}}
+			onYearChange={(year) => {
+				icache.set('year', year);
+			}}
+			onDateSelect={(date) => {
+				icache.set('date', date);
+			}}
+		/>
+	);
 });

--- a/src/examples/src/widgets/calendar/CustomFirstWeekDay.tsx
+++ b/src/examples/src/widgets/calendar/CustomFirstWeekDay.tsx
@@ -1,0 +1,46 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import icache from '@dojo/framework/core/middleware/icache';
+import Calendar, { FirstDayOfWeek } from '@dojo/widgets/calendar';
+
+const factory = create({ icache });
+
+export default factory(function Basic({ middleware: { icache } }) {
+	const date = icache.getOrSet('date', new Date());
+	const month = icache.getOrSet('month', date.getMonth());
+	const year = icache.getOrSet('year', date.getFullYear());
+
+	return (
+		<virtual>
+			<Calendar
+				firstDayOfWeek={FirstDayOfWeek.monday}
+				selectedDate={date}
+				year={year}
+				month={month}
+				onMonthChange={(month) => {
+					icache.set('month', month);
+				}}
+				onYearChange={(year) => {
+					icache.set('year', year);
+				}}
+				onDateSelect={(date) => {
+					icache.set('date', date);
+				}}
+			/>
+			<Calendar
+				firstDayOfWeek={4}
+				selectedDate={date}
+				year={year}
+				month={month}
+				onMonthChange={(month) => {
+					icache.set('month', month);
+				}}
+				onYearChange={(year) => {
+					icache.set('year', year);
+				}}
+				onDateSelect={(date) => {
+					icache.set('date', date);
+				}}
+			/>
+		</virtual>
+	);
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**

Adds support for customising the first day of the week in the calendar via a property, defaulting to the current fixed first day (sunday)

Resolves #561 
