### PR TITLE
Resizable Grid Columns

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -159,9 +159,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
-      "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
+      "version": "7.7.4",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
+      "integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -292,12 +292,12 @@
       }
     },
     "@dojo/cli-build-app": {
-      "version": "7.0.0-alpha.4",
-      "resolved": "https://registry.npmjs.org/@dojo/cli-build-app/-/cli-build-app-7.0.0-alpha.4.tgz",
-      "integrity": "sha512-xUbvkX+jaG6urSgKW8B9Z/FIOXApu+mmozGZIsCU9bCX+50lpEzAUgBEVhJwsuM8N4qOz18xJl/BOEuYGraN2Q==",
+      "version": "7.0.0-alpha.6",
+      "resolved": "https://registry.npmjs.org/@dojo/cli-build-app/-/cli-build-app-7.0.0-alpha.6.tgz",
+      "integrity": "sha512-WX4367IfK4+2+jdUXNhPUm/eEsZQe8EyDvRrplsWQyiXk9gk2CLehcQ5S0NjFvL1got5n0U4RM6vEvhM9ELtZg==",
       "dev": true,
       "requires": {
-        "@dojo/webpack-contrib": "7.0.0-alpha.3",
+        "@dojo/webpack-contrib": "7.0.0-alpha.5",
         "brotli-webpack-plugin": "1.0.0",
         "caniuse-lite": "1.0.30000973",
         "chalk": "2.4.1",
@@ -355,147 +355,10 @@
         "wrapper-webpack-plugin": "2.0.0"
       },
       "dependencies": {
-        "@dojo/webpack-contrib": {
-          "version": "7.0.0-alpha.3",
-          "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-alpha.3.tgz",
-          "integrity": "sha512-eqz9pCdPWjWH7eoxxZ7kyWTBJjVe+XuUD1pjRGhwDpborypD0omnkOakVS5P3WMRurc2lEm2/a7bNKx1yzOOhA==",
-          "dev": true,
-          "requires": {
-            "@dojo/framework": "7.0.0-alpha.4",
-            "acorn": "6.1.1",
-            "acorn-dynamic-import": "4.0.0",
-            "acorn-walk": "6.1.1",
-            "bfj": "6.1.1",
-            "chalk": "2.3.0",
-            "clear-module": "3.1.0",
-            "commander": "2.13.0",
-            "connect-history-api-fallback": "1.6.0",
-            "copy-webpack-plugin": "4.6.0",
-            "cssnano": "4.1.7",
-            "eventsource-polyfill": "0.9.6",
-            "express": "4.16.2",
-            "filesize": "3.5.11",
-            "filter-css": "0.1.2",
-            "fs-extra": "7.0.0",
-            "get-port": "4.0.0",
-            "glob": "^7.1.2",
-            "gzip-size": "4.1.0",
-            "html-webpack-include-assets-plugin": "1.0.6",
-            "istanbul-lib-instrument": "1.10.1",
-            "jsdom": "15.2.0",
-            "loader-utils": "1.1.0",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "node-html-parser": "1.1.11",
-            "opener": "1.4.3",
-            "postcss": "7.0.7",
-            "puppeteer": "1.11.0",
-            "recast": "0.12.7",
-            "source-map": "0.6.1",
-            "ts-loader": "5.4.5",
-            "ts-node": "^8.0.3",
-            "typed-css-modules": "0.3.7",
-            "webpack-hot-middleware": "2.24.3",
-            "workbox-webpack-plugin": "3.6.3",
-            "wrapper-webpack-plugin": "2.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-              "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.1.0",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^4.0.0"
-              }
-            },
-            "connect-history-api-fallback": {
-              "version": "1.6.0",
-              "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
-              "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
-              "dev": true
-            },
-            "ts-loader": {
-              "version": "5.4.5",
-              "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.4.5.tgz",
-              "integrity": "sha512-XYsjfnRQCBum9AMRZpk2rTYSVpdZBpZK+kDh0TeT3kxmQNBDVIeUjdPjY5RZry4eIAb8XHc4gYSUiUWPYvzSRw==",
-              "dev": true,
-              "requires": {
-                "chalk": "^2.3.0",
-                "enhanced-resolve": "^4.0.0",
-                "loader-utils": "^1.0.2",
-                "micromatch": "^3.1.4",
-                "semver": "^5.0.1"
-              }
-            },
-            "ts-node": {
-              "version": "8.5.4",
-              "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
-              "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
-              "dev": true,
-              "requires": {
-                "arg": "^4.1.0",
-                "diff": "^4.0.1",
-                "make-error": "^1.1.1",
-                "source-map-support": "^0.5.6",
-                "yn": "^3.0.0"
-              }
-            },
-            "typed-css-modules": {
-              "version": "0.3.7",
-              "resolved": "https://registry.npmjs.org/typed-css-modules/-/typed-css-modules-0.3.7.tgz",
-              "integrity": "sha512-KR1VG/U0rgFWaiQtXKtFMgKaurs80nvlBvZ7BfuYGLldw6kss/97sd+aMG4CI73BbujvefG7DBjnsBqq2Aowcw==",
-              "dev": true,
-              "requires": {
-                "camelcase": "^4.1.0",
-                "chalk": "^2.1.0",
-                "chokidar": "^2.0.3",
-                "css-modules-loader-core": "^1.1.0",
-                "glob": "^7.1.2",
-                "is-there": "^4.4.2",
-                "mkdirp": "^0.5.1",
-                "yargs": "^8.0.2"
-              }
-            }
-          }
-        },
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-          "dev": true
-        },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
-          }
-        },
-        "diff": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
           "dev": true
         },
         "globby": {
@@ -510,168 +373,6 @@
             "ignore": "^3.3.5",
             "pify": "^3.0.0",
             "slash": "^1.0.0"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-              "dev": true
-            }
-          }
-        },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
-          }
-        },
-        "jsdom": {
-          "version": "15.2.0",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.0.tgz",
-          "integrity": "sha512-+hRyEfjRPFwTYMmSQ3/f7U9nP8ZNZmbkmUek760ZpxnCPWJIhaaLRuUSvpJ36fZKCGENxLwxClzwpOpnXNfChQ==",
-          "dev": true,
-          "requires": {
-            "abab": "^2.0.0",
-            "acorn": "^7.1.0",
-            "acorn-globals": "^4.3.2",
-            "array-equal": "^1.0.0",
-            "cssom": "^0.4.1",
-            "cssstyle": "^2.0.0",
-            "data-urls": "^1.1.0",
-            "domexception": "^1.0.1",
-            "escodegen": "^1.11.1",
-            "html-encoding-sniffer": "^1.0.2",
-            "nwsapi": "^2.1.4",
-            "parse5": "5.1.0",
-            "pn": "^1.1.0",
-            "request": "^2.88.0",
-            "request-promise-native": "^1.0.7",
-            "saxes": "^3.1.9",
-            "symbol-tree": "^3.2.2",
-            "tough-cookie": "^3.0.1",
-            "w3c-hr-time": "^1.0.1",
-            "w3c-xmlserializer": "^1.1.2",
-            "webidl-conversions": "^4.0.2",
-            "whatwg-encoding": "^1.0.5",
-            "whatwg-mimetype": "^2.3.0",
-            "whatwg-url": "^7.0.0",
-            "ws": "^7.0.0",
-            "xml-name-validator": "^3.0.0"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-              "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
-              "dev": true
-            }
-          }
-        },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
-          }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
-        },
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
-          "dev": true
-        },
-        "postcss": {
-          "version": "7.0.7",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
-          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.5.0"
-          },
-          "dependencies": {
-            "has-flag": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
-            },
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -682,97 +383,16 @@
           "requires": {
             "ansi-regex": "^2.0.0"
           }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "^2.0.0"
-          }
-        },
-        "ts-node": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
-          "dev": true,
-          "requires": {
-            "arrify": "^1.0.0",
-            "buffer-from": "^1.1.0",
-            "diff": "^3.1.0",
-            "make-error": "^1.1.1",
-            "minimist": "^1.2.0",
-            "mkdirp": "^0.5.1",
-            "source-map-support": "^0.5.6",
-            "yn": "^2.0.0"
-          },
-          "dependencies": {
-            "diff": {
-              "version": "3.5.0",
-              "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
-              "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
-              "dev": true
-            },
-            "yn": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-              "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
-              "dev": true
-            }
-          }
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "read-pkg-up": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^7.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
-          }
         }
       }
     },
     "@dojo/cli-build-theme": {
-      "version": "7.0.0-alpha.1",
-      "resolved": "https://registry.npmjs.org/@dojo/cli-build-theme/-/cli-build-theme-7.0.0-alpha.1.tgz",
-      "integrity": "sha512-bbCQ3SvCAwOvSzZCUO2Mnft3KonlaMzFUt1eV9Q0vOjPE0q4KEb4gHAGDF2BYdyB19N8kA7kGVWHxbtEwnQjfA==",
+      "version": "7.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@dojo/cli-build-theme/-/cli-build-theme-7.0.0-alpha.2.tgz",
+      "integrity": "sha512-KnfLrrIq/JMmgljUplktwoNbXchCdiJ9jU432bLLRXjI+0i9inxHVLU19Za/QwqshptGnnPisEgK2w8P5/8XjA==",
       "dev": true,
       "requires": {
-        "@dojo/webpack-contrib": "7.0.0-alpha.4",
+        "@dojo/webpack-contrib": "7.0.0-alpha.5",
         "@types/log-update": "3.1.0",
         "chalk": "2.4.1",
         "clean-webpack-plugin": "^3.0.0",
@@ -793,101 +413,6 @@
         "webpack": "4.25.1"
       },
       "dependencies": {
-        "@dojo/webpack-contrib": {
-          "version": "7.0.0-alpha.4",
-          "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-alpha.4.tgz",
-          "integrity": "sha512-ANUj+bm4uM4H1L26qJDtqUgD4A+Yi0eto+kv8DTpqaFSgviGNQvTeAda4R1YSQFoWdYoWEKBi3UabOLflKc6nw==",
-          "dev": true,
-          "requires": {
-            "@dojo/framework": "7.0.0-alpha.4",
-            "acorn": "6.1.1",
-            "acorn-dynamic-import": "4.0.0",
-            "acorn-walk": "6.1.1",
-            "bfj": "6.1.1",
-            "chalk": "2.3.0",
-            "clear-module": "3.1.0",
-            "commander": "2.13.0",
-            "connect-history-api-fallback": "1.6.0",
-            "copy-webpack-plugin": "4.6.0",
-            "cssnano": "4.1.7",
-            "eventsource-polyfill": "0.9.6",
-            "express": "4.16.2",
-            "filesize": "3.5.11",
-            "filter-css": "0.1.2",
-            "fs-extra": "7.0.0",
-            "get-port": "4.0.0",
-            "glob": "^7.1.2",
-            "gzip-size": "4.1.0",
-            "html-webpack-include-assets-plugin": "1.0.6",
-            "istanbul-lib-instrument": "1.10.1",
-            "jsdom": "15.2.0",
-            "loader-utils": "1.1.0",
-            "lodash": "4.17.4",
-            "minimatch": "3.0.4",
-            "mkdirp": "0.5.1",
-            "node-html-parser": "1.1.11",
-            "opener": "1.4.3",
-            "postcss": "7.0.7",
-            "puppeteer": "1.11.0",
-            "recast": "0.12.7",
-            "source-map": "0.6.1",
-            "ts-loader": "5.4.5",
-            "ts-node": "^8.0.3",
-            "typed-css-modules": "0.3.7",
-            "webpack-hot-middleware": "2.24.3",
-            "workbox-webpack-plugin": "3.6.3",
-            "wrapper-webpack-plugin": "2.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.3.0",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
-              "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.1.0",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^4.0.0"
-              }
-            },
-            "cssnano": {
-              "version": "4.1.7",
-              "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.7.tgz",
-              "integrity": "sha512-AiXL90l+MDuQmRNyypG2P7ux7K4XklxYzNNUd5HXZCNcH8/N9bHPcpN97v8tXgRVeFL/Ed8iP8mVmAAu0ZpT7A==",
-              "dev": true,
-              "requires": {
-                "cosmiconfig": "^5.0.0",
-                "cssnano-preset-default": "^4.0.5",
-                "is-resolvable": "^1.0.0",
-                "postcss": "^7.0.0"
-              }
-            },
-            "ts-loader": {
-              "version": "5.4.5",
-              "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.4.5.tgz",
-              "integrity": "sha512-XYsjfnRQCBum9AMRZpk2rTYSVpdZBpZK+kDh0TeT3kxmQNBDVIeUjdPjY5RZry4eIAb8XHc4gYSUiUWPYvzSRw==",
-              "dev": true,
-              "requires": {
-                "chalk": "^2.3.0",
-                "enhanced-resolve": "^4.0.0",
-                "loader-utils": "^1.0.2",
-                "micromatch": "^3.1.4",
-                "semver": "^5.0.1"
-              }
-            }
-          }
-        },
-        "@types/glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
-          "dev": true,
-          "requires": {
-            "@types/events": "*",
-            "@types/minimatch": "*",
-            "@types/node": "*"
-          }
-        },
         "ajv": {
           "version": "6.10.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -901,9 +426,9 @@
           }
         },
         "ansi-regex": {
-          "version": "2.1.1",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
           "dev": true
         },
         "autoprefixer": {
@@ -921,17 +446,6 @@
             "postcss-value-parser": "^4.0.2"
           },
           "dependencies": {
-            "browserslist": {
-              "version": "4.8.0",
-              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.0.tgz",
-              "integrity": "sha512-HYnxc/oLRWvJ3TsGegR0SRL/UDnknGq2s/a8dYYEO+kOQ9m9apKoS5oiathLKZdh/e9uE+/J3j92qPlGD/vTqA==",
-              "dev": true,
-              "requires": {
-                "caniuse-lite": "^1.0.30001012",
-                "electron-to-chromium": "^1.3.317",
-                "node-releases": "^1.1.41"
-              }
-            },
             "chalk": {
               "version": "2.4.2",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -941,34 +455,6 @@
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
-              }
-            },
-            "has-flag": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
-            },
-            "postcss": {
-              "version": "7.0.23",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
-              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
-              "dev": true,
-              "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "6.1.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                  "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                  "dev": true,
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
               }
             },
             "supports-color": {
@@ -997,10 +483,16 @@
             "fill-range": "^7.0.1"
           }
         },
+        "camelcase": {
+          "version": "5.3.1",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+          "dev": true
+        },
         "caniuse-lite": {
-          "version": "1.0.30001013",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001013.tgz",
-          "integrity": "sha512-hOAXaWKuq/UVFgYawxIOdPdyMQdYcwOCDOjnZcKn7wCgFUrhP7smuNZjGLuJlPSgE6aRA4cRJ+bGSrhtEt7ZAg==",
+          "version": "1.0.30001015",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+          "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==",
           "dev": true
         },
         "clean-webpack-plugin": {
@@ -1019,30 +511,6 @@
           "integrity": "sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==",
           "dev": true
         },
-        "cliui": {
-          "version": "3.2.0",
-          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
-          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "^1.0.1",
-            "strip-ansi": "^3.0.1",
-            "wrap-ansi": "^2.0.0"
-          },
-          "dependencies": {
-            "string-width": {
-              "version": "1.0.2",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
-              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "^1.0.0",
-                "is-fullwidth-code-point": "^1.0.0",
-                "strip-ansi": "^3.0.0"
-              }
-            }
-          }
-        },
         "color-convert": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -1056,12 +524,6 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "connect-history-api-fallback": {
-          "version": "1.6.0",
-          "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
-          "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
           "dev": true
         },
         "css-loader": {
@@ -1082,73 +544,6 @@
             "postcss-modules-values": "^3.0.0",
             "postcss-value-parser": "^4.0.0",
             "schema-utils": "^2.0.0"
-          },
-          "dependencies": {
-            "camelcase": {
-              "version": "5.3.1",
-              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-              "dev": true
-            },
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "5.5.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                  "dev": true,
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "has-flag": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
-            },
-            "loader-utils": {
-              "version": "1.2.3",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-              "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-              "dev": true,
-              "requires": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^2.0.0",
-                "json5": "^1.0.1"
-              }
-            },
-            "postcss": {
-              "version": "7.0.23",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
-              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
-              "dev": true,
-              "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-              }
-            },
-            "supports-color": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
           }
         },
         "cssdb": {
@@ -1175,41 +570,6 @@
             "postcss": "^7.0.0"
           }
         },
-        "del": {
-          "version": "4.1.1",
-          "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
-          "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
-          "dev": true,
-          "requires": {
-            "@types/glob": "^7.1.1",
-            "globby": "^6.1.0",
-            "is-path-cwd": "^2.0.0",
-            "is-path-in-cwd": "^2.0.0",
-            "p-map": "^2.0.0",
-            "pify": "^4.0.1",
-            "rimraf": "^2.6.3"
-          },
-          "dependencies": {
-            "pify": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-              "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-              "dev": true
-            }
-          }
-        },
-        "diff": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
-          "dev": true
-        },
-        "electron-to-chromium": {
-          "version": "1.3.322",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
-          "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==",
-          "dev": true
-        },
         "file-loader": {
           "version": "5.0.2",
           "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-5.0.2.tgz",
@@ -1218,19 +578,6 @@
           "requires": {
             "loader-utils": "^1.2.3",
             "schema-utils": "^2.5.0"
-          },
-          "dependencies": {
-            "loader-utils": {
-              "version": "1.2.3",
-              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-              "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
-              "dev": true,
-              "requires": {
-                "big.js": "^5.2.2",
-                "emojis-list": "^2.0.0",
-                "json5": "^1.0.1"
-              }
-            }
           }
         },
         "fill-range": {
@@ -1242,11 +589,15 @@
             "to-regex-range": "^5.0.1"
           }
         },
-        "has-flag": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
-          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
-          "dev": true
+        "find-up": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+          "dev": true,
+          "requires": {
+            "locate-path": "^5.0.0",
+            "path-exists": "^4.0.0"
+          }
         },
         "icss-utils": {
           "version": "4.1.1",
@@ -1255,65 +606,6 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.14"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "5.5.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                  "dev": true,
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "has-flag": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
-            },
-            "postcss": {
-              "version": "7.0.23",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
-              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
-              "dev": true,
-              "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-              }
-            },
-            "supports-color": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "is-fullwidth-code-point": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "^1.0.0"
           }
         },
         "is-number": {
@@ -1321,72 +613,6 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
-        },
-        "is-path-cwd": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-          "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
-          "dev": true
-        },
-        "is-path-in-cwd": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
-          "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
-          "dev": true,
-          "requires": {
-            "is-path-inside": "^2.1.0"
-          }
-        },
-        "is-path-inside": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
-          "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
-          "dev": true,
-          "requires": {
-            "path-is-inside": "^1.0.2"
-          }
-        },
-        "jsdom": {
-          "version": "15.2.0",
-          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.0.tgz",
-          "integrity": "sha512-+hRyEfjRPFwTYMmSQ3/f7U9nP8ZNZmbkmUek760ZpxnCPWJIhaaLRuUSvpJ36fZKCGENxLwxClzwpOpnXNfChQ==",
-          "dev": true,
-          "requires": {
-            "abab": "^2.0.0",
-            "acorn": "^7.1.0",
-            "acorn-globals": "^4.3.2",
-            "array-equal": "^1.0.0",
-            "cssom": "^0.4.1",
-            "cssstyle": "^2.0.0",
-            "data-urls": "^1.1.0",
-            "domexception": "^1.0.1",
-            "escodegen": "^1.11.1",
-            "html-encoding-sniffer": "^1.0.2",
-            "nwsapi": "^2.1.4",
-            "parse5": "5.1.0",
-            "pn": "^1.1.0",
-            "request": "^2.88.0",
-            "request-promise-native": "^1.0.7",
-            "saxes": "^3.1.9",
-            "symbol-tree": "^3.2.2",
-            "tough-cookie": "^3.0.1",
-            "w3c-hr-time": "^1.0.1",
-            "w3c-xmlserializer": "^1.1.2",
-            "webidl-conversions": "^4.0.2",
-            "whatwg-encoding": "^1.0.5",
-            "whatwg-mimetype": "^2.3.0",
-            "whatwg-url": "^7.0.0",
-            "ws": "^7.0.0",
-            "xml-name-validator": "^3.0.0"
-          },
-          "dependencies": {
-            "acorn": {
-              "version": "7.1.0",
-              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
-              "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
-              "dev": true
-            }
-          }
         },
         "json5": {
           "version": "1.0.1",
@@ -1407,16 +633,15 @@
             "universalify": "^0.1.2"
           }
         },
-        "load-json-file": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
-          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+        "loader-utils": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+          "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
           "dev": true,
           "requires": {
-            "graceful-fs": "^4.1.2",
-            "parse-json": "^2.2.0",
-            "pify": "^2.0.0",
-            "strip-bom": "^3.0.0"
+            "big.js": "^5.2.2",
+            "emojis-list": "^2.0.0",
+            "json5": "^1.0.1"
           }
         },
         "locate-path": {
@@ -1427,12 +652,6 @@
           "requires": {
             "p-locate": "^4.1.0"
           }
-        },
-        "lodash": {
-          "version": "4.17.4",
-          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
-          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
-          "dev": true
         },
         "log-symbols": {
           "version": "3.0.0",
@@ -1454,12 +673,6 @@
                 "supports-color": "^5.3.0"
               }
             },
-            "has-flag": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
-            },
             "supports-color": {
               "version": "5.5.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -1480,51 +693,16 @@
             "ansi-escapes": "^3.2.0",
             "cli-cursor": "^2.1.0",
             "wrap-ansi": "^5.0.0"
-          },
-          "dependencies": {
-            "ansi-regex": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
-              "dev": true
-            },
-            "is-fullwidth-code-point": {
-              "version": "2.0.0",
-              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
-              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
-              "dev": true
-            },
-            "string-width": {
-              "version": "3.1.0",
-              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
-              "dev": true,
-              "requires": {
-                "emoji-regex": "^7.0.1",
-                "is-fullwidth-code-point": "^2.0.0",
-                "strip-ansi": "^5.1.0"
-              }
-            },
-            "strip-ansi": {
-              "version": "5.2.0",
-              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
-              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
-              "dev": true,
-              "requires": {
-                "ansi-regex": "^4.1.0"
-              }
-            },
-            "wrap-ansi": {
-              "version": "5.1.0",
-              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-              "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.0",
-                "string-width": "^3.0.0",
-                "strip-ansi": "^5.0.0"
-              }
-            }
+          }
+        },
+        "micromatch": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+          "dev": true,
+          "requires": {
+            "braces": "^3.0.1",
+            "picomatch": "^2.0.5"
           }
         },
         "mimic-fn": {
@@ -1569,23 +747,6 @@
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
           "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
           "dev": true
-        },
-        "node-releases": {
-          "version": "1.1.41",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.41.tgz",
-          "integrity": "sha512-+IctMa7wIs8Cfsa8iYzeaLTFwv5Y4r5jZud+4AnfymzeEXKBCavFX0KBgzVaPVqf0ywa6PrO8/b+bPqdwjGBSg==",
-          "dev": true,
-          "requires": {
-            "semver": "^6.3.0"
-          },
-          "dependencies": {
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
-          }
         },
         "normalize-url": {
           "version": "1.9.1",
@@ -1634,12 +795,6 @@
             "wcwidth": "^1.0.1"
           },
           "dependencies": {
-            "ansi-regex": {
-              "version": "5.0.0",
-              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-              "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
-              "dev": true
-            },
             "ansi-styles": {
               "version": "4.2.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
@@ -1713,46 +868,16 @@
             "p-limit": "^2.2.0"
           }
         },
-        "p-map": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-          "dev": true
-        },
         "p-try": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
-        "parse-json": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
-          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "^1.2.0"
-          }
-        },
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
-          "dev": true
-        },
-        "path-type": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
-          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "^2.0.0"
-          }
-        },
-        "pify": {
-          "version": "2.3.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "pkg-dir": {
@@ -1762,44 +887,39 @@
           "dev": true,
           "requires": {
             "find-up": "^4.0.0"
-          },
-          "dependencies": {
-            "find-up": {
-              "version": "4.1.0",
-              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-              "dev": true,
-              "requires": {
-                "locate-path": "^5.0.0",
-                "path-exists": "^4.0.0"
-              }
-            }
           }
         },
         "postcss": {
-          "version": "7.0.7",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
-          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+          "version": "7.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
+          "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
+            "chalk": "^2.4.2",
             "source-map": "^0.6.1",
-            "supports-color": "^5.5.0"
+            "supports-color": "^6.1.0"
           },
           "dependencies": {
-            "has-flag": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
-            },
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
               "dev": true,
               "requires": {
-                "has-flag": "^3.0.0"
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
               }
             }
           }
@@ -1851,56 +971,6 @@
           "requires": {
             "postcss": "^7.0.14",
             "postcss-values-parser": "^2.0.1"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "5.5.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                  "dev": true,
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "has-flag": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
-            },
-            "postcss": {
-              "version": "7.0.23",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
-              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
-              "dev": true,
-              "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-              }
-            },
-            "supports-color": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
           }
         },
         "postcss-color-mod-function": {
@@ -1931,56 +1001,6 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.14"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "5.5.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                  "dev": true,
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "has-flag": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
-            },
-            "postcss": {
-              "version": "7.0.23",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
-              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
-              "dev": true,
-              "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-              }
-            },
-            "supports-color": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
           }
         },
         "postcss-custom-properties": {
@@ -1991,56 +1011,6 @@
           "requires": {
             "postcss": "^7.0.17",
             "postcss-values-parser": "^2.0.1"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "5.5.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                  "dev": true,
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "has-flag": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
-            },
-            "postcss": {
-              "version": "7.0.23",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
-              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
-              "dev": true,
-              "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-              }
-            },
-            "supports-color": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
           }
         },
         "postcss-custom-selectors": {
@@ -2215,56 +1185,6 @@
             "postcss": "^7.0.16",
             "postcss-selector-parser": "^6.0.2",
             "postcss-value-parser": "^4.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "5.5.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                  "dev": true,
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "has-flag": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
-            },
-            "postcss": {
-              "version": "7.0.23",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
-              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
-              "dev": true,
-              "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-              }
-            },
-            "supports-color": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
           }
         },
         "postcss-modules-scope": {
@@ -2367,56 +1287,6 @@
             "postcss-replace-overflow-wrap": "^3.0.0",
             "postcss-selector-matches": "^4.0.0",
             "postcss-selector-not": "^4.0.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "5.5.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                  "dev": true,
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "has-flag": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
-            },
-            "postcss": {
-              "version": "7.0.23",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
-              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
-              "dev": true,
-              "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-              }
-            },
-            "supports-color": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
           }
         },
         "postcss-pseudo-class-any-link": {
@@ -2505,27 +1375,6 @@
             "uniq": "^1.0.1"
           }
         },
-        "read-pkg": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
-          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "^2.0.0",
-            "normalize-package-data": "^2.3.2",
-            "path-type": "^2.0.0"
-          }
-        },
-        "read-pkg-up": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
-          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
-          "dev": true,
-          "requires": {
-            "find-up": "^2.0.0",
-            "read-pkg": "^2.0.0"
-          }
-        },
         "restore-cursor": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -2546,28 +1395,30 @@
             "ajv-keywords": "^3.4.1"
           }
         },
-        "strip-ansi": {
-          "version": "3.0.1",
-          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "^2.0.0"
-          }
-        },
-        "strip-bom": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
-          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
           "dev": true
         },
-        "supports-color": {
-          "version": "4.5.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
-          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
           "dev": true,
           "requires": {
-            "has-flag": "^2.0.0"
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
           }
         },
         "to-regex-range": {
@@ -2590,101 +1441,29 @@
             "loader-utils": "^1.0.2",
             "micromatch": "^4.0.0",
             "semver": "^6.0.0"
-          },
-          "dependencies": {
-            "micromatch": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-              "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-              "dev": true,
-              "requires": {
-                "braces": "^3.0.1",
-                "picomatch": "^2.0.5"
-              }
-            },
-            "semver": {
-              "version": "6.3.0",
-              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-              "dev": true
-            }
           }
         },
-        "ts-node": {
-          "version": "8.5.4",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
-          "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
+        "wrap-ansi": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
           "dev": true,
           "requires": {
-            "arg": "^4.1.0",
-            "diff": "^4.0.1",
-            "make-error": "^1.1.1",
-            "source-map-support": "^0.5.6",
-            "yn": "^3.0.0"
-          }
-        },
-        "typed-css-modules": {
-          "version": "0.3.7",
-          "resolved": "https://registry.npmjs.org/typed-css-modules/-/typed-css-modules-0.3.7.tgz",
-          "integrity": "sha512-KR1VG/U0rgFWaiQtXKtFMgKaurs80nvlBvZ7BfuYGLldw6kss/97sd+aMG4CI73BbujvefG7DBjnsBqq2Aowcw==",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0",
-            "chalk": "^2.1.0",
-            "chokidar": "^2.0.3",
-            "css-modules-loader-core": "^1.1.0",
-            "glob": "^7.1.2",
-            "is-there": "^4.4.2",
-            "mkdirp": "^0.5.1",
-            "yargs": "^8.0.2"
-          }
-        },
-        "y18n": {
-          "version": "3.2.1",
-          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
-          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
-          "dev": true
-        },
-        "yargs": {
-          "version": "8.0.2",
-          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
-          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0",
-            "cliui": "^3.2.0",
-            "decamelize": "^1.1.1",
-            "get-caller-file": "^1.0.1",
-            "os-locale": "^2.0.0",
-            "read-pkg-up": "^2.0.0",
-            "require-directory": "^2.1.1",
-            "require-main-filename": "^1.0.1",
-            "set-blocking": "^2.0.0",
-            "string-width": "^2.0.0",
-            "which-module": "^2.0.0",
-            "y18n": "^3.2.1",
-            "yargs-parser": "^7.0.0"
-          }
-        },
-        "yargs-parser": {
-          "version": "7.0.0",
-          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
-          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
-          "dev": true,
-          "requires": {
-            "camelcase": "^4.1.0"
+            "ansi-styles": "^3.2.0",
+            "string-width": "^3.0.0",
+            "strip-ansi": "^5.0.0"
           }
         }
       }
     },
     "@dojo/cli-build-widget": {
-      "version": "7.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@dojo/cli-build-widget/-/cli-build-widget-7.0.0-alpha.2.tgz",
-      "integrity": "sha512-p5dyjcihuTcJuA2g76j+f32YOaX2hT0QYU9KgPWu543tV5QsK4XCWXqvxppDaYasWT55+UyWo3Dzw/oDMli6mA==",
+      "version": "7.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@dojo/cli-build-widget/-/cli-build-widget-7.0.0-alpha.5.tgz",
+      "integrity": "sha512-r9CWrYXsqfBqRqgR8MJNX9cmOotn9zTQgzUrezQWXH790E7RqUAKAsK0OnO87+WsL+5p78vqH2m/oHyfh7xGpA==",
       "dev": true,
       "requires": {
-        "@dojo/framework": "7.0.0-alpha.3",
-        "@dojo/webpack-contrib": "7.0.0-alpha.2",
+        "@dojo/framework": "7.0.0-alpha.4",
+        "@dojo/webpack-contrib": "7.0.0-alpha.5",
         "chalk": "2.4.1",
         "clean-webpack-plugin": "1.0.0",
         "cli-columns": "3.1.2",
@@ -2707,6 +1486,7 @@
         "pkg-dir": "2.0.0",
         "postcss-import": "12.0.0",
         "postcss-loader": "3.0.0",
+        "postcss-modules": "1.4.1",
         "postcss-preset-env": "5.3.0",
         "slash": "1.0.0",
         "source-map-loader-cli": "0.0.1",
@@ -2725,28 +1505,6 @@
         "webpack-mild-compile": "3.3.1"
       },
       "dependencies": {
-        "@dojo/framework": {
-          "version": "7.0.0-alpha.3",
-          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.3.tgz",
-          "integrity": "sha512-NbagpENJR0sArFopGUFXF/iqyVM8q8y2QXEzTTIz8Z1IG8taOYntqehITB0fcdt7K7jV0YzC6ScoG1LC1hS5lw==",
-          "dev": true,
-          "requires": {
-            "@types/cldrjs": "0.4.20",
-            "@types/globalize": "0.0.34",
-            "@webcomponents/webcomponentsjs": "1.1.0",
-            "cldrjs": "0.5.0",
-            "cross-fetch": "3.0.2",
-            "css-select-umd": "1.3.0-rc0",
-            "diff": "3.5.0",
-            "globalize": "1.4.0",
-            "immutable": "3.8.2",
-            "intersection-observer": "0.4.2",
-            "pepjs": "0.4.2",
-            "resize-observer-polyfill": "1.5.0",
-            "tslib": "1.9.3",
-            "web-animations-js": "2.3.1"
-          }
-        },
         "file-loader": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
@@ -3263,6 +2021,28 @@
             "type-detect": "^4.0.5"
           }
         },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
         "cldr-data": {
           "version": "36.0.0",
           "resolved": "https://registry.npmjs.org/cldr-data/-/cldr-data-36.0.0.tgz",
@@ -3481,6 +2261,12 @@
           "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
           "dev": true
         },
+        "is-plain-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
+          "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ==",
+          "dev": true
+        },
         "istanbul-lib-coverage": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
@@ -3618,6 +2404,17 @@
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         },
+        "postcss": {
+          "version": "7.0.21",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
+          "integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
         "qs": {
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
@@ -3655,6 +2452,29 @@
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true
             }
+          }
+        },
+        "remark-parse": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.1.tgz",
+          "integrity": "sha512-WOZLa545jYXtSy+txza6ACudKWByQac4S2DmGk+tAGO/3XnVTOxwyCIxB7nTcLlk8Aayhcuf3cV1WV6U6L7/DQ==",
+          "dev": true,
+          "requires": {
+            "collapse-white-space": "^1.0.2",
+            "is-alphabetical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-whitespace-character": "^1.0.0",
+            "is-word-character": "^1.0.0",
+            "markdown-escapes": "^1.0.0",
+            "parse-entities": "^1.1.0",
+            "repeat-string": "^1.5.4",
+            "state-toggle": "^1.0.0",
+            "trim": "0.0.1",
+            "trim-trailing-lines": "^1.0.0",
+            "unherit": "^1.0.4",
+            "unist-util-remove-position": "^1.0.0",
+            "vfile-location": "^2.0.0",
+            "xtend": "^4.0.1"
           }
         },
         "resolve": {
@@ -3776,6 +2596,32 @@
             "yn": "^3.0.0"
           }
         },
+        "unified": {
+          "version": "8.4.1",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.1.tgz",
+          "integrity": "sha512-YPj/uIIZSO7mMIZQj/5Z3hDl4lshWYRQGs5TgUCjHTVdklUWH+O94mK5Cy77SEcmEUwGhnUcudMuH/zIwporqw==",
+          "dev": true,
+          "requires": {
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^2.0.0",
+            "trough": "^1.0.0",
+            "vfile": "^4.0.0"
+          }
+        },
+        "vfile": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.2.tgz",
+          "integrity": "sha512-yhoTU5cDMSsaeaMfJ5g0bUKYkYmZhAh9fn9TZicxqn+Cw4Z439il2v3oT9S0yjlpqlI74aFOQCt3nOV+pxzlkw==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "^2.0.0",
+            "vfile-message": "^2.0.0"
+          }
+        },
         "ws": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.1.tgz",
@@ -3842,12 +2688,12 @@
       }
     },
     "@dojo/webpack-contrib": {
-      "version": "7.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-alpha.2.tgz",
-      "integrity": "sha512-4x/PWMgIpNd7jZnVaUxHFSN2hV5EAiETBfw08IRAdMSyPOX9v6ipy/BlG4z7JsU8kvr743AvMZYhgo+vE0EaWg==",
+      "version": "7.0.0-alpha.5",
+      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-alpha.5.tgz",
+      "integrity": "sha512-5hIpPY53YEImXpDSgcwCpAqCwpKfuBfwTCNUmQ6wctbzvi0BOTFZoA91nGmduobjWSzCpV/yStAEgBtx7gynUQ==",
       "dev": true,
       "requires": {
-        "@dojo/framework": "7.0.0-alpha.2",
+        "@dojo/framework": "7.0.0-alpha.4",
         "acorn": "6.1.1",
         "acorn-dynamic-import": "4.0.0",
         "acorn-walk": "6.1.1",
@@ -3887,28 +2733,6 @@
         "wrapper-webpack-plugin": "2.0.0"
       },
       "dependencies": {
-        "@dojo/framework": {
-          "version": "7.0.0-alpha.2",
-          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.2.tgz",
-          "integrity": "sha512-QjvQgDrUdpWoRT9UWjlyzvukWhjqwDLQgj0hAgTkCXlC/1q95KFAtH7rgrjwY654j5sXEZHKDgrX45PbPLsyXQ==",
-          "dev": true,
-          "requires": {
-            "@types/cldrjs": "0.4.20",
-            "@types/globalize": "0.0.34",
-            "@webcomponents/webcomponentsjs": "1.1.0",
-            "cldrjs": "0.5.0",
-            "cross-fetch": "3.0.2",
-            "css-select-umd": "1.3.0-rc0",
-            "diff": "3.5.0",
-            "globalize": "1.4.0",
-            "immutable": "3.8.2",
-            "intersection-observer": "0.4.2",
-            "pepjs": "0.4.2",
-            "resize-observer-polyfill": "1.5.0",
-            "tslib": "1.9.3",
-            "web-animations-js": "2.3.1"
-          }
-        },
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -3954,6 +2778,12 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
           "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+          "dev": true
+        },
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
           "dev": true
         },
         "has-flag": {
@@ -4055,45 +2885,6 @@
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
-        "postcss": {
-          "version": "7.0.7",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
-          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.5.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              }
-            },
-            "has-flag": {
-              "version": "3.0.0",
-              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-              "dev": true
-            },
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
         "read-pkg": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -4153,9 +2944,9 @@
           }
         },
         "ts-node": {
-          "version": "8.5.2",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.2.tgz",
-          "integrity": "sha512-W1DK/a6BGoV/D4x/SXXm6TSQx6q3blECUzd5TN+j56YEMX3yPVMpHsICLedUw3DvGF3aTQ8hfdR9AKMaHjIi+A==",
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
+          "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
           "dev": true,
           "requires": {
             "arg": "^4.1.0",
@@ -4163,14 +2954,6 @@
             "make-error": "^1.1.1",
             "source-map-support": "^0.5.6",
             "yn": "^3.0.0"
-          },
-          "dependencies": {
-            "diff": {
-              "version": "4.0.1",
-              "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-              "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
-              "dev": true
-            }
           }
         },
         "typed-css-modules": {
@@ -5884,9 +4667,9 @@
       }
     },
     "arg": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
-      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
+      "integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==",
       "dev": true
     },
     "argparse": {
@@ -6133,9 +4916,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
+      "version": "1.9.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
+      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
       "dev": true
     },
     "axe-core": {
@@ -6513,9 +5296,9 @@
       }
     },
     "bluebird": {
-      "version": "3.7.1",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
-      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
+      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
       "dev": true
     },
     "bmp-js": {
@@ -6737,20 +5520,20 @@
       }
     },
     "browserslist": {
-      "version": "4.7.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
-      "integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.0.tgz",
+      "integrity": "sha512-HYnxc/oLRWvJ3TsGegR0SRL/UDnknGq2s/a8dYYEO+kOQ9m9apKoS5oiathLKZdh/e9uE+/J3j92qPlGD/vTqA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001004",
-        "electron-to-chromium": "^1.3.295",
-        "node-releases": "^1.1.38"
+        "caniuse-lite": "^1.0.30001012",
+        "electron-to-chromium": "^1.3.317",
+        "node-releases": "^1.1.41"
       },
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30001010",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001010.tgz",
-          "integrity": "sha512-RA5GH9YjFNea4ZQszdWgh2SC+dpLiRAg4VDQS2b5JRI45OxmbGrYocYHTa9x0bKMQUE7uvHkNPNffUr+pCxSGw==",
+          "version": "1.0.30001015",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+          "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==",
           "dev": true
         }
       }
@@ -7536,9 +6319,9 @@
       }
     },
     "code-block-writer": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.0.0.tgz",
-      "integrity": "sha512-UIlTeLDLvu9YDmxh566yrnKCTBULJNCF+oUoRTv8gmt5/DIqp7pozkUu5hnpUPWjgIHEqkOeAiSGuN8E3A+Wuw==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.0.tgz",
+      "integrity": "sha512-RG9hpXtWFeUWhuUav1YuP/vGcyncW+t90yJLk9fNZs1De2OuHTHKAKThVCokt29PYq5RoJ0QSZaIZ+rvPO23hA==",
       "dev": true
     },
     "code-point-at": {
@@ -9134,17 +7917,37 @@
       }
     },
     "del": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+      "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
       "dev": true,
       "requires": {
+        "@types/glob": "^7.1.1",
         "globby": "^6.1.0",
-        "is-path-cwd": "^1.0.0",
-        "is-path-in-cwd": "^1.0.0",
-        "p-map": "^1.1.1",
-        "pify": "^3.0.0",
-        "rimraf": "^2.2.8"
+        "is-path-cwd": "^2.0.0",
+        "is-path-in-cwd": "^2.0.0",
+        "p-map": "^2.0.0",
+        "pify": "^4.0.1",
+        "rimraf": "^2.6.3"
+      },
+      "dependencies": {
+        "@types/glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+          "dev": true,
+          "requires": {
+            "@types/events": "*",
+            "@types/minimatch": "*",
+            "@types/node": "*"
+          }
+        },
+        "pify": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+          "dev": true
+        }
       }
     },
     "delayed-stream": {
@@ -9375,9 +8178,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.306",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.306.tgz",
-      "integrity": "sha512-frDqXvrIROoYvikSKTIKbHbzO6M3/qC6kCIt/1FOa9kALe++c4VAJnwjSFvf1tYLEUsP2n9XZ4XSCyqc3l7A/A==",
+      "version": "1.3.322",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+      "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==",
       "dev": true
     },
     "elegant-spinner": {
@@ -9387,9 +8190,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.1",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
-      "integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
+      "version": "6.5.2",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
+      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -9479,18 +8282,18 @@
       }
     },
     "es-abstract": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
-      "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
+      "integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.0",
+        "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.0",
+        "has-symbols": "^1.0.1",
         "is-callable": "^1.1.4",
         "is-regex": "^1.0.4",
-        "object-inspect": "^1.6.0",
+        "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "string.prototype.trimleft": "^2.1.0",
         "string.prototype.trimright": "^2.1.0"
@@ -9508,13 +8311,13 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.52",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.52.tgz",
-      "integrity": "sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==",
+      "version": "0.10.53",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
+      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
       "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.2",
+        "es6-symbol": "~3.1.3",
         "next-tick": "~1.0.0"
       },
       "dependencies": {
@@ -9978,9 +8781,9 @@
       }
     },
     "ext": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.2.0.tgz",
-      "integrity": "sha512-0ccUQK/9e3NreLFg6K6np8aPyRgwycx+oFGtfx1dSp7Wj00Ozw9r05FgBRlzjf2XBM7LAzwgLyDscRrtSU91hA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
+      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
       "dev": true,
       "requires": {
         "type": "^2.0.0"
@@ -11743,9 +10546,9 @@
       }
     },
     "handlebars": {
-      "version": "4.5.2",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
-      "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
+      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -13266,18 +12069,29 @@
       }
     },
     "is-path-cwd": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+      "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^1.0.0"
+        "is-path-inside": "^2.1.0"
+      },
+      "dependencies": {
+        "is-path-inside": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+          "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+          "dev": true,
+          "requires": {
+            "path-is-inside": "^1.0.2"
+          }
+        }
       }
     },
     "is-path-inside": {
@@ -13386,12 +12200,12 @@
       }
     },
     "is-symbol": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
-      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
+      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.0"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-there": {
@@ -14066,6 +12880,20 @@
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
         },
+        "del": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+          "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
+          "dev": true,
+          "requires": {
+            "globby": "^6.1.0",
+            "is-path-cwd": "^1.0.0",
+            "is-path-in-cwd": "^1.0.0",
+            "p-map": "^1.1.1",
+            "pify": "^3.0.0",
+            "rimraf": "^2.2.8"
+          }
+        },
         "execa": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -14081,6 +12909,21 @@
             "strip-eof": "^1.0.0"
           }
         },
+        "is-path-cwd": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+          "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
+          "dev": true
+        },
+        "is-path-in-cwd": {
+          "version": "1.0.1",
+          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+          "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
+          "dev": true,
+          "requires": {
+            "is-path-inside": "^1.0.0"
+          }
+        },
         "log-symbols": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -14089,6 +12932,12 @@
           "requires": {
             "chalk": "^2.0.1"
           }
+        },
+        "p-map": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+          "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+          "dev": true
         }
       }
     },
@@ -14107,14 +12956,6 @@
         "listr-verbose-renderer": "^0.5.0",
         "p-map": "^2.0.0",
         "rxjs": "^6.3.3"
-      },
-      "dependencies": {
-        "p-map": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
-          "dev": true
-        }
       }
     },
     "listr-silent-renderer": {
@@ -15106,9 +13947,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.40",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.40.tgz",
-      "integrity": "sha512-r4LPcC5b/bS8BdtWH1fbeK88ib/wg9aqmg6/s3ngNLn2Ewkn/8J6Iw3P9RTlfIAdSdvYvQl2thCY5Y+qTAQ2iQ==",
+      "version": "1.1.42",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
+      "integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
@@ -15715,9 +14556,9 @@
       }
     },
     "p-map": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
       "dev": true
     },
     "p-try": {
@@ -16088,47 +14929,14 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.21",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-      "integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
+      "version": "7.0.7",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+      "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.2",
+        "chalk": "^2.4.1",
         "source-map": "^0.6.1",
-        "supports-color": "^6.1.0"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
+        "supports-color": "^5.5.0"
       }
     },
     "postcss-attribute-case-insensitive": {
@@ -16741,6 +15549,50 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.14"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "postcss": {
+          "version": "7.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
+          "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "postcss-load-config": {
@@ -17761,9 +16613,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
-      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.5.0.tgz",
+      "integrity": "sha512-4vqUjKi2huMu1OJiLhi3jN6jeeKvMZdI1tYgi/njW5zV52jNLgSAZSdN16m9bJFe61/cT8ulmw4qFitV9QRsEA==",
       "dev": true
     },
     "pstree.remy": {
@@ -18302,53 +17154,12 @@
         "remark-parse": "^6.0.0",
         "remark-stringify": "^6.0.0",
         "unified": "^7.0.0"
-      },
-      "dependencies": {
-        "remark-parse": {
-          "version": "6.0.3",
-          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
-          "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
-          "dev": true,
-          "requires": {
-            "collapse-white-space": "^1.0.2",
-            "is-alphabetical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-whitespace-character": "^1.0.0",
-            "is-word-character": "^1.0.0",
-            "markdown-escapes": "^1.0.0",
-            "parse-entities": "^1.1.0",
-            "repeat-string": "^1.5.4",
-            "state-toggle": "^1.0.0",
-            "trim": "0.0.1",
-            "trim-trailing-lines": "^1.0.0",
-            "unherit": "^1.0.4",
-            "unist-util-remove-position": "^1.0.0",
-            "vfile-location": "^2.0.0",
-            "xtend": "^4.0.1"
-          }
-        },
-        "unified": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
-          "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
-          "dev": true,
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "@types/vfile": "^3.0.0",
-            "bail": "^1.0.0",
-            "extend": "^3.0.0",
-            "is-plain-obj": "^1.1.0",
-            "trough": "^1.0.0",
-            "vfile": "^3.0.0",
-            "x-is-string": "^0.1.0"
-          }
-        }
       }
     },
     "remark-parse": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.1.tgz",
-      "integrity": "sha512-WOZLa545jYXtSy+txza6ACudKWByQac4S2DmGk+tAGO/3XnVTOxwyCIxB7nTcLlk8Aayhcuf3cV1WV6U6L7/DQ==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+      "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
       "dev": true,
       "requires": {
         "collapse-white-space": "^1.0.2",
@@ -18598,9 +17409,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.12.0",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
-      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "version": "1.13.1",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
+      "integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -19842,45 +18653,12 @@
                 "supports-color": "^5.3.0"
               }
             },
-            "postcss": {
-              "version": "7.0.23",
-              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
-              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
-              "dev": true,
-              "requires": {
-                "chalk": "^2.4.2",
-                "source-map": "^0.6.1",
-                "supports-color": "^6.1.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "6.1.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-                  "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-                  "dev": true,
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
-              }
-            },
             "postcss-value-parser": {
               "version": "4.0.2",
               "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
               "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
               "dev": true
             }
-          }
-        },
-        "browserslist": {
-          "version": "4.8.0",
-          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.0.tgz",
-          "integrity": "sha512-HYnxc/oLRWvJ3TsGegR0SRL/UDnknGq2s/a8dYYEO+kOQ9m9apKoS5oiathLKZdh/e9uE+/J3j92qPlGD/vTqA==",
-          "dev": true,
-          "requires": {
-            "caniuse-lite": "^1.0.30001012",
-            "electron-to-chromium": "^1.3.317",
-            "node-releases": "^1.1.41"
           }
         },
         "camelcase-keys": {
@@ -19895,9 +18673,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001013",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001013.tgz",
-          "integrity": "sha512-hOAXaWKuq/UVFgYawxIOdPdyMQdYcwOCDOjnZcKn7wCgFUrhP7smuNZjGLuJlPSgE6aRA4cRJ+bGSrhtEt7ZAg==",
+          "version": "1.0.30001015",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+          "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==",
           "dev": true
         },
         "debug": {
@@ -19908,12 +18686,6 @@
           "requires": {
             "ms": "^2.1.1"
           }
-        },
-        "electron-to-chromium": {
-          "version": "1.3.322",
-          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
-          "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==",
-          "dev": true
         },
         "get-stdin": {
           "version": "6.0.0",
@@ -20006,20 +18778,55 @@
             "yargs-parser": "^10.0.0"
           }
         },
-        "node-releases": {
-          "version": "1.1.41",
-          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.41.tgz",
-          "integrity": "sha512-+IctMa7wIs8Cfsa8iYzeaLTFwv5Y4r5jZud+4AnfymzeEXKBCavFX0KBgzVaPVqf0ywa6PrO8/b+bPqdwjGBSg==",
-          "dev": true,
-          "requires": {
-            "semver": "^6.3.0"
-          }
-        },
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
+        },
+        "postcss": {
+          "version": "7.0.23",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
+          "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "source-map": "^0.6.1",
+            "supports-color": "^6.1.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
         },
         "postcss-selector-parser": {
           "version": "3.1.1",
@@ -20062,12 +18869,6 @@
             "indent-string": "^3.0.0",
             "strip-indent": "^2.0.0"
           }
-        },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
         },
         "slash": {
           "version": "2.0.0",
@@ -20817,9 +19618,9 @@
           }
         },
         "fast-glob": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
-          "integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz",
+          "integrity": "sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==",
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
@@ -20916,6 +19717,36 @@
           "requires": {
             "is-number": "^7.0.0"
           }
+        }
+      }
+    },
+    "ts-node": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+      "dev": true,
+      "requires": {
+        "arrify": "^1.0.0",
+        "buffer-from": "^1.1.0",
+        "diff": "^3.1.0",
+        "make-error": "^1.1.1",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "source-map-support": "^0.5.6",
+        "yn": "^2.0.0"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "yn": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+          "dev": true
         }
       }
     },
@@ -21633,43 +20464,19 @@
       }
     },
     "unified": {
-      "version": "8.4.1",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.1.tgz",
-      "integrity": "sha512-YPj/uIIZSO7mMIZQj/5Z3hDl4lshWYRQGs5TgUCjHTVdklUWH+O94mK5Cy77SEcmEUwGhnUcudMuH/zIwporqw==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+      "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
       "dev": true,
       "requires": {
+        "@types/unist": "^2.0.0",
+        "@types/vfile": "^3.0.0",
         "bail": "^1.0.0",
         "extend": "^3.0.0",
-        "is-plain-obj": "^2.0.0",
+        "is-plain-obj": "^1.1.0",
         "trough": "^1.0.0",
-        "vfile": "^4.0.0"
-      },
-      "dependencies": {
-        "is-buffer": {
-          "version": "2.0.4",
-          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
-          "dev": true
-        },
-        "is-plain-obj": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
-          "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ==",
-          "dev": true
-        },
-        "vfile": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.2.tgz",
-          "integrity": "sha512-yhoTU5cDMSsaeaMfJ5g0bUKYkYmZhAh9fn9TZicxqn+Cw4Z439il2v3oT9S0yjlpqlI74aFOQCt3nOV+pxzlkw==",
-          "dev": true,
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "is-buffer": "^2.0.0",
-            "replace-ext": "1.0.0",
-            "unist-util-stringify-position": "^2.0.0",
-            "vfile-message": "^2.0.0"
-          }
-        }
+        "vfile": "^3.0.0",
+        "x-is-string": "^0.1.0"
       }
     },
     "union-value": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -159,9 +159,9 @@
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-      "integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.2.tgz",
+      "integrity": "sha512-JONRbXbTXc9WQE2mAZd1p0Z3DZ/6vaQIkgYMSTP3KjRCyd7rCZCcfhCyX+YjwcKxcZ82UrxbRD358bpExNgrjw==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -292,12 +292,12 @@
       }
     },
     "@dojo/cli-build-app": {
-      "version": "7.0.0-alpha.6",
-      "resolved": "https://registry.npmjs.org/@dojo/cli-build-app/-/cli-build-app-7.0.0-alpha.6.tgz",
-      "integrity": "sha512-WX4367IfK4+2+jdUXNhPUm/eEsZQe8EyDvRrplsWQyiXk9gk2CLehcQ5S0NjFvL1got5n0U4RM6vEvhM9ELtZg==",
+      "version": "7.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@dojo/cli-build-app/-/cli-build-app-7.0.0-alpha.4.tgz",
+      "integrity": "sha512-xUbvkX+jaG6urSgKW8B9Z/FIOXApu+mmozGZIsCU9bCX+50lpEzAUgBEVhJwsuM8N4qOz18xJl/BOEuYGraN2Q==",
       "dev": true,
       "requires": {
-        "@dojo/webpack-contrib": "7.0.0-alpha.5",
+        "@dojo/webpack-contrib": "7.0.0-alpha.3",
         "brotli-webpack-plugin": "1.0.0",
         "caniuse-lite": "1.0.30000973",
         "chalk": "2.4.1",
@@ -355,10 +355,147 @@
         "wrapper-webpack-plugin": "2.0.0"
       },
       "dependencies": {
+        "@dojo/webpack-contrib": {
+          "version": "7.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-alpha.3.tgz",
+          "integrity": "sha512-eqz9pCdPWjWH7eoxxZ7kyWTBJjVe+XuUD1pjRGhwDpborypD0omnkOakVS5P3WMRurc2lEm2/a7bNKx1yzOOhA==",
+          "dev": true,
+          "requires": {
+            "@dojo/framework": "7.0.0-alpha.4",
+            "acorn": "6.1.1",
+            "acorn-dynamic-import": "4.0.0",
+            "acorn-walk": "6.1.1",
+            "bfj": "6.1.1",
+            "chalk": "2.3.0",
+            "clear-module": "3.1.0",
+            "commander": "2.13.0",
+            "connect-history-api-fallback": "1.6.0",
+            "copy-webpack-plugin": "4.6.0",
+            "cssnano": "4.1.7",
+            "eventsource-polyfill": "0.9.6",
+            "express": "4.16.2",
+            "filesize": "3.5.11",
+            "filter-css": "0.1.2",
+            "fs-extra": "7.0.0",
+            "get-port": "4.0.0",
+            "glob": "^7.1.2",
+            "gzip-size": "4.1.0",
+            "html-webpack-include-assets-plugin": "1.0.6",
+            "istanbul-lib-instrument": "1.10.1",
+            "jsdom": "15.2.0",
+            "loader-utils": "1.1.0",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "node-html-parser": "1.1.11",
+            "opener": "1.4.3",
+            "postcss": "7.0.7",
+            "puppeteer": "1.11.0",
+            "recast": "0.12.7",
+            "source-map": "0.6.1",
+            "ts-loader": "5.4.5",
+            "ts-node": "^8.0.3",
+            "typed-css-modules": "0.3.7",
+            "webpack-hot-middleware": "2.24.3",
+            "workbox-webpack-plugin": "3.6.3",
+            "wrapper-webpack-plugin": "2.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+              "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.1.0",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^4.0.0"
+              }
+            },
+            "connect-history-api-fallback": {
+              "version": "1.6.0",
+              "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+              "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+              "dev": true
+            },
+            "ts-loader": {
+              "version": "5.4.5",
+              "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.4.5.tgz",
+              "integrity": "sha512-XYsjfnRQCBum9AMRZpk2rTYSVpdZBpZK+kDh0TeT3kxmQNBDVIeUjdPjY5RZry4eIAb8XHc4gYSUiUWPYvzSRw==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.3.0",
+                "enhanced-resolve": "^4.0.0",
+                "loader-utils": "^1.0.2",
+                "micromatch": "^3.1.4",
+                "semver": "^5.0.1"
+              }
+            },
+            "ts-node": {
+              "version": "8.5.4",
+              "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
+              "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
+              "dev": true,
+              "requires": {
+                "arg": "^4.1.0",
+                "diff": "^4.0.1",
+                "make-error": "^1.1.1",
+                "source-map-support": "^0.5.6",
+                "yn": "^3.0.0"
+              }
+            },
+            "typed-css-modules": {
+              "version": "0.3.7",
+              "resolved": "https://registry.npmjs.org/typed-css-modules/-/typed-css-modules-0.3.7.tgz",
+              "integrity": "sha512-KR1VG/U0rgFWaiQtXKtFMgKaurs80nvlBvZ7BfuYGLldw6kss/97sd+aMG4CI73BbujvefG7DBjnsBqq2Aowcw==",
+              "dev": true,
+              "requires": {
+                "camelcase": "^4.1.0",
+                "chalk": "^2.1.0",
+                "chokidar": "^2.0.3",
+                "css-modules-loader-core": "^1.1.0",
+                "glob": "^7.1.2",
+                "is-there": "^4.4.2",
+                "mkdirp": "^0.5.1",
+                "yargs": "^8.0.2"
+              }
+            }
+          }
+        },
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
           "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
           "dev": true
         },
         "globby": {
@@ -373,6 +510,168 @@
             "ignore": "^3.3.5",
             "pify": "^3.0.0",
             "slash": "^1.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
+          }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "jsdom": {
+          "version": "15.2.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.0.tgz",
+          "integrity": "sha512-+hRyEfjRPFwTYMmSQ3/f7U9nP8ZNZmbkmUek760ZpxnCPWJIhaaLRuUSvpJ36fZKCGENxLwxClzwpOpnXNfChQ==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.0",
+            "acorn": "^7.1.0",
+            "acorn-globals": "^4.3.2",
+            "array-equal": "^1.0.0",
+            "cssom": "^0.4.1",
+            "cssstyle": "^2.0.0",
+            "data-urls": "^1.1.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.11.1",
+            "html-encoding-sniffer": "^1.0.2",
+            "nwsapi": "^2.1.4",
+            "parse5": "5.1.0",
+            "pn": "^1.1.0",
+            "request": "^2.88.0",
+            "request-promise-native": "^1.0.7",
+            "saxes": "^3.1.9",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^3.0.1",
+            "w3c-hr-time": "^1.0.1",
+            "w3c-xmlserializer": "^1.1.2",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^7.0.0",
+            "ws": "^7.0.0",
+            "xml-name-validator": "^3.0.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+              "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+              "dev": true
+            }
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
+        },
+        "minimist": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
+          "dev": true
+        },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
+        },
+        "postcss": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.5.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "strip-ansi": {
@@ -383,16 +682,97 @@
           "requires": {
             "ansi-regex": "^2.0.0"
           }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^2.0.0"
+          }
+        },
+        "ts-node": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
+          "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
+          "dev": true,
+          "requires": {
+            "arrify": "^1.0.0",
+            "buffer-from": "^1.1.0",
+            "diff": "^3.1.0",
+            "make-error": "^1.1.1",
+            "minimist": "^1.2.0",
+            "mkdirp": "^0.5.1",
+            "source-map-support": "^0.5.6",
+            "yn": "^2.0.0"
+          },
+          "dependencies": {
+            "diff": {
+              "version": "3.5.0",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+              "integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+              "dev": true
+            },
+            "yn": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
+              "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
+              "dev": true
+            }
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
+          }
         }
       }
     },
     "@dojo/cli-build-theme": {
-      "version": "7.0.0-alpha.2",
-      "resolved": "https://registry.npmjs.org/@dojo/cli-build-theme/-/cli-build-theme-7.0.0-alpha.2.tgz",
-      "integrity": "sha512-KnfLrrIq/JMmgljUplktwoNbXchCdiJ9jU432bLLRXjI+0i9inxHVLU19Za/QwqshptGnnPisEgK2w8P5/8XjA==",
+      "version": "7.0.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/@dojo/cli-build-theme/-/cli-build-theme-7.0.0-alpha.1.tgz",
+      "integrity": "sha512-bbCQ3SvCAwOvSzZCUO2Mnft3KonlaMzFUt1eV9Q0vOjPE0q4KEb4gHAGDF2BYdyB19N8kA7kGVWHxbtEwnQjfA==",
       "dev": true,
       "requires": {
-        "@dojo/webpack-contrib": "7.0.0-alpha.5",
+        "@dojo/webpack-contrib": "7.0.0-alpha.4",
         "@types/log-update": "3.1.0",
         "chalk": "2.4.1",
         "clean-webpack-plugin": "^3.0.0",
@@ -413,6 +793,101 @@
         "webpack": "4.25.1"
       },
       "dependencies": {
+        "@dojo/webpack-contrib": {
+          "version": "7.0.0-alpha.4",
+          "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-alpha.4.tgz",
+          "integrity": "sha512-ANUj+bm4uM4H1L26qJDtqUgD4A+Yi0eto+kv8DTpqaFSgviGNQvTeAda4R1YSQFoWdYoWEKBi3UabOLflKc6nw==",
+          "dev": true,
+          "requires": {
+            "@dojo/framework": "7.0.0-alpha.4",
+            "acorn": "6.1.1",
+            "acorn-dynamic-import": "4.0.0",
+            "acorn-walk": "6.1.1",
+            "bfj": "6.1.1",
+            "chalk": "2.3.0",
+            "clear-module": "3.1.0",
+            "commander": "2.13.0",
+            "connect-history-api-fallback": "1.6.0",
+            "copy-webpack-plugin": "4.6.0",
+            "cssnano": "4.1.7",
+            "eventsource-polyfill": "0.9.6",
+            "express": "4.16.2",
+            "filesize": "3.5.11",
+            "filter-css": "0.1.2",
+            "fs-extra": "7.0.0",
+            "get-port": "4.0.0",
+            "glob": "^7.1.2",
+            "gzip-size": "4.1.0",
+            "html-webpack-include-assets-plugin": "1.0.6",
+            "istanbul-lib-instrument": "1.10.1",
+            "jsdom": "15.2.0",
+            "loader-utils": "1.1.0",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "node-html-parser": "1.1.11",
+            "opener": "1.4.3",
+            "postcss": "7.0.7",
+            "puppeteer": "1.11.0",
+            "recast": "0.12.7",
+            "source-map": "0.6.1",
+            "ts-loader": "5.4.5",
+            "ts-node": "^8.0.3",
+            "typed-css-modules": "0.3.7",
+            "webpack-hot-middleware": "2.24.3",
+            "workbox-webpack-plugin": "3.6.3",
+            "wrapper-webpack-plugin": "2.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+              "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.1.0",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^4.0.0"
+              }
+            },
+            "cssnano": {
+              "version": "4.1.7",
+              "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.7.tgz",
+              "integrity": "sha512-AiXL90l+MDuQmRNyypG2P7ux7K4XklxYzNNUd5HXZCNcH8/N9bHPcpN97v8tXgRVeFL/Ed8iP8mVmAAu0ZpT7A==",
+              "dev": true,
+              "requires": {
+                "cosmiconfig": "^5.0.0",
+                "cssnano-preset-default": "^4.0.5",
+                "is-resolvable": "^1.0.0",
+                "postcss": "^7.0.0"
+              }
+            },
+            "ts-loader": {
+              "version": "5.4.5",
+              "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.4.5.tgz",
+              "integrity": "sha512-XYsjfnRQCBum9AMRZpk2rTYSVpdZBpZK+kDh0TeT3kxmQNBDVIeUjdPjY5RZry4eIAb8XHc4gYSUiUWPYvzSRw==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.3.0",
+                "enhanced-resolve": "^4.0.0",
+                "loader-utils": "^1.0.2",
+                "micromatch": "^3.1.4",
+                "semver": "^5.0.1"
+              }
+            }
+          }
+        },
+        "@types/glob": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
+          "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
+          "dev": true,
+          "requires": {
+            "@types/events": "*",
+            "@types/minimatch": "*",
+            "@types/node": "*"
+          }
+        },
         "ajv": {
           "version": "6.10.2",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.2.tgz",
@@ -426,9 +901,9 @@
           }
         },
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "autoprefixer": {
@@ -446,6 +921,17 @@
             "postcss-value-parser": "^4.0.2"
           },
           "dependencies": {
+            "browserslist": {
+              "version": "4.8.0",
+              "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.0.tgz",
+              "integrity": "sha512-HYnxc/oLRWvJ3TsGegR0SRL/UDnknGq2s/a8dYYEO+kOQ9m9apKoS5oiathLKZdh/e9uE+/J3j92qPlGD/vTqA==",
+              "dev": true,
+              "requires": {
+                "caniuse-lite": "^1.0.30001012",
+                "electron-to-chromium": "^1.3.317",
+                "node-releases": "^1.1.41"
+              }
+            },
             "chalk": {
               "version": "2.4.2",
               "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
@@ -455,6 +941,34 @@
                 "ansi-styles": "^3.2.1",
                 "escape-string-regexp": "^1.0.5",
                 "supports-color": "^5.3.0"
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "7.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
+              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.2",
+                "source-map": "^0.6.1",
+                "supports-color": "^6.1.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "6.1.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                  "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
               }
             },
             "supports-color": {
@@ -483,12 +997,6 @@
             "fill-range": "^7.0.1"
           }
         },
-        "camelcase": {
-          "version": "5.3.1",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
-          "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
-          "dev": true
-        },
         "caniuse-lite": {
           "version": "1.0.30001013",
           "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001013.tgz",
@@ -511,6 +1019,30 @@
           "integrity": "sha512-tgU3fKwzYjiLEQgPMD9Jt+JjHVL9kW93FiIMX/l7rivvOD4/LL0Mf7gda3+4U2KJBloybwgj5KEoQgGRioMiKQ==",
           "dev": true
         },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
         "color-convert": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -524,6 +1056,12 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "connect-history-api-fallback": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+          "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
           "dev": true
         },
         "css-loader": {
@@ -544,6 +1082,73 @@
             "postcss-modules-values": "^3.0.0",
             "postcss-value-parser": "^4.0.0",
             "schema-utils": "^2.0.0"
+          },
+          "dependencies": {
+            "camelcase": {
+              "version": "5.3.1",
+              "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
+              "integrity": "sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==",
+              "dev": true
+            },
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "loader-utils": {
+              "version": "1.2.3",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+              "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+              "dev": true,
+              "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^2.0.0",
+                "json5": "^1.0.1"
+              }
+            },
+            "postcss": {
+              "version": "7.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
+              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.2",
+                "source-map": "^0.6.1",
+                "supports-color": "^6.1.0"
+              }
+            },
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "cssdb": {
@@ -570,6 +1175,41 @@
             "postcss": "^7.0.0"
           }
         },
+        "del": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
+          "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+          "dev": true,
+          "requires": {
+            "@types/glob": "^7.1.1",
+            "globby": "^6.1.0",
+            "is-path-cwd": "^2.0.0",
+            "is-path-in-cwd": "^2.0.0",
+            "p-map": "^2.0.0",
+            "pify": "^4.0.1",
+            "rimraf": "^2.6.3"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
+              "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
+              "dev": true
+            }
+          }
+        },
+        "diff": {
+          "version": "4.0.1",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+          "dev": true
+        },
+        "electron-to-chromium": {
+          "version": "1.3.322",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+          "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==",
+          "dev": true
+        },
         "file-loader": {
           "version": "5.0.2",
           "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-5.0.2.tgz",
@@ -578,6 +1218,19 @@
           "requires": {
             "loader-utils": "^1.2.3",
             "schema-utils": "^2.5.0"
+          },
+          "dependencies": {
+            "loader-utils": {
+              "version": "1.2.3",
+              "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
+              "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+              "dev": true,
+              "requires": {
+                "big.js": "^5.2.2",
+                "emojis-list": "^2.0.0",
+                "json5": "^1.0.1"
+              }
+            }
           }
         },
         "fill-range": {
@@ -589,15 +1242,11 @@
             "to-regex-range": "^5.0.1"
           }
         },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
-          }
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
         },
         "icss-utils": {
           "version": "4.1.1",
@@ -606,6 +1255,65 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.14"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "7.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
+              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.2",
+                "source-map": "^0.6.1",
+                "supports-color": "^6.1.0"
+              }
+            },
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
           }
         },
         "is-number": {
@@ -613,6 +1321,72 @@
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
+        },
+        "is-path-cwd": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
+          "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+          "dev": true
+        },
+        "is-path-in-cwd": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
+          "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
+          "dev": true,
+          "requires": {
+            "is-path-inside": "^2.1.0"
+          }
+        },
+        "is-path-inside": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
+          "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
+          "dev": true,
+          "requires": {
+            "path-is-inside": "^1.0.2"
+          }
+        },
+        "jsdom": {
+          "version": "15.2.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.0.tgz",
+          "integrity": "sha512-+hRyEfjRPFwTYMmSQ3/f7U9nP8ZNZmbkmUek760ZpxnCPWJIhaaLRuUSvpJ36fZKCGENxLwxClzwpOpnXNfChQ==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.0",
+            "acorn": "^7.1.0",
+            "acorn-globals": "^4.3.2",
+            "array-equal": "^1.0.0",
+            "cssom": "^0.4.1",
+            "cssstyle": "^2.0.0",
+            "data-urls": "^1.1.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.11.1",
+            "html-encoding-sniffer": "^1.0.2",
+            "nwsapi": "^2.1.4",
+            "parse5": "5.1.0",
+            "pn": "^1.1.0",
+            "request": "^2.88.0",
+            "request-promise-native": "^1.0.7",
+            "saxes": "^3.1.9",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^3.0.1",
+            "w3c-hr-time": "^1.0.1",
+            "w3c-xmlserializer": "^1.1.2",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^7.0.0",
+            "ws": "^7.0.0",
+            "xml-name-validator": "^3.0.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.0.tgz",
+              "integrity": "sha512-kL5CuoXA/dgxlBbVrflsflzQ3PAas7RYZB52NOm/6839iVYJgKMJ3cQJD+t2i5+qFa8h3MDpEOJiS64E8JLnSQ==",
+              "dev": true
+            }
+          }
         },
         "json5": {
           "version": "1.0.1",
@@ -633,15 +1407,16 @@
             "universalify": "^0.1.2"
           }
         },
-        "loader-utils": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.2.3.tgz",
-          "integrity": "sha512-fkpz8ejdnEMG3s37wGL07iSBDg99O9D5yflE9RGNH3hRdx9SOwYfnGYdZOUIZitN8E+E2vkq3MUMYMvPYl5ZZA==",
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
           "dev": true,
           "requires": {
-            "big.js": "^5.2.2",
-            "emojis-list": "^2.0.0",
-            "json5": "^1.0.1"
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
           }
         },
         "locate-path": {
@@ -652,6 +1427,12 @@
           "requires": {
             "p-locate": "^4.1.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "log-symbols": {
           "version": "3.0.0",
@@ -673,6 +1454,12 @@
                 "supports-color": "^5.3.0"
               }
             },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
             "supports-color": {
               "version": "5.5.0",
               "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -693,16 +1480,51 @@
             "ansi-escapes": "^3.2.0",
             "cli-cursor": "^2.1.0",
             "wrap-ansi": "^5.0.0"
-          }
-        },
-        "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            },
+            "wrap-ansi": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+              "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
+              }
+            }
           }
         },
         "mimic-fn": {
@@ -747,6 +1569,23 @@
           "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
           "integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==",
           "dev": true
+        },
+        "node-releases": {
+          "version": "1.1.41",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.41.tgz",
+          "integrity": "sha512-+IctMa7wIs8Cfsa8iYzeaLTFwv5Y4r5jZud+4AnfymzeEXKBCavFX0KBgzVaPVqf0ywa6PrO8/b+bPqdwjGBSg==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.3.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
+          }
         },
         "normalize-url": {
           "version": "1.9.1",
@@ -795,6 +1634,12 @@
             "wcwidth": "^1.0.1"
           },
           "dependencies": {
+            "ansi-regex": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+              "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+              "dev": true
+            },
             "ansi-styles": {
               "version": "4.2.0",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.0.tgz",
@@ -868,16 +1713,46 @@
             "p-limit": "^2.2.0"
           }
         },
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+          "dev": true
+        },
         "p-try": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "pkg-dir": {
@@ -887,39 +1762,44 @@
           "dev": true,
           "requires": {
             "find-up": "^4.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+              }
+            }
           }
         },
         "postcss": {
-          "version": "7.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
-          "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.2",
+            "chalk": "^2.4.1",
             "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
+            "supports-color": "^5.5.0"
           },
           "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
               "dev": true,
               "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "5.5.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                  "dev": true,
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
+                "has-flag": "^3.0.0"
               }
             }
           }
@@ -971,6 +1851,56 @@
           "requires": {
             "postcss": "^7.0.14",
             "postcss-values-parser": "^2.0.1"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "7.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
+              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.2",
+                "source-map": "^0.6.1",
+                "supports-color": "^6.1.0"
+              }
+            },
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-color-mod-function": {
@@ -1001,6 +1931,56 @@
           "dev": true,
           "requires": {
             "postcss": "^7.0.14"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "7.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
+              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.2",
+                "source-map": "^0.6.1",
+                "supports-color": "^6.1.0"
+              }
+            },
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-custom-properties": {
@@ -1011,6 +1991,56 @@
           "requires": {
             "postcss": "^7.0.17",
             "postcss-values-parser": "^2.0.1"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "7.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
+              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.2",
+                "source-map": "^0.6.1",
+                "supports-color": "^6.1.0"
+              }
+            },
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-custom-selectors": {
@@ -1185,6 +2215,56 @@
             "postcss": "^7.0.16",
             "postcss-selector-parser": "^6.0.2",
             "postcss-value-parser": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "7.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
+              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.2",
+                "source-map": "^0.6.1",
+                "supports-color": "^6.1.0"
+              }
+            },
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-modules-scope": {
@@ -1287,6 +2367,56 @@
             "postcss-replace-overflow-wrap": "^3.0.0",
             "postcss-selector-matches": "^4.0.0",
             "postcss-selector-not": "^4.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "5.5.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "7.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
+              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.2",
+                "source-map": "^0.6.1",
+                "supports-color": "^6.1.0"
+              }
+            },
+            "supports-color": {
+              "version": "6.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-pseudo-class-any-link": {
@@ -1375,6 +2505,27 @@
             "uniq": "^1.0.1"
           }
         },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
         "restore-cursor": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-3.1.0.tgz",
@@ -1395,30 +2546,28 @@
             "ajv-keywords": "^3.4.1"
           }
         },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "ansi-regex": "^2.0.0"
           }
         },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
         "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "^3.0.0"
+            "has-flag": "^2.0.0"
           }
         },
         "to-regex-range": {
@@ -1441,29 +2590,101 @@
             "loader-utils": "^1.0.2",
             "micromatch": "^4.0.0",
             "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "micromatch": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+              "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+              "dev": true,
+              "requires": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.0.5"
+              }
+            },
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
           }
         },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+        "ts-node": {
+          "version": "8.5.4",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
+          "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
+            "arg": "^4.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "source-map-support": "^0.5.6",
+            "yn": "^3.0.0"
+          }
+        },
+        "typed-css-modules": {
+          "version": "0.3.7",
+          "resolved": "https://registry.npmjs.org/typed-css-modules/-/typed-css-modules-0.3.7.tgz",
+          "integrity": "sha512-KR1VG/U0rgFWaiQtXKtFMgKaurs80nvlBvZ7BfuYGLldw6kss/97sd+aMG4CI73BbujvefG7DBjnsBqq2Aowcw==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0",
+            "chalk": "^2.1.0",
+            "chokidar": "^2.0.3",
+            "css-modules-loader-core": "^1.1.0",
+            "glob": "^7.1.2",
+            "is-there": "^4.4.2",
+            "mkdirp": "^0.5.1",
+            "yargs": "^8.0.2"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
           }
         }
       }
     },
     "@dojo/cli-build-widget": {
-      "version": "7.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@dojo/cli-build-widget/-/cli-build-widget-7.0.0-alpha.5.tgz",
-      "integrity": "sha512-r9CWrYXsqfBqRqgR8MJNX9cmOotn9zTQgzUrezQWXH790E7RqUAKAsK0OnO87+WsL+5p78vqH2m/oHyfh7xGpA==",
+      "version": "7.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@dojo/cli-build-widget/-/cli-build-widget-7.0.0-alpha.2.tgz",
+      "integrity": "sha512-p5dyjcihuTcJuA2g76j+f32YOaX2hT0QYU9KgPWu543tV5QsK4XCWXqvxppDaYasWT55+UyWo3Dzw/oDMli6mA==",
       "dev": true,
       "requires": {
-        "@dojo/framework": "7.0.0-alpha.4",
-        "@dojo/webpack-contrib": "7.0.0-alpha.5",
+        "@dojo/framework": "7.0.0-alpha.3",
+        "@dojo/webpack-contrib": "7.0.0-alpha.2",
         "chalk": "2.4.1",
         "clean-webpack-plugin": "1.0.0",
         "cli-columns": "3.1.2",
@@ -1486,7 +2707,6 @@
         "pkg-dir": "2.0.0",
         "postcss-import": "12.0.0",
         "postcss-loader": "3.0.0",
-        "postcss-modules": "1.4.1",
         "postcss-preset-env": "5.3.0",
         "slash": "1.0.0",
         "source-map-loader-cli": "0.0.1",
@@ -1505,6 +2725,28 @@
         "webpack-mild-compile": "3.3.1"
       },
       "dependencies": {
+        "@dojo/framework": {
+          "version": "7.0.0-alpha.3",
+          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.3.tgz",
+          "integrity": "sha512-NbagpENJR0sArFopGUFXF/iqyVM8q8y2QXEzTTIz8Z1IG8taOYntqehITB0fcdt7K7jV0YzC6ScoG1LC1hS5lw==",
+          "dev": true,
+          "requires": {
+            "@types/cldrjs": "0.4.20",
+            "@types/globalize": "0.0.34",
+            "@webcomponents/webcomponentsjs": "1.1.0",
+            "cldrjs": "0.5.0",
+            "cross-fetch": "3.0.2",
+            "css-select-umd": "1.3.0-rc0",
+            "diff": "3.5.0",
+            "globalize": "1.4.0",
+            "immutable": "3.8.2",
+            "intersection-observer": "0.4.2",
+            "pepjs": "0.4.2",
+            "resize-observer-polyfill": "1.5.0",
+            "tslib": "1.9.3",
+            "web-animations-js": "2.3.1"
+          }
+        },
         "file-loader": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/file-loader/-/file-loader-3.0.1.tgz",
@@ -2021,28 +3263,6 @@
             "type-detect": "^4.0.5"
           }
         },
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
         "cldr-data": {
           "version": "36.0.0",
           "resolved": "https://registry.npmjs.org/cldr-data/-/cldr-data-36.0.0.tgz",
@@ -2261,12 +3481,6 @@
           "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
           "dev": true
         },
-        "is-plain-obj": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
-          "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ==",
-          "dev": true
-        },
         "istanbul-lib-coverage": {
           "version": "2.0.5",
           "resolved": "https://registry.npmjs.org/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.5.tgz",
@@ -2404,17 +3618,6 @@
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
         },
-        "postcss": {
-          "version": "7.0.21",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
-          "integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
         "qs": {
           "version": "6.7.0",
           "resolved": "https://registry.npmjs.org/qs/-/qs-6.7.0.tgz",
@@ -2452,29 +3655,6 @@
               "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
               "dev": true
             }
-          }
-        },
-        "remark-parse": {
-          "version": "7.0.1",
-          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.1.tgz",
-          "integrity": "sha512-WOZLa545jYXtSy+txza6ACudKWByQac4S2DmGk+tAGO/3XnVTOxwyCIxB7nTcLlk8Aayhcuf3cV1WV6U6L7/DQ==",
-          "dev": true,
-          "requires": {
-            "collapse-white-space": "^1.0.2",
-            "is-alphabetical": "^1.0.0",
-            "is-decimal": "^1.0.0",
-            "is-whitespace-character": "^1.0.0",
-            "is-word-character": "^1.0.0",
-            "markdown-escapes": "^1.0.0",
-            "parse-entities": "^1.1.0",
-            "repeat-string": "^1.5.4",
-            "state-toggle": "^1.0.0",
-            "trim": "0.0.1",
-            "trim-trailing-lines": "^1.0.0",
-            "unherit": "^1.0.4",
-            "unist-util-remove-position": "^1.0.0",
-            "vfile-location": "^2.0.0",
-            "xtend": "^4.0.1"
           }
         },
         "resolve": {
@@ -2596,32 +3776,6 @@
             "yn": "^3.0.0"
           }
         },
-        "unified": {
-          "version": "8.4.1",
-          "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.1.tgz",
-          "integrity": "sha512-YPj/uIIZSO7mMIZQj/5Z3hDl4lshWYRQGs5TgUCjHTVdklUWH+O94mK5Cy77SEcmEUwGhnUcudMuH/zIwporqw==",
-          "dev": true,
-          "requires": {
-            "bail": "^1.0.0",
-            "extend": "^3.0.0",
-            "is-plain-obj": "^2.0.0",
-            "trough": "^1.0.0",
-            "vfile": "^4.0.0"
-          }
-        },
-        "vfile": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.2.tgz",
-          "integrity": "sha512-yhoTU5cDMSsaeaMfJ5g0bUKYkYmZhAh9fn9TZicxqn+Cw4Z439il2v3oT9S0yjlpqlI74aFOQCt3nOV+pxzlkw==",
-          "dev": true,
-          "requires": {
-            "@types/unist": "^2.0.0",
-            "is-buffer": "^2.0.0",
-            "replace-ext": "1.0.0",
-            "unist-util-stringify-position": "^2.0.0",
-            "vfile-message": "^2.0.0"
-          }
-        },
         "ws": {
           "version": "7.0.1",
           "resolved": "https://registry.npmjs.org/ws/-/ws-7.0.1.tgz",
@@ -2688,12 +3842,12 @@
       }
     },
     "@dojo/webpack-contrib": {
-      "version": "7.0.0-alpha.5",
-      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-alpha.5.tgz",
-      "integrity": "sha512-5hIpPY53YEImXpDSgcwCpAqCwpKfuBfwTCNUmQ6wctbzvi0BOTFZoA91nGmduobjWSzCpV/yStAEgBtx7gynUQ==",
+      "version": "7.0.0-alpha.2",
+      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-alpha.2.tgz",
+      "integrity": "sha512-4x/PWMgIpNd7jZnVaUxHFSN2hV5EAiETBfw08IRAdMSyPOX9v6ipy/BlG4z7JsU8kvr743AvMZYhgo+vE0EaWg==",
       "dev": true,
       "requires": {
-        "@dojo/framework": "7.0.0-alpha.4",
+        "@dojo/framework": "7.0.0-alpha.2",
         "acorn": "6.1.1",
         "acorn-dynamic-import": "4.0.0",
         "acorn-walk": "6.1.1",
@@ -2733,6 +3887,28 @@
         "wrapper-webpack-plugin": "2.0.0"
       },
       "dependencies": {
+        "@dojo/framework": {
+          "version": "7.0.0-alpha.2",
+          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.2.tgz",
+          "integrity": "sha512-QjvQgDrUdpWoRT9UWjlyzvukWhjqwDLQgj0hAgTkCXlC/1q95KFAtH7rgrjwY654j5sXEZHKDgrX45PbPLsyXQ==",
+          "dev": true,
+          "requires": {
+            "@types/cldrjs": "0.4.20",
+            "@types/globalize": "0.0.34",
+            "@webcomponents/webcomponentsjs": "1.1.0",
+            "cldrjs": "0.5.0",
+            "cross-fetch": "3.0.2",
+            "css-select-umd": "1.3.0-rc0",
+            "diff": "3.5.0",
+            "globalize": "1.4.0",
+            "immutable": "3.8.2",
+            "intersection-observer": "0.4.2",
+            "pepjs": "0.4.2",
+            "resize-observer-polyfill": "1.5.0",
+            "tslib": "1.9.3",
+            "web-animations-js": "2.3.1"
+          }
+        },
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -2778,12 +3954,6 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
           "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
-          "dev": true
-        },
-        "diff": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
-          "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
           "dev": true
         },
         "has-flag": {
@@ -2885,6 +4055,45 @@
           "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
+        "postcss": {
+          "version": "7.0.7",
+          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
+          "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.1",
+            "source-map": "^0.6.1",
+            "supports-color": "^5.5.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.4.2",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+              }
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
         "read-pkg": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
@@ -2944,9 +4153,9 @@
           }
         },
         "ts-node": {
-          "version": "8.5.4",
-          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.4.tgz",
-          "integrity": "sha512-izbVCRV68EasEPQ8MSIGBNK9dc/4sYJJKYA+IarMQct1RtEot6Xp0bXuClsbUSnKpg50ho+aOAx8en5c+y4OFw==",
+          "version": "8.5.2",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.5.2.tgz",
+          "integrity": "sha512-W1DK/a6BGoV/D4x/SXXm6TSQx6q3blECUzd5TN+j56YEMX3yPVMpHsICLedUw3DvGF3aTQ8hfdR9AKMaHjIi+A==",
           "dev": true,
           "requires": {
             "arg": "^4.1.0",
@@ -2954,6 +4163,14 @@
             "make-error": "^1.1.1",
             "source-map-support": "^0.5.6",
             "yn": "^3.0.0"
+          },
+          "dependencies": {
+            "diff": {
+              "version": "4.0.1",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.1.tgz",
+              "integrity": "sha512-s2+XdvhPCOF01LRQBC8hf4vhbVmI2CGS5aZnxLJlT5FtdhPCDFq80q++zK2KlrVorVDdL5BOGZ/VfLrVtYNF+Q==",
+              "dev": true
+            }
           }
         },
         "typed-css-modules": {
@@ -4667,9 +5884,9 @@
       }
     },
     "arg": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.2.tgz",
-      "integrity": "sha512-+ytCkGcBtHZ3V2r2Z06AncYO8jz46UEamcspGoU8lHcEbpn6J77QK0vdWvChsclg/tM5XIJC5tnjmPp7Eq6Obg==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/arg/-/arg-4.1.1.tgz",
+      "integrity": "sha512-SlmP3fEA88MBv0PypnXZ8ZfJhwmDeIE3SP71j37AiXQBXYosPV0x6uISAaHYSlSVhmHOVkomen0tbGk6Anlebw==",
       "dev": true
     },
     "argparse": {
@@ -4916,9 +6133,9 @@
       "dev": true
     },
     "aws4": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.0.tgz",
-      "integrity": "sha512-Uvq6hVe90D0B2WEnUqtdgY1bATGz3mw33nH9Y+dmA+w5DHvUmBgkr5rM/KCHpCsiFNRUfokW/szpPPgMK2hm4A==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
+      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ==",
       "dev": true
     },
     "axe-core": {
@@ -5296,9 +6513,9 @@
       }
     },
     "bluebird": {
-      "version": "3.7.2",
-      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.2.tgz",
-      "integrity": "sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-3.7.1.tgz",
+      "integrity": "sha512-DdmyoGCleJnkbp3nkbxTLJ18rjDsE4yCggEwKNXkeV123sPNfOCYeDoeuOY+F2FrSjO1YXcTU+dsy96KMy+gcg==",
       "dev": true
     },
     "bmp-js": {
@@ -5520,20 +6737,20 @@
       }
     },
     "browserslist": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.0.tgz",
-      "integrity": "sha512-HYnxc/oLRWvJ3TsGegR0SRL/UDnknGq2s/a8dYYEO+kOQ9m9apKoS5oiathLKZdh/e9uE+/J3j92qPlGD/vTqA==",
+      "version": "4.7.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.7.2.tgz",
+      "integrity": "sha512-uZavT/gZXJd2UTi9Ov7/Z340WOSQ3+m1iBVRUknf+okKxonL9P83S3ctiBDtuRmRu8PiCHjqyueqQ9HYlJhxiw==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001012",
-        "electron-to-chromium": "^1.3.317",
-        "node-releases": "^1.1.41"
+        "caniuse-lite": "^1.0.30001004",
+        "electron-to-chromium": "^1.3.295",
+        "node-releases": "^1.1.38"
       },
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30001013",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001013.tgz",
-          "integrity": "sha512-hOAXaWKuq/UVFgYawxIOdPdyMQdYcwOCDOjnZcKn7wCgFUrhP7smuNZjGLuJlPSgE6aRA4cRJ+bGSrhtEt7ZAg==",
+          "version": "1.0.30001010",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001010.tgz",
+          "integrity": "sha512-RA5GH9YjFNea4ZQszdWgh2SC+dpLiRAg4VDQS2b5JRI45OxmbGrYocYHTa9x0bKMQUE7uvHkNPNffUr+pCxSGw==",
           "dev": true
         }
       }
@@ -6319,9 +7536,9 @@
       }
     },
     "code-block-writer": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.1.0.tgz",
-      "integrity": "sha512-RG9hpXtWFeUWhuUav1YuP/vGcyncW+t90yJLk9fNZs1De2OuHTHKAKThVCokt29PYq5RoJ0QSZaIZ+rvPO23hA==",
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/code-block-writer/-/code-block-writer-10.0.0.tgz",
+      "integrity": "sha512-UIlTeLDLvu9YDmxh566yrnKCTBULJNCF+oUoRTv8gmt5/DIqp7pozkUu5hnpUPWjgIHEqkOeAiSGuN8E3A+Wuw==",
       "dev": true
     },
     "code-point-at": {
@@ -7917,37 +9134,17 @@
       }
     },
     "del": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/del/-/del-4.1.1.tgz",
-      "integrity": "sha512-QwGuEUouP2kVwQenAsOof5Fv8K9t3D8Ca8NxcXKrIpEHjTXK5J2nXLdP+ALI1cgv8wj7KuwBhTwBkOZSJKM5XQ==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
+      "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
       "dev": true,
       "requires": {
-        "@types/glob": "^7.1.1",
         "globby": "^6.1.0",
-        "is-path-cwd": "^2.0.0",
-        "is-path-in-cwd": "^2.0.0",
-        "p-map": "^2.0.0",
-        "pify": "^4.0.1",
-        "rimraf": "^2.6.3"
-      },
-      "dependencies": {
-        "@types/glob": {
-          "version": "7.1.1",
-          "resolved": "https://registry.npmjs.org/@types/glob/-/glob-7.1.1.tgz",
-          "integrity": "sha512-1Bh06cbWJUHMC97acuD6UMG29nMt0Aqz1vF3guLfG+kHHJhy3AyohZFFxYk2f7Q1SQIrNwvncxAE0N/9s70F2w==",
-          "dev": true,
-          "requires": {
-            "@types/events": "*",
-            "@types/minimatch": "*",
-            "@types/node": "*"
-          }
-        },
-        "pify": {
-          "version": "4.0.1",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
-          "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
-          "dev": true
-        }
+        "is-path-cwd": "^1.0.0",
+        "is-path-in-cwd": "^1.0.0",
+        "p-map": "^1.1.1",
+        "pify": "^3.0.0",
+        "rimraf": "^2.2.8"
       }
     },
     "delayed-stream": {
@@ -8178,9 +9375,9 @@
       "dev": true
     },
     "electron-to-chromium": {
-      "version": "1.3.322",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
-      "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==",
+      "version": "1.3.306",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.306.tgz",
+      "integrity": "sha512-frDqXvrIROoYvikSKTIKbHbzO6M3/qC6kCIt/1FOa9kALe++c4VAJnwjSFvf1tYLEUsP2n9XZ4XSCyqc3l7A/A==",
       "dev": true
     },
     "elegant-spinner": {
@@ -8190,9 +9387,9 @@
       "dev": true
     },
     "elliptic": {
-      "version": "6.5.2",
-      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.2.tgz",
-      "integrity": "sha512-f4x70okzZbIQl/NSRLkI/+tteV/9WqL98zx+SQ69KbXxmVrmjwsNUPn/gYJJ0sHvEak24cZgHIPegRePAtA/xw==",
+      "version": "6.5.1",
+      "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.5.1.tgz",
+      "integrity": "sha512-xvJINNLbTeWQjrl6X+7eQCrIy/YPv5XCpKW6kB5mKvtnGILoLDcySuwomfdzt0BMdLNVnuRNTuzKNHj0bva1Cg==",
       "dev": true,
       "requires": {
         "bn.js": "^4.4.0",
@@ -8282,18 +9479,18 @@
       }
     },
     "es-abstract": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
-      "integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.0.tgz",
+      "integrity": "sha512-xdQnfykZ9JMEiasTAJZJdMWCQ1Vm00NBw79/AWi7ELfZuuPCSOMDZbT9mkOfSctVtfhb+sAAzrm+j//GjjLHLg==",
       "dev": true,
       "requires": {
-        "es-to-primitive": "^1.2.1",
+        "es-to-primitive": "^1.2.0",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
-        "has-symbols": "^1.0.1",
+        "has-symbols": "^1.0.0",
         "is-callable": "^1.1.4",
         "is-regex": "^1.0.4",
-        "object-inspect": "^1.7.0",
+        "object-inspect": "^1.6.0",
         "object-keys": "^1.1.1",
         "string.prototype.trimleft": "^2.1.0",
         "string.prototype.trimright": "^2.1.0"
@@ -8311,13 +9508,13 @@
       }
     },
     "es5-ext": {
-      "version": "0.10.53",
-      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.53.tgz",
-      "integrity": "sha512-Xs2Stw6NiNHWypzRTY1MtaG/uJlwCk8kH81920ma8mvN8Xq1gsfhZvpkImLQArw8AHnv8MT2I45J3c0R8slE+Q==",
+      "version": "0.10.52",
+      "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.52.tgz",
+      "integrity": "sha512-bWCbE9fbpYQY4CU6hJbJ1vSz70EClMlDgJ7BmwI+zEJhxrwjesZRPglGJlsZhu0334U3hI+gaspwksH9IGD6ag==",
       "dev": true,
       "requires": {
         "es6-iterator": "~2.0.3",
-        "es6-symbol": "~3.1.3",
+        "es6-symbol": "~3.1.2",
         "next-tick": "~1.0.0"
       },
       "dependencies": {
@@ -8781,9 +9978,9 @@
       }
     },
     "ext": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/ext/-/ext-1.4.0.tgz",
-      "integrity": "sha512-Key5NIsUxdqKg3vIsdw9dSuXpPCQ297y6wBjL30edxwPgt2E44WcWBZey/ZvUc6sERLTxKdyCu4gZFmUbk1Q7A==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/ext/-/ext-1.2.0.tgz",
+      "integrity": "sha512-0ccUQK/9e3NreLFg6K6np8aPyRgwycx+oFGtfx1dSp7Wj00Ozw9r05FgBRlzjf2XBM7LAzwgLyDscRrtSU91hA==",
       "dev": true,
       "requires": {
         "type": "^2.0.0"
@@ -10546,9 +11743,9 @@
       }
     },
     "handlebars": {
-      "version": "4.5.3",
-      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.3.tgz",
-      "integrity": "sha512-3yPecJoJHK/4c6aZhSvxOyG4vJKDshV36VHp0iVCDVh7o9w2vwi3NSnL2MMPj3YdduqaBcu7cGbggJQM0br9xA==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.5.2.tgz",
+      "integrity": "sha512-29Zxv/cynYB7mkT1rVWQnV7mGX6v7H/miQ6dbEpYTKq5eJBN7PsRB+ViYJlcT6JINTSu4dVB9kOqEun78h6Exg==",
       "dev": true,
       "requires": {
         "neo-async": "^2.6.0",
@@ -12069,29 +13266,18 @@
       }
     },
     "is-path-cwd": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-2.2.0.tgz",
-      "integrity": "sha512-w942bTcih8fdJPJmQHFzkS76NEP8Kzzvmw92cXsazb8intwLqPibPPdXf4ANdKV3rYMuuQYGIWtvz9JilB3NFQ==",
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
+      "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
       "dev": true
     },
     "is-path-in-cwd": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-2.1.0.tgz",
-      "integrity": "sha512-rNocXHgipO+rvnP6dk3zI20RpOtrAM/kzbB258Uw5BWr3TpXi861yzjo16Dn4hUox07iw5AyeMLHWsujkjzvRQ==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
+      "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
       "dev": true,
       "requires": {
-        "is-path-inside": "^2.1.0"
-      },
-      "dependencies": {
-        "is-path-inside": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-2.1.0.tgz",
-          "integrity": "sha512-wiyhTzfDWsvwAW53OBWF5zuvaOGlZ6PwYxAbPVDhpm+gM09xKQGjBq/8uYN12aDvMxnAnq3dxTyoSoRNmg5YFg==",
-          "dev": true,
-          "requires": {
-            "path-is-inside": "^1.0.2"
-          }
-        }
+        "is-path-inside": "^1.0.0"
       }
     },
     "is-path-inside": {
@@ -12200,12 +13386,12 @@
       }
     },
     "is-symbol": {
-      "version": "1.0.3",
-      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.3.tgz",
-      "integrity": "sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/is-symbol/-/is-symbol-1.0.2.tgz",
+      "integrity": "sha512-HS8bZ9ox60yCJLH9snBpIwv9pYUAkcuLhSA1oero1UB5y9aiQpRA8y2ex945AOtCZL1lJDeIk3G5LthswI46Lw==",
       "dev": true,
       "requires": {
-        "has-symbols": "^1.0.1"
+        "has-symbols": "^1.0.0"
       }
     },
     "is-there": {
@@ -12880,20 +14066,6 @@
           "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
           "dev": true
         },
-        "del": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
-          "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-          "dev": true,
-          "requires": {
-            "globby": "^6.1.0",
-            "is-path-cwd": "^1.0.0",
-            "is-path-in-cwd": "^1.0.0",
-            "p-map": "^1.1.1",
-            "pify": "^3.0.0",
-            "rimraf": "^2.2.8"
-          }
-        },
         "execa": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -12909,21 +14081,6 @@
             "strip-eof": "^1.0.0"
           }
         },
-        "is-path-cwd": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/is-path-cwd/-/is-path-cwd-1.0.0.tgz",
-          "integrity": "sha1-0iXsIxMuie3Tj9p2dHLmLmXxEG0=",
-          "dev": true
-        },
-        "is-path-in-cwd": {
-          "version": "1.0.1",
-          "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.1.tgz",
-          "integrity": "sha512-FjV1RTW48E7CWM7eE/J2NJvAEEVektecDBVBE5Hh3nM1Jd0kvhHtX68Pr3xsDf857xt3Y4AkwVULK1Vku62aaQ==",
-          "dev": true,
-          "requires": {
-            "is-path-inside": "^1.0.0"
-          }
-        },
         "log-symbols": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
@@ -12932,12 +14089,6 @@
           "requires": {
             "chalk": "^2.0.1"
           }
-        },
-        "p-map": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
-          "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
-          "dev": true
         }
       }
     },
@@ -12956,6 +14107,14 @@
         "listr-verbose-renderer": "^0.5.0",
         "p-map": "^2.0.0",
         "rxjs": "^6.3.3"
+      },
+      "dependencies": {
+        "p-map": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
+          "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+          "dev": true
+        }
       }
     },
     "listr-silent-renderer": {
@@ -13947,9 +15106,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.41",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.41.tgz",
-      "integrity": "sha512-+IctMa7wIs8Cfsa8iYzeaLTFwv5Y4r5jZud+4AnfymzeEXKBCavFX0KBgzVaPVqf0ywa6PrO8/b+bPqdwjGBSg==",
+      "version": "1.1.40",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.40.tgz",
+      "integrity": "sha512-r4LPcC5b/bS8BdtWH1fbeK88ib/wg9aqmg6/s3ngNLn2Ewkn/8J6Iw3P9RTlfIAdSdvYvQl2thCY5Y+qTAQ2iQ==",
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
@@ -14556,9 +15715,9 @@
       }
     },
     "p-map": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-2.1.0.tgz",
-      "integrity": "sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-1.2.0.tgz",
+      "integrity": "sha512-r6zKACMNhjPJMTl8KcFH4li//gkrXWfbD6feV8l6doRHlzljFWGJ2AP6iKaCJXyZmAUMOPtvbW7EXkbWO/pLEA==",
       "dev": true
     },
     "p-try": {
@@ -14929,14 +16088,47 @@
       "dev": true
     },
     "postcss": {
-      "version": "7.0.7",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.7.tgz",
-      "integrity": "sha512-HThWSJEPkupqew2fnuQMEI2YcTj/8gMV3n80cMdJsKxfIh5tHf7nM5JigNX6LxVMqo6zkgQNAI88hyFvBk41Pg==",
+      "version": "7.0.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.21.tgz",
+      "integrity": "sha512-uIFtJElxJo29QC753JzhidoAhvp/e/Exezkdhfmt8AymWT6/5B7W1WmponYWkHk2eg6sONyTch0A3nkMPun3SQ==",
       "dev": true,
       "requires": {
-        "chalk": "^2.4.1",
+        "chalk": "^2.4.2",
         "source-map": "^0.6.1",
-        "supports-color": "^5.5.0"
+        "supports-color": "^6.1.0"
+      },
+      "dependencies": {
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          },
+          "dependencies": {
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
+          }
+        },
+        "supports-color": {
+          "version": "6.1.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "postcss-attribute-case-insensitive": {
@@ -15549,50 +16741,6 @@
       "dev": true,
       "requires": {
         "postcss": "^7.0.14"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "2.4.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^3.2.1",
-            "escape-string-regexp": "^1.0.5",
-            "supports-color": "^5.3.0"
-          },
-          "dependencies": {
-            "supports-color": {
-              "version": "5.5.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
-        },
-        "postcss": {
-          "version": "7.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
-          "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          }
-        },
-        "supports-color": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-          "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^3.0.0"
-          }
-        }
       }
     },
     "postcss-load-config": {
@@ -16613,9 +17761,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.5.0.tgz",
-      "integrity": "sha512-4vqUjKi2huMu1OJiLhi3jN6jeeKvMZdI1tYgi/njW5zV52jNLgSAZSdN16m9bJFe61/cT8ulmw4qFitV9QRsEA==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.4.0.tgz",
+      "integrity": "sha512-HZzqCGPecFLyoRj5HLfuDSKYTJkAfB5thKBIkRHtGjWwY7p1dAyveIbXIq4tO0KYfDF2tHqPUgY9SDnGm00uFw==",
       "dev": true
     },
     "pstree.remy": {
@@ -17154,12 +18302,53 @@
         "remark-parse": "^6.0.0",
         "remark-stringify": "^6.0.0",
         "unified": "^7.0.0"
+      },
+      "dependencies": {
+        "remark-parse": {
+          "version": "6.0.3",
+          "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
+          "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
+          "dev": true,
+          "requires": {
+            "collapse-white-space": "^1.0.2",
+            "is-alphabetical": "^1.0.0",
+            "is-decimal": "^1.0.0",
+            "is-whitespace-character": "^1.0.0",
+            "is-word-character": "^1.0.0",
+            "markdown-escapes": "^1.0.0",
+            "parse-entities": "^1.1.0",
+            "repeat-string": "^1.5.4",
+            "state-toggle": "^1.0.0",
+            "trim": "0.0.1",
+            "trim-trailing-lines": "^1.0.0",
+            "unherit": "^1.0.4",
+            "unist-util-remove-position": "^1.0.0",
+            "vfile-location": "^2.0.0",
+            "xtend": "^4.0.1"
+          }
+        },
+        "unified": {
+          "version": "7.1.0",
+          "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
+          "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "@types/vfile": "^3.0.0",
+            "bail": "^1.0.0",
+            "extend": "^3.0.0",
+            "is-plain-obj": "^1.1.0",
+            "trough": "^1.0.0",
+            "vfile": "^3.0.0",
+            "x-is-string": "^0.1.0"
+          }
+        }
       }
     },
     "remark-parse": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-6.0.3.tgz",
-      "integrity": "sha512-QbDXWN4HfKTUC0hHa4teU463KclLAnwpn/FBn87j9cKYJWWawbiLgMfP2Q4XwhxxuuuOxHlw+pSN0OKuJwyVvg==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-7.0.1.tgz",
+      "integrity": "sha512-WOZLa545jYXtSy+txza6ACudKWByQac4S2DmGk+tAGO/3XnVTOxwyCIxB7nTcLlk8Aayhcuf3cV1WV6U6L7/DQ==",
       "dev": true,
       "requires": {
         "collapse-white-space": "^1.0.2",
@@ -17409,9 +18598,9 @@
       "dev": true
     },
     "resolve": {
-      "version": "1.13.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.13.1.tgz",
-      "integrity": "sha512-CxqObCX8K8YtAhOBRg+lrcdn+LK+WYOS8tSjqSFbjtrI5PnS63QPhZl4+yKfrU9tdsbMu9Anr/amegT87M9Z6w==",
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -18653,12 +19842,45 @@
                 "supports-color": "^5.3.0"
               }
             },
+            "postcss": {
+              "version": "7.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
+              "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.2",
+                "source-map": "^0.6.1",
+                "supports-color": "^6.1.0"
+              },
+              "dependencies": {
+                "supports-color": {
+                  "version": "6.1.0",
+                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
+                  "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
+                  "dev": true,
+                  "requires": {
+                    "has-flag": "^3.0.0"
+                  }
+                }
+              }
+            },
             "postcss-value-parser": {
               "version": "4.0.2",
               "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.2.tgz",
               "integrity": "sha512-LmeoohTpp/K4UiyQCwuGWlONxXamGzCMtFxLq4W1nZVGIQLYvMCJx3yAF9qyyuFpflABI9yVdtJAqbihOsCsJQ==",
               "dev": true
             }
+          }
+        },
+        "browserslist": {
+          "version": "4.8.0",
+          "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.0.tgz",
+          "integrity": "sha512-HYnxc/oLRWvJ3TsGegR0SRL/UDnknGq2s/a8dYYEO+kOQ9m9apKoS5oiathLKZdh/e9uE+/J3j92qPlGD/vTqA==",
+          "dev": true,
+          "requires": {
+            "caniuse-lite": "^1.0.30001012",
+            "electron-to-chromium": "^1.3.317",
+            "node-releases": "^1.1.41"
           }
         },
         "camelcase-keys": {
@@ -18686,6 +19908,12 @@
           "requires": {
             "ms": "^2.1.1"
           }
+        },
+        "electron-to-chromium": {
+          "version": "1.3.322",
+          "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.322.tgz",
+          "integrity": "sha512-Tc8JQEfGQ1MzfSzI/bTlSr7btJv/FFO7Yh6tanqVmIWOuNCu6/D1MilIEgLtmWqIrsv+o4IjpLAhgMBr/ncNAA==",
+          "dev": true
         },
         "get-stdin": {
           "version": "6.0.0",
@@ -18778,55 +20006,20 @@
             "yargs-parser": "^10.0.0"
           }
         },
+        "node-releases": {
+          "version": "1.1.41",
+          "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.41.tgz",
+          "integrity": "sha512-+IctMa7wIs8Cfsa8iYzeaLTFwv5Y4r5jZud+4AnfymzeEXKBCavFX0KBgzVaPVqf0ywa6PrO8/b+bPqdwjGBSg==",
+          "dev": true,
+          "requires": {
+            "semver": "^6.3.0"
+          }
+        },
         "pify": {
           "version": "4.0.1",
           "resolved": "https://registry.npmjs.org/pify/-/pify-4.0.1.tgz",
           "integrity": "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g==",
           "dev": true
-        },
-        "postcss": {
-          "version": "7.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-7.0.23.tgz",
-          "integrity": "sha512-hOlMf3ouRIFXD+j2VJecwssTwbvsPGJVMzupptg+85WA+i7MwyrydmQAgY3R+m0Bc0exunhbJmijy8u8+vufuQ==",
-          "dev": true,
-          "requires": {
-            "chalk": "^2.4.2",
-            "source-map": "^0.6.1",
-            "supports-color": "^6.1.0"
-          },
-          "dependencies": {
-            "chalk": {
-              "version": "2.4.2",
-              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-              "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-              "dev": true,
-              "requires": {
-                "ansi-styles": "^3.2.1",
-                "escape-string-regexp": "^1.0.5",
-                "supports-color": "^5.3.0"
-              },
-              "dependencies": {
-                "supports-color": {
-                  "version": "5.5.0",
-                  "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-                  "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-                  "dev": true,
-                  "requires": {
-                    "has-flag": "^3.0.0"
-                  }
-                }
-              }
-            },
-            "supports-color": {
-              "version": "6.1.0",
-              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-6.1.0.tgz",
-              "integrity": "sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==",
-              "dev": true,
-              "requires": {
-                "has-flag": "^3.0.0"
-              }
-            }
-          }
         },
         "postcss-selector-parser": {
           "version": "3.1.1",
@@ -18869,6 +20062,12 @@
             "indent-string": "^3.0.0",
             "strip-indent": "^2.0.0"
           }
+        },
+        "semver": {
+          "version": "6.3.0",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+          "dev": true
         },
         "slash": {
           "version": "2.0.0",
@@ -19618,9 +20817,9 @@
           }
         },
         "fast-glob": {
-          "version": "3.1.1",
-          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.1.tgz",
-          "integrity": "sha512-nTCREpBY8w8r+boyFYAx21iL6faSsQynliPHM4Uf56SbkyohCNxpVPEH9xrF5TXKy+IsjkPUHDKiUkzBVRXn9g==",
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.1.0.tgz",
+          "integrity": "sha512-TrUz3THiq2Vy3bjfQUB2wNyPdGBeGmdjbzzBLhfHN4YFurYptCKwGq/TfiRavbGywFRzY6U2CdmQ1zmsY5yYaw==",
           "dev": true,
           "requires": {
             "@nodelib/fs.stat": "^2.0.2",
@@ -19717,36 +20916,6 @@
           "requires": {
             "is-number": "^7.0.0"
           }
-        }
-      }
-    },
-    "ts-node": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-7.0.1.tgz",
-      "integrity": "sha512-BVwVbPJRspzNh2yfslyT1PSbl5uIk03EZlb493RKHN4qej/D06n1cEhjlOJG69oFsE7OT8XjpTUcYf6pKTLMhw==",
-      "dev": true,
-      "requires": {
-        "arrify": "^1.0.0",
-        "buffer-from": "^1.1.0",
-        "diff": "^3.1.0",
-        "make-error": "^1.1.1",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
-        "source-map-support": "^0.5.6",
-        "yn": "^2.0.0"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.2.0",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
-          "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ=",
-          "dev": true
-        },
-        "yn": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/yn/-/yn-2.0.0.tgz",
-          "integrity": "sha1-5a2ryKz0CPY4X8dklWhMiOavaJo=",
-          "dev": true
         }
       }
     },
@@ -20464,19 +21633,43 @@
       }
     },
     "unified": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/unified/-/unified-7.1.0.tgz",
-      "integrity": "sha512-lbk82UOIGuCEsZhPj8rNAkXSDXd6p0QLzIuSsCdxrqnqU56St4eyOB+AlXsVgVeRmetPTYydIuvFfpDIed8mqw==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-8.4.1.tgz",
+      "integrity": "sha512-YPj/uIIZSO7mMIZQj/5Z3hDl4lshWYRQGs5TgUCjHTVdklUWH+O94mK5Cy77SEcmEUwGhnUcudMuH/zIwporqw==",
       "dev": true,
       "requires": {
-        "@types/unist": "^2.0.0",
-        "@types/vfile": "^3.0.0",
         "bail": "^1.0.0",
         "extend": "^3.0.0",
-        "is-plain-obj": "^1.1.0",
+        "is-plain-obj": "^2.0.0",
         "trough": "^1.0.0",
-        "vfile": "^3.0.0",
-        "x-is-string": "^0.1.0"
+        "vfile": "^4.0.0"
+      },
+      "dependencies": {
+        "is-buffer": {
+          "version": "2.0.4",
+          "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+          "integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A==",
+          "dev": true
+        },
+        "is-plain-obj": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-2.0.0.tgz",
+          "integrity": "sha512-EYisGhpgSCwspmIuRHGjROWTon2Xp8Z7U03Wubk/bTL5TTRC5R1rGVgyjzBrk9+ULdH6cRD06KRcw/xfqhVYKQ==",
+          "dev": true
+        },
+        "vfile": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/vfile/-/vfile-4.0.2.tgz",
+          "integrity": "sha512-yhoTU5cDMSsaeaMfJ5g0bUKYkYmZhAh9fn9TZicxqn+Cw4Z439il2v3oT9S0yjlpqlI74aFOQCt3nOV+pxzlkw==",
+          "dev": true,
+          "requires": {
+            "@types/unist": "^2.0.0",
+            "is-buffer": "^2.0.0",
+            "replace-ext": "1.0.0",
+            "unist-util-stringify-position": "^2.0.0",
+            "vfile-message": "^2.0.0"
+          }
+        }
       }
     },
     "union-value": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,15 +14,15 @@
       }
     },
     "@babel/core": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.4.tgz",
-      "integrity": "sha512-+bYbx56j4nYBmpsWtnPUsKW3NdnYxbqyfrP2w9wILBuHzdfIKz9prieZK0DFPyIzkjYVUe4QkusGL07r5pXznQ==",
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.7.5.tgz",
+      "integrity": "sha512-M42+ScN4+1S9iB6f+TL7QBpoQETxbclx+KNoKJABghnKYE+fMzSGqst0BZJc8CpI625bwPwYgUyRvxZ+0mZzpw==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.5.5",
         "@babel/generator": "^7.7.4",
         "@babel/helpers": "^7.7.4",
-        "@babel/parser": "^7.7.4",
+        "@babel/parser": "^7.7.5",
         "@babel/template": "^7.7.4",
         "@babel/traverse": "^7.7.4",
         "@babel/types": "^7.7.4",
@@ -153,15 +153,15 @@
       }
     },
     "@babel/parser": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.4.tgz",
-      "integrity": "sha512-jIwvLO0zCL+O/LmEJQjWA75MQTWwx3c3u2JOTDK5D3/9egrWRRA0/0hk9XXywYnXZVVpzrBYeIQTmhwUaePI9g==",
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.7.5.tgz",
+      "integrity": "sha512-KNlOe9+/nk4i29g0VXgl8PEXIRms5xKLJeuZ6UptN0fHv+jDiriG+y94X6qAgWTR0h3KaoM1wK5G5h7MHFRSig==",
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.4.tgz",
-      "integrity": "sha512-r24eVUUr0QqNZa+qrImUk8fn5SPhHq+IfYvIoIMg0do3GdK9sMdiLKP3GYVVaxpPKORgm8KRKaNTEhAjgIpLMw==",
+      "version": "7.7.5",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.7.5.tgz",
+      "integrity": "sha512-UXhClKWTL7/vlYX49kETXti6VbpPJK/pdsIOqUMhUUES/lqThpNTsmC/0aU/IW4uozDUx17axjeqel7SCYF6EQ==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.2"
@@ -5520,14 +5520,14 @@
       }
     },
     "browserslist": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.0.tgz",
-      "integrity": "sha512-HYnxc/oLRWvJ3TsGegR0SRL/UDnknGq2s/a8dYYEO+kOQ9m9apKoS5oiathLKZdh/e9uE+/J3j92qPlGD/vTqA==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+      "integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001012",
-        "electron-to-chromium": "^1.3.317",
-        "node-releases": "^1.1.41"
+        "caniuse-lite": "^1.0.30001015",
+        "electron-to-chromium": "^1.3.322",
+        "node-releases": "^1.1.42"
       },
       "dependencies": {
         "caniuse-lite": {
@@ -8282,9 +8282,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
-      "integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.3.tgz",
+      "integrity": "sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -16613,9 +16613,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.5.0.tgz",
-      "integrity": "sha512-4vqUjKi2huMu1OJiLhi3jN6jeeKvMZdI1tYgi/njW5zV52jNLgSAZSdN16m9bJFe61/cT8ulmw4qFitV9QRsEA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
+      "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA==",
       "dev": true
     },
     "pstree.remy": {
@@ -17824,9 +17824,9 @@
       }
     },
     "simple-git": {
-      "version": "1.126.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.126.0.tgz",
-      "integrity": "sha512-47mqHxgZnN8XRa9HbpWprzUv3Ooqz9RY/LSZgvA7jCkW8jcwLahMz7LKugY91KZehfG0sCVPtgXiU72hd6b1Bw==",
+      "version": "1.128.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.128.0.tgz",
+      "integrity": "sha512-bi8ff+gA+GJgmskbkbLBuykkvsuWv0lPEXjCDQkUvr2DrOpsVcowk9BqqQAl8gQkiyLhzgFIKvirDiwWFBDMqg==",
       "dev": true,
       "requires": {
         "debug": "^4.0.1"

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -32,6 +32,7 @@ import GridCustomFilterRenderer from './widgets/grid/CustomFilterRenderer';
 import CustomSortRenderer from './widgets/grid/CustomSortRenderer';
 import EditableCells from './widgets/grid/EditableCells';
 import Filtering from './widgets/grid/Filtering';
+import ColumnResize from './widgets/grid/ColumnResize';
 import Restful from './widgets/grid/Restful';
 import Sorting from './widgets/grid/Sorting';
 import AltTextIcon from './widgets/icon/AltText';
@@ -340,6 +341,11 @@ export const config = {
 					filename: 'CustomSortRenderer',
 					module: CustomSortRenderer,
 					title: 'Grid with Customized Sort Rendering'
+				},
+				{
+					filename: 'ColumnResize',
+					module: ColumnResize,
+					title: 'Grid with resizable columns'
 				},
 				{
 					filename: 'Restful',

--- a/src/examples/src/widgets/grid/ColumnResize.tsx
+++ b/src/examples/src/widgets/grid/ColumnResize.tsx
@@ -1,0 +1,40 @@
+import { tsx, create } from '@dojo/framework/core/vdom';
+
+import Grid from '@dojo/widgets/grid';
+import { ColumnConfig } from '@dojo/widgets/grid/interfaces';
+import { createFetcher } from '@dojo/widgets/grid/utils';
+
+import { createData } from './data';
+
+const columnConfig: ColumnConfig[] = [
+	{
+		id: 'id',
+		title: 'ID',
+		resizable: true
+	},
+	{
+		id: 'firstName',
+		title: 'First Name',
+		resizable: true
+	},
+	{
+		id: 'middleName',
+		title: 'Middle Name'
+	},
+	{
+		id: 'lastName',
+		title: 'Last Name'
+	},
+	{
+		id: 'otherName',
+		title: 'Other Name',
+		resizable: true
+	}
+];
+
+const fetcher = createFetcher(createData());
+const factory = create();
+
+export default factory(function ColumnResize() {
+	return <Grid fetcher={fetcher} columnConfig={columnConfig} height={450} />;
+});

--- a/src/examples/src/widgets/grid/Filtering.tsx
+++ b/src/examples/src/widgets/grid/Filtering.tsx
@@ -17,9 +17,17 @@ const columnConfig: ColumnConfig[] = [
 		filterable: true
 	},
 	{
+		id: 'middleName',
+		title: 'Middle Name'
+	},
+	{
 		id: 'lastName',
 		title: 'Last Name',
 		filterable: true
+	},
+	{
+		id: 'otherName',
+		title: 'Other Name'
 	}
 ];
 

--- a/src/examples/src/widgets/grid/data.tsx
+++ b/src/examples/src/widgets/grid/data.tsx
@@ -210,7 +210,9 @@ export function createData(rows: number = 10000) {
 		data.push({
 			id: i,
 			firstName: firstNames[Math.floor(Math.random() * firstNames.length)],
+			middleName: firstNames[Math.floor(Math.random() * firstNames.length)],
 			lastName: lastNames[Math.floor(Math.random() * lastNames.length)],
+			otherName: lastNames[Math.floor(Math.random() * lastNames.length)],
 			gender: gender[i % 2]
 		});
 	}

--- a/src/grid/Body.tsx
+++ b/src/grid/Body.tsx
@@ -175,8 +175,15 @@ export default class Body<S> extends ThemedMixin(WidgetBase)<BodyProperties<S>> 
 			totalRows = 0,
 			pageSize,
 			height,
-			width
+			width,
+			columnWidths
 		} = this.properties;
+
+		const rowWidth =
+			columnWidths &&
+			Object.keys(columnWidths).reduce((rowWidth, key) => {
+				return rowWidth + columnWidths[key];
+			}, 0);
 
 		if (!this._rowHeight) {
 			const firstRow = placeholderRowRenderer(0);
@@ -215,12 +222,14 @@ export default class Body<S> extends ThemedMixin(WidgetBase)<BodyProperties<S>> 
 		}
 
 		return v('div', containerProperties, [
-			v('div', { key: 'top', styles: { height: `${topPaddingHeight}px` } }),
-			...rows,
-			v('div', {
-				key: 'bottom',
-				styles: { height: `${bottomPaddingHeight}px` }
-			})
+			v('div', { styles: rowWidth ? { width: `${rowWidth}px` } : {} }, [
+				v('div', { key: 'top', styles: { height: `${topPaddingHeight}px` } }),
+				...rows,
+				v('div', {
+					key: 'bottom',
+					styles: { height: `${bottomPaddingHeight}px` }
+				})
+			])
 		]);
 	}
 }

--- a/src/grid/Body.tsx
+++ b/src/grid/Body.tsx
@@ -36,7 +36,7 @@ export interface BodyProperties<S> {
 	/** Called when the page changes */
 	pageChange: (page: number) => void;
 	/** Handler for scroll events */
-	onScroll: (value: number) => void;
+	onScroll?: (value: number) => void;
 	columnWidths?: { [index: string]: number };
 }
 
@@ -81,8 +81,9 @@ export default class Body<S> extends ThemedMixin(WidgetBase)<BodyProperties<S>> 
 	}
 
 	private _onScroll(event: UIEvent) {
-		const { totalRows = 0 } = this.properties;
+		const { totalRows = 0, onScroll } = this.properties;
 		const scrollTop = (event.target as HTMLElement).scrollTop;
+		const scrollLeft = (event.target as HTMLElement).scrollLeft;
 		const topRow = Math.round(scrollTop / this._rowHeight);
 		const bottomRow = topRow + this._rowsInView;
 		if (topRow <= this._start) {
@@ -93,6 +94,7 @@ export default class Body<S> extends ThemedMixin(WidgetBase)<BodyProperties<S>> 
 			this._start = Math.min(topRow, totalRows - this._renderPageSize);
 			this._end = Math.min(totalRows, this._start + this._renderPageSize * 2);
 		}
+		onScroll && onScroll(scrollLeft);
 		this.invalidate();
 	}
 

--- a/src/grid/Body.tsx
+++ b/src/grid/Body.tsx
@@ -23,6 +23,8 @@ export interface BodyProperties<S> {
 	pages: GridPages<S>;
 	/** The height (in pixels) */
 	height: number;
+	width?: number;
+	rowWidth?: number;
 	/** Configuration for grid columns (id, title, properties, and custom renderer) */
 	columnConfig: ColumnConfig[];
 	/** Custom renderer for the placeholder row used while data is loaded */
@@ -35,6 +37,7 @@ export interface BodyProperties<S> {
 	pageChange: (page: number) => void;
 	/** Handler for scroll events */
 	onScroll: (value: number) => void;
+	columnWidths?: { [index: string]: number };
 }
 
 const offscreen = (dnode: DNode) => {
@@ -80,7 +83,6 @@ export default class Body<S> extends ThemedMixin(WidgetBase)<BodyProperties<S>> 
 	private _onScroll(event: UIEvent) {
 		const { totalRows = 0 } = this.properties;
 		const scrollTop = (event.target as HTMLElement).scrollTop;
-		const scrollLeft = (event.target as HTMLElement).scrollLeft;
 		const topRow = Math.round(scrollTop / this._rowHeight);
 		const bottomRow = topRow + this._rowsInView;
 		if (topRow <= this._start) {
@@ -91,7 +93,6 @@ export default class Body<S> extends ThemedMixin(WidgetBase)<BodyProperties<S>> 
 			this._start = Math.min(topRow, totalRows - this._renderPageSize);
 			this._end = Math.min(totalRows, this._start + this._renderPageSize * 2);
 		}
-		this.properties.onScroll(scrollLeft);
 		this.invalidate();
 	}
 
@@ -112,7 +113,8 @@ export default class Body<S> extends ThemedMixin(WidgetBase)<BodyProperties<S>> 
 			pageChange,
 			totalRows,
 			theme,
-			classes
+			classes,
+			columnWidths
 		} = this.properties;
 
 		const startPage = Math.max(Math.ceil(start / pageSize), 1);
@@ -150,7 +152,8 @@ export default class Body<S> extends ThemedMixin(WidgetBase)<BodyProperties<S>> 
 						classes,
 						item,
 						columnConfig,
-						updater: this._updater
+						updater: this._updater,
+						columnWidths
 					})
 				);
 			} else {
@@ -168,7 +171,8 @@ export default class Body<S> extends ThemedMixin(WidgetBase)<BodyProperties<S>> 
 			placeholderRowRenderer = defaultPlaceholderRowRenderer,
 			totalRows = 0,
 			pageSize,
-			height
+			height,
+			width
 		} = this.properties;
 
 		if (!this._rowHeight) {
@@ -194,7 +198,9 @@ export default class Body<S> extends ThemedMixin(WidgetBase)<BodyProperties<S>> 
 			classes: [this.theme(css.root), fixedCss.rootFixed],
 			role: 'rowgroup',
 			onscroll: this._onScroll,
-			styles: { height: `${height}px` }
+			styles: width
+				? { height: `${height}px`, width: `${width}px` }
+				: { height: `${height}px` }
 		};
 
 		if (this._resetScroll) {

--- a/src/grid/Body.tsx
+++ b/src/grid/Body.tsx
@@ -23,8 +23,8 @@ export interface BodyProperties<S> {
 	pages: GridPages<S>;
 	/** The height (in pixels) */
 	height: number;
+	/** The width (in pixels) */
 	width?: number;
-	rowWidth?: number;
 	/** Configuration for grid columns (id, title, properties, and custom renderer) */
 	columnConfig: ColumnConfig[];
 	/** Custom renderer for the placeholder row used while data is loaded */
@@ -37,6 +37,7 @@ export interface BodyProperties<S> {
 	pageChange: (page: number) => void;
 	/** Handler for scroll events */
 	onScroll?: (value: number) => void;
+	/** Calculated column widths */
 	columnWidths?: { [index: string]: number };
 }
 

--- a/src/grid/Cell.tsx
+++ b/src/grid/Cell.tsx
@@ -21,6 +21,7 @@ export interface CellProperties extends FocusProperties {
 	rawValue: string;
 	/** Called when the Cell's value is saved by the editor */
 	updater: (value: any) => void;
+	width?: number;
 }
 
 @theme(css)
@@ -86,40 +87,52 @@ export default class Cell extends ThemedMixin(FocusMixin(WidgetBase))<CellProper
 	}
 
 	protected render(): DNode {
-		let { editable, rawValue, theme, classes } = this.properties;
+		let { editable, rawValue, theme, classes, width } = this.properties;
 
-		return v('div', { role: 'cell', classes: [this.theme(css.root), fixedCss.rootFixed] }, [
-			this._editing
-				? w(TextInput, {
-						key: 'input',
-						theme,
-						classes,
-						label: `Edit ${rawValue}`,
-						labelHidden: true,
-						extraClasses: { input: this.theme(css.input) } as any,
-						focus: this._focusKey === 'input' ? this.shouldFocus : () => false,
-						value: this._editingValue,
-						onValue: this._onInput,
-						onBlur: this._onBlur,
-						onKeyDown: this._onKeyDown
-				  })
-				: this.renderContent(),
-			editable && !this._editing
-				? w(
-						Button,
-						{
-							key: 'button',
+		return v(
+			'div',
+			{
+				role: 'cell',
+				styles: width
+					? {
+							flex: `0 1 ${width}px`
+					  }
+					: {},
+				classes: [this.theme(css.root), fixedCss.rootFixed]
+			},
+			[
+				this._editing
+					? w(TextInput, {
+							key: 'input',
 							theme,
 							classes,
-							aria: { describedby: this._idBase },
-							focus: this._focusKey === 'button' ? this.shouldFocus : () => false,
-							type: 'button',
-							extraClasses: { root: this.theme(css.edit) } as any,
-							onClick: this._onEdit
-						},
-						[w(Icon, { type: 'editIcon', altText: 'Edit', classes, theme })]
-				  )
-				: null
-		]);
+							label: `Edit ${rawValue}`,
+							labelHidden: true,
+							extraClasses: { input: this.theme(css.input) } as any,
+							focus: this._focusKey === 'input' ? this.shouldFocus : () => false,
+							value: this._editingValue,
+							onValue: this._onInput,
+							onBlur: this._onBlur,
+							onKeyDown: this._onKeyDown
+					  })
+					: this.renderContent(),
+				editable && !this._editing
+					? w(
+							Button,
+							{
+								key: 'button',
+								theme,
+								classes,
+								aria: { describedby: this._idBase },
+								focus: this._focusKey === 'button' ? this.shouldFocus : () => false,
+								type: 'button',
+								extraClasses: { root: this.theme(css.edit) } as any,
+								onClick: this._onEdit
+							},
+							[w(Icon, { type: 'editIcon', altText: 'Edit', classes, theme })]
+					  )
+					: null
+			]
+		);
 	}
 }

--- a/src/grid/Cell.tsx
+++ b/src/grid/Cell.tsx
@@ -21,6 +21,7 @@ export interface CellProperties extends FocusProperties {
 	rawValue: string;
 	/** Called when the Cell's value is saved by the editor */
 	updater: (value: any) => void;
+	/** The width (in pixels) */
 	width?: number;
 }
 

--- a/src/grid/Header.tsx
+++ b/src/grid/Header.tsx
@@ -40,8 +40,11 @@ export interface HeaderProperties {
 	sortRenderer?: SortRenderer;
 	/** Custom renderer displaying applied filters */
 	filterRenderer?: FilterRenderer;
+	/** Callback on column resize */
 	onColumnResize?: (index: number, value: number) => void;
+	/** Calculated column widths */
 	columnWidths?: { [index: string]: number };
+	/** The width (in pixels) */
 	width?: number;
 }
 

--- a/src/grid/Header.tsx
+++ b/src/grid/Header.tsx
@@ -44,8 +44,6 @@ export interface HeaderProperties {
 	onColumnResize?: (index: number, value: number) => void;
 	/** Calculated column widths */
 	columnWidths?: { [index: string]: number };
-	/** The width (in pixels) */
-	width?: number;
 }
 
 @theme(css)
@@ -114,14 +112,19 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 			sortRenderer = this._sortRenderer,
 			filterRenderer = this._filterRenderer,
 			columnWidths,
-			width,
 			onColumnResize
 		} = this.properties;
+
+		const rowWidth =
+			columnWidths &&
+			Object.keys(columnWidths).reduce((rowWidth, key) => {
+				return rowWidth + columnWidths[key];
+			}, 0);
 
 		return v(
 			'div',
 			{
-				styles: width ? { width: `${width}px` } : {},
+				styles: rowWidth ? { width: `${rowWidth}px` } : {},
 				classes: [this.theme(css.root), fixedCss.rootFixed],
 				role: 'row'
 			},

--- a/src/grid/Row.tsx
+++ b/src/grid/Row.tsx
@@ -17,6 +17,7 @@ export interface RowProperties {
 	columnConfig: ColumnConfig[];
 	/** Handles updating the value of a cell */
 	updater: (rowNumber: number, columnId: string, value: any) => void;
+	/** Calculated column widths */
 	columnWidths?: { [index: string]: number };
 }
 

--- a/src/grid/Row.tsx
+++ b/src/grid/Row.tsx
@@ -17,12 +17,13 @@ export interface RowProperties {
 	columnConfig: ColumnConfig[];
 	/** Handles updating the value of a cell */
 	updater: (rowNumber: number, columnId: string, value: any) => void;
+	columnWidths?: { [index: string]: number };
 }
 
 @theme(css)
 export default class Row extends ThemedMixin(WidgetBase)<RowProperties> {
 	protected render(): DNode {
-		const { item, columnConfig, id, theme, classes } = this.properties;
+		const { item, columnConfig, id, theme, classes, columnWidths } = this.properties;
 		let columns = columnConfig.map(
 			(config) => {
 				let value: string | DNode = `${item[config.id]}`;
@@ -38,7 +39,8 @@ export default class Row extends ThemedMixin(WidgetBase)<RowProperties> {
 					},
 					value,
 					editable: config.editable,
-					rawValue: `${item[config.id]}`
+					rawValue: `${item[config.id]}`,
+					width: columnWidths ? columnWidths[config.id] : undefined
 				});
 			},
 			[] as DNode[]

--- a/src/grid/index.tsx
+++ b/src/grid/index.tsx
@@ -178,7 +178,7 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 			this._gridWidth = bodyWidth;
 		}
 
-		const hasResizableColumns = columnConfig.some((config) => config.resizable);
+		const hasResizableColumns = columnConfig.some((config) => !!config.resizable);
 
 		return v(
 			'div',

--- a/src/grid/index.tsx
+++ b/src/grid/index.tsx
@@ -182,7 +182,7 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 				{} as any
 			);
 			this._rowWidth = Math.max(bodyWidth, MIN_COLUMN_WIDTH * columnConfig.length);
-			this._gridWidth = Math.max(bodyWidth, MIN_COLUMN_WIDTH * columnConfig.length);;
+			this._gridWidth = Math.max(bodyWidth, MIN_COLUMN_WIDTH * columnConfig.length);
 		}
 
 		const hasResizableColumns = columnConfig.some((config) => !!config.resizable);
@@ -199,10 +199,7 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 				v(
 					'div',
 					{
-						styles:
-							hasResizableColumns && this._gridWidth
-								? { overflowX: 'auto' }
-								: {}
+						styles: hasResizableColumns && this._gridWidth ? { overflowX: 'auto' } : {}
 					},
 					[
 						v(

--- a/src/grid/index.tsx
+++ b/src/grid/index.tsx
@@ -172,7 +172,7 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 		const { bodyHeight, bodyWidth, headerWidth } = this._getBodyDimensions();
 		this.meta(Resize).get('root');
 
-		if (bodyWidth && headerWidth && !this._columnWidths) {
+		if (bodyWidth && headerWidth && hasResizableColumns && !this._columnWidths) {
 			const width = headerWidth / columnConfig.length;
 			this._columnWidths = columnConfig.reduce(
 				(sizes, { id }) => {

--- a/src/grid/index.tsx
+++ b/src/grid/index.tsx
@@ -112,7 +112,6 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 			value = value - (currentColumnWidth + value - MIN_COLUMN_WIDTH);
 		}
 
-		// this._rowWidth = this._rowWidth + value;
 		this._columnWidths = {
 			...this._columnWidths,
 			[columnConfig[index].id]: currentColumnWidth + value
@@ -146,7 +145,6 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 	}
 
 	private _onScroll(value: number) {
-		console.log('here');
 		this._scrollLeft = value;
 		this.invalidate();
 	}

--- a/src/grid/index.tsx
+++ b/src/grid/index.tsx
@@ -61,6 +61,7 @@ const MIN_COLUMN_WIDTH = 100;
 export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> {
 	private _store = new Store<GridState<S>>();
 	private _handle: any;
+	private _scrollLeft = 0;
 	private _pageSize = 100;
 	private _columnWidths: { [index: string]: number } | undefined;
 	private _rowWidth = 0;
@@ -145,6 +146,12 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 		pageChangeProcess(this._store)({ id: storeId, page });
 	}
 
+	private _onScroll(value: number) {
+		console.log('here');
+		this._scrollLeft = value;
+		this.invalidate();
+	}
+
 	protected render(): DNode {
 		const {
 			columnConfig,
@@ -174,8 +181,8 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 				},
 				{} as any
 			);
-			this._rowWidth = bodyWidth;
-			this._gridWidth = bodyWidth;
+			this._rowWidth = Math.max(bodyWidth, MIN_COLUMN_WIDTH * columnConfig.length);
+			this._gridWidth = Math.max(bodyWidth, MIN_COLUMN_WIDTH * columnConfig.length);;
 		}
 
 		const hasResizableColumns = columnConfig.some((config) => !!config.resizable);
@@ -194,7 +201,7 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 					{
 						styles:
 							hasResizableColumns && this._gridWidth
-								? { overflowX: 'auto', width: `${this._gridWidth}px` }
+								? { overflowX: 'auto' }
 								: {}
 					},
 					[
@@ -202,6 +209,7 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 							'div',
 							{
 								key: 'header',
+								scrollLeft: this._scrollLeft,
 								styles:
 									hasResizableColumns && this._rowWidth && this._gridWidth
 										? {
@@ -249,6 +257,7 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 							fetcher: this._fetcher,
 							pageChange: this._pageChange,
 							updater: this._updater,
+							onScroll: hasResizableColumns ? undefined : this._onScroll,
 							height: bodyHeight,
 							width:
 								hasResizableColumns && this._rowWidth && this._gridWidth

--- a/src/grid/interfaces.d.ts
+++ b/src/grid/interfaces.d.ts
@@ -40,6 +40,7 @@ export interface ColumnConfig {
 	filterable?: boolean;
 	sortable?: boolean;
 	editable?: boolean;
+	resizable?: boolean;
 	renderer?: (props: any) => DNode;
 }
 

--- a/src/grid/styles/header.m.css
+++ b/src/grid/styles/header.m.css
@@ -1,7 +1,27 @@
 .rootFixed {
 	display: flex;
+	height: 100%;
 }
 
 .cellFixed {
 	flex: 1 100%;
+	position: relative;
+}
+
+.column {
+	min-width: 100%;
+}
+
+.resize {
+	position: absolute;
+	right: -3px;
+	width: 5px;
+	top: 0;
+	bottom: 0;
+	cursor: col-resize;
+	z-index: 1;
+}
+
+.resize:hover {
+	background: rgba(0, 0, 0, 0.25);
 }

--- a/src/grid/styles/header.m.css
+++ b/src/grid/styles/header.m.css
@@ -22,6 +22,6 @@
 	z-index: 1;
 }
 
-.resize:hover {
+.resize:hover, .resize:active {
 	background: rgba(0, 0, 0, 0.25);
 }

--- a/src/grid/styles/header.m.css
+++ b/src/grid/styles/header.m.css
@@ -22,6 +22,7 @@
 	z-index: 1;
 }
 
-.resize:hover, .resize:active {
+.resize:hover,
+.resize:active {
 	background: rgba(0, 0, 0, 0.25);
 }

--- a/src/grid/styles/header.m.css.d.ts
+++ b/src/grid/styles/header.m.css.d.ts
@@ -1,2 +1,4 @@
 export const rootFixed: string;
 export const cellFixed: string;
+export const column: string;
+export const resize: string;

--- a/src/grid/tests/unit/Body.spec.tsx
+++ b/src/grid/tests/unit/Body.spec.tsx
@@ -71,9 +71,11 @@ describe('Body', () => {
 					styles: { height: '400px' }
 				},
 				[
-					v('div', { key: 'top', styles: { height: '0px' } }),
-					...rows,
-					v('div', { key: 'bottom', styles: { height: '31500px' } })
+					v('div', { styles: {} }, [
+						v('div', { key: 'top', styles: { height: '0px' } }),
+						...rows,
+						v('div', { key: 'bottom', styles: { height: '31500px' } })
+					])
 				]
 			)
 		);
@@ -126,9 +128,11 @@ describe('Body', () => {
 					styles: { height: '400px' }
 				},
 				[
-					v('div', { key: 'top', styles: { height: '0px' } }),
-					...rows,
-					v('div', { key: 'bottom', styles: { height: '31500px' } })
+					v('div', { styles: {} }, [
+						v('div', { key: 'top', styles: { height: '0px' } }),
+						...rows,
+						v('div', { key: 'bottom', styles: { height: '31500px' } })
+					])
 				]
 			)
 		);
@@ -165,9 +169,11 @@ describe('Body', () => {
 					styles: { height: '400px' }
 				},
 				[
-					v('div', { key: 'top', styles: { height: '0px' } }),
-					...rows,
-					v('div', { key: 'bottom', styles: { height: '0px' } })
+					v('div', { styles: {} }, [
+						v('div', { key: 'top', styles: { height: '0px' } }),
+						...rows,
+						v('div', { key: 'bottom', styles: { height: '0px' } })
+					])
 				]
 			)
 		);
@@ -222,9 +228,11 @@ describe('Body', () => {
 					styles: { height: '400px' }
 				},
 				[
-					v('div', { key: 'top', styles: { height: '0px' } }),
-					...rows,
-					v('div', { key: 'bottom', styles: { height: '31500px' } })
+					v('div', { styles: {} }, [
+						v('div', { key: 'top', styles: { height: '0px' } }),
+						...rows,
+						v('div', { key: 'bottom', styles: { height: '31500px' } })
+					])
 				]
 			)
 		);
@@ -252,9 +260,11 @@ describe('Body', () => {
 					styles: { height: '400px' }
 				},
 				[
-					v('div', { key: 'top', styles: { height: '10010px' } }),
-					...rows,
-					v('div', { key: 'bottom', styles: { height: '23310px' } })
+					v('div', { styles: {} }, [
+						v('div', { key: 'top', styles: { height: '10010px' } }),
+						...rows,
+						v('div', { key: 'bottom', styles: { height: '23310px' } })
+					])
 				]
 			)
 		);
@@ -272,9 +282,11 @@ describe('Body', () => {
 					styles: { height: '400px' }
 				},
 				[
-					v('div', { key: 'top', styles: { height: '10010px' } }),
-					...rows,
-					v('div', { key: 'bottom', styles: { height: '23310px' } })
+					v('div', { styles: {} }, [
+						v('div', { key: 'top', styles: { height: '10010px' } }),
+						...rows,
+						v('div', { key: 'bottom', styles: { height: '23310px' } })
+					])
 				]
 			)
 		);

--- a/src/grid/tests/unit/Body.spec.tsx
+++ b/src/grid/tests/unit/Body.spec.tsx
@@ -361,5 +361,63 @@ describe('Body', () => {
 			h.expect(() => h.getRender());
 			assert.isTrue(pageChangeStub.calledWith(3));
 		});
+
+		it('should set the body to the correct width', () => {
+			const pageChangeStub = stub();
+			const page: any[] = [];
+			for (let i = 0; i < 100; i++) {
+				const item = { id: 'id' };
+				page.push(item);
+			}
+
+			const columnConfig = [
+				{
+					id: 'id',
+					title: 'Id'
+				}
+			];
+
+			const h = harness(() =>
+				w(Body, {
+					totalRows: 1000,
+					pageSize: 100,
+					height: 400,
+					pages: {},
+					columnConfig,
+					fetcher: noop,
+					updater: noop,
+					pageChange: pageChangeStub,
+					columnWidths: {
+						id: 100
+					},
+					width: 100
+				})
+			);
+
+			const rows: any[] = [];
+			for (let i = 0; i < 100; i++) {
+				rows.push(w(PlaceholderRow, { key: i }));
+			}
+
+			h.expect(() =>
+				v(
+					'div',
+					{
+						key: 'root',
+						classes: [css.root, fixedCss.rootFixed],
+						role: 'rowgroup',
+						onscroll: noop,
+						styles: { height: '400px', width: '100px' }
+					},
+					[
+						v('div', { styles: { width: '100px' } }, [
+							v('div', { key: 'top', styles: { height: '0px' } }),
+							...rows,
+							v('div', { key: 'bottom', styles: { height: '31500px' } })
+						])
+					]
+				)
+			);
+		});
 	});
 });

--- a/src/grid/tests/unit/Body.spec.tsx
+++ b/src/grid/tests/unit/Body.spec.tsx
@@ -47,11 +47,11 @@ describe('Body', () => {
 				pageSize: 100,
 				height: 400,
 				pages: {},
-				columnConfig: [] as any,
+				columnConfig: [],
 				fetcher: noop,
 				updater: noop,
 				pageChange: noop,
-				onScroll: noop
+				columnWidths: {}
 			})
 		);
 
@@ -93,7 +93,8 @@ describe('Body', () => {
 					columnConfig: [] as any,
 					updater: noop,
 					classes: undefined,
-					theme: undefined
+					theme: undefined,
+					columnWidths: {}
 				})
 			);
 		}
@@ -110,7 +111,7 @@ describe('Body', () => {
 				fetcher: noop,
 				updater: noop,
 				pageChange: noop,
-				onScroll: noop
+				columnWidths: {}
 			})
 		);
 
@@ -144,7 +145,7 @@ describe('Body', () => {
 				fetcher: noop,
 				updater: noop,
 				pageChange: noop,
-				onScroll: noop
+				columnWidths: {}
 			})
 		);
 
@@ -186,13 +187,13 @@ describe('Body', () => {
 					columnConfig: [] as any,
 					updater: noop,
 					classes: undefined,
-					theme: undefined
+					theme: undefined,
+					columnWidths: {}
 				})
 			);
 		}
 
 		const fetcherStub = stub();
-		const onScrollStub = stub();
 
 		const h = harness(() =>
 			w(Body, {
@@ -206,7 +207,7 @@ describe('Body', () => {
 				fetcher: fetcherStub,
 				updater: noop,
 				pageChange: noop,
-				onScroll: onScrollStub
+				columnWidths: {}
 			})
 		);
 
@@ -259,7 +260,6 @@ describe('Body', () => {
 		);
 
 		assert.isTrue(fetcherStub.called);
-		assert.isTrue(onScrollStub.called);
 
 		h.expect(() =>
 			v(
@@ -301,7 +301,7 @@ describe('Body', () => {
 					fetcher: noop,
 					updater: noop,
 					pageChange: pageChangeStub,
-					onScroll: noop
+					columnWidths: {}
 				})
 			);
 
@@ -335,7 +335,7 @@ describe('Body', () => {
 					fetcher: noop,
 					updater: noop,
 					pageChange: pageChangeStub,
-					onScroll: noop
+					columnWidths: {}
 				})
 			);
 			// scroll to row 286

--- a/src/grid/tests/unit/Cell.spec.tsx
+++ b/src/grid/tests/unit/Cell.spec.tsx
@@ -38,6 +38,7 @@ const expectedEditing = function() {
 		'div',
 		{
 			role: 'cell',
+			styles: { flex: '0 1 100px' },
 			classes: [css.root, fixedCss.rootFixed]
 		},
 		[
@@ -63,6 +64,7 @@ const expectedEditable = function(focusButton = false) {
 		'div',
 		{
 			role: 'cell',
+			styles: { flex: '0 1 100px' },
 			classes: [css.root, fixedCss.rootFixed]
 		},
 		[
@@ -106,7 +108,8 @@ describe('Cell', () => {
 			w(Cell, {
 				value: 'id',
 				rawValue: 'id',
-				updater: noop
+				updater: noop,
+				width: 100
 			})
 		);
 		h.expect(() =>
@@ -114,6 +117,7 @@ describe('Cell', () => {
 				'div',
 				{
 					classes: [css.root, fixedCss.rootFixed],
+					styles: { flex: '0 1 100px' },
 					role: 'cell'
 				},
 				[
@@ -136,13 +140,15 @@ describe('Cell', () => {
 			w(Cell, {
 				value: v('div', ['id']),
 				rawValue: 'id',
-				updater: noop
+				updater: noop,
+				width: 100
 			})
 		);
 		h.expect(() =>
 			v(
 				'div',
 				{
+					styles: { flex: '0 1 100px' },
 					classes: [css.root, fixedCss.rootFixed],
 					role: 'cell'
 				},
@@ -167,7 +173,8 @@ describe('Cell', () => {
 			w(Cell, {
 				value: 'id',
 				rawValue: 'id',
-				updater: updaterStub
+				updater: updaterStub,
+				width: 100
 			})
 		);
 		h.expect(() =>
@@ -175,6 +182,7 @@ describe('Cell', () => {
 				'div',
 				{
 					classes: [css.root, fixedCss.rootFixed],
+					styles: { flex: '0 1 100px' },
 					role: 'cell'
 				},
 				[
@@ -198,6 +206,7 @@ describe('Cell', () => {
 				'div',
 				{
 					classes: [css.root, fixedCss.rootFixed],
+					styles: { flex: '0 1 100px' },
 					role: 'cell'
 				},
 				[
@@ -222,7 +231,8 @@ describe('Cell', () => {
 				value: 'id',
 				rawValue: 'id',
 				updater: updaterStub,
-				editable: true
+				editable: true,
+				width: 100
 			})
 		);
 		h.expect(expectedEditable);
@@ -239,7 +249,8 @@ describe('Cell', () => {
 				value: 'id',
 				rawValue: 'id',
 				updater: updaterStub,
-				editable: true
+				editable: true,
+				width: 100
 			})
 		);
 		h.expect(expectedEditable);
@@ -261,7 +272,8 @@ describe('Cell', () => {
 				value: 'id',
 				rawValue: 'id',
 				updater: updaterStub,
-				editable: true
+				editable: true,
+				width: 100
 			})
 		);
 		h.expect(expectedEditable);
@@ -283,7 +295,8 @@ describe('Cell', () => {
 				value: 'id',
 				rawValue: 'id',
 				updater: updaterStub,
-				editable: true
+				editable: true,
+				width: 100
 			})
 		);
 		h.expect(expectedEditable);
@@ -305,7 +318,8 @@ describe('Cell', () => {
 				value: 'id',
 				rawValue: 'id',
 				updater: updaterStub,
-				editable: true
+				editable: true,
+				width: 100
 			});
 		}, [compareInputFocused]);
 		h.trigger('@content', 'ondblclick');
@@ -319,7 +333,8 @@ describe('Cell', () => {
 				value: 'id',
 				rawValue: 'id',
 				updater: updaterStub,
-				editable: true
+				editable: true,
+				width: 100
 			});
 		}, [compareButtonFocused]);
 
@@ -338,7 +353,8 @@ describe('Cell', () => {
 				value: 'id',
 				rawValue: 'id',
 				updater: updaterStub,
-				editable: true
+				editable: true,
+				width: 100
 			});
 		}, [compareButtonFocused]);
 

--- a/src/grid/tests/unit/Grid.spec.tsx
+++ b/src/grid/tests/unit/Grid.spec.tsx
@@ -64,56 +64,50 @@ describe('Grid', () => {
 					'aria-rowcount': null
 				},
 				[
-					v('div', { styles: {} }, [
-						v(
-							'div',
-							{
-								key: 'header',
-								styles: {},
-								classes: [css.header, fixedCss.headerFixed, css.filterGroup],
-								row: 'rowgroup',
-								scrollLeft: 0
-							},
-							[
-								v('div', { key: 'header-wrapper' }, [
-									w(Header, {
-										key: 'header-row',
-										columnConfig: filterableConfig,
-										sorter: noop,
-										sort: undefined,
-										filter: undefined,
-										filterer: noop,
-										classes: undefined,
-										theme: undefined,
-										filterRenderer: undefined,
-										sortRenderer: undefined,
-										columnWidths: {
-											id: 1000
-										},
-										onColumnResize: noop
-									})
-								])
-							]
-						),
-						w(Body, {
-							key: 'body',
-							onScroll: noop,
-							pages: {},
-							totalRows: undefined,
-							pageSize: 100,
-							columnConfig: filterableConfig,
-							pageChange: noop,
-							width: undefined,
-							updater: noop,
-							fetcher: noop,
-							height: 300,
-							classes: undefined,
-							theme: undefined,
-							columnWidths: {
-								id: 1000
-							}
-						})
-					]),
+					v(
+						'div',
+						{
+							key: 'header',
+							styles: {},
+							classes: [css.header, fixedCss.headerFixed, css.filterGroup],
+							row: 'rowgroup',
+							scrollLeft: 0
+						},
+						[
+							v('div', { key: 'header-wrapper' }, [
+								w(Header, {
+									key: 'header-row',
+									columnConfig: filterableConfig,
+									sorter: noop,
+									sort: undefined,
+									filter: undefined,
+									filterer: noop,
+									classes: undefined,
+									theme: undefined,
+									filterRenderer: undefined,
+									sortRenderer: undefined,
+									columnWidths: undefined,
+									onColumnResize: noop
+								})
+							])
+						]
+					),
+					w(Body, {
+						key: 'body',
+						onScroll: noop,
+						pages: {},
+						totalRows: undefined,
+						pageSize: 100,
+						columnConfig: filterableConfig,
+						pageChange: noop,
+						width: undefined,
+						updater: noop,
+						fetcher: noop,
+						height: 300,
+						classes: undefined,
+						theme: undefined,
+						columnWidths: undefined
+					}),
 					v('div', { key: 'footer' }, [
 						w(Footer, {
 							key: 'footer-row',
@@ -167,64 +161,58 @@ describe('Grid', () => {
 					'aria-rowcount': '100'
 				},
 				[
-					v('div', { styles: {} }, [
-						v(
-							'div',
-							{
-								key: 'header',
-								classes: [css.header, fixedCss.headerFixed, css.filterGroup],
-								styles: {},
-								row: 'rowgroup',
-								scrollLeft: 0
-							},
-							[
-								v('div', { key: 'header-wrapper' }, [
-									w(Header, {
-										key: 'header-row',
-										columnConfig: filterableConfig,
-										sorter: noop,
-										sort: {
-											columnId: 'id',
-											direction: 'asc'
-										},
-										filter: {
-											columnId: 'id',
-											value: 'id'
-										},
-										filterer: noop,
-										classes: undefined,
-										theme: undefined,
-										filterRenderer: undefined,
-										sortRenderer: undefined,
-										columnWidths: {
-											id: 1000
-										},
-										onColumnResize: noop
-									})
-								])
-							]
-						),
-						w(Body, {
-							key: 'body',
-							onScroll: noop,
-							pages: {
-								'page-1': [{ id: 'id' }]
-							},
-							totalRows: 100,
-							pageSize: 100,
-							columnConfig: filterableConfig,
-							pageChange: noop,
-							width: undefined,
-							updater: noop,
-							fetcher: noop,
-							height: 300,
-							classes: undefined,
-							theme: undefined,
-							columnWidths: {
-								id: 1000
-							}
-						})
-					]),
+					v(
+						'div',
+						{
+							key: 'header',
+							classes: [css.header, fixedCss.headerFixed, css.filterGroup],
+							styles: {},
+							row: 'rowgroup',
+							scrollLeft: 0
+						},
+						[
+							v('div', { key: 'header-wrapper' }, [
+								w(Header, {
+									key: 'header-row',
+									columnConfig: filterableConfig,
+									sorter: noop,
+									sort: {
+										columnId: 'id',
+										direction: 'asc'
+									},
+									filter: {
+										columnId: 'id',
+										value: 'id'
+									},
+									filterer: noop,
+									classes: undefined,
+									theme: undefined,
+									filterRenderer: undefined,
+									sortRenderer: undefined,
+									columnWidths: undefined,
+									onColumnResize: noop
+								})
+							])
+						]
+					),
+					w(Body, {
+						key: 'body',
+						onScroll: noop,
+						pages: {
+							'page-1': [{ id: 'id' }]
+						},
+						totalRows: 100,
+						pageSize: 100,
+						columnConfig: filterableConfig,
+						pageChange: noop,
+						width: undefined,
+						updater: noop,
+						fetcher: noop,
+						height: 300,
+						classes: undefined,
+						theme: undefined,
+						columnWidths: undefined
+					}),
 					v('div', { key: 'footer' }, [
 						w(Footer, {
 							key: 'footer-row',
@@ -265,56 +253,50 @@ describe('Grid', () => {
 					'aria-rowcount': null
 				},
 				[
-					v('div', { styles: {} }, [
-						v(
-							'div',
-							{
-								key: 'header',
-								classes: [css.header, fixedCss.headerFixed, css.filterGroup],
-								styles: {},
-								row: 'rowgroup',
-								scrollLeft: 0
-							},
-							[
-								v('div', { key: 'header-wrapper' }, [
-									w(Header, {
-										key: 'header-row',
-										columnConfig: filterableConfig,
-										sorter: noop,
-										sort: undefined,
-										filter: undefined,
-										filterer: noop,
-										classes: undefined,
-										theme: undefined,
-										filterRenderer: undefined,
-										sortRenderer: undefined,
-										columnWidths: {
-											id: 1000
-										},
-										onColumnResize: noop
-									})
-								])
-							]
-						),
-						w(Body, {
-							key: 'body',
-							onScroll: noop,
-							pages: {},
-							totalRows: undefined,
-							pageSize: 100,
-							columnConfig: filterableConfig,
-							pageChange: noop,
-							width: undefined,
-							updater: noop,
-							fetcher: noop,
-							height: 300,
-							classes: undefined,
-							theme: undefined,
-							columnWidths: {
-								id: 1000
-							}
-						})
-					]),
+					v(
+						'div',
+						{
+							key: 'header',
+							classes: [css.header, fixedCss.headerFixed, css.filterGroup],
+							styles: {},
+							row: 'rowgroup',
+							scrollLeft: 0
+						},
+						[
+							v('div', { key: 'header-wrapper' }, [
+								w(Header, {
+									key: 'header-row',
+									columnConfig: filterableConfig,
+									sorter: noop,
+									sort: undefined,
+									filter: undefined,
+									filterer: noop,
+									classes: undefined,
+									theme: undefined,
+									filterRenderer: undefined,
+									sortRenderer: undefined,
+									columnWidths: undefined,
+									onColumnResize: noop
+								})
+							])
+						]
+					),
+					w(Body, {
+						key: 'body',
+						onScroll: noop,
+						pages: {},
+						totalRows: undefined,
+						pageSize: 100,
+						columnConfig: filterableConfig,
+						pageChange: noop,
+						width: undefined,
+						updater: noop,
+						fetcher: noop,
+						height: 300,
+						classes: undefined,
+						theme: undefined,
+						columnWidths: undefined
+					}),
 					v('div', { key: 'footer' }, [
 						w(Footer, {
 							key: 'footer-row',
@@ -352,52 +334,50 @@ describe('Grid', () => {
 					'aria-rowcount': null
 				},
 				[
-					v('div', { styles: {} }, [
-						v(
-							'div',
-							{
-								key: 'header',
-								classes: [css.header, fixedCss.headerFixed, null],
-								styles: {},
-								row: 'rowgroup',
-								scrollLeft: 0
-							},
-							[
-								v('div', { key: 'header-wrapper' }, [
-									w(Header, {
-										key: 'header-row',
-										columnConfig,
-										sorter: noop,
-										sort: undefined,
-										filter: undefined,
-										filterer: noop,
-										classes: undefined,
-										theme: undefined,
-										filterRenderer: undefined,
-										sortRenderer: undefined,
-										columnWidths: {},
-										onColumnResize: noop
-									})
-								])
-							]
-						),
-						w(Body, {
-							key: 'body',
-							onScroll: noop,
-							pages: {},
-							totalRows: undefined,
-							pageSize: 100,
-							columnConfig,
-							pageChange: noop,
-							width: undefined,
-							updater: noop,
-							fetcher: noop,
-							height: 50,
-							classes: undefined,
-							theme: undefined,
-							columnWidths: {}
-						})
-					]),
+					v(
+						'div',
+						{
+							key: 'header',
+							classes: [css.header, fixedCss.headerFixed, null],
+							styles: {},
+							row: 'rowgroup',
+							scrollLeft: 0
+						},
+						[
+							v('div', { key: 'header-wrapper' }, [
+								w(Header, {
+									key: 'header-row',
+									columnConfig,
+									sorter: noop,
+									sort: undefined,
+									filter: undefined,
+									filterer: noop,
+									classes: undefined,
+									theme: undefined,
+									filterRenderer: undefined,
+									sortRenderer: undefined,
+									columnWidths: undefined,
+									onColumnResize: noop
+								})
+							])
+						]
+					),
+					w(Body, {
+						key: 'body',
+						onScroll: noop,
+						pages: {},
+						totalRows: undefined,
+						pageSize: 100,
+						columnConfig,
+						pageChange: noop,
+						width: undefined,
+						updater: noop,
+						fetcher: noop,
+						height: 50,
+						classes: undefined,
+						theme: undefined,
+						columnWidths: undefined
+					}),
 					v('div', { key: 'footer' }, [
 						w(Footer, {
 							key: 'footer-row',
@@ -433,58 +413,56 @@ describe('Grid', () => {
 					'aria-rowcount': null
 				},
 				[
-					v('div', { styles: {} }, [
-						v(
-							'div',
-							{
-								key: 'header',
-								scrollLeft: 0,
-								styles: {},
-								classes: [css.header, fixedCss.headerFixed, null],
-								row: 'rowgroup'
-							},
-							[
-								v(
-									'div',
-									{
-										key: 'header-wrapper'
-									},
-									[
-										w(Header, {
-											key: 'header-row',
-											columnConfig,
-											columnWidths: {},
-											sorter: noop,
-											sort: undefined,
-											filter: undefined,
-											onColumnResize: noop,
-											filterer: noop,
-											classes: undefined,
-											theme: undefined,
-											filterRenderer: undefined,
-											sortRenderer: undefined
-										})
-									]
-								)
-							]
-						),
-						w(Body, {
-							key: 'body',
-							pages: {},
-							totalRows: undefined,
-							pageSize: 100,
-							columnConfig,
-							columnWidths: {},
-							pageChange: noop,
-							updater: noop,
-							fetcher: noop,
-							onScroll: noop,
-							height: 300,
-							classes: undefined,
-							theme: undefined,
-							width: undefined
-						})
-					]),
+					v(
+						'div',
+						{
+							key: 'header',
+							scrollLeft: 0,
+							styles: {},
+							classes: [css.header, fixedCss.headerFixed, null],
+							row: 'rowgroup'
+						},
+						[
+							v(
+								'div',
+								{
+									key: 'header-wrapper'
+								},
+								[
+									w(Header, {
+										key: 'header-row',
+										columnConfig,
+										columnWidths: undefined,
+										sorter: noop,
+										sort: undefined,
+										filter: undefined,
+										onColumnResize: noop,
+										filterer: noop,
+										classes: undefined,
+										theme: undefined,
+										filterRenderer: undefined,
+										sortRenderer: undefined
+									})
+								]
+							)
+						]
+					),
+					w(Body, {
+						key: 'body',
+						pages: {},
+						totalRows: undefined,
+						pageSize: 100,
+						columnConfig,
+						columnWidths: undefined,
+						pageChange: noop,
+						updater: noop,
+						fetcher: noop,
+						onScroll: noop,
+						height: 300,
+						classes: undefined,
+						theme: undefined,
+						width: undefined
+					}),
 					v('div', { key: 'footer' }, [
 						w(Footer, {
 							key: 'footer-row',
@@ -511,58 +489,56 @@ describe('Grid', () => {
 					'aria-rowcount': null
 				},
 				[
-					v('div', { styles: {} }, [
-						v(
-							'div',
-							{
-								key: 'header',
-								scrollLeft: 10,
-								styles: {},
-								classes: [css.header, fixedCss.headerFixed, null],
-								row: 'rowgroup'
-							},
-							[
-								v(
-									'div',
-									{
-										key: 'header-wrapper'
-									},
-									[
-										w(Header, {
-											key: 'header-row',
-											columnConfig,
-											columnWidths: {},
-											sorter: noop,
-											sort: undefined,
-											onColumnResize: noop,
-											filter: undefined,
-											filterer: noop,
-											classes: undefined,
-											theme: undefined,
-											filterRenderer: undefined,
-											sortRenderer: undefined
-										})
-									]
-								)
-							]
-						),
-						w(Body, {
-							key: 'body',
-							pages: {},
-							totalRows: undefined,
-							pageSize: 100,
-							columnConfig,
-							columnWidths: {},
-							pageChange: noop,
-							updater: noop,
-							fetcher: noop,
-							onScroll: noop,
-							height: 300,
-							classes: undefined,
-							theme: undefined,
-							width: undefined
-						})
-					]),
+					v(
+						'div',
+						{
+							key: 'header',
+							scrollLeft: 10,
+							styles: {},
+							classes: [css.header, fixedCss.headerFixed, null],
+							row: 'rowgroup'
+						},
+						[
+							v(
+								'div',
+								{
+									key: 'header-wrapper'
+								},
+								[
+									w(Header, {
+										key: 'header-row',
+										columnConfig,
+										columnWidths: undefined,
+										sorter: noop,
+										sort: undefined,
+										onColumnResize: noop,
+										filter: undefined,
+										filterer: noop,
+										classes: undefined,
+										theme: undefined,
+										filterRenderer: undefined,
+										sortRenderer: undefined
+									})
+								]
+							)
+						]
+					),
+					w(Body, {
+						key: 'body',
+						pages: {},
+						totalRows: undefined,
+						pageSize: 100,
+						columnConfig,
+						columnWidths: undefined,
+						pageChange: noop,
+						updater: noop,
+						fetcher: noop,
+						onScroll: noop,
+						height: 300,
+						classes: undefined,
+						theme: undefined,
+						width: undefined
+					}),
 					v('div', { key: 'footer' }, [
 						w(Footer, {
 							key: 'footer-row',

--- a/src/grid/tests/unit/Grid.spec.tsx
+++ b/src/grid/tests/unit/Grid.spec.tsx
@@ -412,4 +412,169 @@ describe('Grid', () => {
 			)
 		);
 	});
+
+	it('should set the scrollLeft of the header when onScroll is called', () => {
+		const h = harness(() =>
+			w(MockMetaMixin(Grid, mockMeta), {
+				fetcher: noop,
+				updater: noop,
+				columnConfig,
+				height: 500
+			})
+		);
+
+		h.expect(() =>
+			v(
+				'div',
+				{
+					key: 'root',
+					classes: [css.root, fixedCss.rootFixed],
+					role: 'table',
+					'aria-rowcount': null
+				},
+				[
+					v('div', { styles: {} }, [
+						v(
+							'div',
+							{
+								key: 'header',
+								scrollLeft: 0,
+								styles: {},
+								classes: [css.header, fixedCss.headerFixed, null],
+								row: 'rowgroup'
+							},
+							[
+								v(
+									'div',
+									{
+										key: 'header-wrapper'
+									},
+									[
+										w(Header, {
+											key: 'header-row',
+											columnConfig,
+											columnWidths: {},
+											sorter: noop,
+											sort: undefined,
+											filter: undefined,
+											onColumnResize: noop,
+											filterer: noop,
+											classes: undefined,
+											theme: undefined,
+											filterRenderer: undefined,
+											sortRenderer: undefined
+										})
+									]
+								)
+							]
+						),
+						w(Body, {
+							key: 'body',
+							pages: {},
+							totalRows: undefined,
+							pageSize: 100,
+							columnConfig,
+							columnWidths: {},
+							pageChange: noop,
+							updater: noop,
+							fetcher: noop,
+							onScroll: noop,
+							height: 300,
+							classes: undefined,
+							theme: undefined,
+							width: undefined
+						})
+					]),
+					v('div', { key: 'footer' }, [
+						w(Footer, {
+							key: 'footer-row',
+							total: undefined,
+							page: 1,
+							pageSize: 100,
+							classes: undefined,
+							theme: undefined
+						})
+					])
+				]
+			)
+		);
+
+		h.trigger('@body', 'onScroll', 10);
+
+		h.expect(() =>
+			v(
+				'div',
+				{
+					key: 'root',
+					classes: [css.root, fixedCss.rootFixed],
+					role: 'table',
+					'aria-rowcount': null
+				},
+				[
+					v('div', { styles: {} }, [
+						v(
+							'div',
+							{
+								key: 'header',
+								scrollLeft: 10,
+								styles: {},
+								classes: [css.header, fixedCss.headerFixed, null],
+								row: 'rowgroup'
+							},
+							[
+								v(
+									'div',
+									{
+										key: 'header-wrapper'
+									},
+									[
+										w(Header, {
+											key: 'header-row',
+											columnConfig,
+											columnWidths: {},
+											sorter: noop,
+											sort: undefined,
+											onColumnResize: noop,
+											filter: undefined,
+											filterer: noop,
+											classes: undefined,
+											theme: undefined,
+											filterRenderer: undefined,
+											sortRenderer: undefined
+										})
+									]
+								)
+							]
+						),
+						w(Body, {
+							key: 'body',
+							pages: {},
+							totalRows: undefined,
+							pageSize: 100,
+							columnConfig,
+							columnWidths: {},
+							pageChange: noop,
+							updater: noop,
+							fetcher: noop,
+							onScroll: noop,
+							height: 300,
+							classes: undefined,
+							theme: undefined,
+							width: undefined
+						})
+					]),
+					v('div', { key: 'footer' }, [
+						w(Footer, {
+							key: 'footer-row',
+							total: undefined,
+							page: 1,
+							pageSize: 100,
+							classes: undefined,
+							theme: undefined
+						})
+					])
+				]
+			)
+		);
+	});
 });

--- a/src/grid/tests/unit/Grid.spec.tsx
+++ b/src/grid/tests/unit/Grid.spec.tsx
@@ -24,8 +24,10 @@ const noop: any = () => {};
 const columnConfig: ColumnConfig[] = [];
 
 let mockDimensionsGet = stub();
-mockDimensionsGet.withArgs('header').returns({ size: { height: 150 } });
+mockDimensionsGet.withArgs('header').returns({ size: { height: 150, width: 1000 } });
+mockDimensionsGet.withArgs('header-wrapper').returns({ size: { height: 150, width: 1000 } });
 mockDimensionsGet.withArgs('footer').returns({ size: { height: 50 } });
+mockDimensionsGet.withArgs('root').returns({ size: { width: 50 } });
 const metaDimensionsReturn = {
 	get: mockDimensionsGet,
 	has: () => false
@@ -38,22 +40,6 @@ mockMeta.withArgs(Dimensions).returns(metaDimensionsReturn);
 mockMeta.withArgs(Resize).returns(metaResizeReturn);
 
 describe('Grid', () => {
-	it('should render only the container when no dimensions', () => {
-		const h = harness(() =>
-			w(Grid, {
-				fetcher: noop,
-				updater: noop,
-				columnConfig,
-				storeId: 'id',
-				height: 0
-			})
-		);
-
-		h.expect(() =>
-			v('div', { key: 'root', classes: [css.root, fixedCss.rootFixed], role: 'table' })
-		);
-	});
-
 	it('should use store from properties when passed', () => {
 		const store = new Store();
 		const storeSpy = spy(store, 'onChange');
@@ -78,43 +64,54 @@ describe('Grid', () => {
 					'aria-rowcount': null
 				},
 				[
-					v(
-						'div',
-						{
-							key: 'header',
-							scrollLeft: 0,
-							classes: [css.header, fixedCss.headerFixed, css.filterGroup],
-							row: 'rowgroup'
-						},
-						[
-							w(Header, {
-								key: 'header-row',
-								columnConfig: filterableConfig,
-								sorter: noop,
-								sort: undefined,
-								filter: undefined,
-								filterer: noop,
-								classes: undefined,
-								theme: undefined,
-								filterRenderer: undefined,
-								sortRenderer: undefined
-							})
-						]
-					),
-					w(Body, {
-						key: 'body',
-						pages: {},
-						totalRows: undefined,
-						pageSize: 100,
-						columnConfig: filterableConfig,
-						pageChange: noop,
-						updater: noop,
-						fetcher: noop,
-						onScroll: noop,
-						height: 300,
-						classes: undefined,
-						theme: undefined
-					}),
+					v('div', { styles: {} }, [
+						v(
+							'div',
+							{
+								key: 'header',
+								styles: {},
+								classes: [css.header, fixedCss.headerFixed, css.filterGroup],
+								row: 'rowgroup'
+							},
+							[
+								v('div', { key: 'header-wrapper' }, [
+									w(Header, {
+										key: 'header-row',
+										columnConfig: filterableConfig,
+										sorter: noop,
+										sort: undefined,
+										filter: undefined,
+										filterer: noop,
+										classes: undefined,
+										theme: undefined,
+										filterRenderer: undefined,
+										sortRenderer: undefined,
+										columnWidths: {
+											id: 1000
+										},
+										onColumnResize: noop
+									})
+								])
+							]
+						),
+						w(Body, {
+							key: 'body',
+							pages: {},
+							totalRows: undefined,
+							pageSize: 100,
+							columnConfig: filterableConfig,
+							pageChange: noop,
+							width: undefined,
+							updater: noop,
+							fetcher: noop,
+							height: 300,
+							classes: undefined,
+							theme: undefined,
+							columnWidths: {
+								id: 1000
+							}
+						})
+					]),
 					v('div', { key: 'footer' }, [
 						w(Footer, {
 							key: 'footer-row',
@@ -168,51 +165,62 @@ describe('Grid', () => {
 					'aria-rowcount': '100'
 				},
 				[
-					v(
-						'div',
-						{
-							key: 'header',
-							scrollLeft: 0,
-							classes: [css.header, fixedCss.headerFixed, css.filterGroup],
-							row: 'rowgroup'
-						},
-						[
-							w(Header, {
-								key: 'header-row',
-								columnConfig: filterableConfig,
-								sorter: noop,
-								sort: {
-									columnId: 'id',
-									direction: 'asc'
-								},
-								filter: {
-									columnId: 'id',
-									value: 'id'
-								},
-								filterer: noop,
-								classes: undefined,
-								theme: undefined,
-								filterRenderer: undefined,
-								sortRenderer: undefined
-							})
-						]
-					),
-					w(Body, {
-						key: 'body',
-						pages: {
-							'page-1': [{ id: 'id' }]
-						},
-						totalRows: 100,
-						pageSize: 100,
-						columnConfig: filterableConfig,
-						pageChange: noop,
-						updater: noop,
-						fetcher: noop,
-						onScroll: noop,
-						height: 300,
-						classes: undefined,
-						theme: undefined
-					}),
+					v('div', { styles: {} }, [
+						v(
+							'div',
+							{
+								key: 'header',
+								classes: [css.header, fixedCss.headerFixed, css.filterGroup],
+								styles: {},
+								row: 'rowgroup'
+							},
+							[
+								v('div', { key: 'header-wrapper' }, [
+									w(Header, {
+										key: 'header-row',
+										columnConfig: filterableConfig,
+										sorter: noop,
+										sort: {
+											columnId: 'id',
+											direction: 'asc'
+										},
+										filter: {
+											columnId: 'id',
+											value: 'id'
+										},
+										filterer: noop,
+										classes: undefined,
+										theme: undefined,
+										filterRenderer: undefined,
+										sortRenderer: undefined,
+										columnWidths: {
+											id: 1000
+										},
+										onColumnResize: noop
+									})
+								])
+							]
+						),
+						w(Body, {
+							key: 'body',
+							pages: {
+								'page-1': [{ id: 'id' }]
+							},
+							totalRows: 100,
+							pageSize: 100,
+							columnConfig: filterableConfig,
+							pageChange: noop,
+							width: undefined,
+							updater: noop,
+							fetcher: noop,
+							height: 300,
+							classes: undefined,
+							theme: undefined,
+							columnWidths: {
+								id: 1000
+							}
+						})
+					]),
 					v('div', { key: 'footer' }, [
 						w(Footer, {
 							key: 'footer-row',
@@ -253,43 +261,54 @@ describe('Grid', () => {
 					'aria-rowcount': null
 				},
 				[
-					v(
-						'div',
-						{
-							key: 'header',
-							scrollLeft: 0,
-							classes: [css.header, fixedCss.headerFixed, css.filterGroup],
-							row: 'rowgroup'
-						},
-						[
-							w(Header, {
-								key: 'header-row',
-								columnConfig: filterableConfig,
-								sorter: noop,
-								sort: undefined,
-								filter: undefined,
-								filterer: noop,
-								classes: undefined,
-								theme: undefined,
-								filterRenderer: undefined,
-								sortRenderer: undefined
-							})
-						]
-					),
-					w(Body, {
-						key: 'body',
-						pages: {},
-						totalRows: undefined,
-						pageSize: 100,
-						columnConfig: filterableConfig,
-						pageChange: noop,
-						updater: noop,
-						fetcher: noop,
-						onScroll: noop,
-						height: 300,
-						classes: undefined,
-						theme: undefined
-					}),
+					v('div', { styles: {} }, [
+						v(
+							'div',
+							{
+								key: 'header',
+								classes: [css.header, fixedCss.headerFixed, css.filterGroup],
+								styles: {},
+								row: 'rowgroup'
+							},
+							[
+								v('div', { key: 'header-wrapper' }, [
+									w(Header, {
+										key: 'header-row',
+										columnConfig: filterableConfig,
+										sorter: noop,
+										sort: undefined,
+										filter: undefined,
+										filterer: noop,
+										classes: undefined,
+										theme: undefined,
+										filterRenderer: undefined,
+										sortRenderer: undefined,
+										columnWidths: {
+											id: 1000
+										},
+										onColumnResize: noop
+									})
+								])
+							]
+						),
+						w(Body, {
+							key: 'body',
+							pages: {},
+							totalRows: undefined,
+							pageSize: 100,
+							columnConfig: filterableConfig,
+							pageChange: noop,
+							width: undefined,
+							updater: noop,
+							fetcher: noop,
+							height: 300,
+							classes: undefined,
+							theme: undefined,
+							columnWidths: {
+								id: 1000
+							}
+						})
+					]),
 					v('div', { key: 'footer' }, [
 						w(Footer, {
 							key: 'footer-row',
@@ -327,178 +346,50 @@ describe('Grid', () => {
 					'aria-rowcount': null
 				},
 				[
-					v(
-						'div',
-						{
-							key: 'header',
-							scrollLeft: 0,
-							classes: [css.header, fixedCss.headerFixed, null],
-							row: 'rowgroup'
-						},
-						[
-							w(Header, {
-								key: 'header-row',
-								columnConfig,
-								sorter: noop,
-								sort: undefined,
-								filter: undefined,
-								filterer: noop,
-								classes: undefined,
-								theme: undefined,
-								filterRenderer: undefined,
-								sortRenderer: undefined
-							})
-						]
-					),
-					w(Body, {
-						key: 'body',
-						pages: {},
-						totalRows: undefined,
-						pageSize: 100,
-						columnConfig,
-						pageChange: noop,
-						updater: noop,
-						fetcher: noop,
-						onScroll: noop,
-						height: 50,
-						classes: undefined,
-						theme: undefined
-					}),
-					v('div', { key: 'footer' }, [
-						w(Footer, {
-							key: 'footer-row',
-							total: undefined,
-							page: 1,
+					v('div', { styles: {} }, [
+						v(
+							'div',
+							{
+								key: 'header',
+								classes: [css.header, fixedCss.headerFixed, null],
+								styles: {},
+								row: 'rowgroup'
+							},
+							[
+								v('div', { key: 'header-wrapper' }, [
+									w(Header, {
+										key: 'header-row',
+										columnConfig,
+										sorter: noop,
+										sort: undefined,
+										filter: undefined,
+										filterer: noop,
+										classes: undefined,
+										theme: undefined,
+										filterRenderer: undefined,
+										sortRenderer: undefined,
+										columnWidths: {},
+										onColumnResize: noop
+									})
+								])
+							]
+						),
+						w(Body, {
+							key: 'body',
+							pages: {},
+							totalRows: undefined,
 							pageSize: 100,
+							columnConfig,
+							pageChange: noop,
+							width: undefined,
+							updater: noop,
+							fetcher: noop,
+							height: 50,
 							classes: undefined,
-							theme: undefined
+							theme: undefined,
+							columnWidths: {}
 						})
-					])
-				]
-			)
-		);
-	});
-
-	it('should set the scrollLeft of the header when onScroll is called', () => {
-		const h = harness(() =>
-			w(MockMetaMixin(Grid, mockMeta), {
-				fetcher: noop,
-				updater: noop,
-				columnConfig,
-				height: 500
-			})
-		);
-
-		h.expect(() =>
-			v(
-				'div',
-				{
-					key: 'root',
-					classes: [css.root, fixedCss.rootFixed],
-					role: 'table',
-					'aria-rowcount': null
-				},
-				[
-					v(
-						'div',
-						{
-							key: 'header',
-							scrollLeft: 0,
-							classes: [css.header, fixedCss.headerFixed, null],
-							row: 'rowgroup'
-						},
-						[
-							w(Header, {
-								key: 'header-row',
-								columnConfig,
-								sorter: noop,
-								sort: undefined,
-								filter: undefined,
-								filterer: noop,
-								classes: undefined,
-								theme: undefined,
-								filterRenderer: undefined,
-								sortRenderer: undefined
-							})
-						]
-					),
-					w(Body, {
-						key: 'body',
-						pages: {},
-						totalRows: undefined,
-						pageSize: 100,
-						columnConfig,
-						pageChange: noop,
-						updater: noop,
-						fetcher: noop,
-						onScroll: noop,
-						height: 300,
-						classes: undefined,
-						theme: undefined
-					}),
-					v('div', { key: 'footer' }, [
-						w(Footer, {
-							key: 'footer-row',
-							total: undefined,
-							page: 1,
-							pageSize: 100,
-							classes: undefined,
-							theme: undefined
-						})
-					])
-				]
-			)
-		);
-
-		h.trigger('@body', 'onScroll', 10);
-
-		h.expect(() =>
-			v(
-				'div',
-				{
-					key: 'root',
-					classes: [css.root, fixedCss.rootFixed],
-					role: 'table',
-					'aria-rowcount': null
-				},
-				[
-					v(
-						'div',
-						{
-							key: 'header',
-							scrollLeft: 10,
-							classes: [css.header, fixedCss.headerFixed, null],
-							row: 'rowgroup'
-						},
-						[
-							w(Header, {
-								key: 'header-row',
-								columnConfig,
-								sorter: noop,
-								sort: undefined,
-								filter: undefined,
-								filterer: noop,
-								classes: undefined,
-								theme: undefined,
-								filterRenderer: undefined,
-								sortRenderer: undefined
-							})
-						]
-					),
-					w(Body, {
-						key: 'body',
-						pages: {},
-						totalRows: undefined,
-						pageSize: 100,
-						columnConfig,
-						pageChange: noop,
-						updater: noop,
-						fetcher: noop,
-						onScroll: noop,
-						height: 300,
-						classes: undefined,
-						theme: undefined
-					}),
+					]),
 					v('div', { key: 'footer' }, [
 						w(Footer, {
 							key: 'footer-row',

--- a/src/grid/tests/unit/Grid.spec.tsx
+++ b/src/grid/tests/unit/Grid.spec.tsx
@@ -71,7 +71,8 @@ describe('Grid', () => {
 								key: 'header',
 								styles: {},
 								classes: [css.header, fixedCss.headerFixed, css.filterGroup],
-								row: 'rowgroup'
+								row: 'rowgroup',
+								scrollLeft: 0
 							},
 							[
 								v('div', { key: 'header-wrapper' }, [
@@ -96,6 +97,7 @@ describe('Grid', () => {
 						),
 						w(Body, {
 							key: 'body',
+							onScroll: noop,
 							pages: {},
 							totalRows: undefined,
 							pageSize: 100,
@@ -172,7 +174,8 @@ describe('Grid', () => {
 								key: 'header',
 								classes: [css.header, fixedCss.headerFixed, css.filterGroup],
 								styles: {},
-								row: 'rowgroup'
+								row: 'rowgroup',
+								scrollLeft: 0
 							},
 							[
 								v('div', { key: 'header-wrapper' }, [
@@ -203,6 +206,7 @@ describe('Grid', () => {
 						),
 						w(Body, {
 							key: 'body',
+							onScroll: noop,
 							pages: {
 								'page-1': [{ id: 'id' }]
 							},
@@ -268,7 +272,8 @@ describe('Grid', () => {
 								key: 'header',
 								classes: [css.header, fixedCss.headerFixed, css.filterGroup],
 								styles: {},
-								row: 'rowgroup'
+								row: 'rowgroup',
+								scrollLeft: 0
 							},
 							[
 								v('div', { key: 'header-wrapper' }, [
@@ -293,6 +298,7 @@ describe('Grid', () => {
 						),
 						w(Body, {
 							key: 'body',
+							onScroll: noop,
 							pages: {},
 							totalRows: undefined,
 							pageSize: 100,
@@ -353,7 +359,8 @@ describe('Grid', () => {
 								key: 'header',
 								classes: [css.header, fixedCss.headerFixed, null],
 								styles: {},
-								row: 'rowgroup'
+								row: 'rowgroup',
+								scrollLeft: 0
 							},
 							[
 								v('div', { key: 'header-wrapper' }, [
@@ -376,6 +383,7 @@ describe('Grid', () => {
 						),
 						w(Body, {
 							key: 'body',
+							onScroll: noop,
 							pages: {},
 							totalRows: undefined,
 							pageSize: 100,

--- a/src/grid/tests/unit/Grid.spec.tsx
+++ b/src/grid/tests/unit/Grid.spec.tsx
@@ -553,4 +553,107 @@ describe('Grid', () => {
 			)
 		);
 	});
+
+	it('should set pass widths when any of the columns are resizable', () => {
+		const columnConfig = [
+			{
+				id: 'id',
+				title: 'Id',
+				resizable: true
+			},
+			{
+				id: 'name',
+				title: 'Name',
+				resizable: true
+			}
+		];
+		const h = harness(() =>
+			w(MockMetaMixin(Grid, mockMeta), {
+				fetcher: noop,
+				updater: noop,
+				columnConfig,
+				height: 500
+			})
+		);
+
+		h.expect(() =>
+			v(
+				'div',
+				{
+					key: 'root',
+					classes: [css.root, fixedCss.rootFixed],
+					role: 'table',
+					'aria-rowcount': null
+				},
+				[
+					v(
+						'div',
+						{
+							key: 'header',
+							scrollLeft: 0,
+							styles: { width: '1000px' },
+							classes: [css.header, fixedCss.headerFixed, null],
+							row: 'rowgroup'
+						},
+						[
+							v(
+								'div',
+								{
+									key: 'header-wrapper'
+								},
+								[
+									w(Header, {
+										key: 'header-row',
+										columnConfig,
+										columnWidths: {
+											id: 500,
+											name: 500
+										},
+										sorter: noop,
+										sort: undefined,
+										filter: undefined,
+										onColumnResize: noop,
+										filterer: noop,
+										classes: undefined,
+										theme: undefined,
+										filterRenderer: undefined,
+										sortRenderer: undefined
+									})
+								]
+							)
+						]
+					),
+					w(Body, {
+						key: 'body',
+						pages: {},
+						totalRows: undefined,
+						pageSize: 100,
+						columnConfig,
+						columnWidths: {
+							id: 500,
+							name: 500
+						},
+						pageChange: noop,
+						updater: noop,
+						fetcher: noop,
+						onScroll: noop,
+						height: 300,
+						classes: undefined,
+						theme: undefined,
+						width: 1000
+					}),
+					v('div', { key: 'footer' }, [
+						w(Footer, {
+							key: 'footer-row',
+							total: undefined,
+							page: 1,
+							pageSize: 100,
+							classes: undefined,
+							theme: undefined
+						})
+					])
+				]
+			)
+		);
+	});
 });

--- a/src/grid/tests/unit/Header.spec.tsx
+++ b/src/grid/tests/unit/Header.spec.tsx
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import { stub } from 'sinon';
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/core/vdom';
+import { tsx, v, w } from '@dojo/framework/core/vdom';
 import TextInput from '../../../text-input/index';
 import Icon from '../../../icon/index';
 
@@ -39,6 +39,16 @@ const advancedColumnConfig = [
 	}
 ];
 
+function getColumnWidths(columns: any[]): { [index: string]: number } {
+	return columns.reduce(
+		(widths, column) => {
+			widths[column.id] = 100;
+			return widths;
+		},
+		{} as any
+	);
+}
+
 describe('Header', () => {
 	it('should render basic header', () => {
 		const sorterStub = stub();
@@ -47,15 +57,22 @@ describe('Header', () => {
 			w(Header, {
 				columnConfig,
 				sorter: sorterStub,
-				filterer: filtererStub
+				filterer: filtererStub,
+				columnWidths: {
+					title: 100,
+					firstName: 250
+				}
 			})
 		);
 		h.expect(() =>
-			v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row' }, [
+			v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row', styles: {} }, [
 				v(
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
+						styles: {
+							flex: '0 1 100px'
+						},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -65,6 +82,9 @@ describe('Header', () => {
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
+						styles: {
+							flex: '0 1 250px'
+						},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -81,16 +101,20 @@ describe('Header', () => {
 			w(Header, {
 				columnConfig: advancedColumnConfig,
 				sorter: sorterStub,
-				filterer: filtererStub
+				filterer: filtererStub,
+				columnWidths: getColumnWidths(advancedColumnConfig)
 			})
 		);
 
 		h.expect(() =>
-			v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row' }, [
+			v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row', styles: {} }, [
 				v(
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
+						styles: {
+							flex: '0 1 100px'
+						},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -100,6 +124,9 @@ describe('Header', () => {
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
+						styles: {
+							flex: '0 1 100px'
+						},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -107,7 +134,7 @@ describe('Header', () => {
 						v(
 							'div',
 							{
-								classes: [css.sortable, null, null, null],
+								classes: [fixedCss.column, css.sortable, null, null, null],
 								onclick: noop
 							},
 							[
@@ -157,16 +184,20 @@ describe('Header', () => {
 				sort: {
 					columnId: 'firstName',
 					direction: 'asc'
-				}
+				},
+				columnWidths: getColumnWidths(advancedColumnConfig)
 			})
 		);
 
 		h.expect(() =>
-			v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row' }, [
+			v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row', styles: {} }, [
 				v(
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
+						styles: {
+							flex: '0 1 100px'
+						},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -176,6 +207,9 @@ describe('Header', () => {
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
+						styles: {
+							flex: '0 1 100px'
+						},
 						role: 'columnheader',
 						'aria-sort': 'ascending'
 					},
@@ -183,7 +217,7 @@ describe('Header', () => {
 						v(
 							'div',
 							{
-								classes: [css.sortable, css.sorted, null, css.asc],
+								classes: [fixedCss.column, css.sortable, css.sorted, null, css.asc],
 								onclick: noop
 							},
 							[
@@ -233,16 +267,20 @@ describe('Header', () => {
 				sort: {
 					columnId: 'firstName',
 					direction: 'desc'
-				}
+				},
+				columnWidths: getColumnWidths(advancedColumnConfig)
 			})
 		);
 
 		h.expect(() =>
-			v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row' }, [
+			v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row', styles: {} }, [
 				v(
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
+						styles: {
+							flex: '0 1 100px'
+						},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -252,6 +290,9 @@ describe('Header', () => {
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
+						styles: {
+							flex: '0 1 100px'
+						},
 						role: 'columnheader',
 						'aria-sort': 'descending'
 					},
@@ -259,7 +300,13 @@ describe('Header', () => {
 						v(
 							'div',
 							{
-								classes: [css.sortable, css.sorted, css.desc, null],
+								classes: [
+									fixedCss.column,
+									css.sortable,
+									css.sorted,
+									css.desc,
+									null
+								],
 								onclick: noop
 							},
 							[
@@ -308,16 +355,20 @@ describe('Header', () => {
 				filterer: filtererStub,
 				filter: {
 					firstName: 'my filter'
-				}
+				},
+				columnWidths: getColumnWidths(advancedColumnConfig)
 			})
 		);
 
 		h.expect(() =>
-			v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row' }, [
+			v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row', styles: {} }, [
 				v(
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
+						styles: {
+							flex: '0 1 100px'
+						},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -327,6 +378,9 @@ describe('Header', () => {
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
+						styles: {
+							flex: '0 1 100px'
+						},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -334,7 +388,7 @@ describe('Header', () => {
 						v(
 							'div',
 							{
-								classes: [css.sortable, null, null, null],
+								classes: [fixedCss.column, css.sortable, null, null, null],
 								onclick: noop
 							},
 							[
@@ -380,7 +434,8 @@ describe('Header', () => {
 			w(Header, {
 				columnConfig: advancedColumnConfig,
 				sorter: sorterStub,
-				filterer: filtererStub
+				filterer: filtererStub,
+				columnWidths: getColumnWidths(advancedColumnConfig)
 			})
 		);
 
@@ -396,7 +451,8 @@ describe('Header', () => {
 				w(Header, {
 					columnConfig: advancedColumnConfig,
 					sorter: sorterStub,
-					filterer: filtererStub
+					filterer: filtererStub,
+					columnWidths: getColumnWidths(advancedColumnConfig)
 				})
 			);
 
@@ -419,7 +475,8 @@ describe('Header', () => {
 					sort: {
 						columnId: 'firstName',
 						direction: 'desc'
-					}
+					},
+					columnWidths: getColumnWidths(advancedColumnConfig)
 				})
 			);
 
@@ -442,7 +499,8 @@ describe('Header', () => {
 					sort: {
 						columnId: 'firstName',
 						direction: 'asc'
-					}
+					},
+					columnWidths: getColumnWidths(advancedColumnConfig)
 				})
 			);
 
@@ -472,16 +530,20 @@ describe('Header', () => {
 						return v('div', { key: 'sort', onclick: sorter }, [
 							`custom renderer - ${direction} - ${title}`
 						]);
-					}
+					},
+					columnWidths: getColumnWidths(advancedColumnConfig)
 				})
 			);
 
 			h.expect(() =>
-				v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row' }, [
+				v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row', styles: {} }, [
 					v(
 						'div',
 						{
 							classes: [css.cell, fixedCss.cellFixed],
+							styles: {
+								flex: '0 1 100px'
+							},
 							role: 'columnheader',
 							'aria-sort': null
 						},
@@ -491,6 +553,9 @@ describe('Header', () => {
 						'div',
 						{
 							classes: [css.cell, fixedCss.cellFixed],
+							styles: {
+								flex: '0 1 100px'
+							},
 							role: 'columnheader',
 							'aria-sort': 'ascending'
 						},
@@ -498,7 +563,13 @@ describe('Header', () => {
 							v(
 								'div',
 								{
-									classes: [css.sortable, css.sorted, null, css.asc],
+									classes: [
+										fixedCss.column,
+										css.sortable,
+										css.sorted,
+										null,
+										css.asc
+									],
 									onclick: noop
 								},
 								[
@@ -543,16 +614,20 @@ describe('Header', () => {
 						return v('div', { key: 'sort', onclick: sorter }, [
 							`custom renderer - ${direction} - ${title}`
 						]);
-					}
+					},
+					columnWidths: getColumnWidths(advancedColumnConfig)
 				})
 			);
 
 			h.expect(() =>
-				v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row' }, [
+				v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row', styles: {} }, [
 					v(
 						'div',
 						{
 							classes: [css.cell, fixedCss.cellFixed],
+							styles: {
+								flex: '0 1 100px'
+							},
 							role: 'columnheader',
 							'aria-sort': null
 						},
@@ -562,6 +637,9 @@ describe('Header', () => {
 						'div',
 						{
 							classes: [css.cell, fixedCss.cellFixed],
+							styles: {
+								flex: '0 1 100px'
+							},
 							role: 'columnheader',
 							'aria-sort': 'descending'
 						},
@@ -569,7 +647,13 @@ describe('Header', () => {
 							v(
 								'div',
 								{
-									classes: [css.sortable, css.sorted, css.desc, null],
+									classes: [
+										fixedCss.column,
+										css.sortable,
+										css.sorted,
+										css.desc,
+										null
+									],
 									onclick: noop
 								},
 								[
@@ -614,16 +698,20 @@ describe('Header', () => {
 							v('input', { value: filterValue, onValue: doFilter }),
 							v('span', [`${title} - ${columnConfig.id}`])
 						]);
-					}
+					},
+					columnWidths: getColumnWidths(advancedColumnConfig)
 				})
 			);
 
 			h.expect(() =>
-				v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row' }, [
+				v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row', styles: {} }, [
 					v(
 						'div',
 						{
 							classes: [css.cell, fixedCss.cellFixed],
+							styles: {
+								flex: '0 1 100px'
+							},
 							role: 'columnheader',
 							'aria-sort': null
 						},
@@ -633,6 +721,9 @@ describe('Header', () => {
 						'div',
 						{
 							classes: [css.cell, fixedCss.cellFixed],
+							styles: {
+								flex: '0 1 100px'
+							},
 							role: 'columnheader',
 							'aria-sort': null
 						},
@@ -640,7 +731,7 @@ describe('Header', () => {
 							v(
 								'div',
 								{
-									classes: [css.sortable, null, null, null],
+									classes: [fixedCss.column, css.sortable, null, null, null],
 									onclick: noop
 								},
 								[
@@ -671,5 +762,62 @@ describe('Header', () => {
 				])
 			);
 		});
+	});
+	it('should use resizable columns', () => {
+		const columnConfig = [
+			{
+				id: 'title',
+				title: 'Title',
+				resizable: true
+			},
+			{
+				id: 'firstName',
+				title: 'First Name',
+				resizable: true
+			}
+		];
+
+		const h = harness(() => (
+			<Header
+				filterer={noop}
+				sorter={noop}
+				columnConfig={columnConfig}
+				columnWidths={getColumnWidths(columnConfig)}
+			/>
+		));
+		h.expect(() =>
+			v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row', styles: {} }, [
+				v(
+					'div',
+					{
+						classes: [css.cell, fixedCss.cellFixed],
+						styles: {
+							flex: '0 1 100px'
+						},
+						role: 'columnheader',
+						'aria-sort': null
+					},
+					[
+						v('div', {}, ['Title']),
+						v('span', { key: 'title-resize', classes: [fixedCss.resize] })
+					]
+				),
+				v(
+					'div',
+					{
+						classes: [css.cell, fixedCss.cellFixed],
+						styles: {
+							flex: '0 1 100px'
+						},
+						role: 'columnheader',
+						'aria-sort': null
+					},
+					[
+						v('div', {}, ['First Name']),
+						v('span', { key: 'firstName-resize', classes: [fixedCss.resize] })
+					]
+				)
+			])
+		);
 	});
 });

--- a/src/grid/tests/unit/Header.spec.tsx
+++ b/src/grid/tests/unit/Header.spec.tsx
@@ -58,10 +58,7 @@ describe('Header', () => {
 				columnConfig,
 				sorter: sorterStub,
 				filterer: filtererStub,
-				columnWidths: {
-					title: 100,
-					firstName: 250
-				}
+				columnWidths: undefined
 			})
 		);
 		h.expect(() =>
@@ -70,9 +67,7 @@ describe('Header', () => {
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
-						styles: {
-							flex: '0 1 100px'
-						},
+						styles: {},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -82,9 +77,7 @@ describe('Header', () => {
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
-						styles: {
-							flex: '0 1 250px'
-						},
+						styles: {},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -102,7 +95,7 @@ describe('Header', () => {
 				columnConfig: advancedColumnConfig,
 				sorter: sorterStub,
 				filterer: filtererStub,
-				columnWidths: getColumnWidths(advancedColumnConfig)
+				columnWidths: undefined
 			})
 		);
 
@@ -112,9 +105,7 @@ describe('Header', () => {
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
-						styles: {
-							flex: '0 1 100px'
-						},
+						styles: {},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -124,9 +115,7 @@ describe('Header', () => {
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
-						styles: {
-							flex: '0 1 100px'
-						},
+						styles: {},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -185,7 +174,7 @@ describe('Header', () => {
 					columnId: 'firstName',
 					direction: 'asc'
 				},
-				columnWidths: getColumnWidths(advancedColumnConfig)
+				columnWidths: undefined
 			})
 		);
 
@@ -195,9 +184,7 @@ describe('Header', () => {
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
-						styles: {
-							flex: '0 1 100px'
-						},
+						styles: {},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -207,9 +194,7 @@ describe('Header', () => {
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
-						styles: {
-							flex: '0 1 100px'
-						},
+						styles: {},
 						role: 'columnheader',
 						'aria-sort': 'ascending'
 					},
@@ -268,7 +253,7 @@ describe('Header', () => {
 					columnId: 'firstName',
 					direction: 'desc'
 				},
-				columnWidths: getColumnWidths(advancedColumnConfig)
+				columnWidths: undefined
 			})
 		);
 
@@ -278,9 +263,7 @@ describe('Header', () => {
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
-						styles: {
-							flex: '0 1 100px'
-						},
+						styles: {},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -290,9 +273,7 @@ describe('Header', () => {
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
-						styles: {
-							flex: '0 1 100px'
-						},
+						styles: {},
 						role: 'columnheader',
 						'aria-sort': 'descending'
 					},
@@ -356,7 +337,7 @@ describe('Header', () => {
 				filter: {
 					firstName: 'my filter'
 				},
-				columnWidths: getColumnWidths(advancedColumnConfig)
+				columnWidths: undefined
 			})
 		);
 
@@ -366,9 +347,7 @@ describe('Header', () => {
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
-						styles: {
-							flex: '0 1 100px'
-						},
+						styles: {},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -378,9 +357,7 @@ describe('Header', () => {
 					'div',
 					{
 						classes: [css.cell, fixedCss.cellFixed],
-						styles: {
-							flex: '0 1 100px'
-						},
+						styles: {},
 						role: 'columnheader',
 						'aria-sort': null
 					},
@@ -435,7 +412,7 @@ describe('Header', () => {
 				columnConfig: advancedColumnConfig,
 				sorter: sorterStub,
 				filterer: filtererStub,
-				columnWidths: getColumnWidths(advancedColumnConfig)
+				columnWidths: undefined
 			})
 		);
 
@@ -452,7 +429,7 @@ describe('Header', () => {
 					columnConfig: advancedColumnConfig,
 					sorter: sorterStub,
 					filterer: filtererStub,
-					columnWidths: getColumnWidths(advancedColumnConfig)
+					columnWidths: undefined
 				})
 			);
 
@@ -476,7 +453,7 @@ describe('Header', () => {
 						columnId: 'firstName',
 						direction: 'desc'
 					},
-					columnWidths: getColumnWidths(advancedColumnConfig)
+					columnWidths: undefined
 				})
 			);
 
@@ -500,7 +477,7 @@ describe('Header', () => {
 						columnId: 'firstName',
 						direction: 'asc'
 					},
-					columnWidths: getColumnWidths(advancedColumnConfig)
+					columnWidths: undefined
 				})
 			);
 
@@ -531,7 +508,7 @@ describe('Header', () => {
 							`custom renderer - ${direction} - ${title}`
 						]);
 					},
-					columnWidths: getColumnWidths(advancedColumnConfig)
+					columnWidths: undefined
 				})
 			);
 
@@ -541,9 +518,7 @@ describe('Header', () => {
 						'div',
 						{
 							classes: [css.cell, fixedCss.cellFixed],
-							styles: {
-								flex: '0 1 100px'
-							},
+							styles: {},
 							role: 'columnheader',
 							'aria-sort': null
 						},
@@ -553,9 +528,7 @@ describe('Header', () => {
 						'div',
 						{
 							classes: [css.cell, fixedCss.cellFixed],
-							styles: {
-								flex: '0 1 100px'
-							},
+							styles: {},
 							role: 'columnheader',
 							'aria-sort': 'ascending'
 						},
@@ -615,7 +588,7 @@ describe('Header', () => {
 							`custom renderer - ${direction} - ${title}`
 						]);
 					},
-					columnWidths: getColumnWidths(advancedColumnConfig)
+					columnWidths: undefined
 				})
 			);
 
@@ -625,9 +598,7 @@ describe('Header', () => {
 						'div',
 						{
 							classes: [css.cell, fixedCss.cellFixed],
-							styles: {
-								flex: '0 1 100px'
-							},
+							styles: {},
 							role: 'columnheader',
 							'aria-sort': null
 						},
@@ -637,9 +608,7 @@ describe('Header', () => {
 						'div',
 						{
 							classes: [css.cell, fixedCss.cellFixed],
-							styles: {
-								flex: '0 1 100px'
-							},
+							styles: {},
 							role: 'columnheader',
 							'aria-sort': 'descending'
 						},
@@ -699,7 +668,7 @@ describe('Header', () => {
 							v('span', [`${title} - ${columnConfig.id}`])
 						]);
 					},
-					columnWidths: getColumnWidths(advancedColumnConfig)
+					columnWidths: undefined
 				})
 			);
 
@@ -709,9 +678,7 @@ describe('Header', () => {
 						'div',
 						{
 							classes: [css.cell, fixedCss.cellFixed],
-							styles: {
-								flex: '0 1 100px'
-							},
+							styles: {},
 							role: 'columnheader',
 							'aria-sort': null
 						},
@@ -721,9 +688,7 @@ describe('Header', () => {
 						'div',
 						{
 							classes: [css.cell, fixedCss.cellFixed],
-							styles: {
-								flex: '0 1 100px'
-							},
+							styles: {},
 							role: 'columnheader',
 							'aria-sort': null
 						},
@@ -786,38 +751,46 @@ describe('Header', () => {
 			/>
 		));
 		h.expect(() =>
-			v('div', { classes: [css.root, fixedCss.rootFixed], role: 'row', styles: {} }, [
-				v(
-					'div',
-					{
-						classes: [css.cell, fixedCss.cellFixed],
-						styles: {
-							flex: '0 1 100px'
+			v(
+				'div',
+				{
+					classes: [css.root, fixedCss.rootFixed],
+					role: 'row',
+					styles: { width: '200px' }
+				},
+				[
+					v(
+						'div',
+						{
+							classes: [css.cell, fixedCss.cellFixed],
+							styles: {
+								flex: '0 1 100px'
+							},
+							role: 'columnheader',
+							'aria-sort': null
 						},
-						role: 'columnheader',
-						'aria-sort': null
-					},
-					[
-						v('div', {}, ['Title']),
-						v('span', { key: 'title-resize', classes: [fixedCss.resize] })
-					]
-				),
-				v(
-					'div',
-					{
-						classes: [css.cell, fixedCss.cellFixed],
-						styles: {
-							flex: '0 1 100px'
+						[
+							v('div', {}, ['Title']),
+							v('span', { key: 'title-resize', classes: [fixedCss.resize] })
+						]
+					),
+					v(
+						'div',
+						{
+							classes: [css.cell, fixedCss.cellFixed],
+							styles: {
+								flex: '0 1 100px'
+							},
+							role: 'columnheader',
+							'aria-sort': null
 						},
-						role: 'columnheader',
-						'aria-sort': null
-					},
-					[
-						v('div', {}, ['First Name']),
-						v('span', { key: 'firstName-resize', classes: [fixedCss.resize] })
-					]
-				)
-			])
+						[
+							v('div', {}, ['First Name']),
+							v('span', { key: 'firstName-resize', classes: [fixedCss.resize] })
+						]
+					)
+				]
+			)
 		);
 	});
 });

--- a/src/grid/tests/unit/Row.spec.tsx
+++ b/src/grid/tests/unit/Row.spec.tsx
@@ -14,7 +14,7 @@ const noop = () => {};
 describe('Row', () => {
 	it('should render without columns', () => {
 		const h = harness(() =>
-			w(Row, { id: 1, item: {}, columnConfig: [] as any, updater: noop })
+			w(Row, { id: 1, item: {}, columnConfig: [] as any, updater: noop, columnWidths: {} })
 		);
 		h.expect(() =>
 			v(
@@ -31,7 +31,13 @@ describe('Row', () => {
 			title: 'id'
 		};
 		const h = harness(() =>
-			w(Row, { id: 1, item: { id: 'id' }, columnConfig: [columnConfig], updater: noop })
+			w(Row, {
+				id: 1,
+				item: { id: 'id' },
+				columnConfig: [columnConfig],
+				updater: noop,
+				columnWidths: { id: 100 }
+			})
 		);
 		h.expect(() =>
 			v(
@@ -45,7 +51,8 @@ describe('Row', () => {
 						editable: undefined,
 						rawValue: 'id',
 						classes: undefined,
-						theme: undefined
+						theme: undefined,
+						width: 100
 					})
 				]
 			)
@@ -59,7 +66,13 @@ describe('Row', () => {
 			renderer: () => 'transformed'
 		};
 		const h = harness(() =>
-			w(Row, { id: 1, item: { id: 'id' }, columnConfig: [columnConfig], updater: noop })
+			w(Row, {
+				id: 1,
+				item: { id: 'id' },
+				columnConfig: [columnConfig],
+				updater: noop,
+				columnWidths: { id: 100 }
+			})
 		);
 		h.expect(() =>
 			v(
@@ -73,7 +86,8 @@ describe('Row', () => {
 						editable: undefined,
 						rawValue: 'id',
 						classes: undefined,
-						theme: undefined
+						theme: undefined,
+						width: 100
 					})
 				]
 			)

--- a/src/theme/default/grid-header.m.css
+++ b/src/theme/default/grid-header.m.css
@@ -8,7 +8,7 @@
 .cell {
 	border: 1px solid var(--component-color);
 	border-top-style: none;
-	border-right-style: none;
+	border-left-style: none;
 	border-bottom-style: none;
 	font-weight: 600;
 	padding: 6px 4px;

--- a/src/theme/dojo/grid-cell.m.css
+++ b/src/theme/dojo/grid-cell.m.css
@@ -2,7 +2,7 @@
 
 .root {
 	align-items: center;
-	border-left: var(--border-width) solid var(--color-border);
+	border-right: var(--border-width) solid var(--color-border);
 	color: var(--color-text-faded);
 	justify-content: space-between;
 	min-width: 100px;

--- a/src/theme/dojo/grid-header.m.css
+++ b/src/theme/dojo/grid-header.m.css
@@ -2,12 +2,13 @@
 
 .root {
 	font-size: var(--font-size-base);
+	background-color: var(--color-background-faded);
 }
 
 .cell {
 	align-items: center;
 	background-color: var(--color-background-faded);
-	border-left: var(--border-width) solid var(--color-border);
+	border-right: var(--border-width) solid var(--color-border);
 	color: var(--color-text-primary);
 	display: flex;
 	flex-direction: column;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Adds support for resizable grid columns via a new optional property in `ColumnConfig`. Setting column as `resizable` will enable the column to be resized via clicking the right side column border and dragging left or right.

```ts
const columnConfig = [
    {
          id: 'id',
          title: 'Id',
          resizable: true
    },
    {
          id: 'name',
          title: 'Name'
    },
    {
          id: 'id',
          title: 'Id',
          resizable: true
    }
];
```

**Note:** The column widths are not persistent across instances of the grid and cannot be set externally to the grid.

Resolves #935 
