### PR TITLE
Hack some styles in to the existing intern html reporter

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -44,8 +44,8 @@
 					"to": "intern/index.html"
 				},
 				{
-					"from": "src/examples/intern.json",
-					"to": "intern/intern.json"
+					"from": "src/examples/intern",
+					"to": "intern"
 				}
 			]
 		}

--- a/src/examples/intern/intern.json
+++ b/src/examples/intern/intern.json
@@ -1,5 +1,8 @@
 {
 	"basePath": "..",
+	"plugins": [
+		"./intern/reporter.js"
+	],
 	"suites": [
 		"./main.js"
 	]

--- a/src/examples/intern/reporter.js
+++ b/src/examples/intern/reporter.js
@@ -1,0 +1,42 @@
+const style = document.createElement('style');
+style.innerHTML = `
+html,
+body {
+	background: white !important;
+	font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', 'Helvetica Neue', Arial, sans-serif !important;
+	font-weight: normal !important;
+}
+
+.internReportContainer {
+	margin-top: 40px !important;
+}
+
+.testResult {
+	display: table-row !important;
+}
+
+.testResult .skipped,
+.summary,
+.reportHeader,
+.reportControls,
+.testStatus:before,
+tr td:first-child,
+tr td:nth-child(4) {
+	display: none !important;
+}
+
+.report .suite td.title {
+	font-weight: normal !important;
+}
+
+tr.testResult.passed {
+	background: #ecf9ec !important;
+}
+
+.testResult .column-info {
+	unicode-bidi: embed;
+	font-family: monospace;
+	white-space: pre-wrap;
+}
+`;
+document.head.appendChild(style);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit or Functional tests are included in the PR

**Description:**
In lieu of writing an actual new reporter (which we will do in the future), for now just override some existing css styles in the intern reporter.

* removes header to give more screen estate
* removes summary to give more screen estate
* expands all suites always
* hides expands/collapse controls as broken with the above
* make the column info be like a `pre` element
