### PR TITLE
add examples for raised button

### DIFF
--- a/src/examples/src/config.ts
+++ b/src/examples/src/config.ts
@@ -48,6 +48,8 @@ import BasicPopup from './widgets/popup/Basic';
 import BasicProgress from './widgets/progress/Basic';
 import BasicRadio from './widgets/radio/Basic';
 import BasicRaisedButton from './widgets/raised-button/Basic';
+import RaisedDisabledSubmit from './widgets/raised-button/DisabledSubmit';
+import RaisedToggleButton from './widgets/raised-button/ToggleButton';
 import BasicRangeSlider from './widgets/range-slider/Basic';
 import AdvancedOptions from './widgets/select/AdvancedOptions';
 import BasicSelect from './widgets/select/Basic';
@@ -460,6 +462,18 @@ export const config: Config = {
 		}
 	},
 	'raised-button': {
+		examples: [
+			{
+				filename: 'DisabledSubmit',
+				module: RaisedDisabledSubmit,
+				title: 'Disabled Submit Button'
+			},
+			{
+				filename: 'ToggleButton',
+				module: RaisedToggleButton,
+				title: 'Toggle Button'
+			}
+		],
 		overview: {
 			example: {
 				filename: 'Basic',

--- a/src/examples/src/widgets/raised-button/DisabledSubmit.tsx
+++ b/src/examples/src/widgets/raised-button/DisabledSubmit.tsx
@@ -1,0 +1,12 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import RaisedButton from '@dojo/widgets/raised-button';
+
+const factory = create();
+
+export default factory(function DisabledSubmitButton() {
+	return (
+		<RaisedButton type="submit" disabled>
+			Submit
+		</RaisedButton>
+	);
+});

--- a/src/examples/src/widgets/raised-button/ToggleButton.tsx
+++ b/src/examples/src/widgets/raised-button/ToggleButton.tsx
@@ -1,0 +1,15 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import RaisedButton from '@dojo/widgets/raised-button';
+import icache from '@dojo/framework/core/middleware/icache';
+
+const factory = create({ icache });
+
+export default factory(function ToggleButton({ middleware: { icache } }) {
+	const pressed = icache.getOrSet('pressed', false);
+
+	return (
+		<RaisedButton pressed={pressed} onClick={() => icache.set('pressed', !pressed)}>
+			Toggle Button
+		</RaisedButton>
+	);
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds additional examples for the raised button, matching other button widgets

Related to #876 
