### PR TITLE
Fixes calendar date util test error

### DIFF
--- a/src/calendar/tests/unit/date-utils.spec.ts
+++ b/src/calendar/tests/unit/date-utils.spec.ts
@@ -9,7 +9,7 @@ registerSuite('Calendar date utils', {
 			const janFirst2019 = new Date(2019, 0, 1);
 
 			assert.isFalse(monthInMin(2018, 10, janFirst2019));
-			assert.isFalse(monthInMin(2018, 11, janFirst2019, true));
+			assert.isFalse(monthInMin(2018, 11, janFirst2019));
 			assert.isTrue(monthInMin(2019, 0, janFirst2019));
 			assert.isTrue(monthInMin(2019, 1, janFirst2019));
 		},

--- a/src/calendar/tests/unit/date-utils.spec.ts
+++ b/src/calendar/tests/unit/date-utils.spec.ts
@@ -7,8 +7,6 @@ registerSuite('Calendar date utils', {
 	tests: {
 		'monthInMin checks year/month against the first of the year'() {
 			const janFirst2019 = new Date(2019, 0, 1);
-			console.log('janFirst2019', janFirst2019);
-			console.log(' janFirst2019 full year', janFirst2019.getFullYear());
 
 			assert.isFalse(monthInMin(2018, 10, janFirst2019));
 			assert.isFalse(monthInMin(2018, 11, janFirst2019, true));

--- a/src/calendar/tests/unit/date-utils.spec.ts
+++ b/src/calendar/tests/unit/date-utils.spec.ts
@@ -6,15 +6,17 @@ import { monthInMin } from '../../date-utils';
 registerSuite('Calendar date utils', {
 	tests: {
 		'monthInMin checks year/month against the first of the year'() {
-			const janFirst2019 = new Date('2019-01-01');
+			const janFirst2019 = new Date(2019, 0, 1);
+			console.log('janFirst2019', janFirst2019);
+			console.log(' janFirst2019 full year', janFirst2019.getFullYear());
 
 			assert.isFalse(monthInMin(2018, 10, janFirst2019));
-			assert.isFalse(monthInMin(2018, 11, janFirst2019));
+			assert.isFalse(monthInMin(2018, 11, janFirst2019, true));
 			assert.isTrue(monthInMin(2019, 0, janFirst2019));
 			assert.isTrue(monthInMin(2019, 1, janFirst2019));
 		},
 		'monthInMin checks year/month against the last day the year'() {
-			const decThirtyFirst2018 = new Date('2018-12-31');
+			const decThirtyFirst2018 = new Date(2018, 11, 31);
 
 			assert.isFalse(monthInMin(2018, 9, decThirtyFirst2018));
 			assert.isFalse(monthInMin(2018, 10, decThirtyFirst2018));
@@ -22,7 +24,7 @@ registerSuite('Calendar date utils', {
 			assert.isTrue(monthInMin(2019, 1, decThirtyFirst2018));
 		},
 		'monthInMin checks year/month against leap day'() {
-			const febTwentyNine2020 = new Date('2020-02-29');
+			const febTwentyNine2020 = new Date(2020, 1, 29);
 
 			assert.isFalse(monthInMin(2019, 11, febTwentyNine2020));
 			assert.isFalse(monthInMin(2020, 0, febTwentyNine2020));
@@ -30,7 +32,7 @@ registerSuite('Calendar date utils', {
 			assert.isTrue(monthInMin(2020, 2, febTwentyNine2020));
 		},
 		'monthInMin supports out of index months'() {
-			const janFirst2019 = new Date('2019-01-01');
+			const janFirst2019 = new Date(2019, 0, 1);
 
 			assert.isFalse(monthInMin(2017, 14, janFirst2019));
 			assert.isTrue(monthInMin(2018, 12, janFirst2019));


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* NA Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* NA WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [x] The PR passes CI testing
* [x] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
The calendar date util tests for `monthInMin` were failing as they were using the Date constructor to parse strings which proved inconsistent and caused tests to fail in some timezones. This switches the tests to using individual date and time component values instead https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Date

Resolves: #919
