### PR TITLE
Support running tests in the example runner

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -32,7 +32,7 @@
 				},
 				{
 					"from": "node_modules/intern/loaders/default.js",
-					"to": "loaders/default.js"
+					"to": "intern/loaders/default.js"
 				},
 				{
 					"from": "node_modules/intern/index.html",

--- a/.dojorc
+++ b/.dojorc
@@ -5,6 +5,7 @@
 		},
 		"build-time-render": {
 			"root": "app",
+			"renderer": "jsdom",
 			"writeHtml": false
 		},
 		"features": {

--- a/.dojorc
+++ b/.dojorc
@@ -18,7 +18,28 @@
 			"cldr-data/supplemental/plurals",
 			"cldr-data/supplemental/timeData",
 			"cldr-data/supplemental/weekData"
-		]
+		],
+		"externals": {
+			"outputPath": ".",
+			"dependencies": [
+				{
+					"from": "node_modules/intern/browser",
+					"to": "browser"
+				},
+				{
+					"from": "node_modules/intern/loaders",
+					"to": "intern/loaders"
+				},
+				{
+					"from": "node_modules/intern/index.html",
+					"to": "intern.html"
+				},
+				{
+					"from": "src/examples/intern.json",
+					"to": "intern.json"
+				}
+			]
+		}
 	},
 	"build-widget": {
 		"prefix": "dojo",

--- a/.dojorc
+++ b/.dojorc
@@ -36,11 +36,11 @@
 				},
 				{
 					"from": "node_modules/intern/index.html",
-					"to": "intern.html"
+					"to": "intern/index.html"
 				},
 				{
 					"from": "src/examples/intern.json",
-					"to": "intern.json"
+					"to": "intern/intern.json"
 				}
 			]
 		}

--- a/.dojorc
+++ b/.dojorc
@@ -27,8 +27,8 @@
 					"to": "browser"
 				},
 				{
-					"from": "node_modules/intern/loaders",
-					"to": "intern/loaders"
+					"from": "node_modules/intern/loaders/default.js",
+					"to": "loaders/default.js"
 				},
 				{
 					"from": "node_modules/intern/index.html",

--- a/.dojorc
+++ b/.dojorc
@@ -1,5 +1,8 @@
 {
 	"build-app": {
+		"experimental": {
+			"speed": true
+		},
 		"build-time-render": {
 			"root": "app"
 		},

--- a/.dojorc
+++ b/.dojorc
@@ -4,7 +4,8 @@
 			"speed": true
 		},
 		"build-time-render": {
-			"root": "app"
+			"root": "app",
+			"writeHtml": false
 		},
 		"features": {
 			"docs": false

--- a/.dojorc
+++ b/.dojorc
@@ -23,8 +23,12 @@
 			"outputPath": ".",
 			"dependencies": [
 				{
-					"from": "node_modules/intern/browser",
-					"to": "browser"
+					"from": "node_modules/intern/browser/intern.js",
+					"to": "browser/intern.js"
+				},
+				{
+					"from": "node_modules/intern/browser/config.js",
+					"to": "browser/config.js"
 				},
 				{
 					"from": "node_modules/intern/loaders/default.js",

--- a/package-lock.json
+++ b/package-lock.json
@@ -16407,15 +16407,9 @@
           }
         },
         "caniuse-lite": {
-<<<<<<< HEAD
-          "version": "1.0.30001009",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001009.tgz",
-          "integrity": "sha512-M3rEqHN6SaVjgo4bIik7HsGcWXsi+lI9WA0p51RPMFx5gXfduyOXWJrc0R4xBkSK1pgNf4CNgy5M+6H+WiEP8g==",
-=======
           "version": "1.0.30001011",
           "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001011.tgz",
           "integrity": "sha512-h+Eqyn/YA6o6ZTqpS86PyRmNWOs1r54EBDcd2NTwwfsXQ8re1B38SnB+p2RKF8OUsyEIjeDU8XGec1RGO/wYCg==",
->>>>>>> bump dojo versions
           "dev": true
         },
         "debug": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -390,19 +390,6 @@
             "ansi-regex": "^2.0.0"
           }
         },
-        "ts-loader": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.3.0.tgz",
-          "integrity": "sha512-lGSNs7szRFj/rK9T1EQuayE3QNLg6izDUxt5jpmq0RG1rU2bapAt7E7uLckLCUPeO1jwxCiet2oRaWovc53UAg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.3.0",
-            "enhanced-resolve": "^4.0.0",
-            "loader-utils": "^1.0.2",
-            "micromatch": "^3.1.4",
-            "semver": "^5.0.1"
-          }
-        },
         "ts-node": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
@@ -2087,6 +2074,7 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -2734,7 +2722,8 @@
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
+      "dev": true
     },
     "bignumber.js": {
       "version": "2.4.0",
@@ -3294,6 +3283,7 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
+      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -3843,6 +3833,7 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -3850,7 +3841,8 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
     },
     "color-string": {
       "version": "1.5.3",
@@ -4315,7 +4307,8 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "dev": true
     },
     "cosmiconfig": {
       "version": "5.2.1",
@@ -5617,7 +5610,8 @@
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
+      "dev": true
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -5647,6 +5641,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
       "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
+      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "memory-fs": "^0.5.0",
@@ -5669,6 +5664,7 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
+      "dev": true,
       "requires": {
         "prr": "~1.0.1"
       }
@@ -5840,7 +5836,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escodegen": {
       "version": "1.12.0",
@@ -7935,7 +7932,8 @@
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "dev": true
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -8010,7 +8008,8 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -8820,7 +8819,8 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
     },
     "ini": {
       "version": "1.3.5",
@@ -9645,7 +9645,8 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "dev": true
     },
     "isemail": {
       "version": "3.2.0",
@@ -10040,7 +10041,8 @@
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
+      "dev": true
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -10475,6 +10477,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
+      "dev": true,
       "requires": {
         "big.js": "^3.1.3",
         "emojis-list": "^2.0.0",
@@ -10824,6 +10827,7 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
       "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
+      "dev": true,
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
@@ -12203,7 +12207,8 @@
     "picomatch": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
-      "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA=="
+      "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==",
+      "dev": true
     },
     "pidtree": {
       "version": "0.3.0",
@@ -13828,7 +13833,8 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "dev": true
     },
     "progress": {
       "version": "2.0.3",
@@ -13886,7 +13892,8 @@
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -14259,6 +14266,7 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
+      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -14272,7 +14280,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         }
       }
     },
@@ -15741,6 +15750,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       },
@@ -15748,7 +15758,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "dev": true
         }
       }
     },
@@ -16232,6 +16243,7 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -16332,7 +16344,8 @@
     "tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
+      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
+      "dev": true
     },
     "tar-fs": {
       "version": "2.0.0",
@@ -16808,60 +16821,16 @@
       "dev": true
     },
     "ts-loader": {
-      "version": "6.2.1",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.1.tgz",
-      "integrity": "sha512-Dd9FekWuABGgjE1g0TlQJ+4dFUfYGbYcs52/HQObE0ZmUNjQlmLAS7xXsSzy23AMaMwipsx5sNHvoEpT2CZq1g==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.3.0.tgz",
+      "integrity": "sha512-lGSNs7szRFj/rK9T1EQuayE3QNLg6izDUxt5jpmq0RG1rU2bapAt7E7uLckLCUPeO1jwxCiet2oRaWovc53UAg==",
+      "dev": true,
       "requires": {
         "chalk": "^2.3.0",
         "enhanced-resolve": "^4.0.0",
         "loader-utils": "^1.0.2",
-        "micromatch": "^4.0.0",
-        "semver": "^6.0.0"
-      },
-      "dependencies": {
-        "braces": {
-          "version": "3.0.2",
-          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
-          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-          "requires": {
-            "fill-range": "^7.0.1"
-          }
-        },
-        "fill-range": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
-          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-          "requires": {
-            "to-regex-range": "^5.0.1"
-          }
-        },
-        "is-number": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
-        },
-        "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
-          }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-        },
-        "to-regex-range": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
-          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-          "requires": {
-            "is-number": "^7.0.0"
-          }
-        }
+        "micromatch": "^3.1.4",
+        "semver": "^5.0.1"
       }
     },
     "ts-morph": {
@@ -18160,7 +18129,8 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "dev": true
     },
     "util.promisify": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -390,6 +390,19 @@
             "ansi-regex": "^2.0.0"
           }
         },
+        "ts-loader": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.3.0.tgz",
+          "integrity": "sha512-lGSNs7szRFj/rK9T1EQuayE3QNLg6izDUxt5jpmq0RG1rU2bapAt7E7uLckLCUPeO1jwxCiet2oRaWovc53UAg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.3.0",
+            "enhanced-resolve": "^4.0.0",
+            "loader-utils": "^1.0.2",
+            "micromatch": "^3.1.4",
+            "semver": "^5.0.1"
+          }
+        },
         "ts-node": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
@@ -2074,7 +2087,6 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
       "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-      "dev": true,
       "requires": {
         "color-convert": "^1.9.0"
       }
@@ -2722,8 +2734,7 @@
     "big.js": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/big.js/-/big.js-3.2.0.tgz",
-      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q==",
-      "dev": true
+      "integrity": "sha512-+hN/Zh2D08Mx65pZ/4g5bsmNiZUuChDiQfTUQ7qJr4/kuopCr88xZsAXv6mBoZEsUI4OuGHlX59qE94K2mMW8Q=="
     },
     "bignumber.js": {
       "version": "2.4.0",
@@ -3283,7 +3294,6 @@
       "version": "2.4.1",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.1.tgz",
       "integrity": "sha512-ObN6h1v2fTJSmUXoS3nMQ92LbDK9be4TV+6G+omQlGJFdcUX5heKi1LZ1YnRMIgwTLEj3E24bT6tYni50rlCfQ==",
-      "dev": true,
       "requires": {
         "ansi-styles": "^3.2.1",
         "escape-string-regexp": "^1.0.5",
@@ -3833,7 +3843,6 @@
       "version": "1.9.3",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
       "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-      "dev": true,
       "requires": {
         "color-name": "1.1.3"
       }
@@ -3841,8 +3850,7 @@
     "color-name": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-      "dev": true
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
     },
     "color-string": {
       "version": "1.5.3",
@@ -4307,8 +4315,7 @@
     "core-util-is": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-      "dev": true
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
     },
     "cosmiconfig": {
       "version": "5.2.1",
@@ -5610,8 +5617,7 @@
     "emojis-list": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-2.1.0.tgz",
-      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k=",
-      "dev": true
+      "integrity": "sha1-TapNnbAPmBmIDHn6RXrlsJof04k="
     },
     "encodeurl": {
       "version": "1.0.2",
@@ -5641,7 +5647,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-4.1.1.tgz",
       "integrity": "sha512-98p2zE+rL7/g/DzMHMTF4zZlCgeVdJ7yr6xzEpJRYwFYrGi9ANdn5DnJURg6RpBkyk60XYDnWIv51VfIhfNGuA==",
-      "dev": true,
       "requires": {
         "graceful-fs": "^4.1.2",
         "memory-fs": "^0.5.0",
@@ -5664,7 +5669,6 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "dev": true,
       "requires": {
         "prr": "~1.0.1"
       }
@@ -5836,8 +5840,7 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escodegen": {
       "version": "1.12.0",
@@ -7932,8 +7935,7 @@
     "graceful-fs": {
       "version": "4.2.3",
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-      "dev": true
+      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
     },
     "graceful-readlink": {
       "version": "1.0.1",
@@ -8008,8 +8010,7 @@
     "has-flag": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-      "dev": true
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
     },
     "has-symbols": {
       "version": "1.0.0",
@@ -8819,8 +8820,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -9645,8 +9645,7 @@
     "isarray": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-      "dev": true
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
     },
     "isemail": {
       "version": "3.2.0",
@@ -10041,8 +10040,7 @@
     "json5": {
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/json5/-/json5-0.5.1.tgz",
-      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE=",
-      "dev": true
+      "integrity": "sha1-Hq3nrMASA0rYTiOWdn6tn6VJWCE="
     },
     "jsonfile": {
       "version": "4.0.0",
@@ -10477,7 +10475,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-      "dev": true,
       "requires": {
         "big.js": "^3.1.3",
         "emojis-list": "^2.0.0",
@@ -10827,7 +10824,6 @@
       "version": "0.5.0",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.5.0.tgz",
       "integrity": "sha512-jA0rdU5KoQMC0e6ppoNRtpp6vjFq6+NY7r8hywnC7V+1Xj/MtHwGIbB1QaK/dunyjWteJzmkpd7ooeWg10T7GA==",
-      "dev": true,
       "requires": {
         "errno": "^0.1.3",
         "readable-stream": "^2.0.1"
@@ -12207,8 +12203,7 @@
     "picomatch": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.1.1.tgz",
-      "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA==",
-      "dev": true
+      "integrity": "sha512-OYMyqkKzK7blWO/+XZYP6w8hH0LDvkBvdvKukti+7kqYFCiEAk+gI3DWnryapc0Dau05ugGTy0foQ6mqn4AHYA=="
     },
     "pidtree": {
       "version": "0.3.0",
@@ -13833,8 +13828,7 @@
     "process-nextick-args": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "dev": true
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
     },
     "progress": {
       "version": "2.0.3",
@@ -13892,8 +13886,7 @@
     "prr": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/prr/-/prr-1.0.1.tgz",
-      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY=",
-      "dev": true
+      "integrity": "sha1-0/wRS6BplaRexok/SEzrHXj19HY="
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -14266,7 +14259,6 @@
       "version": "2.3.6",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.6.tgz",
       "integrity": "sha512-tQtKA9WIAhBF3+VLAseyMqZeBjW0AHJoxOtYqSUZNJxauErmLbVm2FW1y+J/YA9dUrAC39ITejlZWhVIwawkKw==",
-      "dev": true,
       "requires": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -14280,8 +14272,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -15750,7 +15741,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-      "dev": true,
       "requires": {
         "safe-buffer": "~5.1.0"
       },
@@ -15758,8 +15748,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-          "dev": true
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
         }
       }
     },
@@ -16243,7 +16232,6 @@
       "version": "5.5.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
       "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-      "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
       }
@@ -16344,8 +16332,7 @@
     "tapable": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/tapable/-/tapable-1.1.3.tgz",
-      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA==",
-      "dev": true
+      "integrity": "sha512-4WK/bYZmj8xLr+HUCODHGF1ZFzsYffasLUgEiMBY4fgtltdO6B4WJtlSbPaDTLpYTcGVwM2qLnFTICEcNxs3kA=="
     },
     "tar-fs": {
       "version": "2.0.0",
@@ -16821,16 +16808,60 @@
       "dev": true
     },
     "ts-loader": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.3.0.tgz",
-      "integrity": "sha512-lGSNs7szRFj/rK9T1EQuayE3QNLg6izDUxt5jpmq0RG1rU2bapAt7E7uLckLCUPeO1jwxCiet2oRaWovc53UAg==",
-      "dev": true,
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-6.2.1.tgz",
+      "integrity": "sha512-Dd9FekWuABGgjE1g0TlQJ+4dFUfYGbYcs52/HQObE0ZmUNjQlmLAS7xXsSzy23AMaMwipsx5sNHvoEpT2CZq1g==",
       "requires": {
         "chalk": "^2.3.0",
         "enhanced-resolve": "^4.0.0",
         "loader-utils": "^1.0.2",
-        "micromatch": "^3.1.4",
-        "semver": "^5.0.1"
+        "micromatch": "^4.0.0",
+        "semver": "^6.0.0"
+      },
+      "dependencies": {
+        "braces": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
+          "integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+          "requires": {
+            "fill-range": "^7.0.1"
+          }
+        },
+        "fill-range": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
+          "integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+          "requires": {
+            "to-regex-range": "^5.0.1"
+          }
+        },
+        "is-number": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+          "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
+          }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+        },
+        "to-regex-range": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+          "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+          "requires": {
+            "is-number": "^7.0.0"
+          }
+        }
       }
     },
     "ts-morph": {
@@ -18129,8 +18160,7 @@
     "util-deprecate": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-      "dev": true
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
     },
     "util.promisify": {
       "version": "1.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -292,12 +292,12 @@
       }
     },
     "@dojo/cli-build-app": {
-      "version": "7.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@dojo/cli-build-app/-/cli-build-app-7.0.0-alpha.2.tgz",
-      "integrity": "sha512-0RQOzseZgTEZm9tgaNuU9ObaMr0pl9J+YvJrF4Jq4u9IwljNILalHO/Zp6Ltcir2PtfoeEcOov5OZ4JTE4c/oA==",
+      "version": "7.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@dojo/cli-build-app/-/cli-build-app-7.0.0-alpha.4.tgz",
+      "integrity": "sha512-xUbvkX+jaG6urSgKW8B9Z/FIOXApu+mmozGZIsCU9bCX+50lpEzAUgBEVhJwsuM8N4qOz18xJl/BOEuYGraN2Q==",
       "dev": true,
       "requires": {
-        "@dojo/webpack-contrib": "7.0.0-alpha.2",
+        "@dojo/webpack-contrib": "7.0.0-alpha.3",
         "brotli-webpack-plugin": "1.0.0",
         "caniuse-lite": "1.0.30000973",
         "chalk": "2.4.1",
@@ -355,10 +355,147 @@
         "wrapper-webpack-plugin": "2.0.0"
       },
       "dependencies": {
+        "@dojo/webpack-contrib": {
+          "version": "7.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-alpha.3.tgz",
+          "integrity": "sha512-eqz9pCdPWjWH7eoxxZ7kyWTBJjVe+XuUD1pjRGhwDpborypD0omnkOakVS5P3WMRurc2lEm2/a7bNKx1yzOOhA==",
+          "dev": true,
+          "requires": {
+            "@dojo/framework": "7.0.0-alpha.4",
+            "acorn": "6.1.1",
+            "acorn-dynamic-import": "4.0.0",
+            "acorn-walk": "6.1.1",
+            "bfj": "6.1.1",
+            "chalk": "2.3.0",
+            "clear-module": "3.1.0",
+            "commander": "2.13.0",
+            "connect-history-api-fallback": "1.6.0",
+            "copy-webpack-plugin": "4.6.0",
+            "cssnano": "4.1.7",
+            "eventsource-polyfill": "0.9.6",
+            "express": "4.16.2",
+            "filesize": "3.5.11",
+            "filter-css": "0.1.2",
+            "fs-extra": "7.0.0",
+            "get-port": "4.0.0",
+            "glob": "^7.1.2",
+            "gzip-size": "4.1.0",
+            "html-webpack-include-assets-plugin": "1.0.6",
+            "istanbul-lib-instrument": "1.10.1",
+            "jsdom": "15.2.0",
+            "loader-utils": "1.1.0",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "node-html-parser": "1.1.11",
+            "opener": "1.4.3",
+            "postcss": "7.0.7",
+            "puppeteer": "1.11.0",
+            "recast": "0.12.7",
+            "source-map": "0.6.1",
+            "ts-loader": "5.4.5",
+            "ts-node": "^8.0.3",
+            "typed-css-modules": "0.3.7",
+            "webpack-hot-middleware": "2.24.3",
+            "workbox-webpack-plugin": "3.6.3",
+            "wrapper-webpack-plugin": "2.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+              "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.1.0",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^4.0.0"
+              }
+            },
+            "connect-history-api-fallback": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+              "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+              "dev": true
+            },
+            "ts-loader": {
+              "version": "5.4.5",
+              "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.4.5.tgz",
+              "integrity": "sha512-XYsjfnRQCBum9AMRZpk2rTYSVpdZBpZK+kDh0TeT3kxmQNBDVIeUjdPjY5RZry4eIAb8XHc4gYSUiUWPYvzSRw==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.3.0",
+                "enhanced-resolve": "^4.0.0",
+                "loader-utils": "^1.0.2",
+                "micromatch": "^3.1.4",
+                "semver": "^5.0.1"
+              }
+            },
+            "ts-node": {
+              "version": "8.5.2",
+              "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.2.tgz",
+              "integrity": "sha512-W1DK/a6BGoV/D4x/SXXm6TSQx6q3blECUzd5TN+j56YEMX3yPVMpHsICLedUw3DvGF3aTQ8hfdR9AKMaHjIi+A==",
+              "dev": true,
+              "requires": {
+                "arg": "^4.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "source-map-support": "^0.5.6",
+                "yn": "^3.0.0"
+              }
+            },
+            "typed-css-modules": {
+              "version": "0.3.7",
+              "resolved": "https://registry.npmjs.org/typed-css-modules/-/typed-css-modules-0.3.7.tgz",
+              "integrity": "sha512-KR1VG/U0rgFWaiQtXKtFMgKaurs80nvlBvZ7BfuYGLldw6kss/97sd+aMG4CI73BbujvefG7DBjnsBqq2Aowcw==",
+              "dev": true,
+              "requires": {
+                "camelcase": "^4.1.0",
+                "chalk": "^2.1.0",
+                "chokidar": "^2.0.3",
+                "css-modules-loader-core": "^1.1.0",
+                "glob": "^7.1.2",
+                "is-there": "^4.4.2",
+                "mkdirp": "^0.5.1",
+                "yargs": "^8.0.2"
+              }
+            }
+          }
+        },
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
           "dev": true
         },
         "globby": {
@@ -373,13 +510,169 @@
             "ignore": "^3.3.5",
             "pify": "^3.0.0",
             "slash": "^1.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
           }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "jsdom": {
+          "version": "15.2.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.0.tgz",
+          "integrity": "sha512-+hRyEfjRPFwTYMmSQ3/f7U9nP8ZNZmbkmUek760ZpxnCPWJIhaaLRuUSvpJ36fZKCGENxLwxClzwpOpnXNfChQ==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.0",
+            "acorn": "^7.1.0",
+            "acorn-globals": "^4.3.2",
+            "array-equal": "^1.0.0",
+            "cssom": "^0.4.1",
+            "cssstyle": "^2.0.0",
+            "data-urls": "^1.1.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.11.1",
+            "html-encoding-sniffer": "^1.0.2",
+            "nwsapi": "^2.1.4",
+            "parse5": "5.1.0",
+            "pn": "^1.1.0",
+            "request": "^2.88.0",
+            "request-promise-native": "^1.0.7",
+            "saxes": "^3.1.9",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^3.0.1",
+            "w3c-hr-time": "^1.0.1",
+            "w3c-xmlserializer": "^1.1.2",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^7.0.0",
+            "ws": "^7.0.0",
+            "xml-name-validator": "^3.0.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+              "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+              "dev": true
+            }
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
           "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
           "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
           "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.5.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
         },
         "strip-ansi": {
           "version": "3.0.1",
@@ -388,6 +681,21 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^2.0.0"
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^2.0.0"
           }
         },
         "ts-node": {
@@ -404,13 +712,57 @@
             "mkdirp": "^0.5.1",
             "source-map-support": "^0.5.6",
             "yn": "^2.0.0"
+          },
+          "dependencies": {
+            "diff": {
+              "version": "3.5.0",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+              "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+              "dev": true
+            },
+            "yn": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+              "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+              "dev": true
+            }
           }
         },
-        "yn": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
           "dev": true
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
         }
       }
     },
@@ -462,6 +814,28 @@
         "webpack-mild-compile": "3.3.1"
       },
       "dependencies": {
+        "@dojo/framework": {
+          "version": "7.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.3.tgz",
+          "integrity": "sha512-NbagpENJR0sArFopGUFXF/iqyVM8q8y2QXEzTTIz8Z1IG8taOYntqehITB0fcdt7K7jV0YzC6ScoG1LC1hS5lw==",
+          "dev": true,
+          "requires": {
+            "@types/cldrjs": "0.4.20",
+            "@types/globalize": "0.0.34",
+            "@webcomponents/webcomponentsjs": "1.1.0",
+            "cldrjs": "0.5.0",
+            "cross-fetch": "3.0.2",
+            "css-select-umd": "1.3.0-rc0",
+            "diff": "3.5.0",
+            "globalize": "1.4.0",
+            "immutable": "3.8.2",
+            "intersection-observer": "0.4.2",
+            "pepjs": "0.4.2",
+            "resize-observer-polyfill": "1.5.0",
+            "tslib": "1.9.3",
+            "web-animations-js": "2.3.1"
+          }
+        },
         "file-loader": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
@@ -553,6 +927,28 @@
         "typescript": "~3.4.5"
       },
       "dependencies": {
+        "@dojo/framework": {
+          "version": "7.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.3.tgz",
+          "integrity": "sha512-NbagpENJR0sArFopGUFXF/iqyVM8q8y2QXEzTTIz8Z1IG8taOYntqehITB0fcdt7K7jV0YzC6ScoG1LC1hS5lw==",
+          "dev": true,
+          "requires": {
+            "@types/cldrjs": "0.4.20",
+            "@types/globalize": "0.0.34",
+            "@webcomponents/webcomponentsjs": "1.1.0",
+            "cldrjs": "0.5.0",
+            "cross-fetch": "3.0.2",
+            "css-select-umd": "1.3.0-rc0",
+            "diff": "3.5.0",
+            "globalize": "1.4.0",
+            "immutable": "3.8.2",
+            "intersection-observer": "0.4.2",
+            "pepjs": "0.4.2",
+            "resize-observer-polyfill": "1.5.0",
+            "tslib": "1.9.3",
+            "web-animations-js": "2.3.1"
+          }
+        },
         "abab": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -739,9 +1135,9 @@
       }
     },
     "@dojo/framework": {
-      "version": "7.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.3.tgz",
-      "integrity": "sha512-NbagpENJR0sArFopGUFXF/iqyVM8q8y2QXEzTTIz8Z1IG8taOYntqehITB0fcdt7K7jV0YzC6ScoG1LC1hS5lw==",
+      "version": "7.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.4.tgz",
+      "integrity": "sha512-CmciKG2sWhW5+jDo5WQF/2np4jouwDfelf/U3SLMzQ9L9lG+eQPDjDPfFFVgN2N+5OxoczP3dDoEb9CDrB5HHQ==",
       "dev": true,
       "requires": {
         "@types/cldrjs": "0.4.20",
@@ -6858,15 +7254,6 @@
         "debug": "^3.0.0"
       }
     },
-    "for-each": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.3.tgz",
-      "integrity": "sha512-jqYfLp7mo9vIyQf8ykW2v7A+2N4QjeCeI5+Dz9XraiO1ign81wjiH7Fb9vSOWvQfNtmSa4H2RoQTrrXivdUZmw==",
-      "dev": true,
-      "requires": {
-        "is-callable": "^1.1.3"
-      }
-    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",
@@ -12061,14 +12448,10 @@
       }
     },
     "parse-headers": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.2.tgz",
-      "integrity": "sha512-/LypJhzFmyBIDYP9aDVgeyEb5sQfbfY5mnDq4hVhlQ69js87wXfmEI5V3xI6vvXasqebp0oCytYFLxsBVfCzSg==",
-      "dev": true,
-      "requires": {
-        "for-each": "^0.3.3",
-        "string.prototype.trim": "^1.1.2"
-      }
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/parse-headers/-/parse-headers-2.0.3.tgz",
+      "integrity": "sha512-QhhZ+DCCit2Coi2vmAKbq5RGTRcQUOE2+REgv8vdyu7MnYx2eZztegqtTx99TZ86GTIwqiy3+4nQTWZ2tgmdCA==",
+      "dev": true
     },
     "parse-json": {
       "version": "4.0.0",
@@ -15715,17 +16098,6 @@
         "function-bind": "^1.0.2"
       }
     },
-    "string.prototype.trim": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trim/-/string.prototype.trim-1.2.0.tgz",
-      "integrity": "sha512-9EIjYD/WdlvLpn987+ctkLf0FfvBefOCuiEr2henD8X+7jfwPnyvTdmW8OJhj5p+M0/96mBdynLWkxUr+rHlpg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.13.0",
-        "function-bind": "^1.1.1"
-      }
-    },
     "string.prototype.trimleft": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.0.tgz",
@@ -15957,17 +16329,17 @@
           }
         },
         "autoprefixer": {
-          "version": "9.7.1",
-          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.1.tgz",
-          "integrity": "sha512-w3b5y1PXWlhYulevrTJ0lizkQ5CyqfeU6BIRDbuhsMupstHQOeb1Ur80tcB1zxSu7AwyY/qCQ7Vvqklh31ZBFw==",
+          "version": "9.7.2",
+          "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.2.tgz",
+          "integrity": "sha512-LCAfcdej1182uVvPOZnytbq61AhnOZ/4JelDaJGDeNwewyU1AMaNthcHsyz1NRjTmd2FkurMckLWfkHg3Z//KA==",
           "dev": true,
           "requires": {
-            "browserslist": "^4.7.2",
-            "caniuse-lite": "^1.0.30001006",
+            "browserslist": "^4.7.3",
+            "caniuse-lite": "^1.0.30001010",
             "chalk": "^2.4.2",
             "normalize-range": "^0.1.2",
             "num2fraction": "^1.2.2",
-            "postcss": "^7.0.21",
+            "postcss": "^7.0.23",
             "postcss-value-parser": "^4.0.2"
           },
           "dependencies": {
@@ -15982,12 +16354,45 @@
                 "supports-color": "^5.3.0"
               }
             },
+            "postcss": {
+              "version": "7.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
+              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.2",
+                "source-map": "^0.6.1",
+                "supports-color": "^6.1.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "6.1.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                  "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
             "postcss-value-parser": {
               "version": "4.0.2",
               "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
               "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
               "dev": true
             }
+          }
+        },
+        "browserslist": {
+          "version": "4.7.3",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.3.tgz",
+          "integrity": "sha512-jWvmhqYpx+9EZm/FxcZSbUZyDEvDTLDi3nSAKbzEkyWvtI0mNSmUosey+5awDW1RUlrgXbQb5A6qY1xQH9U6MQ==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001010",
+            "electron-to-chromium": "^1.3.306",
+            "node-releases": "^1.1.40"
           }
         },
         "camelcase-keys": {
@@ -16002,9 +16407,15 @@
           }
         },
         "caniuse-lite": {
+<<<<<<< HEAD
           "version": "1.0.30001009",
           "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001009.tgz",
           "integrity": "sha512-M3rEqHN6SaVjgo4bIik7HsGcWXsi+lI9WA0p51RPMFx5gXfduyOXWJrc0R4xBkSK1pgNf4CNgy5M+6H+WiEP8g==",
+=======
+          "version": "1.0.30001011",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001011.tgz",
+          "integrity": "sha512-h+Eqyn/YA6o6ZTqpS86PyRmNWOs1r54EBDcd2NTwwfsXQ8re1B38SnB+p2RKF8OUsyEIjeDU8XGec1RGO/wYCg==",
+>>>>>>> bump dojo versions
           "dev": true
         },
         "debug": {
@@ -16107,6 +16518,15 @@
             "yargs-parser": "^10.0.0"
           }
         },
+        "node-releases": {
+          "version": "1.1.40",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.40.tgz",
+          "integrity": "sha512-r4LPcC5b/bS8BdtWH1fbeK88ib/wg9aqmg6/s3ngNLn2Ewkn/8J6Iw3P9RTlfIAdSdvYvQl2thCY5Y+qTAQ2iQ==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.3.0"
+          }
+        },
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
@@ -16154,6 +16574,12 @@
             "indent-string": "^3.0.0",
             "strip-indent": "^2.0.0"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         },
         "slash": {
           "version": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -44,14 +44,14 @@
     }
   },
   "peerDependencies": {
-    "@dojo/framework": "7.0.0-alpha.3"
+    "@dojo/framework": "7.0.0-alpha.4"
   },
   "devDependencies": {
     "@dojo/cli": "7.0.0-alpha.1",
-    "@dojo/cli-build-app": "7.0.0-alpha.2",
+    "@dojo/cli-build-app": "7.0.0-alpha.4",
     "@dojo/cli-build-widget": "7.0.0-alpha.2",
     "@dojo/cli-test-intern": "7.0.0-alpha.3",
-    "@dojo/framework": "7.0.0-alpha.3",
+    "@dojo/framework": "7.0.0-alpha.4",
     "@dojo/loader": "^2.0.0",
     "@dojo/scripts": "^4.0.2",
     "@dojo/themes": "^6.0.0",

--- a/package.json
+++ b/package.json
@@ -88,7 +88,6 @@
     "unified": "8.4.1"
   },
   "dependencies": {
-    "ts-loader": "^6.2.1",
     "tslib": "~1.9.1"
   },
   "lint-staged": {

--- a/package.json
+++ b/package.json
@@ -88,6 +88,7 @@
     "unified": "8.4.1"
   },
   "dependencies": {
+    "ts-loader": "^6.2.1",
     "tslib": "~1.9.1"
   },
   "lint-staged": {

--- a/src/examples/intern.json
+++ b/src/examples/intern.json
@@ -1,0 +1,6 @@
+{
+  "suites": [
+	  "./bootstrap.js",
+	  "./main.js"
+  ]
+}

--- a/src/examples/intern.json
+++ b/src/examples/intern.json
@@ -1,6 +1,6 @@
 {
-  "suites": [
-	  "./bootstrap.js",
-	  "./main.js"
-  ]
+	"basePath": "..",
+	"suites": [
+		"./main.js"
+	]
 }

--- a/src/examples/package.json
+++ b/src/examples/package.json
@@ -13,8 +13,8 @@
   },
   "dependencies": {
     "@dojo/cli": "7.0.0-alpha.1",
-    "@dojo/cli-build-app": "7.0.0-alpha.2",
-    "@dojo/framework": "7.0.0-alpha.3",
+    "@dojo/cli-build-app": "7.0.0-alpha.4",
+    "@dojo/framework": "7.0.0-alpha.4",
     "@dojo/themes": "^6.0.0",
     "@dojo/widgets": "^6.0.0",
     "@types/jsdom": "2.0.*",

--- a/src/examples/src/App.tsx
+++ b/src/examples/src/App.tsx
@@ -54,8 +54,9 @@ export default factory(function App({ properties, middleware: { block } }) {
 			<main classes={[css.main]}>
 				<Outlet
 					id="example"
-					renderer={({ params }) => {
+					renderer={({ params, queryParams }) => {
 						const { widget: widgetName, example: exampleName } = params;
+						const active = queryParams.active ? queryParams.active : 'example';
 						const widgetConfig = configs[widgetName];
 						const { overview, examples = [] } = widgetConfig;
 						const isBasic = exampleName === 'basic';
@@ -80,7 +81,11 @@ export default factory(function App({ properties, middleware: { block } }) {
 								<div classes={[css.content]}>
 									{isBasic && includeDocs && <div innerHTML={readmeContent} />}
 									<h1>{isBasic ? 'Basic Usage' : example.title}</h1>
-									<Example widgetName={widgetName} content={content}>
+									<Example
+										widgetName={widgetName}
+										content={content}
+										active={active}
+									>
 										<example.module />
 									</Example>
 									{includeDocs && (

--- a/src/examples/src/App.tsx
+++ b/src/examples/src/App.tsx
@@ -80,7 +80,7 @@ export default factory(function App({ properties, middleware: { block } }) {
 								<div classes={[css.content]}>
 									{isBasic && includeDocs && <div innerHTML={readmeContent} />}
 									<h1>{isBasic ? 'Basic Usage' : example.title}</h1>
-									<Example content={content}>
+									<Example widgetName={widgetName} content={content}>
 										<example.module />
 									</Example>
 									{includeDocs && (

--- a/src/examples/src/Example.m.css
+++ b/src/examples/src/Example.m.css
@@ -3,3 +3,9 @@
 	overflow-x: hidden;
 	overflow-y: scroll;
 }
+
+.iframe {
+	width: 100%;
+	height: 95%;
+	border: none;
+}

--- a/src/examples/src/Example.m.css.d.ts
+++ b/src/examples/src/Example.m.css.d.ts
@@ -1,1 +1,2 @@
 export const tab: string;
+export const iframe: string;

--- a/src/examples/src/Example.tsx
+++ b/src/examples/src/Example.tsx
@@ -1,4 +1,5 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
+import has from '@dojo/framework/core/has';
 import icache from '@dojo/framework/core/middleware/icache';
 import TabController from '@dojo/widgets/tab-controller';
 import Tab from '@dojo/widgets/tab';
@@ -7,13 +8,14 @@ import * as css from './Example.m.css';
 
 interface ExampleProperties {
 	content?: string;
+	widgetName: string;
 }
 
 const factory = create({ icache }).properties<ExampleProperties>();
 
 export default factory(function Example({ children, properties, middleware: { icache } }) {
 	const activeIndex = icache.getOrSet('active', 0);
-	const { content } = properties();
+	const { content, widgetName } = properties();
 	const tabs = [
 		<Tab key="example" label="Example">
 			<div classes={css.tab}>{children()}</div>
@@ -26,6 +28,21 @@ export default factory(function Example({ children, properties, middleware: { ic
 					<pre classes={['language-ts']}>
 						<code classes={['language-ts']} innerHTML={content} />
 					</pre>
+				</div>
+			</Tab>
+		);
+	}
+	if (has('dojo-debug')) {
+		const testIndex = has('docs') ? 2 : 1;
+		tabs.push(
+			<Tab key="tests" label="Tests">
+				<div classes={css.tab}>
+					{icache.get('active') === testIndex && (
+						<iframe
+							classes={css.iframe}
+							src={`./intern?config=intern.json&widget=${widgetName}`}
+						/>
+					)}
 				</div>
 			</Tab>
 		);

--- a/src/examples/src/Example.tsx
+++ b/src/examples/src/Example.tsx
@@ -50,7 +50,7 @@ export default factory(function Example({ children, properties, middleware: { in
 					{activeTab === tabNames.indexOf('tests') && (
 						<iframe
 							classes={css.iframe}
-							src={`./intern?config=intern.json&widget=${widgetName}`}
+							src={`./intern?config=intern/intern.json&widget=${widgetName}`}
 						/>
 					)}
 				</div>

--- a/src/examples/src/Example.tsx
+++ b/src/examples/src/Example.tsx
@@ -23,7 +23,7 @@ export default factory(function Example({ children, properties, middleware: { in
 	if (content) {
 		tabNames.push('code');
 	}
-	if (has('dojo-debug')) {
+	if (!has('docs')) {
 		tabNames.push('tests');
 	}
 	const activeTab = tabNames.indexOf(active) === -1 ? 0 : tabNames.indexOf(active);
@@ -43,7 +43,7 @@ export default factory(function Example({ children, properties, middleware: { in
 			</Tab>
 		);
 	}
-	if (has('dojo-debug')) {
+	if (!has('docs')) {
 		tabs.push(
 			<Tab key="tests" label="Tests">
 				<div classes={css.tab}>

--- a/src/examples/src/Example.tsx
+++ b/src/examples/src/Example.tsx
@@ -13,13 +13,13 @@ interface ExampleProperties {
 	active: string;
 }
 
-const tabNames = ['example'];
-
 const factory = create({ injector }).properties<ExampleProperties>();
 
 export default factory(function Example({ children, properties, middleware: { injector } }) {
 	const router = injector.get<Router>('router');
 	const { content, widgetName, active } = properties();
+	const tabNames = ['example'];
+
 	if (content) {
 		tabNames.push('code');
 	}

--- a/src/examples/src/Example.tsx
+++ b/src/examples/src/Example.tsx
@@ -50,7 +50,7 @@ export default factory(function Example({ children, properties, middleware: { in
 					{activeTab === tabNames.indexOf('tests') && (
 						<iframe
 							classes={css.iframe}
-							src={`./intern.html?config=intern.json&widget=${widgetName}`}
+							src={`./intern?config=intern.json&widget=${widgetName}`}
 						/>
 					)}
 				</div>

--- a/src/examples/src/Landing.tsx
+++ b/src/examples/src/Landing.tsx
@@ -53,7 +53,11 @@ export default factory(function Landing({ properties, middleware: { icache } }) 
 							return (
 								<div key={widget} classes={css.card}>
 									<LinkedCard
-										params={{ widget: widget, example: 'basic' }}
+										params={{
+											widget: widget,
+											example: 'basic',
+											active: 'example'
+										}}
 										outlet="example"
 									>
 										<h4 classes={css.title}>{formatWidgetName(widget)}</h4>

--- a/src/examples/src/Menu.tsx
+++ b/src/examples/src/Menu.tsx
@@ -26,7 +26,7 @@ export default factory(function Menu({ properties }) {
 							<ActiveLink
 								to="example"
 								classes={css.link}
-								params={{ widget, example: 'basic' }}
+								params={{ widget, example: 'basic', active: 'example' }}
 								matchParams={{ widget }}
 								activeClasses={[css.selected]}
 							>

--- a/src/examples/src/main.tsx
+++ b/src/examples/src/main.tsx
@@ -1,3 +1,4 @@
+import global from '@dojo/framework/shim/global';
 import has from '@dojo/framework/core/has';
 import renderer, { tsx } from '@dojo/framework/core/vdom';
 import Registry from '@dojo/framework/core/Registry';
@@ -9,12 +10,24 @@ import '@dojo/themes/dojo/index.css';
 import routes from './routes';
 import App from './App';
 
-const includeDocs = Boolean(
-	has('docs') === 'false' ? false : has('docs') === 'true' ? true : has('docs')
-);
-const registry = new Registry();
-registerThemeInjector(dojo, registry);
-registerRouterInjector(routes, registry);
+if (global.intern) {
+	const tests = (require as any).context('./', true, /\.spec\.ts(x)?$/);
+	const url = new URL(window.location.href);
+	const params = url.searchParams;
+	const widget = params.get('widget');
+	tests.keys().forEach((id: string) => {
+		if (widget && id.indexOf(widget) !== -1) {
+			tests(id);
+		}
+	});
+} else {
+	const includeDocs = Boolean(
+		has('docs') === 'false' ? false : has('docs') === 'true' ? true : has('docs')
+	);
+	const registry = new Registry();
+	registerThemeInjector(dojo, registry);
+	registerRouterInjector(routes, registry);
 
-const r = renderer(() => <App includeDocs={includeDocs} />);
-r.mount({ registry, domNode: document.getElementById('app')! });
+	const r = renderer(() => <App includeDocs={includeDocs} />);
+	r.mount({ registry, domNode: document.getElementById('app')! });
+}

--- a/src/examples/src/main.tsx
+++ b/src/examples/src/main.tsx
@@ -11,7 +11,7 @@ import routes from './routes';
 import App from './App';
 
 if (global.intern) {
-	const tests = (require as any).context('./', true, /\.spec\.ts(x)?$/);
+	const tests = (require as any).context('../../', true, /\.spec\.ts(x)?$/);
 	const url = new URL(window.location.href);
 	const params = url.searchParams;
 	const widget = params.get('widget');

--- a/src/examples/src/main.tsx
+++ b/src/examples/src/main.tsx
@@ -7,20 +7,13 @@ import { registerRouterInjector } from '@dojo/framework/routing/RouterInjector';
 import dojo from '@dojo/themes/dojo';
 import '@dojo/themes/dojo/index.css';
 
+`!has('dojo-debug')`;
+import './tests';
+
 import routes from './routes';
 import App from './App';
 
-if (global.intern) {
-	const tests = (require as any).context('../../', true, /\.spec\.ts(x)?$/);
-	const url = new URL(window.location.href);
-	const params = url.searchParams;
-	const widget = params.get('widget');
-	tests.keys().forEach((id: string) => {
-		if (widget && id.indexOf(widget) !== -1) {
-			tests(id);
-		}
-	});
-} else {
+if (!global.intern) {
 	const includeDocs = Boolean(
 		has('docs') === 'false' ? false : has('docs') === 'true' ? true : has('docs')
 	);

--- a/src/examples/src/main.tsx
+++ b/src/examples/src/main.tsx
@@ -7,7 +7,7 @@ import { registerRouterInjector } from '@dojo/framework/routing/RouterInjector';
 import dojo from '@dojo/themes/dojo';
 import '@dojo/themes/dojo/index.css';
 
-`!has('dojo-debug')`;
+`!has('docs')`;
 import './tests';
 
 import routes from './routes';

--- a/src/examples/src/routes.tsx
+++ b/src/examples/src/routes.tsx
@@ -9,7 +9,7 @@ export default [
 		outlet: 'basic',
 		children: [
 			{
-				path: '{example}',
+				path: '{example}?{active}',
 				outlet: 'example'
 			}
 		]

--- a/src/examples/src/tests.tsx
+++ b/src/examples/src/tests.tsx
@@ -1,0 +1,9 @@
+const tests = (require as any).context('../../', true, /\.spec\.ts(x)?$/);
+const url = new URL(window.location.href);
+const params = url.searchParams;
+const widget = params.get('widget');
+tests.keys().forEach((id: string) => {
+	if (widget && id.indexOf(widget) !== -1) {
+		tests(id);
+	}
+});

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,1 +1,15 @@
-import './examples/src/main';
+import global from '@dojo/framework/shim/global';
+
+if (!global.intern) {
+	import('./examples/src/main');
+} else {
+	const tests = (require as any).context('./', true, /\.spec\.ts(x)?$/);
+	const url = new URL(window.location.href);
+	const params = url.searchParams;
+	const widget = params.get('widget');
+	tests.keys().forEach((id: string) => {
+		if (widget && id.indexOf(widget) !== -1) {
+			tests(id);
+		}
+	});
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,15 +1,1 @@
-import global from '@dojo/framework/shim/global';
-
-if (!global.intern) {
-	import('./examples/src/main');
-} else {
-	const tests = (require as any).context('./', true, /\.spec\.ts(x)?$/);
-	const url = new URL(window.location.href);
-	const params = url.searchParams;
-	const widget = params.get('widget');
-	tests.keys().forEach((id: string) => {
-		if (widget && id.indexOf(widget) !== -1) {
-			tests(id);
-		}
-	});
-}
+import('./examples/src/main');

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -1,1 +1,1 @@
-import('./examples/src/main');
+import './examples/src/main';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**
Adds support for running tests in browser as part of the example runner. An extra Tests tab is added to each widget example, which runs it's own suite. This means you can dev and test in the example runner with a single command.

Needs some updates from webpack-contrib/cli-build-app
