### PR TITLE
move progress bar examples

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -67,6 +67,10 @@ import MenuPopup from './widgets/popup/MenuPopup';
 import SetWidth from './widgets/popup/SetWidth';
 import Underlay from './widgets/popup/Underlay';
 import BasicProgress from './widgets/progress/Basic';
+import ProgressWithChangingValues from './widgets/progress/ProgressWithChangingValues';
+import ProgressWithCustomOutput from './widgets/progress/ProgressWithCustomOutput';
+import ProgressWithMax from './widgets/progress/ProgressWithMax';
+import ProgressWithoutOutput from './widgets/progress/ProgressWithoutOutput';
 import BasicRadio from './widgets/radio/Basic';
 import BasicRaisedButton from './widgets/raised-button/Basic';
 import RaisedDisabledSubmit from './widgets/raised-button/DisabledSubmit';
@@ -557,6 +561,24 @@ export const config = {
 			}
 		},
 		progress: {
+			examples: [
+				{
+					filename: 'ProgressWithChangingValues',
+					module: ProgressWithChangingValues
+				},
+				{
+					filename: 'ProgressWithMax',
+					module: ProgressWithMax
+				},
+				{
+					filename: 'ProgressWithCustomOutput',
+					module: ProgressWithCustomOutput
+				},
+				{
+					filename: 'ProgressWithoutOutput',
+					module: ProgressWithoutOutput
+				}
+			],
 			overview: {
 				example: {
 					filename: 'Basic',

--- a/src/examples/src/widgets/progress/ProgressWithChangingValues.tsx
+++ b/src/examples/src/widgets/progress/ProgressWithChangingValues.tsx
@@ -13,7 +13,7 @@ export default factory(function ProgressWithChangingvalues({ middleware: { icach
 		<div>
 			<Progress value={value} max={max} />
 			<div>
-				<Button onClick={() => icache.set('value', value - step < 0 ? 0 : value - step)}>
+				<Button onClick={() => icache.set('value', Math.max(0, value - step))}>
 					Decrease
 				</Button>
 				<Button

--- a/src/examples/src/widgets/progress/ProgressWithChangingValues.tsx
+++ b/src/examples/src/widgets/progress/ProgressWithChangingValues.tsx
@@ -17,7 +17,7 @@ export default factory(function ProgressWithChangingvalues({ middleware: { icach
 					Decrease
 				</Button>
 				<Button
-					onClick={() => icache.set('value', value + step > max ? max : value + step)}
+					onClick={() => icache.set('value', Math.min(value + step, max))}
 				>
 					Increase
 				</Button>

--- a/src/examples/src/widgets/progress/ProgressWithChangingValues.tsx
+++ b/src/examples/src/widgets/progress/ProgressWithChangingValues.tsx
@@ -1,0 +1,27 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import { icache } from '@dojo/framework/core/middleware/icache';
+import Progress from '@dojo/widgets/progress';
+import Button from '@dojo/widgets/button';
+
+const factory = create({ icache });
+
+export default factory(function ProgressWithChangingvalues({ middleware: { icache } }) {
+	const max = 100;
+	const step = 10;
+	const value = icache.getOrSet<number>('value', 0);
+	return (
+		<div>
+			<Progress value={value} max={max} />
+			<div>
+				<Button onClick={() => icache.set('value', value - step < 0 ? 0 : value - step)}>
+					Decrease
+				</Button>
+				<Button
+					onClick={() => icache.set('value', value + step > max ? max : value + step)}
+				>
+					Increase
+				</Button>
+			</div>
+		</div>
+	);
+});

--- a/src/examples/src/widgets/progress/ProgressWithCustomOutput.tsx
+++ b/src/examples/src/widgets/progress/ProgressWithCustomOutput.tsx
@@ -1,0 +1,17 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Progress from '@dojo/widgets/progress';
+
+const factory = create();
+
+export default factory(function ProgressWithCustomOutput() {
+	const value = 250;
+	const max = 750;
+
+	return (
+		<Progress
+			value={value}
+			max={max}
+			output={(value, percent) => `${value} of ${max} is ${percent}%`}
+		/>
+	);
+});

--- a/src/examples/src/widgets/progress/ProgressWithMax.tsx
+++ b/src/examples/src/widgets/progress/ProgressWithMax.tsx
@@ -3,6 +3,6 @@ import Progress from '@dojo/widgets/progress';
 
 const factory = create();
 
-export default factory(function Basic() {
-	return <Progress value={50} />;
+export default factory(function ProgressWithMax() {
+	return <Progress value={0.3} max={1} />;
 });

--- a/src/examples/src/widgets/progress/ProgressWithoutOutput.tsx
+++ b/src/examples/src/widgets/progress/ProgressWithoutOutput.tsx
@@ -3,6 +3,6 @@ import Progress from '@dojo/widgets/progress';
 
 const factory = create();
 
-export default factory(function Basic() {
-	return <Progress value={50} />;
+export default factory(function ProgressWithoutOutput() {
+	return <Progress value={50} showOutput={false} />;
 });


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:** Moved progress bar examples to new format and structure

Resolves #825 
