### PR TITLE
Support multiple theme css files in the example documentation

### DIFF
--- a/src/examples/src/theme.block.ts
+++ b/src/examples/src/theme.block.ts
@@ -1,28 +1,48 @@
 import * as postcss from 'postcss';
 import * as fs from 'fs';
+import * as path from 'canonical-path';
+import { Project } from 'ts-morph';
 
 interface ThemeInterface {
 	[index: string]: { [index: string]: string };
 }
 
 export default function(config: { [index: string]: string }): ThemeInterface {
-	return Object.keys(config).reduce((properties, widget) => {
-		const root = postcss.parse(fs.readFileSync(`./src/theme/${widget}.m.css`));
+	const project = new Project({
+		tsConfigFilePath: path.join(__dirname, '..', '..', '..', 'tsconfig.json')
+	});
+	return Object.keys(config).reduce((properties, widgetName) => {
 		const classHash = {} as any;
 		let comment = '';
-		root.walk((node) => {
-			if (node.type === 'comment') {
-				comment = node.text;
-			} else if (node.type === 'rule' && node.selector.match(/^\./)) {
-				const selector = /^\.[a-zA-Z0-9]*/.exec(node.selector);
-				if (selector && !classHash[selector[0]]) {
-					classHash[selector[0]] = comment;
+		const filename = config[widgetName] || 'index';
+		let sourceFile = project.getSourceFile(`./src/${widgetName}/${filename}.ts`);
+		if (!sourceFile) {
+			sourceFile = project.getSourceFile(`./src/${widgetName}/${filename}.tsx`);
+		}
+		if (sourceFile) {
+			const imports = sourceFile!.getImportDeclarations();
+			imports.forEach((importDeclaration) => {
+				const moduleSpecifierValue = importDeclaration.getModuleSpecifierValue();
+				const match = moduleSpecifierValue.match(/.*\/theme\/(.*\.m\.css)$/);
+				if (match) {
+					const cssFilename = match[1];
+					const root = postcss.parse(fs.readFileSync(`./src/theme/${cssFilename}`));
+					root.walk((node) => {
+						if (node.type === 'comment') {
+							comment = node.text;
+						} else if (node.type === 'rule' && node.selector.match(/^\./)) {
+							const selector = /^\.[a-zA-Z0-9]*/.exec(node.selector);
+							if (selector && !classHash[selector[0]]) {
+								classHash[selector[0]] = comment;
+							}
+							comment = '';
+						} else {
+							comment = '';
+						}
+					});
 				}
-				comment = '';
-			} else {
-				comment = '';
-			}
-		});
-		return { ...properties, [widget]: classHash };
+			});
+		}
+		return { ...properties, [widgetName]: classHash };
 	}, {});
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

**Description:**
Adds support for multiple theme css files in the documentation, for the widget variant scenario.

before: https://dojowidgets-20igmn3ra.now.sh/#widget/number-input/basic
after: https://dojowidgets-8t7a3tgnp.now.sh/#widget/number-input/basic