### PR TITLE
ignore time when checking min and max dates

### DIFF
--- a/src/calendar/date-utils.tsx
+++ b/src/calendar/date-utils.tsx
@@ -13,3 +13,11 @@ export function monthInMax(year: number, month: number, maxDate?: Date) {
 	}
 	return true;
 }
+
+function stripTime(date: Date) {
+	return new Date(date.getFullYear(), date.getMonth(), date.getDate());
+}
+
+export function isOutOfDateRange(dateObj: Date, min?: Date, max?: Date) {
+	return Boolean((min && dateObj < stripTime(min)) || (max && stripTime(dateObj) > max));
+}

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -6,7 +6,7 @@ import { DNode } from '@dojo/framework/core/interfaces';
 import { uuid } from '@dojo/framework/core/util';
 import commonBundle from '../common/nls/common';
 import { formatAriaProperties, Keys } from '../common/util';
-import { monthInMin, monthInMax } from './date-utils';
+import { monthInMin, monthInMax, isOutOfDateRange } from './date-utils';
 import CalendarCell from './CalendarCell';
 import DatePicker, { Paging } from './DatePicker';
 import Icon from '../icon/index';
@@ -320,9 +320,7 @@ export class Calendar extends I18nMixin(ThemedMixin(WidgetBase))<CalendarPropert
 
 		const date = dateObj.getDate();
 		const { theme, classes } = this.properties;
-		const outOfRange = Boolean(
-			(minDate && dateObj < minDate) || (maxDate && dateObj > maxDate)
-		);
+		const outOfRange = isOutOfDateRange(dateObj, minDate, maxDate);
 		const focusable = currentMonth && date === this._focusedDay;
 
 		return w(CalendarCell, {

--- a/src/calendar/tests/unit/Calendar.spec.tsx
+++ b/src/calendar/tests/unit/Calendar.spec.tsx
@@ -834,6 +834,26 @@ registerSuite('Calendar with min-max', {
 			h.expect(baseMinMaxTemplate.setProperty('@date-8', 'selected', true));
 		},
 
+		'Time is ignored for minDate and maxDate'() {
+			process.env.TZ = 'Europe/London';
+			const minDate = new Date('June 3, 2017 23:59:59.999');
+			const maxDate = new Date('June 29, 2017 00:00:00.000');
+
+			const h = harness(() =>
+				w(Calendar, {
+					selectedDate: testDate,
+					minDate,
+					maxDate
+				})
+			);
+			h.expect(
+				baseMinMaxTemplate
+					.setProperty('@date-8', 'selected', true)
+					.setProperty('@date-picker', 'minDate', minDate)
+					.setProperty('@date-picker', 'maxDate', maxDate)
+			);
+		},
+
 		'Set the focusable date when the month change makes it invalid'() {
 			const maxDate = new Date('June 24, 2017');
 			const calendarProperties: CalendarProperties = {

--- a/src/calendar/tests/unit/date-utils.spec.tsx
+++ b/src/calendar/tests/unit/date-utils.spec.tsx
@@ -1,7 +1,10 @@
+import { isOutOfDateRange, monthInMin } from '../../date-utils';
+
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
-import { monthInMin } from '../../date-utils';
+const fullDate = new Date(1979, 2, 20, 7, 33, 12);
+const shortDate = new Date(2019, 11, 3);
 
 registerSuite('Calendar date utils', {
 	tests: {
@@ -36,6 +39,72 @@ registerSuite('Calendar date utils', {
 			assert.isTrue(monthInMin(2018, 12, janFirst2019));
 			assert.isFalse(monthInMin(2019, -1, janFirst2019));
 			assert.isTrue(monthInMin(2020, -2, janFirst2019));
+		},
+		isOutOfDateRange: {
+			'no range is always inside the range'() {
+				assert.isFalse(isOutOfDateRange(fullDate));
+				assert.isFalse(isOutOfDateRange(shortDate));
+			},
+			'dates on the minimum day are inside the range'() {
+				const min = new Date(
+					fullDate.getFullYear(),
+					fullDate.getMonth(),
+					fullDate.getDate(),
+					23,
+					59,
+					59,
+					999
+				);
+				assert.isFalse(isOutOfDateRange(fullDate, min));
+			},
+			'dates on the maximum day are inside the range'() {
+				const max = new Date('2017-06-29T00:00:00');
+				const dateObj = new Date('2017-06-29T23:59:59.999');
+				assert.isFalse(isOutOfDateRange(dateObj, undefined, max));
+			},
+			'dates equal to minimum are inside the range'() {
+				assert.isFalse(isOutOfDateRange(fullDate, fullDate));
+			},
+			'dates equal to maximum are inside the range'() {
+				assert.isFalse(isOutOfDateRange(fullDate, undefined, fullDate));
+			},
+			'dates on the same day as the most narrow range are inside the range'() {
+				const min = new Date(
+					fullDate.getFullYear(),
+					fullDate.getMonth(),
+					fullDate.getDate(),
+					23,
+					59,
+					59,
+					999
+				);
+				const max = new Date(
+					fullDate.getFullYear(),
+					fullDate.getMonth(),
+					fullDate.getDate(),
+					0,
+					0,
+					0,
+					0
+				);
+				assert.isFalse(isOutOfDateRange(fullDate, min, max));
+			},
+			'when min is present dates before are out of the range'() {
+				const min = new Date(
+					fullDate.getFullYear(),
+					fullDate.getMonth(),
+					fullDate.getDate() + 1
+				);
+				assert.isTrue(isOutOfDateRange(fullDate, min));
+			},
+			'when max is present dates after are out of the range'() {
+				const max = new Date(
+					fullDate.getFullYear(),
+					fullDate.getMonth(),
+					fullDate.getDate() - 1
+				);
+				assert.isTrue(isOutOfDateRange(fullDate, undefined, max));
+			}
 		}
 	}
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Updated the Calendar to only take the year, month, and day portions of a date when determining if a day is outside of the min/max dates. Previously it was possible to set a min / max date with a time that would place a day outside of a given range; e.g. if `{ minDate: new Date() }` was used the current day would be outside of the minDate range.

Resolves #857
