### PR TITLE
Add theme prefix and fix classes clash

### DIFF
--- a/src/middleware/tests/theme.spec.tsx
+++ b/src/middleware/tests/theme.spec.tsx
@@ -200,9 +200,6 @@ registerSuite('theme-middleware', {
 			const baseCss = { ' _key': 'base', root: 'base-root', input: 'base-input' };
 			const variantCss = { ' _key': 'variant', prefixRoot: 'variant-root' };
 			const theme = {
-				base: {
-					root: 'base-theme-root'
-				},
 				variant: {
 					prefixInput: 'variant-theme-input'
 				}
@@ -218,7 +215,7 @@ registerSuite('theme-middleware', {
 
 			h.expect(
 				baseTemplate.setChildren('@root', () => [
-					JSON.stringify({ root: 'variant-theme-root', input: 'base-input' })
+					JSON.stringify({ root: 'base-root', input: 'variant-theme-input' })
 				])
 			);
 		}

--- a/src/middleware/tests/theme.spec.tsx
+++ b/src/middleware/tests/theme.spec.tsx
@@ -218,6 +218,37 @@ registerSuite('theme-middleware', {
 					JSON.stringify({ root: 'base-root', input: 'variant-theme-input' })
 				])
 			);
+		},
+
+		'Resolves prefixed theme classes correctly when used with `classes` property and composes classes'() {
+			const baseCss = {
+				' _key': 'base',
+				root: 'base-root',
+				input: 'base-input composed-input'
+			};
+			const variantCss = { ' _key': 'variant', prefixRoot: 'variant-root' };
+			const theme = {
+				variant: {
+					prefixInput: 'variant-theme-input composed-input'
+				}
+			};
+			const h = harness(() => (
+				<PrefixTestWidget
+					baseCss={baseCss}
+					variantCss={variantCss}
+					theme={theme}
+					classes={{ variant: { prefixRoot: ['variant-classes-prefix-root'] } }}
+				/>
+			));
+
+			h.expect(
+				baseTemplate.setChildren('@root', () => [
+					JSON.stringify({
+						root: 'base-root',
+						input: 'variant-theme-input composed-input'
+					})
+				])
+			);
 		}
 	}
 });

--- a/src/middleware/tests/theme.spec.tsx
+++ b/src/middleware/tests/theme.spec.tsx
@@ -194,6 +194,33 @@ registerSuite('theme-middleware', {
 					JSON.stringify({ root: 'variant-theme-root', input: 'base-input' })
 				])
 			);
+		},
+
+		'Resolves prefixed theme classes correctly when used with `classes` property'() {
+			const baseCss = { ' _key': 'base', root: 'base-root', input: 'base-input' };
+			const variantCss = { ' _key': 'variant', prefixRoot: 'variant-root' };
+			const theme = {
+				base: {
+					root: 'base-theme-root'
+				},
+				variant: {
+					prefixInput: 'variant-theme-input'
+				}
+			};
+			const h = harness(() => (
+				<PrefixTestWidget
+					baseCss={baseCss}
+					variantCss={variantCss}
+					theme={theme}
+					classes={{ variant: { prefixRoot: ['variant-classes-prefix-root'] } }}
+				/>
+			));
+
+			h.expect(
+				baseTemplate.setChildren('@root', () => [
+					JSON.stringify({ root: 'variant-theme-root', input: 'base-input' })
+				])
+			);
 		}
 	}
 });

--- a/src/middleware/tests/theme.spec.tsx
+++ b/src/middleware/tests/theme.spec.tsx
@@ -163,13 +163,19 @@ registerSuite('theme-middleware', {
 					baseCss={baseCss}
 					variantCss={variantCss}
 					theme={theme}
-					classes={{ variant: { a: ['variant-classes-a'] } }}
+					classes={{
+						variant: { a: ['variant-classes-a'] },
+						base: { a: ['base-classes-a'] }
+					}}
 				/>
 			));
 
 			h.expect(
 				baseTemplate.setChildren('@root', () => [
-					JSON.stringify({ a: 'base-theme-a', b: 'variant-theme-b' })
+					JSON.stringify({
+						a: 'base-theme-a base-classes-a variant-classes-a',
+						b: 'variant-theme-b'
+					})
 				])
 			);
 		},
@@ -215,7 +221,10 @@ registerSuite('theme-middleware', {
 
 			h.expect(
 				baseTemplate.setChildren('@root', () => [
-					JSON.stringify({ root: 'base-root', input: 'variant-theme-input' })
+					JSON.stringify({
+						root: 'base-root variant-classes-prefix-root',
+						input: 'variant-theme-input'
+					})
 				])
 			);
 		},
@@ -237,14 +246,17 @@ registerSuite('theme-middleware', {
 					baseCss={baseCss}
 					variantCss={variantCss}
 					theme={theme}
-					classes={{ variant: { prefixRoot: ['variant-classes-prefix-root'] } }}
+					classes={{
+						base: { root: ['base-classes-prefix-root'] },
+						variant: { prefixRoot: ['variant-classes-prefix-root'] }
+					}}
 				/>
 			));
 
 			h.expect(
 				baseTemplate.setChildren('@root', () => [
 					JSON.stringify({
-						root: 'base-root',
+						root: 'base-root base-classes-prefix-root variant-classes-prefix-root',
 						input: 'variant-theme-input composed-input'
 					})
 				])

--- a/src/middleware/tests/theme.spec.tsx
+++ b/src/middleware/tests/theme.spec.tsx
@@ -26,6 +26,21 @@ const TestWidget = factory(function TestWidget({ properties, middleware: { theme
 	);
 });
 
+const PrefixTestWidget = factory(function TestWidget({ properties, middleware: { theme } }) {
+	const { baseCss, variantCss } = properties();
+	return (
+		<div key="root">
+			{JSON.stringify(
+				theme.compose(
+					baseCss,
+					variantCss,
+					'prefix'
+				)
+			)}
+		</div>
+	);
+});
+
 const baseTemplate = assertionTemplate(() => <div key="root" />);
 
 registerSuite('theme-middleware', {
@@ -101,6 +116,55 @@ registerSuite('theme-middleware', {
 			h.expect(
 				baseTemplate.setChildren('@root', () => [
 					JSON.stringify({ a: 'base-theme-a', b: 'variant-theme-b' })
+				])
+			);
+		},
+
+		'Resolves theme classes correctly when used with `classes` property'() {
+			const baseCss = { ' _key': 'base', a: 'base-a', b: 'base-b' };
+			const variantCss = { ' _key': 'variant', a: 'variant-a', b: 'variant-b' };
+			const theme = {
+				base: {
+					a: 'base-theme-a'
+				},
+				variant: {
+					b: 'variant-theme-b'
+				}
+			};
+			const h = harness(() => (
+				<TestWidget
+					baseCss={baseCss}
+					variantCss={variantCss}
+					theme={theme}
+					classes={{ variant: { a: ['variant-classes-a'] } }}
+				/>
+			));
+
+			h.expect(
+				baseTemplate.setChildren('@root', () => [
+					JSON.stringify({ a: 'base-theme-a', b: 'variant-theme-b' })
+				])
+			);
+		},
+
+		'Can be used with a prefix to pick out theme classes for a child widget'() {
+			const baseCss = { ' _key': 'base', root: 'base-root', input: 'base-input' };
+			const variantCss = { ' _key': 'variant', prefixRoot: 'variant-root' };
+			const theme = {
+				base: {
+					root: 'base-theme-root'
+				},
+				variant: {
+					prefixRoot: 'variant-theme-root'
+				}
+			};
+			const h = harness(() => (
+				<PrefixTestWidget baseCss={baseCss} variantCss={variantCss} theme={theme} />
+			));
+
+			h.expect(
+				baseTemplate.setChildren('@root', () => [
+					JSON.stringify({ root: 'variant-theme-root', input: 'base-input' })
 				])
 			);
 		}

--- a/src/middleware/tests/theme.spec.tsx
+++ b/src/middleware/tests/theme.spec.tsx
@@ -120,6 +120,33 @@ registerSuite('theme-middleware', {
 			);
 		},
 
+		'Resolves themes correctly when using composes resulting in space-separated classnames'() {
+			const baseCss = { ' _key': 'base', a: 'base-a', b: 'base-b' };
+			const variantCss = {
+				' _key': 'variant',
+				a: 'variant-a composed-variant-a',
+				b: 'variant-b'
+			};
+			const theme = {
+				base: {
+					a: 'base-theme-a'
+				},
+				variant: {
+					// composed-variant-a in both themed / unthemed classnames
+					a: 'variant-theme-a composed-variant-a'
+				}
+			};
+			const h = harness(() => (
+				<TestWidget baseCss={baseCss} variantCss={variantCss} theme={theme} />
+			));
+
+			h.expect(
+				baseTemplate.setChildren('@root', () => [
+					JSON.stringify({ a: 'variant-theme-a composed-variant-a', b: 'base-b' })
+				])
+			);
+		},
+
 		'Resolves theme classes correctly when used with `classes` property'() {
 			const baseCss = { ' _key': 'base', a: 'base-a', b: 'base-b' };
 			const variantCss = { ' _key': 'variant', a: 'variant-a', b: 'variant-b' };

--- a/src/middleware/theme.ts
+++ b/src/middleware/theme.ts
@@ -6,12 +6,41 @@ const factory = create({ coreTheme });
 
 const theme = factory(function({ middleware: { coreTheme } }) {
 	return {
-		compose(baseCss: ClassNames, variantCss: ClassNames) {
-			const allVariantThemeClasses: ClassNames = coreTheme.classes(variantCss);
+		compose(baseCss: ClassNames, variantCss: ClassNames, prefix?: string) {
+			let allVariantThemeClasses: ClassNames = coreTheme.classes(variantCss);
 			const sanitizedVariantThemeClasses: ClassNames = {};
+			const prefixClassNameMap: { [key: string]: string } = {};
+
+			if (prefix) {
+				allVariantThemeClasses = Object.keys(allVariantThemeClasses).reduce(
+					(themeClasses, className) => {
+						if (className.indexOf(prefix) === 0) {
+							let newClassName = className.replace(prefix, '');
+							newClassName =
+								newClassName.charAt(0).toLowerCase() + newClassName.slice(1);
+							prefixClassNameMap[newClassName] = className;
+
+							return {
+								...themeClasses,
+								[newClassName]: allVariantThemeClasses[className]
+							};
+						} else {
+							return themeClasses;
+						}
+					},
+					{}
+				);
+			}
 
 			for (let className in allVariantThemeClasses) {
-				if (allVariantThemeClasses[className] !== variantCss[className]) {
+				const splitVariantThemeClasses = allVariantThemeClasses[className].split(' ');
+				const hasMatch = splitVariantThemeClasses.some(
+					(splitThemeClass) =>
+						splitThemeClass ===
+						variantCss[prefix ? prefixClassNameMap[className] : className]
+				);
+
+				if (!hasMatch) {
 					sanitizedVariantThemeClasses[className] = allVariantThemeClasses[className];
 				}
 			}

--- a/src/middleware/theme.ts
+++ b/src/middleware/theme.ts
@@ -60,7 +60,10 @@ const theme = factory(function({ middleware: { coreTheme, cache, injector }, pro
 			}
 
 			for (let className in allVariantThemeClasses) {
-				if (allVariantThemeClasses[className] !== variantCss[className]) {
+				if (
+					allVariantThemeClasses[className] !==
+					variantCss[prefix ? prefixClassNameMap[className] : className]
+				) {
 					sanitizedVariantThemeClasses[className] = allVariantThemeClasses[className];
 				}
 			}

--- a/src/middleware/theme.ts
+++ b/src/middleware/theme.ts
@@ -9,10 +9,12 @@ const theme = factory(function({ middleware: { coreTheme }, properties }) {
 	return {
 		compose(baseCss: ClassNames, variantCss: ClassNames, prefix?: string) {
 			let allVariantThemeClasses: ClassNames = coreTheme.classes(variantCss);
+			const allBaseThemeClasses: ClassNames = coreTheme.classes(baseCss);
+
 			const { classes } = properties();
 			const variantKey = variantCss[THEME_KEY];
 
-			const sanitizedVariantThemeClasses: ClassNames = {};
+			const sanitizedThemeClasses: ClassNames = allBaseThemeClasses;
 
 			if (prefix) {
 				allVariantThemeClasses = Object.keys(allVariantThemeClasses).reduce(
@@ -34,38 +36,31 @@ const theme = factory(function({ middleware: { coreTheme }, properties }) {
 				);
 			}
 
-			const variantClassesMap: ClassNames = {};
-
 			for (let className in allVariantThemeClasses) {
 				const calculatedClassName = prefix
 					? `${prefix}${className.charAt(0).toUpperCase() + className.slice(1)}`
 					: className;
 				let compare = variantCss[calculatedClassName];
-				const variantClasses =
-					classes && classes[variantKey] && classes[variantKey][calculatedClassName];
 
-				if (variantClasses && variantClasses.length) {
-					compare = `${compare} ${variantClasses.join(' ')}`;
-					variantClassesMap[className] = variantClasses.join(' ');
+				let variantClasses = '';
+				if (classes && classes[variantKey] && classes[variantKey][calculatedClassName]) {
+					variantClasses = classes[variantKey][calculatedClassName].join(' ');
+				}
+
+				if (variantClasses) {
+					compare = `${compare} ${variantClasses}`;
 				}
 
 				if (allVariantThemeClasses[className] !== compare) {
-					sanitizedVariantThemeClasses[className] = allVariantThemeClasses[className];
+					sanitizedThemeClasses[className] = allVariantThemeClasses[className];
 				}
+
+				sanitizedThemeClasses[className] = `${
+					sanitizedThemeClasses[className]
+				} ${variantClasses}`.trim();
 			}
 
-			const returnTheme = {
-				...coreTheme.classes(baseCss),
-				...sanitizedVariantThemeClasses
-			};
-
-			for (let className in variantClassesMap) {
-				returnTheme[className] = `${returnTheme[className]} ${
-					variantClassesMap[className]
-				}`;
-			}
-
-			return returnTheme;
+			return sanitizedThemeClasses;
 		},
 		...coreTheme
 	};

--- a/src/middleware/theme.ts
+++ b/src/middleware/theme.ts
@@ -60,7 +60,9 @@ const theme = factory(function({ middleware: { coreTheme }, properties }) {
 			};
 
 			for (let className in variantClassesMap) {
-				returnTheme[className] += ` ${variantClassesMap[className]}`;
+				returnTheme[className] = `${returnTheme[className]} ${
+					variantClassesMap[className]
+				}`;
 			}
 
 			return returnTheme;

--- a/src/middleware/theme.ts
+++ b/src/middleware/theme.ts
@@ -44,15 +44,13 @@ const theme = factory(function({ middleware: { coreTheme }, properties }) {
 				const variantClasses =
 					classes && classes[variantKey] && classes[variantKey][calculatedClassName];
 
-				if (variantClasses) {
+				if (variantClasses && variantClasses.length) {
 					compare = `${compare} ${variantClasses.join(' ')}`;
-				}
-				if (allVariantThemeClasses[className] !== compare) {
-					sanitizedVariantThemeClasses[className] = allVariantThemeClasses[className];
+					variantClassesMap[className] = variantClasses.join(' ');
 				}
 
-				if (variantClasses && variantClasses.length) {
-					variantClassesMap[className] = variantClasses.join(' ');
+				if (allVariantThemeClasses[className] !== compare) {
+					sanitizedVariantThemeClasses[className] = allVariantThemeClasses[className];
 				}
 			}
 
@@ -62,9 +60,7 @@ const theme = factory(function({ middleware: { coreTheme }, properties }) {
 			};
 
 			for (let className in variantClassesMap) {
-				returnTheme[className] = `${returnTheme[className]} ${
-					variantClassesMap[className]
-				}`;
+				returnTheme[className] += ` ${variantClassesMap[className]}`;
 			}
 
 			return returnTheme;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit or Functional tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds `prefix` and fixes issue related to `theme.compose` when used with `classes`.


Resolves #904 
Resolves #905 
