### PR TITLE
Theme compose reloaded

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widgets",
-  "version": "6.0.1-pre",
+  "version": "7.0.0-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2530,9 +2530,9 @@
       }
     },
     "arg": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
-      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
+      "integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==",
       "dev": true
     },
     "argparse": {
@@ -6572,9 +6572,9 @@
       }
     },
     "ext": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.2.0.tgz",
-      "integrity": "sha512-0ccUQK/9e3NreLFg6K6np8aPyRgwycx+oFGtfx1dSp7Wj00Ozw9r05FgBRlzjf2XBM7LAzwgLyDscRrtSU91hA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.2.1.tgz",
+      "integrity": "sha512-x+OKKC57tNiLhDW26UmWtvQBpvO+2wxdC/A0jP7RkmjAc4gze9/U98hQyIYJUzo9A+o9ntMHpC+LH3pWMSbrVQ==",
       "dev": true,
       "requires": {
         "type": "^2.0.0"
@@ -15094,9 +15094,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.2.tgz",
-      "integrity": "sha512-cAVTI2VLHWYsGOirfeYVVQ7ZDejtQ9fp4YhYckWDEkFfqbVjaT11iM8k6xSAfGFMM+gDpZjMnFssPu8we+mqFw==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.0.tgz",
+      "integrity": "sha512-HHZ3hmOrk5SvybTb18xq4Ek2uLqLO5/goFCYUyvn26nWox4hdlKlfC/+dChIZ6qc4ZeYcN9ekTz0yyHsFgumMw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dojo/widgets",
-  "version": "7.0.0-pre",
+  "version": "6.0.1-pre",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -2524,16 +2524,15 @@
       "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
       "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
       "dev": true,
-      "optional": true,
       "requires": {
         "delegates": "^1.0.0",
         "readable-stream": "^2.0.6"
       }
     },
     "arg": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
-      "integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
+      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
       "dev": true
     },
     "argparse": {
@@ -4530,8 +4529,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
       "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -5762,8 +5760,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
       "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "depd": {
       "version": "1.1.2",
@@ -5806,8 +5803,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
       "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "diff": {
       "version": "3.5.0",
@@ -6576,9 +6572,9 @@
       }
     },
     "ext": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.2.1.tgz",
-      "integrity": "sha512-x+OKKC57tNiLhDW26UmWtvQBpvO+2wxdC/A0jP7RkmjAc4gze9/U98hQyIYJUzo9A+o9ntMHpC+LH3pWMSbrVQ==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.2.0.tgz",
+      "integrity": "sha512-0ccUQK/9e3NreLFg6K6np8aPyRgwycx+oFGtfx1dSp7Wj00Ozw9r05FgBRlzjf2XBM7LAzwgLyDscRrtSU91hA==",
       "dev": true,
       "requires": {
         "type": "^2.0.0"
@@ -7380,8 +7376,7 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -7402,14 +7397,12 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -7424,20 +7417,17 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -7554,8 +7544,7 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "ini": {
           "version": "1.3.5",
@@ -7567,7 +7556,6 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7582,7 +7570,6 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -7590,14 +7577,12 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -7616,7 +7601,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -7697,8 +7681,7 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -7710,7 +7693,6 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -7796,8 +7778,7 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -7833,7 +7814,6 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7853,7 +7833,6 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -7897,14 +7876,12 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true,
-          "optional": true
+          "dev": true
         }
       }
     },
@@ -7930,7 +7907,6 @@
       "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
       "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
       "dev": true,
-      "optional": true,
       "requires": {
         "aproba": "^1.0.3",
         "console-control-strings": "^1.0.0",
@@ -7946,15 +7922,13 @@
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true,
-          "optional": true
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -7964,7 +7938,6 @@
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
           "dev": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -7976,7 +7949,6 @@
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
-          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -8410,8 +8382,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
       "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "has-value": {
       "version": "1.0.0",
@@ -11921,7 +11892,6 @@
       "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
       "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
       "dev": true,
-      "optional": true,
       "requires": {
         "are-we-there-yet": "~1.1.2",
         "console-control-strings": "~1.1.0",
@@ -15124,9 +15094,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.13.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.0.tgz",
-      "integrity": "sha512-HHZ3hmOrk5SvybTb18xq4Ek2uLqLO5/goFCYUyvn26nWox4hdlKlfC/+dChIZ6qc4ZeYcN9ekTz0yyHsFgumMw==",
+      "version": "1.12.2",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.2.tgz",
+      "integrity": "sha512-cAVTI2VLHWYsGOirfeYVVQ7ZDejtQ9fp4YhYckWDEkFfqbVjaT11iM8k6xSAfGFMM+gDpZjMnFssPu8we+mqFw==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -19217,15 +19187,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
       "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "wide-align": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
       "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
       "dev": true,
-      "optional": true,
       "requires": {
         "string-width": "^1.0.2 || 2"
       }

--- a/src/common/tests/support/test-helpers.ts
+++ b/src/common/tests/support/test-helpers.ts
@@ -94,18 +94,7 @@ export function MockMetaMixin<T extends Constructor<WidgetBase<any>>>(
 	};
 }
 
-export const themeComparator = (css: any) => (value: any) => {
-	const { ' _key': key, ...classes } = css;
-	return JSON.stringify(classes) === JSON.stringify(value[key]);
-};
-
-export const compareTheme = (css: any) => ({
-	selector: '*',
-	property: 'theme',
-	comparator: themeComparator(css)
-});
-
-export const comparePrefixTheme = {
+export const compareTheme = {
 	selector: '*',
 	property: 'theme',
 	comparator: isObjectComparator

--- a/src/constrained-input/tests/unit/ConstrainedInput.spec.tsx
+++ b/src/constrained-input/tests/unit/ConstrainedInput.spec.tsx
@@ -29,7 +29,7 @@ describe('ConstrainedInput', () => {
 	it('renders with default properties', () => {
 		const h = harness(() => <ConstrainedInput rules={rules} />, {
 			middleware: [[validation, createMockValidationMiddleware(() => true)]],
-			customComparator: [compareTheme(textInputCss)]
+			customComparator: [compareTheme]
 		});
 
 		h.expect(() => (
@@ -47,7 +47,7 @@ describe('ConstrainedInput', () => {
 	it('passes properties to the input widget', () => {
 		const h = harness(() => <ConstrainedInput rules={rules} label="Test Label" />, {
 			middleware: [[validation, createMockValidationMiddleware(() => true)]],
-			customComparator: [compareTheme(textInputCss)]
+			customComparator: [compareTheme]
 		});
 		h.expect(() => (
 			<TextInput
@@ -75,7 +75,7 @@ describe('ConstrainedInput', () => {
 			),
 			{
 				middleware: [[validation, createMockValidationMiddleware(() => true)]],
-				customComparator: [compareTheme(textInputCss)]
+				customComparator: [compareTheme]
 			}
 		);
 

--- a/src/email-input/tests/EmailInput.spec.tsx
+++ b/src/email-input/tests/EmailInput.spec.tsx
@@ -26,7 +26,7 @@ const expected = assertionTemplate(() => (
 registerSuite('EmailInput', {
 	tests: {
 		'default properties'() {
-			const h = harness(() => <EmailInput />, [compareTheme(textInputCss)]);
+			const h = harness(() => <EmailInput />, [compareTheme]);
 			h.expect(expected);
 		}
 	}

--- a/src/menu/tests/Menu.spec.tsx
+++ b/src/menu/tests/Menu.spec.tsx
@@ -3,11 +3,7 @@ import { tsx } from '@dojo/framework/core/vdom';
 import global from '@dojo/framework/shim/global';
 import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
 import Menu, { MenuOption } from '../';
-import {
-	compareId,
-	createHarness,
-	comparePrefixTheme
-} from '../../common/tests/support/test-helpers';
+import { compareId, createHarness, compareTheme } from '../../common/tests/support/test-helpers';
 import { Keys } from '../../common/util';
 import * as css from '../../theme/menu.m.css';
 import MenuItem from '../MenuItem';
@@ -23,7 +19,7 @@ const compareAriaActiveDescendant = {
 	comparator: (property: any) => typeof property === 'string'
 };
 
-const harness = createHarness([comparePrefixTheme, compareId, compareAriaActiveDescendant]);
+const harness = createHarness([compareTheme, compareId, compareAriaActiveDescendant]);
 
 describe('Menu - Menu', () => {
 	const animalOptions: MenuOption[] = [

--- a/src/middleware/tests/theme.spec.tsx
+++ b/src/middleware/tests/theme.spec.tsx
@@ -45,7 +45,7 @@ const baseTemplate = assertionTemplate(() => <div key="root" />);
 
 registerSuite('theme-middleware', {
 	tests: {
-		'variant used if there is no base theme or variant theme'() {
+		'variant used if it exists and there is no theme'() {
 			const baseCss = { ' _key': 'base', a: 'base-a', b: 'base-b' };
 			const variantCss = { ' _key': 'test', a: 'variant-a' };
 			const h = harness(() => <TestWidget baseCss={baseCss} variantCss={variantCss} />);

--- a/src/middleware/tests/theme.spec.tsx
+++ b/src/middleware/tests/theme.spec.tsx
@@ -45,19 +45,19 @@ const baseTemplate = assertionTemplate(() => <div key="root" />);
 
 registerSuite('theme-middleware', {
 	tests: {
-		'Base used when no theme applied'() {
+		'variant used if there is no base theme or variant theme'() {
 			const baseCss = { ' _key': 'base', a: 'base-a', b: 'base-b' };
 			const variantCss = { ' _key': 'test', a: 'variant-a' };
 			const h = harness(() => <TestWidget baseCss={baseCss} variantCss={variantCss} />);
 
 			h.expect(
 				baseTemplate.setChildren('@root', () => [
-					JSON.stringify({ a: 'base-a', b: 'base-b' })
+					JSON.stringify({ a: 'variant-a', b: 'base-b' })
 				])
 			);
 		},
 
-		'Base theme comes through'() {
+		'Base theme comes through when variant is not themed'() {
 			const baseCss = { ' _key': 'base', a: 'base-a', b: 'base-b' };
 			const variantCss = { ' _key': 'test', a: 'variant-a' };
 			const theme = {
@@ -142,7 +142,7 @@ registerSuite('theme-middleware', {
 
 			h.expect(
 				baseTemplate.setChildren('@root', () => [
-					JSON.stringify({ a: 'variant-theme-a composed-variant-a', b: 'base-b' })
+					JSON.stringify({ a: 'variant-theme-a composed-variant-a', b: 'variant-b' })
 				])
 			);
 		},
@@ -222,7 +222,7 @@ registerSuite('theme-middleware', {
 			h.expect(
 				baseTemplate.setChildren('@root', () => [
 					JSON.stringify({
-						root: 'base-root variant-classes-prefix-root',
+						root: 'variant-root variant-classes-prefix-root',
 						input: 'variant-theme-input'
 					})
 				])
@@ -256,7 +256,7 @@ registerSuite('theme-middleware', {
 			h.expect(
 				baseTemplate.setChildren('@root', () => [
 					JSON.stringify({
-						root: 'base-root base-classes-prefix-root variant-classes-prefix-root',
+						root: 'variant-root variant-classes-prefix-root',
 						input: 'variant-theme-input composed-input'
 					})
 				])

--- a/src/middleware/theme.ts
+++ b/src/middleware/theme.ts
@@ -64,7 +64,7 @@ const theme = factory(function({ middleware: { coreTheme }, properties }) {
 				}
 
 				// if the base is themed but variant is not, take the base theme
-				// else, take the variant theme - which may be the base
+				// else, take the variant theme - which may be the variant's base-css
 				const baseThemed = allBaseThemeClasses[className] !== baseCompare;
 				const variantThemed = allVariantThemeClasses[className] !== variantCompare;
 
@@ -74,13 +74,11 @@ const theme = factory(function({ middleware: { coreTheme }, properties }) {
 					sanitizedThemeClasses[className] = allVariantThemeClasses[className];
 				}
 
-				// if (allVariantThemeClasses[className] !== variantCompare) {
-				// 	sanitizedThemeClasses[className] = allVariantThemeClasses[className];
-				// }
-
-				sanitizedThemeClasses[className] = `${
-					sanitizedThemeClasses[className]
-				} ${variantClasses}`.trim();
+				if (sanitizedThemeClasses[className].indexOf(variantClasses) < 0) {
+					sanitizedThemeClasses[className] = `${
+						sanitizedThemeClasses[className]
+					} ${variantClasses}`.trim();
+				}
 			}
 
 			return sanitizedThemeClasses;

--- a/src/middleware/theme.ts
+++ b/src/middleware/theme.ts
@@ -51,6 +51,9 @@ const theme = factory(function({ middleware: { coreTheme }, properties }) {
 					compare = `${compare} ${variantClasses}`;
 				}
 
+				// if the base is themed but variant is not, take the base theme
+				// else, take the variant theme - which may be the base
+
 				if (allVariantThemeClasses[className] !== compare) {
 					sanitizedThemeClasses[className] = allVariantThemeClasses[className];
 				}

--- a/src/middleware/theme.ts
+++ b/src/middleware/theme.ts
@@ -13,6 +13,7 @@ const theme = factory(function({ middleware: { coreTheme }, properties }) {
 
 			const { classes } = properties();
 			const variantKey = variantCss[THEME_KEY];
+			const baseKey = baseCss[THEME_KEY];
 
 			const sanitizedThemeClasses: ClassNames = allBaseThemeClasses;
 
@@ -40,23 +41,42 @@ const theme = factory(function({ middleware: { coreTheme }, properties }) {
 				const calculatedClassName = prefix
 					? `${prefix}${className.charAt(0).toUpperCase() + className.slice(1)}`
 					: className;
-				let compare = variantCss[calculatedClassName];
+				let variantCompare = variantCss[calculatedClassName];
+				let baseCompare = baseCss[className];
 
 				let variantClasses = '';
+				let baseClasses = '';
+
 				if (classes && classes[variantKey] && classes[variantKey][calculatedClassName]) {
 					variantClasses = classes[variantKey][calculatedClassName].join(' ');
 				}
 
+				if (classes && classes[baseKey] && classes[baseKey][className]) {
+					baseClasses = classes[baseKey][className].join(' ');
+				}
+
 				if (variantClasses) {
-					compare = `${compare} ${variantClasses}`;
+					variantCompare = `${variantCompare} ${variantClasses}`;
+				}
+
+				if (baseClasses) {
+					baseCompare = `${baseCompare} ${baseClasses}`;
 				}
 
 				// if the base is themed but variant is not, take the base theme
 				// else, take the variant theme - which may be the base
+				const baseThemed = allBaseThemeClasses[className] !== baseCompare;
+				const variantThemed = allVariantThemeClasses[className] !== variantCompare;
 
-				if (allVariantThemeClasses[className] !== compare) {
+				if (baseThemed && !variantThemed) {
+					sanitizedThemeClasses[className] = allBaseThemeClasses[className];
+				} else {
 					sanitizedThemeClasses[className] = allVariantThemeClasses[className];
 				}
+
+				// if (allVariantThemeClasses[className] !== variantCompare) {
+				// 	sanitizedThemeClasses[className] = allVariantThemeClasses[className];
+				// }
 
 				sanitizedThemeClasses[className] = `${
 					sanitizedThemeClasses[className]

--- a/src/number-input/tests/unit/NumberInput.spec.tsx
+++ b/src/number-input/tests/unit/NumberInput.spec.tsx
@@ -26,7 +26,7 @@ const baseTemplate = assertionTemplate(() => (
 registerSuite('NumberInput', {
 	tests: {
 		'default properties'() {
-			const h = harness(() => <NumberInput />, [compareTheme(textInputCss)]);
+			const h = harness(() => <NumberInput />, [compareTheme]);
 			h.expect(baseTemplate);
 		},
 		'passes expected properties to underlying TextInput'() {
@@ -54,9 +54,7 @@ registerSuite('NumberInput', {
 				widgetId: 'widgetId'
 			};
 
-			const h = harness(() => <NumberInput {...baseProperties} />, [
-				compareTheme(textInputCss)
-			]);
+			const h = harness(() => <NumberInput {...baseProperties} />, [compareTheme]);
 			h.expect(
 				baseTemplate.setProperties(':root', {
 					...baseProperties,
@@ -68,7 +66,7 @@ registerSuite('NumberInput', {
 		},
 		'passes correct value to underlying TextInput'() {
 			const value = 42;
-			const h = harness(() => <NumberInput value={value} />, [compareTheme(textInputCss)]);
+			const h = harness(() => <NumberInput value={value} />, [compareTheme]);
 			h.expect(baseTemplate.setProperty(':root', 'value', value.toString()));
 		},
 		'calls onValue with correct value'() {

--- a/src/outlined-button/tests/unit/OutlinedButton.spec.tsx
+++ b/src/outlined-button/tests/unit/OutlinedButton.spec.tsx
@@ -16,13 +16,13 @@ const baseAssertion = assertionTemplate(() => (
 registerSuite('OutlinedButton', {
 	tests: {
 		'no content'() {
-			const h = harness(() => <OutlinedButton />, [compareTheme(buttonCss)]);
+			const h = harness(() => <OutlinedButton />, [compareTheme]);
 			h.expect(baseAssertion);
 		},
 
 		'properties and children'() {
 			const h = harness(() => <OutlinedButton type="submit" name="bar" disabled={true} />, [
-				compareTheme(buttonCss)
+				compareTheme
 			]);
 			h.expect(() => (
 				<Button

--- a/src/raised-button/tests/unit/RaisedButton.spec.tsx
+++ b/src/raised-button/tests/unit/RaisedButton.spec.tsx
@@ -16,13 +16,13 @@ const baseTemplate = assertionTemplate(() => (
 registerSuite('RaisedButton', {
 	tests: {
 		'no content'() {
-			const h = harness(() => <RaisedButton />, [compareTheme(buttonCss)]);
+			const h = harness(() => <RaisedButton />, [compareTheme]);
 			h.expect(baseTemplate);
 		},
 
 		'properties and attributes'() {
 			const h = harness(() => <RaisedButton type="submit" name="bar" disabled={true} />, [
-				compareTheme(buttonCss)
+				compareTheme
 			]);
 			h.expect(() => (
 				<Button

--- a/src/theme/button.m.css
+++ b/src/theme/button.m.css
@@ -3,6 +3,7 @@
 .root {
 	cursor: pointer;
 	display: inline-block;
+	padding: 10px;
 }
 
 .pressed::before {

--- a/src/theme/constrained-input.m.css
+++ b/src/theme/constrained-input.m.css
@@ -1,1 +1,3 @@
-.root {}
+.root {
+	composes: root from './text-input.m.css';
+}

--- a/src/theme/email-input.m.css
+++ b/src/theme/email-input.m.css
@@ -1,1 +1,3 @@
-.root {}
+.root {
+	composes: root from './text-input.m.css';
+}

--- a/src/theme/menu.m.css
+++ b/src/theme/menu.m.css
@@ -6,20 +6,20 @@
 
 /* Root class of each menu item */
 .itemRoot {
-
+	composes: root from './menu-item.m.css';
 }
 
 /* Added to selected items, only applicable in listbbox mode */
 .itemSelected {
-
+	composes: selected from './list-box-item.m.css';
 }
 
 /* Added to active items */
 .itemActive {
-
+	composes: active from './menu-item.m.css';
 }
 
 /* Added to disabled items */
 .itemDisabled {
-
+	composes: disabled from './menu-item.m.css';
 }

--- a/src/theme/number-input.m.css
+++ b/src/theme/number-input.m.css
@@ -1,3 +1,3 @@
-.root{
-	
+.root {
+	composes: root from './text-input.m.css';
 }

--- a/src/theme/outlined-button.m.css
+++ b/src/theme/outlined-button.m.css
@@ -1,7 +1,11 @@
-@import '../common/styles/variables.css';
+.root {
+	composes: root from './button.m.css';
+}
 
-.root {}
+.disabled {
+	composes: disabled from './button.m.css';
+}
 
-.disabled {}
-
-.pressed {}
+.pressed {
+	composes: pressed from './button.m.css';
+}

--- a/src/theme/raised-button.m.css
+++ b/src/theme/raised-button.m.css
@@ -1,7 +1,11 @@
 .root {
-
+	composes: root from './button.m.css';
 }
 
 .disabled {
+	composes: disabled from './button.m.css';
+}
 
+.pressed {
+	composes: pressed from './button.m.css';
 }

--- a/src/theme/raised-button.m.css.d.ts
+++ b/src/theme/raised-button.m.css.d.ts
@@ -1,2 +1,3 @@
 export const root: string;
 export const disabled: string;
+export const pressed: string;


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Amends the `theme.compose` code to use the base-variant css if the base component is not themed.
The effect of this is that the base-theme for the variant will be used so that widgets such as `outline-button` can have an appropriate base theme.

**impacts of this change:**

- all widgets that use `theme.compose` will have to manually use `composes` within their base-theme css on classes they wish to be themeable but to use the base-component's css.

ie. 

```css
/* outline-button.m.css */
.root {
   composes: root from './button.m.css';
   border: 1px solid black;
}
```

- In the above, outline-button case, if a dojo / material etc theme is created and applied via a theme injector for `button`, but not `outline-button`, the outline-button will lose it's base-css and use the button's theme.


Resolves #916 
