### PR TITLE
Add iconWrapper element/class to chip

### DIFF
--- a/src/chip/index.tsx
+++ b/src/chip/index.tsx
@@ -63,12 +63,12 @@ export default factory(function Chip({ properties, middleware: { theme } }) {
 				}
 			}}
 		>
-			{iconRenderer && iconRenderer(checked)}
+			{iconRenderer && <span classes={themedCss.iconWrapper}>{iconRenderer(checked)}</span>}
 			<span classes={themedCss.label}>{label}</span>
 			{onClose && (
 				<span
 					key="closeButton"
-					classes={themedCss.closeIcon}
+					classes={themedCss.closeIconWrapper}
 					tabIndex={0}
 					role="button"
 					onclick={(event) => {

--- a/src/chip/tests/Chip.spec.tsx
+++ b/src/chip/tests/Chip.spec.tsx
@@ -38,7 +38,13 @@ describe('Chip', () => {
 			<Chip label={label} iconRenderer={() => <Icon type="plusIcon" />} />
 		));
 
-		h.expect(template.prepend(':root', () => [<Icon type="plusIcon" />]));
+		h.expect(
+			template.prepend(':root', () => [
+				<span classes={css.iconWrapper}>
+					<Icon type="plusIcon" />
+				</span>
+			])
+		);
 	});
 
 	it('should pass checked property to iconRenderer', () => {
@@ -46,11 +52,17 @@ describe('Chip', () => {
 			<Chip
 				label={label}
 				checked={true}
-				iconRenderer={(checked) => <div>{String(checked)}</div>}
+				iconRenderer={(checked) => <span>{String(checked)}</span>}
 			/>
 		));
 
-		h.expect(template.prepend(':root', () => [<div>true</div>]));
+		h.expect(
+			template.prepend(':root', () => [
+				<span classes={css.iconWrapper}>
+					<span>true</span>
+				</span>
+			])
+		);
 	});
 
 	it('should render with a close icon when onClose is provided', () => {
@@ -59,7 +71,7 @@ describe('Chip', () => {
 			template.append(':root', () => [
 				<span
 					key="closeButton"
-					classes={css.closeIcon}
+					classes={css.closeIconWrapper}
 					tabIndex={0}
 					role="button"
 					onclick={noop}
@@ -79,7 +91,7 @@ describe('Chip', () => {
 			template.append(':root', () => [
 				<span
 					key="closeButton"
-					classes={css.closeIcon}
+					classes={css.closeIconWrapper}
 					tabIndex={0}
 					role="button"
 					onclick={noop}
@@ -92,7 +104,7 @@ describe('Chip', () => {
 	});
 
 	it('should not use a closeIconRenderer if provided without a callback', () => {
-		const h = harness(() => <Chip label={label} closeRenderer={() => <div>Close</div>} />);
+		const h = harness(() => <Chip label={label} closeRenderer={() => <span>Close</span>} />);
 
 		h.expect(template);
 	});
@@ -107,7 +119,7 @@ describe('Chip', () => {
 				.append(':root', () => [
 					<span
 						key="closeButton"
-						classes={css.closeIcon}
+						classes={css.closeIconWrapper}
 						tabIndex={0}
 						role="button"
 						onclick={noop}
@@ -116,7 +128,11 @@ describe('Chip', () => {
 						<Icon type="closeIcon" />
 					</span>
 				])
-				.prepend(':root', () => [<Icon type="plusIcon" />])
+				.prepend(':root', () => [
+					<span classes={css.iconWrapper}>
+						<Icon type="plusIcon" />
+					</span>
+				])
 		);
 	});
 
@@ -157,7 +173,7 @@ describe('Chip', () => {
 				.append(':root', () => [
 					<span
 						key="closeButton"
-						classes={css.closeIcon}
+						classes={css.closeIconWrapper}
 						tabIndex={0}
 						role="button"
 						onclick={noop}
@@ -166,7 +182,11 @@ describe('Chip', () => {
 						<Icon type="closeIcon" />
 					</span>
 				])
-				.prepend(':root', () => [<Icon type="plusIcon" />])
+				.prepend(':root', () => [
+					<span classes={css.iconWrapper}>
+						<Icon type="plusIcon" />
+					</span>
+				])
 		);
 
 		const event = {
@@ -205,7 +225,7 @@ describe('Chip', () => {
 				.append(':root', () => [
 					<span
 						key="closeButton"
-						classes={css.closeIcon}
+						classes={css.closeIconWrapper}
 						tabIndex={0}
 						role="button"
 						onclick={noop}
@@ -214,7 +234,11 @@ describe('Chip', () => {
 						<Icon type="closeIcon" />
 					</span>
 				])
-				.prepend(':root', () => [<Icon type="plusIcon" />])
+				.prepend(':root', () => [
+					<span classes={css.iconWrapper}>
+						<Icon type="plusIcon" />
+					</span>
+				])
 		);
 
 		[Keys.Enter, Keys.Space, Keys.Left].forEach((which) => {

--- a/src/theme/chip.m.css
+++ b/src/theme/chip.m.css
@@ -1,8 +1,10 @@
 .root {}
 
+.iconWrapper {}
+
 .label {}
 
-.closeIcon {
+.closeIconWrapper {
 	cursor: pointer;
 }
 

--- a/src/theme/chip.m.css.d.ts
+++ b/src/theme/chip.m.css.d.ts
@@ -1,5 +1,6 @@
 export const root: string;
+export const iconWrapper: string;
 export const label: string;
-export const closeIcon: string;
+export const closeIconWrapper: string;
 export const clickable: string;
 export const disabled: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds an additional icon wrapper element and class to enable a proper material theme to be created for the chip. Also changes `closeIcon` to `closeIconWrapper` to be more accurate and consistent.
