### PR TITLE
Added descriptions for all widget properties

### DIFF
--- a/src/calendar/CalendarCell.tsx
+++ b/src/calendar/CalendarCell.tsx
@@ -5,32 +5,26 @@ import { v } from '@dojo/framework/core/vdom';
 import { DNode } from '@dojo/framework/core/interfaces';
 import * as css from '../theme/default/calendar.m.css';
 
-/**
- * @type CalendarCellProperties
- *
- * Properties that can be set on a Calendar Date Cell
- *
- * @property callFocus        Used to immediately call focus on the cell
- * @property date             Integer date value
- * @property disabled         Boolean, whether the date is in the displayed month
- * @property focusable        Boolean, whether the date can receive tab focus
- * @property onClick          Callback function for the click event
- * @property onFocusCalled    Callback function when the cell receives focus
- * @property onKeyDown        Callback function for the key down event
- * @property outOfRange       Boolean, true if the date is outside the min/max
- * @property selected         True if the date is currently selected
- * @property today            True if the date the same as the current day
- */
 export interface CalendarCellProperties extends ThemedProperties {
+	/** Used to immediately call focus on the cell */
 	callFocus?: boolean;
+	/** The set date value */
 	date: number;
+	/** Whether the date is in the displayed month */
 	disabled?: boolean;
+	/** Whether the date can receive tab focus */
 	focusable?: boolean;
+	/** Handler for the click event */
 	onClick?(date: number, disabled: boolean): void;
+	/** Handler for when the cell receives focus */
 	onFocusCalled?(): void;
+	/** Handler for the key down event */
 	onKeyDown?(key: number, preventDefault: () => void): void;
+	/** if the date is outside the min/max */
 	outOfRange?: boolean;
+	/** if the date is currently selected */
 	selected?: boolean;
+	/** if the date the same as the current day */
 	today?: boolean;
 }
 

--- a/src/calendar/DatePicker.tsx
+++ b/src/calendar/DatePicker.tsx
@@ -28,36 +28,30 @@ export enum Controls {
 	year = 'year'
 }
 
-/**
- * @type DatePickerProperties
- *
- * Properties that can be set on a Calendar component
- *
- * @property labelId              Set id to reference label containing current month and year
- * @property labels               Customize or internationalize accessible helper text
- * @property maxDate              Maximum date to be picked
- * @property minDate              Minimum date to be picked
- * @property month                Currently displayed month, zero-based
- * @property monthNames           Array of full and abbreviated month names
- * @property onPopupChange        Called when a user action occurs that triggers a change in the month or year popup state
- * @property onRequestMonthChange Called when a month should change; receives the zero-based month number
- * @property onRequestYearChange  Called when a year should change; receives the year as an integer
- * @property renderMonthLabel     Format the displayed current month and year
- * @property year                 Currently displayed year
- * @property yearRange            Number of years to display in a single page of the year popup
- */
 export interface DatePickerProperties extends ThemedProperties {
+	/** Id to reference label containing current month and year */
 	labelId?: string;
+	/** Customize or internationalize accessible helper text */
 	labels: typeof calendarBundle.messages;
+	/** Maximum date to be picked */
 	maxDate?: Date;
+	/** Minimum date to be picked */
 	minDate?: Date;
+	/** Currently displayed month (zero-based) */
 	month: number;
+	/** Array of full and abbreviated month names */
 	monthNames: { short: string; long: string }[];
+	/** Handles when a user action occurs that triggers a change in the month or year popup state */
 	onPopupChange?(open: boolean): void;
+	/** Handles when a month should change (month is zero-based) */
 	onRequestMonthChange?(month: number): void;
+	/** Handles when a year should change */
 	onRequestYearChange?(year: number): void;
+	/** Formats the displayed current month and year */
 	renderMonthLabel?(month: number, year: number): string;
+	/** Currently displayed year */
 	year: number;
+	/** Number of years to display in a single page of the year popup */
 	yearRange?: number;
 }
 

--- a/src/checkbox/index.tsx
+++ b/src/checkbox/index.tsx
@@ -12,29 +12,43 @@ import * as css from '../theme/default/checkbox.m.css';
 export interface CheckboxProperties extends ThemedProperties, FocusProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
-	/**  Checked/unchecked property of the radio */
+	/**  Checked/unchecked property of the control */
 	checked?: boolean;
+	/** Set the disabled property of the control */
 	disabled?: boolean;
+	/** Adds a <label> element with the supplied text */
 	label?: string;
+	/** Adds the label element after (true) or before (false) */
 	labelAfter?: boolean;
+	/** Hides the label from view while still remaining accessible for screen readers */
 	labelHidden?: boolean;
 	/** The type of user interface to show for this Checkbox */
 	mode?: Mode;
+	/** The name of the checkbox */
 	name?: string;
-	/** Label to show in the "off" positin of a toggle */
+	/** Label to show in the "off" position of a toggle */
 	offLabel?: DNode;
+	/** Handler for when the element is blurred */
 	onBlur?(): void;
+	/** Handler for when the element is focused */
 	onFocus?(): void;
-	/** Label to show in the "on" positin of a toggle */
+	/** Label to show in the "on" position of a toggle */
 	onLabel?: DNode;
+	/** Handler for when the pointer moves out of the element */
 	onOut?(): void;
+	/** Handler for when the pointer moves over the element */
 	onOver?(): void;
+	/** Handler for when the value of the widget changes */
 	onValue?(checked: boolean): void;
+	/** Makes the checkbox readonly (it may be focused but not changed) */
 	readOnly?: boolean;
+	/** Sets the checkbox input as required to complete the form */
 	required?: boolean;
+	/** Toggles the invalid/valid states of the Checkbox affecting how it is displayed */
 	valid?: boolean;
 	/** The current value */
 	value?: string;
+	/** The id used for the form input element */
 	widgetId?: string;
 }
 

--- a/src/chip/index.tsx
+++ b/src/chip/index.tsx
@@ -12,7 +12,7 @@ export interface ChipProperties {
 	label: string;
 	/** Renders a close icon, ignored if `onClose` is not provided */
 	closeRenderer?(): RenderResult;
-	/** A callback when the close icon is clicked, if `closeRenderer is not provided a default X icon will be used */
+	/** A callback when the close icon is clicked, if `closeRenderer` is not provided a default X icon will be used */
 	onClose?(): void;
 	/** An optional callback for the the widget is clicked */
 	onClick?(): void;

--- a/src/combobox/index.tsx
+++ b/src/combobox/index.tsx
@@ -46,12 +46,15 @@ export interface ComboboxProperties extends ThemedProperties, FocusProperties, I
 	onFocus?(): void;
 	/** Called when menu visibility changes */
 	onMenuChange?(open: boolean): void;
+	/** Called when the pointer moves out of the element */
 	onOut?(): void;
+	/** Called when the pointer moves over the element */
 	onOver?(): void;
 	/** Called when results are shown; should be used to set `results` */
 	onRequestResults?(): void;
 	/** Called when result is selected */
 	onResultSelect?(result: any): void;
+	/** Called when the validation state changes */
 	onValidate?: (valid: boolean | undefined, message: string) => void;
 	/** Called when the value changes */
 	onValue?(value: string): void;

--- a/src/global-event/index.tsx
+++ b/src/global-event/index.tsx
@@ -9,7 +9,9 @@ export interface ListenerObject {
 }
 
 export interface GlobalEventProperties extends Partial<RegisteredListeners> {
+	/** The global window object */
 	window?: ListenerObject;
+	/** The document for this context */
 	document?: ListenerObject;
 }
 

--- a/src/grid/Body.tsx
+++ b/src/grid/Body.tsx
@@ -15,15 +15,25 @@ import { diffProperty } from '@dojo/framework/core/decorators/diffProperty';
 import { auto, reference } from '@dojo/framework/core/diff';
 
 export interface BodyProperties<S> {
+	/** The total number of rows */
 	totalRows?: number;
+	/** The number of elements to a page */
 	pageSize: number;
+	/** A list of paginated grids */
 	pages: GridPages<S>;
+	/** The height (in pixels) */
 	height: number;
+	/** Configuration for grid columns (id, title, properties, and custom renderer) */
 	columnConfig: ColumnConfig[];
+	/** Custom renderer for the placeholder row used while data is loaded */
 	placeholderRowRenderer?: (index: number) => DNode;
+	/** Used to fetch additional pages of information */
 	fetcher: (page: number, pageSize: number) => void;
+	/** Called when a cell is updated */
 	updater: (page: number, rowNumber: number, columnId: string, value: string) => void;
+	/** Called when the page changes */
 	pageChange: (page: number) => void;
+	/** Handler for scroll events */
 	onScroll: (value: number) => void;
 }
 

--- a/src/grid/Cell.tsx
+++ b/src/grid/Cell.tsx
@@ -13,9 +13,13 @@ import * as fixedCss from './styles/cell.m.css';
 import * as css from '../theme/default/grid-cell.m.css';
 
 export interface CellProperties extends FocusProperties {
+	/** The display value (or widget) of the cell */
 	value: string | DNode;
+	/** If the cell's value may be updated */
 	editable?: boolean;
+	/** The underlying string value of the cell (used by the editor) */
 	rawValue: string;
+	/** Called when the Cell's value is saved by the editor */
 	updater: (value: any) => void;
 }
 

--- a/src/grid/Footer.tsx
+++ b/src/grid/Footer.tsx
@@ -6,8 +6,11 @@ import { DNode } from '@dojo/framework/core/interfaces';
 import * as css from '../theme/default/grid-footer.m.css';
 
 export interface FooterProperties {
+	/** The total number of rows */
 	total?: number;
+	/** The current page */
 	page: number;
+	/** The number of rows per page */
 	pageSize: number;
 }
 

--- a/src/grid/Header.tsx
+++ b/src/grid/Header.tsx
@@ -23,14 +23,21 @@ export interface FilterRenderer {
 }
 
 export interface HeaderProperties {
+	/** Configuration for grid columns (id, title, properties, and custom renderer) */
 	columnConfig: ColumnConfig[];
+	/** Handles changing the sort order of a column */
 	sorter: (columnId: string, direction: 'asc' | 'desc') => void;
+	/** Handles filtering rows based on a given column */
 	filterer: (columnId: string, value: any) => void;
+	/** Applied filters */
 	filter?: {
 		[index: string]: string;
 	};
+	/** Applied sort options */
 	sort?: SortOptions;
+	/** Custom column renderer for displaying sort options */
 	sortRenderer?: SortRenderer;
+	/** Custom renderer displaying applied filters */
 	filterRenderer?: FilterRenderer;
 }
 

--- a/src/grid/Row.tsx
+++ b/src/grid/Row.tsx
@@ -9,9 +9,13 @@ import * as fixedCss from './styles/row.m.css';
 import * as css from '../theme/default/grid-row.m.css';
 
 export interface RowProperties {
+	/** identifier for the row */
 	id: number;
+	/** A list of values indexed on the column id */
 	item: { [index: string]: any };
+	/** Configuration for grid columns (id, title, properties, and custom renderer)  */
 	columnConfig: ColumnConfig[];
+	/** Handles updating the value of a cell */
 	updater: (rowNumber: number, columnId: string, value: any) => void;
 }
 

--- a/src/helper-text/index.tsx
+++ b/src/helper-text/index.tsx
@@ -5,7 +5,9 @@ import { v } from '@dojo/framework/core/vdom';
 import { VNode } from '@dojo/framework/core/interfaces';
 
 export interface HelperTextProperties extends ThemedProperties {
+	/** The supplied helper text */
 	text?: string;
+	/** If `HelperText` indicates a valid condition */
 	valid?: boolean;
 }
 

--- a/src/label/index.tsx
+++ b/src/label/index.tsx
@@ -9,23 +9,23 @@ import * as baseCss from '../common/styles/base.m.css';
 export interface LabelProperties extends ThemedProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
-	/**  */
+	/** If the label should be disabled */
 	disabled?: boolean;
-	/**  */
+	/** If the label is focused */
 	focused?: boolean;
 	/** ID to explicitly associate the label with an input element */
 	forId?: string;
-	/**  */
+	/** If the label should be invisible (it will remain accessible to screen readers) */
 	hidden?: boolean;
-	/**  */
+	/** If the label is read only */
 	readOnly?: boolean;
-	/**  */
+	/** If the label is required */
 	required?: boolean;
-	/**  */
+	/** If the label should use the secondary styling */
 	secondary?: boolean;
-	/**  */
+	/** If the label is valid */
 	valid?: boolean;
-	/**  */
+	/** ID of the underlying label element */
 	widgetId?: string;
 }
 

--- a/src/listbox/ListboxOption.tsx
+++ b/src/listbox/ListboxOption.tsx
@@ -6,6 +6,7 @@ import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import * as css from '../theme/default/listbox.m.css';
 
 export interface ListboxOptionProperties extends ThemedProperties {
+	active?: boolean;
 	/** Specific theme used for ListboxOption */
 	css?: (string | null)[];
 	/** If the widget is disabled */

--- a/src/listbox/ListboxOption.tsx
+++ b/src/listbox/ListboxOption.tsx
@@ -6,14 +6,21 @@ import { WidgetBase } from '@dojo/framework/core/WidgetBase';
 import * as css from '../theme/default/listbox.m.css';
 
 export interface ListboxOptionProperties extends ThemedProperties {
-	active?: boolean;
+	/** Specific theme used for ListboxOption */
 	css?: (string | null)[];
+	/** If the widget is disabled */
 	disabled?: boolean;
+	/** The id to apply to this widget top level for a11y */
 	id: string;
+	/** The index of this ListboxOption */
 	index: number;
+	/** The label displayed for this ListboxOption */
 	label: DNode;
+	/** The associated value supplied to `onClick` */
 	option: any;
+	/** if this option is selected */
 	selected?: boolean;
+	/** Handler for when this is clicked */
 	onClick?(option: any, index: number, key?: string | number): void;
 }
 

--- a/src/listbox/index.tsx
+++ b/src/listbox/index.tsx
@@ -38,10 +38,11 @@ export interface ListboxProperties extends ThemedProperties, FocusProperties {
 	getOptionLabel?(option: any, index: number): DNode;
 	/** Function that accepts option data and returns a boolean for selected/unselected */
 	getOptionSelected?(option: any, index: number): boolean;
-	/** Adds currect semantics for a multiselect listbox */
+	/** Adds current semantics for a multiselect listbox */
 	multiselect?: boolean;
 	/** Called with the index of the new requested active descendant */
 	onActiveIndexChange?(index: number): void;
+	/** Called on a keyboard event */
 	onKeyDown?(event: KeyboardEvent): void;
 	/** Called with the option data of the new requested selected item */
 	onOptionSelect?(option: any, index: number): void;

--- a/src/menu/ListBoxItem.tsx
+++ b/src/menu/ListBoxItem.tsx
@@ -19,7 +19,7 @@ export interface ListBoxItemProperties {
 	onActive(dimensions: DimensionResults): void;
 	/** When set to true, the item will set `scrollIntoView` on it's root dom node */
 	scrollIntoView?: boolean;
-	/** Prpoperty to set the disabled state of the item */
+	/** Property to set the disabled state of the item */
 	disabled?: boolean;
 	/** The id to apply to this widget top level for a11y */
 	id: string;

--- a/src/menu/MenuItem.tsx
+++ b/src/menu/MenuItem.tsx
@@ -17,7 +17,7 @@ export interface MenuItemProperties {
 	onActive(dimensions: DimensionResults): void;
 	/** When set to true, the item will set `scrollIntoView` on it's root dom node */
 	scrollIntoView?: boolean;
-	/** Prpoperty to set the disabled state of the item */
+	/** Property to set the disabled state of the item */
 	disabled?: boolean;
 	/** The id to apply to this widget top level for a11y */
 	id: string;

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -9,11 +9,11 @@ import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 export type PopupPosition = 'above' | 'below';
 
 export interface PopupProperties {
-	/** if the popup wrapper should match the trigger width, defaults to true */
+	/** If the popup wrapper should match the trigger width (defaults to true) */
 	matchWidth?: boolean;
-	/** where the popup should render relative to the trigger, defaults to below */
+	/** Where the popup should render relative to the trigger (defaults to "below") */
 	position?: PopupPosition;
-	/** if the underlay should be visible, defaults to false */
+	/** If the underlay should be visible (defaults to false) */
 	underlayVisible?: boolean;
 }
 

--- a/src/radio/index.tsx
+++ b/src/radio/index.tsx
@@ -12,37 +12,37 @@ import * as css from '../theme/default/radio.m.css';
 export interface RadioProperties extends ThemedProperties, FocusProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
-	/**  */
+	/** Checked/unchecked property of the radio */
 	checked?: boolean;
-	/**  */
+	/** Set the disabled property of the control */
 	disabled?: boolean;
-	/**  */
+	/** Adds a <label> element with the supplied text */
 	label?: string;
-	/**  */
+	/** Adds the label element after (true) or before (false) */
 	labelAfter?: boolean;
-	/**  */
+	/** Hides the label from view while still remaining accessible for screen readers */
 	labelHidden?: boolean;
-	/**  */
+	/** The name of the radio button */
 	name?: string;
-	/**  */
+	/** Handler for when the element is blurred */
 	onBlur?(): void;
-	/**  */
+	/** Handler for when the element is focused */
 	onFocus?(): void;
-	/**  */
+	/** Handler for when the pointer moves out of the element */
 	onOut?(): void;
-	/**  */
+	/** Handler for when the pointer moves over the element */
 	onOver?(): void;
-	/**  */
+	/** Handler for when the value of the widget changes */
 	onValue?(checked: boolean): void;
-	/**  */
+	/** Makes the radio readonly (it may be focused but not changed) */
 	readOnly?: boolean;
-	/**  */
+	/** Sets the radio input as required to complete the form */
 	required?: boolean;
-	/**  */
+	/** Toggles the invalid/valid states of the Radio affecting how it is displayed */
 	valid?: boolean;
-	/**  */
+	/** The current value */
 	value?: string;
-	/**  */
+	/** The id used for the form input element */
 	widgetId?: string;
 }
 

--- a/src/range-slider/index.tsx
+++ b/src/range-slider/index.tsx
@@ -16,55 +16,55 @@ type RangeValue = { min: number; max: number };
 export interface RangeSliderProperties extends ThemedProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
-	/**  */
+	/** Set the disabled property of the control */
 	disabled?: boolean;
-	/**  */
+	/** Adds a <label> element with the supplied text */
 	label?: string;
-	/**  */
+	/** Adds the label element after (true) or before (false) */
 	labelAfter?: boolean;
-	/**  */
+	/** Hides the label from view while still remaining accessible for screen readers */
 	labelHidden?: boolean;
-	/**  */
+	/** The maximum value allowed */
 	max?: number;
-	/**  */
+	/** The label displayed at the maximum range */
 	maximumLabel?: string;
-	/**  */
+	/** The name of the max slider */
 	maxName?: string;
-	/**  */
+	/** The minimum value allowed */
 	min?: number;
-	/**  */
+	/** The label displayed at the minimum range */
 	minimumLabel?: string;
-	/**  */
+	/** The name of the minimum range */
 	minName?: string;
-	/**  */
+	/** The name of the slider input */
 	name?: string;
-	/**  */
+	/** Handler for when the element is blurred */
 	onBlur?(): void;
-	/**  */
+	/** Handler for when the element is focused */
 	onFocus?(): void;
-	/**  */
+	/** Handler for when the pointer moves out of the element */
 	onOut?(): void;
-	/**  */
+	/** Handler for when the pointer moves over the element */
 	onOver?(): void;
-	/**  */
+	/** Handler for when the value of the widget changes */
 	onValue?(value: RangeValue): void;
-	/**  */
+	/** A renderer used to display the output values (min, max) */
 	output?(value: RangeValue): DNode;
-	/**  */
+	/** If the rendered output should be displayed as a tooltip */
 	outputIsTooltip?: boolean;
-	/**  */
+	/** Makes the slider readonly (it may be focused but not changed) */
 	readOnly?: boolean;
-	/**  */
+	/** If the range slider must be set */
 	required?: boolean;
-	/**  */
+	/** If the rendered output should be displayed */
 	showOutput?: boolean;
-	/**  */
+	/** The amount which the slider may be changed */
 	step?: number;
-	/**  */
+	/** If the values provided by the slider are valid */
 	valid?: boolean;
-	/**  */
+	/** The current vlaue */
 	value?: RangeValue;
-	/**  */
+	/** The id used for the form input element */
 	widgetId?: string;
 }
 

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -18,7 +18,7 @@ import * as css from '../theme/default/select.m.css';
 export interface SelectProperties<T = any> extends ThemedProperties, FocusProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
-	/**  */
+	/** Set the disabled property of the control */
 	disabled?: boolean;
 	/** Function that accepts an option's data and index and returns a boolean */
 	getOptionDisabled?(option: T, index: number): boolean;
@@ -32,39 +32,39 @@ export interface SelectProperties<T = any> extends ThemedProperties, FocusProper
 	getOptionText?(option: T): string;
 	/** Function that accepts an option's data and index and returns a string value */
 	getOptionValue?(option: T, index: number): string;
-	/**  */
+	/** Renders helper text with the Select */
 	helperText?: string;
-	/**  */
+	/** Adds a <label> element with the supplied text */
 	label?: string;
-	/**  */
+	/** Hides the label from view while still remaining accessible for screen readers */
 	labelHidden?: boolean;
-	/**  */
+	/** The name of the select field */
 	name?: string;
-	/**  */
+	/** Handler for when the element is blurred */
 	onBlur?(): void;
-	/**  */
+	/** Handler for when the element is focused */
 	onFocus?(): void;
-	/**  */
+	/** Handler for when the pointer moves out of the element */
 	onOut?(): void;
-	/**  */
+	/** Handler for when the pointer moves over the element */
 	onOver?(): void;
-	/**  */
+	/** Handler for when the value of the widget changes */
 	onValue?(option: T): void;
 	/** Array of any type of data for the options */
 	options?: T[];
 	/** Optional placeholder text, only valid for custom select widgets (useNativeElement must be false or undefined) */
 	placeholder?: string;
-	/**  */
+	/** Makes the select readonly (it may be focused but not changed) */
 	readOnly?: boolean;
-	/**  */
+	/** Sets the input as required to complete the form */
 	required?: boolean;
 	/** Use the native <select> element if true */
 	useNativeElement?: boolean;
-	/**  */
+	/** If the value provided is valid */
 	valid?: boolean;
 	/** The current value */
 	value?: string;
-	/**  */
+	/** The id used for the form input element */
 	widgetId?: string;
 }
 

--- a/src/slider/index.tsx
+++ b/src/slider/index.tsx
@@ -13,43 +13,43 @@ import * as css from '../theme/default/slider.m.css';
 export interface SliderProperties extends ThemedProperties, FocusProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
-	/**  */
+	/** Set the disabled property of the control */
 	disabled?: boolean;
-	/**  */
+	/** Adds a <label> element with the supplied text */
 	label?: string;
-	/**  */
+	/** Adds the label element after (true) or before (false) */
 	labelAfter?: boolean;
-	/**  */
+	/** Hides the label from view while still remaining accessible for screen readers */
 	labelHidden?: boolean;
 	/** The maximum value for the slider */
 	max?: number;
 	/** The minimum value for the slider */
 	min?: number;
-	/**  */
+	/** The name of the input element */
 	name?: string;
-	/**  */
+	/** Handler for when the element is blurred */
 	onBlur?(): void;
-	/**  */
+	/** Handler for when the element is focused */
 	onFocus?(): void;
-	/**  */
+	/** Handler for when the pointer moves out of the element */
 	onOut?(): void;
-	/**  */
+	/** Handler for when the pointer moves over the element */
 	onOver?(): void;
-	/**  */
+	/** Handler for when the value of the widget changes */
 	onValue?(value?: number): void;
 	/** An optional function that returns a string or DNode for custom output format */
 	output?(value: number): DNode;
-	/**  */
+	/** If the rendered output should be displayed as a tooltip */
 	outputIsTooltip?: boolean;
-	/**  */
+	/** Makes the slider readonly (it may be focused but not changed) */
 	readOnly?: boolean;
-	/**  */
+	/** If the slider must be set */
 	required?: boolean;
 	/** Toggles visibility of slider output */
 	showOutput?: boolean;
 	/** Size of the slider increment */
 	step?: number;
-	/**  */
+	/** If the value provided by the slider are valid */
 	valid?: boolean;
 	/** The current value */
 	value?: number;
@@ -57,7 +57,7 @@ export interface SliderProperties extends ThemedProperties, FocusProperties {
 	vertical?: boolean;
 	/** Length of the vertical slider (only used if vertical is true) */
 	verticalHeight?: string;
-	/**  */
+	/** The id used for the form input element */
 	widgetId?: string;
 }
 

--- a/src/snackbar/index.tsx
+++ b/src/snackbar/index.tsx
@@ -5,17 +5,17 @@ import { tsx } from '@dojo/framework/core/vdom';
 import * as css from '../theme/default/snackbar.m.css';
 
 export interface SnackbarProperties {
-	/**  */
+	/** If the snackbar is displayed */
 	open: boolean;
-	/**  */
+	/** Renders the message portion of the snackbar */
 	messageRenderer: () => RenderResult;
-	/**  */
+	/** If provided, render actions that the user may select */
 	actionsRenderer?: () => RenderResult;
-	/**  */
+	/** The type of snackbar message */
 	type?: 'success' | 'error';
-	/**  */
+	/** If the snackbar contents should be justified at the start */
 	leading?: boolean;
-	/**  */
+	/** If the snackbar content should be rendered as a column */
 	stacked?: boolean;
 }
 

--- a/src/split-pane/index.tsx
+++ b/src/split-pane/index.tsx
@@ -19,11 +19,11 @@ export enum Direction {
 }
 
 export interface SplitPaneProperties extends ThemedProperties {
-	/**  */
+	/** The width at which the pane is collapsed */
 	collapseWidth?: number;
 	/** Orientation of this SplitPane, can be `row` or `column` */
 	direction?: Direction;
-	/**  */
+	/** Called when the pane is collapsed */
 	onCollapse?(collapsed: boolean): void;
 	/** Called when the divider is dragged; should be used to update `size` */
 	onResize?(size: number): void;

--- a/src/tab-controller/TabButton.tsx
+++ b/src/tab-controller/TabButton.tsx
@@ -9,40 +9,34 @@ import { Keys } from '../common/util';
 
 import * as css from '../theme/default/tab-controller.m.css';
 
-/**
- * @type TabButtonProperties
- *
- * Properties that can be set on a TabButton component
- *
- * @property active             Determines whether this tab button is active
- * @property closeable          Determines whether this tab can be closed
- * @property controls           ID of the DOM element this tab button controls
- * @property disabled           Determines whether this tab can become active
- * @property id                 ID of this tab button DOM element
- * @property index              The position of this tab button
- * @property onClick            Called when this tab button is clicked
- * @property onCloseClick       Called when this tab button's close icon is clicked
- * @property onDownArrowPress   Called when the down arrow button is pressed
- * @property onEndPress         Called when the end button is pressed
- * @property onHomePress        Called when the home button is pressed
- * @property onLeftArrowPress   Called when the left arrow button is pressed
- * @property onRightArrowPress  Called when the right arrow button is pressed
- * @property onUpArrowPress     Called when the up arrow button is pressed
- */
 export interface TabButtonProperties extends ThemedProperties, FocusProperties, I18nProperties {
+	/** Determines whether this tab button is active */
 	active?: boolean;
+	/** Determines whether this tab can be closed */
 	closeable?: boolean;
+	/** ID of the DOM element this tab button controls */
 	controls: string;
+	/** Determines whether this tab can become active */
 	disabled?: boolean;
+	/** The id to apply to this widget top level for a11y */
 	id: string;
+	/** The position of this tab button */
 	index: number;
+	/** Called when this tab button is clicked */
 	onClick?: (index: number) => void;
+	/** Called when this tab button's close icon is clicked */
 	onCloseClick?: (index: number) => void;
+	/** Called when the down arrow button is pressed */
 	onDownArrowPress?: () => void;
+	/** Called when the end button is pressed */
 	onEndPress?: () => void;
+	/** Called when the home button is pressed */
 	onHomePress?: () => void;
+	/** Called when the left arrow button is pressed */
 	onLeftArrowPress?: () => void;
+	/** Called when the right arrow button is pressed */
 	onRightArrowPress?: () => void;
+	/** Called when the up arrow button is pressed */
 	onUpArrowPress?: () => void;
 }
 

--- a/src/tab/index.tsx
+++ b/src/tab/index.tsx
@@ -19,7 +19,7 @@ export interface TabProperties extends ThemedProperties {
 	label?: DNode;
 	/** ID of DOM element that serves as a label for this tab */
 	labelledBy?: string;
-	/**  */
+	/** If the tab should be shown */
 	show?: boolean;
 	/** ID of this underlying DOM element */
 	widgetId?: string;

--- a/src/text-area/index.tsx
+++ b/src/text-area/index.tsx
@@ -16,53 +16,53 @@ export interface TextAreaProperties extends ThemedProperties, FocusProperties {
 	aria?: { [key: string]: string | null };
 	/** Number of columns, controls the width of the textarea */
 	columns?: number;
-	/**  */
+	/** Custom validator used to validate the contents of the TextArea */
 	customValidator?: (value: string) => { valid?: boolean; message?: string } | void;
-	/**  */
+	/** Set the disabled property of the control */
 	disabled?: boolean;
-	/**  */
+	/** Renders helper text to the user */
 	helperText?: string;
-	/**  */
+	/** Adds a <label> element with the supplied text */
 	label?: string;
-	/**  */
+	/** Hides the label from view while still remaining accessible for screen readers */
 	labelHidden?: boolean;
 	/** Maximum number of characters allowed in the input */
 	maxLength?: number | string;
 	/** Minimum number of characters allowed in the input */
 	minLength?: number | string;
-	/**  */
+	/** The name of the field */
 	name?: string;
-	/**  */
+	/** Handler for when the element is blurred */
 	onBlur?(): void;
-	/**  */
+	/** Handler of when the element is clicked */
 	onClick?(): void;
-	/**  */
+	/** Handler for when the element is focused */
 	onFocus?(): void;
-	/**  */
+	/** Handler for when a key is depressed in the element */
 	onKeyDown?(key: number, preventDefault: () => void): void;
-	/**  */
+	/** Handler for when a key is released in the element */
 	onKeyUp?(key: number, preventDefault: () => void): void;
-	/**  */
+	/** Handler for when the pointer moves out of the element */
 	onOut?(): void;
-	/**  */
+	/** Handler for when the pointer moves over the element */
 	onOver?(): void;
-	/**  */
+	/** Called when TextArea's state is validated */
 	onValidate?: (valid: boolean | undefined, message: string) => void;
-	/**  */
+	/** Handler for when the value of the widget changes */
 	onValue?(value?: string): void;
-	/** Placeholder text */
+	/** Placeholder text displayed in an empty TextArea */
 	placeholder?: string;
-	/**  */
+	/** Makes the field readonly (it may be focused but not changed) */
 	readOnly?: boolean;
-	/**  */
+	/** Sets the input as required to complete the form */
 	required?: boolean;
 	/** Number of rows, controls the height of the textarea */
 	rows?: number;
-	/**  */
+	/** If the field is valid and optionally display a message */
 	valid?: { valid?: boolean; message?: string } | boolean;
 	/** The current value */
 	value?: string;
-	/**  */
+	/** The id used for the form input element */
 	widgetId?: string;
 	/** Controls text wrapping. Can be "hard", "soft", or "off" */
 	wrapText?: 'hard' | 'soft' | 'off';

--- a/src/text-input/index.tsx
+++ b/src/text-input/index.tsx
@@ -79,7 +79,7 @@ export interface BaseInputProperties<T extends { value: any } = { value: string 
 }
 
 export interface TextInputProperties extends BaseInputProperties {
-	/**  */
+	/** Custom validator used to validate the contents of the input */
 	customValidator?: (value: string) => { valid?: boolean; message?: string } | void;
 	/** The min value a number can be */
 	min?: number | string;

--- a/src/time-picker/index.tsx
+++ b/src/time-picker/index.tsx
@@ -23,7 +23,7 @@ export interface TimePickerProperties extends ThemedProperties, FocusProperties 
 	autoBlur?: boolean;
 	/** Determines whether the custom input should be able to be cleared */
 	clearable?: boolean;
-	/**  */
+	/** Set the disabled property of the control */
 	disabled?: boolean;
 	/** The maximum time to display in the menu (defaults to '23:59:59') */
 	end?: string;
@@ -33,25 +33,25 @@ export interface TimePickerProperties extends ThemedProperties, FocusProperties 
 	inputProperties?: TextInputProperties;
 	/** Used to determine if an item should be disabled */
 	isOptionDisabled?(result: any): boolean;
-	/**  */
+	/** Adds a <label> element with the supplied text */
 	label?: string;
-	/**  */
+	/** Adds the label element after (true) or before (false) */
 	labelAfter?: boolean;
-	/**  */
+	/** Hides the label from view while still remaining accessible for screen readers */
 	labelHidden?: boolean;
-	/**  */
+	/** The name of the field */
 	name?: string;
 	/** Called when the input is blurred */
 	onBlur?(): void;
-	/**  */
+	/** Called when the input is clicked */
 	onClick?(): void;
 	/** Called when the input is focused */
 	onFocus?(): void;
 	/** Called when menu visibility changes */
 	onMenuChange?(open: boolean, key?: string | number): void;
-	/**  */
+	/** Called when the pointer moves out of the element */
 	onOut?(): void;
-	/**  */
+	/** Called when the pointer moves over the element */
 	onOver?(): void;
 	/** Called when options are shown; should be used to set `options` */
 	onRequestOptions?(key?: string | number): void;
@@ -61,9 +61,9 @@ export interface TimePickerProperties extends ThemedProperties, FocusProperties 
 	openOnFocus?: boolean;
 	/** Options for the current input; should be set in response to `onRequestOptions` */
 	options?: TimeUnits[];
-	/**  */
+	/** Makes the radio readonly (it may be focused but not changed) */
 	readOnly?: boolean;
-	/**  */
+	/** Indicates the input is required to complete the form */
 	required?: boolean;
 	/** The minimum time to display in the menu (defaults to '00:00:00') */
 	start?: string;
@@ -71,11 +71,11 @@ export interface TimePickerProperties extends ThemedProperties, FocusProperties 
 	step?: number;
 	/** Use the native <input type="time"> element if true */
 	useNativeElement?: boolean;
-	/**  */
+	/** If the value of the input is valid */
 	valid?: boolean;
 	/** The current value */
 	value?: string;
-	/**  */
+	/** The id used for the form input element */
 	widgetId?: string;
 }
 

--- a/src/toolbar/index.tsx
+++ b/src/toolbar/index.tsx
@@ -15,7 +15,7 @@ import { GlobalEvent } from '../global-event/index';
 export { Align };
 
 export interface ToolbarProperties extends ThemedProperties, I18nProperties {
-	/**  */
+	/** The position to slide out the pane (bottom, left, right, top) */
 	align?: Align;
 	/** Width at which to collapse actions into a SlidePane */
 	collapseWidth?: number;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds missing descriptions for all widget properties

Resolves #812 
