### PR TITLE
Adding PasswordInput widget

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -25,6 +25,7 @@
 			"src/menu",
 			"src/number-input",
 			"src/outlined-button",
+			"src/password-input",
 			"src/popup",
 			"src/progress",
 			"src/radio",

--- a/package-lock.json
+++ b/package-lock.json
@@ -490,9 +490,9 @@
           "dev": true
         },
         "caniuse-lite": {
-          "version": "1.0.30001013",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001013.tgz",
-          "integrity": "sha512-hOAXaWKuq/UVFgYawxIOdPdyMQdYcwOCDOjnZcKn7wCgFUrhP7smuNZjGLuJlPSgE6aRA4cRJ+bGSrhtEt7ZAg==",
+          "version": "1.0.30001015",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+          "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==",
           "dev": true
         },
         "clean-webpack-plugin": {
@@ -5520,20 +5520,20 @@
       }
     },
     "browserslist": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.0.tgz",
-      "integrity": "sha512-HYnxc/oLRWvJ3TsGegR0SRL/UDnknGq2s/a8dYYEO+kOQ9m9apKoS5oiathLKZdh/e9uE+/J3j92qPlGD/vTqA==",
+      "version": "4.8.2",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
+      "integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001012",
-        "electron-to-chromium": "^1.3.317",
-        "node-releases": "^1.1.41"
+        "caniuse-lite": "^1.0.30001015",
+        "electron-to-chromium": "^1.3.322",
+        "node-releases": "^1.1.42"
       },
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30001013",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001013.tgz",
-          "integrity": "sha512-hOAXaWKuq/UVFgYawxIOdPdyMQdYcwOCDOjnZcKn7wCgFUrhP7smuNZjGLuJlPSgE6aRA4cRJ+bGSrhtEt7ZAg==",
+          "version": "1.0.30001015",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+          "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==",
           "dev": true
         }
       }
@@ -8282,9 +8282,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.16.2",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
-      "integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.3.tgz",
+      "integrity": "sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -13947,9 +13947,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.41",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.41.tgz",
-      "integrity": "sha512-+IctMa7wIs8Cfsa8iYzeaLTFwv5Y4r5jZud+4AnfymzeEXKBCavFX0KBgzVaPVqf0ywa6PrO8/b+bPqdwjGBSg==",
+      "version": "1.1.42",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
+      "integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
@@ -16613,9 +16613,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.5.0.tgz",
-      "integrity": "sha512-4vqUjKi2huMu1OJiLhi3jN6jeeKvMZdI1tYgi/njW5zV52jNLgSAZSdN16m9bJFe61/cT8ulmw4qFitV9QRsEA==",
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
+      "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA==",
       "dev": true
     },
     "pstree.remy": {
@@ -17824,9 +17824,9 @@
       }
     },
     "simple-git": {
-      "version": "1.126.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.126.0.tgz",
-      "integrity": "sha512-47mqHxgZnN8XRa9HbpWprzUv3Ooqz9RY/LSZgvA7jCkW8jcwLahMz7LKugY91KZehfG0sCVPtgXiU72hd6b1Bw==",
+      "version": "1.128.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.128.0.tgz",
+      "integrity": "sha512-bi8ff+gA+GJgmskbkbLBuykkvsuWv0lPEXjCDQkUvr2DrOpsVcowk9BqqQAl8gQkiyLhzgFIKvirDiwWFBDMqg==",
       "dev": true,
       "requires": {
         "debug": "^4.0.1"
@@ -18673,9 +18673,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001013",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001013.tgz",
-          "integrity": "sha512-hOAXaWKuq/UVFgYawxIOdPdyMQdYcwOCDOjnZcKn7wCgFUrhP7smuNZjGLuJlPSgE6aRA4cRJ+bGSrhtEt7ZAg==",
+          "version": "1.0.30001015",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
+          "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==",
           "dev": true
         },
         "debug": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -490,9 +490,9 @@
           "dev": true
         },
         "caniuse-lite": {
-          "version": "1.0.30001015",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
-          "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==",
+          "version": "1.0.30001013",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001013.tgz",
+          "integrity": "sha512-hOAXaWKuq/UVFgYawxIOdPdyMQdYcwOCDOjnZcKn7wCgFUrhP7smuNZjGLuJlPSgE6aRA4cRJ+bGSrhtEt7ZAg==",
           "dev": true
         },
         "clean-webpack-plugin": {
@@ -5520,20 +5520,20 @@
       }
     },
     "browserslist": {
-      "version": "4.8.2",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.2.tgz",
-      "integrity": "sha512-+M4oeaTplPm/f1pXDw84YohEv7B1i/2Aisei8s4s6k3QsoSHa7i5sz8u/cGQkkatCPxMASKxPualR4wwYgVboA==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.8.0.tgz",
+      "integrity": "sha512-HYnxc/oLRWvJ3TsGegR0SRL/UDnknGq2s/a8dYYEO+kOQ9m9apKoS5oiathLKZdh/e9uE+/J3j92qPlGD/vTqA==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001015",
-        "electron-to-chromium": "^1.3.322",
-        "node-releases": "^1.1.42"
+        "caniuse-lite": "^1.0.30001012",
+        "electron-to-chromium": "^1.3.317",
+        "node-releases": "^1.1.41"
       },
       "dependencies": {
         "caniuse-lite": {
-          "version": "1.0.30001015",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
-          "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==",
+          "version": "1.0.30001013",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001013.tgz",
+          "integrity": "sha512-hOAXaWKuq/UVFgYawxIOdPdyMQdYcwOCDOjnZcKn7wCgFUrhP7smuNZjGLuJlPSgE6aRA4cRJ+bGSrhtEt7ZAg==",
           "dev": true
         }
       }
@@ -8282,9 +8282,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.3.tgz",
-      "integrity": "sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==",
+      "version": "1.16.2",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.2.tgz",
+      "integrity": "sha512-jYo/J8XU2emLXl3OLwfwtuFfuF2w6DYPs+xy9ZfVyPkDcrauu6LYrw/q2TyCtrbc/KUdCiC5e9UajRhgNkVopA==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -13947,9 +13947,9 @@
       }
     },
     "node-releases": {
-      "version": "1.1.42",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.42.tgz",
-      "integrity": "sha512-OQ/ESmUqGawI2PRX+XIRao44qWYBBfN54ImQYdWVTQqUckuejOg76ysSqDBK8NG3zwySRVnX36JwDQ6x+9GxzA==",
+      "version": "1.1.41",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.41.tgz",
+      "integrity": "sha512-+IctMa7wIs8Cfsa8iYzeaLTFwv5Y4r5jZud+4AnfymzeEXKBCavFX0KBgzVaPVqf0ywa6PrO8/b+bPqdwjGBSg==",
       "dev": true,
       "requires": {
         "semver": "^6.3.0"
@@ -16613,9 +16613,9 @@
       "dev": true
     },
     "psl": {
-      "version": "1.6.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.6.0.tgz",
-      "integrity": "sha512-SYKKmVel98NCOYXpkwUqZqh0ahZeeKfmisiLIcEZdsb+WbLv02g/dI5BUmZnIyOe7RzZtLax81nnb2HbvC2tzA==",
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/psl/-/psl-1.5.0.tgz",
+      "integrity": "sha512-4vqUjKi2huMu1OJiLhi3jN6jeeKvMZdI1tYgi/njW5zV52jNLgSAZSdN16m9bJFe61/cT8ulmw4qFitV9QRsEA==",
       "dev": true
     },
     "pstree.remy": {
@@ -17824,9 +17824,9 @@
       }
     },
     "simple-git": {
-      "version": "1.128.0",
-      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.128.0.tgz",
-      "integrity": "sha512-bi8ff+gA+GJgmskbkbLBuykkvsuWv0lPEXjCDQkUvr2DrOpsVcowk9BqqQAl8gQkiyLhzgFIKvirDiwWFBDMqg==",
+      "version": "1.126.0",
+      "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-1.126.0.tgz",
+      "integrity": "sha512-47mqHxgZnN8XRa9HbpWprzUv3Ooqz9RY/LSZgvA7jCkW8jcwLahMz7LKugY91KZehfG0sCVPtgXiU72hd6b1Bw==",
       "dev": true,
       "requires": {
         "debug": "^4.0.1"
@@ -18673,9 +18673,9 @@
           }
         },
         "caniuse-lite": {
-          "version": "1.0.30001015",
-          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001015.tgz",
-          "integrity": "sha512-/xL2AbW/XWHNu1gnIrO8UitBGoFthcsDgU9VLK1/dpsoxbaD5LscHozKze05R6WLsBvLhqv78dAPozMFQBYLbQ==",
+          "version": "1.0.30001013",
+          "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001013.tgz",
+          "integrity": "sha512-hOAXaWKuq/UVFgYawxIOdPdyMQdYcwOCDOjnZcKn7wCgFUrhP7smuNZjGLuJlPSgE6aRA4cRJ+bGSrhtEt7ZAg==",
           "dev": true
         },
         "debug": {

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -46,6 +46,7 @@ import BasicNumberInput from './widgets/number-input/Basic';
 import BasicOutlinedButton from './widgets/outlined-button/Basic';
 import OutlinedDisabledSubmit from './widgets/outlined-button/DisabledSubmit';
 import OutlinedToggleButton from './widgets/outlined-button/ToggleButton';
+import BasicPassword from './widgets/password-input/Basic';
 import BasicPopup from './widgets/popup/Basic';
 import BasicProgress from './widgets/progress/Basic';
 import BasicRadio from './widgets/radio/Basic';
@@ -418,6 +419,14 @@ export const config = {
 				example: {
 					filename: 'Basic',
 					module: BasicMenu
+				}
+			}
+		},
+		'password-input': {
+			overview: {
+				example: {
+					filename: 'Basic',
+					module: BasicPassword
 				}
 			}
 		},

--- a/src/examples/src/widgets/password-input/Basic.tsx
+++ b/src/examples/src/widgets/password-input/Basic.tsx
@@ -1,0 +1,28 @@
+import icache from '@dojo/framework/core/middleware/icache';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import PasswordInput from '@dojo/widgets/password-input';
+
+const factory = create({ icache });
+
+export default factory(function Basic({ middleware: { icache } }) {
+	const value = icache.getOrSet('value', '');
+
+	return (
+		<PasswordInput
+			rules={{
+				length: {
+					min: 4
+				},
+				contains: {
+					atLeast: 2,
+					uppercase: 1,
+					specialCharacters: 1,
+					numbers: 1
+				}
+			}}
+			value={value}
+			onValue={(value) => icache.set('value', value)}
+			label="Enter Password"
+		/>
+	);
+});

--- a/src/password-input/README.md
+++ b/src/password-input/README.md
@@ -1,0 +1,8 @@
+# @dojo/widgets/password-input
+
+Dojo's `PasswordInput` provides a simple to use input box for entering passwords. The rules that which the password must follow are equivalent to the rules of the `ConstrainedInput` widget. 
+
+## Features
+
+- Handles validation state / messaging internally so the consumer does not have to
+- Easily validates against a set of predefined rules

--- a/src/password-input/index.tsx
+++ b/src/password-input/index.tsx
@@ -1,0 +1,52 @@
+import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Button from '../button';
+import Icon from '../icon';
+import ConstrainedInput, { ConstrainedInputProperties } from '../constrained-input';
+import theme from '../middleware/theme';
+import * as css from '../theme/default/password-input.m.css';
+import * as textInputCss from '../theme/default/text-input.m.css';
+
+export interface PasswordInputProperties extends Exclude<ConstrainedInputProperties, 'type'> {}
+
+export interface PasswordInputState {
+	showPassword: boolean;
+}
+
+const factory = create({
+	icache: createICacheMiddleware<PasswordInputState>(),
+	theme
+}).properties<PasswordInputProperties>();
+export const PasswordInput = factory(function PasswordInput({
+	middleware: { theme, icache },
+	properties
+}) {
+	const props = properties();
+	const showPassword = icache.getOrSet('showPassword', false);
+
+	const trailing = (
+		<Button
+			onClick={() => {
+				icache.set('showPassword', !showPassword);
+			}}
+			classes={{ '@dojo/widgets/button': { root: [css.togglePasswordButton] } }}
+		>
+			<Icon type={showPassword ? 'eyeSlashIcon' : 'eyeIcon'} />
+		</Button>
+	);
+
+	return (
+		<ConstrainedInput
+			{...props}
+			key="root"
+			type={showPassword ? 'text' : 'password'}
+			theme={theme.compose(
+				textInputCss,
+				css
+			)}
+			trailing={() => trailing}
+		/>
+	);
+});
+
+export default PasswordInput;

--- a/src/password-input/tests/unit/password-input.spec.tsx
+++ b/src/password-input/tests/unit/password-input.spec.tsx
@@ -1,0 +1,80 @@
+import harness from '@dojo/framework/testing/harness';
+import { compareTheme } from '../../../common/tests/support/test-helpers';
+import * as textInputCss from '../../../theme/default/text-input.m.css';
+import Button from '../../../button';
+import Icon from '../../../icon';
+import ConstrainedInput from '../../../constrained-input';
+import * as css from '../../../theme/default/password-input.m.css';
+import PasswordInput from '../..';
+
+import { tsx } from '@dojo/framework/core/vdom';
+
+const { describe, it } = intern.getInterface('bdd');
+
+const rules = { length: { min: 1 } };
+
+describe('PasswordInput', () => {
+	it('renders with default properties', () => {
+		const h = harness(() => <PasswordInput rules={rules} />, [compareTheme]);
+		h.expect(() => (
+			<ConstrainedInput
+				rules={rules}
+				key="root"
+				type={'password'}
+				theme={{ '@dojo/widgets/text-input': textInputCss }}
+				trailing={() => undefined}
+			/>
+		));
+	});
+
+	it('renders as a text input after click', () => {
+		const h = harness(() => <PasswordInput rules={rules} />, [compareTheme]);
+		h.expect(() => (
+			<ConstrainedInput
+				rules={rules}
+				key="root"
+				type={'password'}
+				theme={{ '@dojo/widgets/text-input': textInputCss }}
+				trailing={() => undefined}
+			/>
+		));
+
+		const eyeRender = h.trigger('@root', 'trailing');
+		h.expect(
+			() => (
+				<Button
+					onClick={() => {}}
+					classes={{ '@dojo/widgets/button': { root: [css.togglePasswordButton] } }}
+				>
+					<Icon type="eyeIcon" />
+				</Button>
+			),
+			() => eyeRender
+		);
+
+		h.trigger('@root', (node: any) => node.properties.trailing().properties.onClick);
+
+		h.expect(() => (
+			<ConstrainedInput
+				rules={rules}
+				key="root"
+				type={'text'}
+				theme={{ '@dojo/widgets/text-input': textInputCss }}
+				trailing={() => undefined}
+			/>
+		));
+
+		const slashRender = h.trigger('@root', 'trailing');
+		h.expect(
+			() => (
+				<Button
+					onClick={() => {}}
+					classes={{ '@dojo/widgets/button': { root: [css.togglePasswordButton] } }}
+				>
+					<Icon type="eyeSlashIcon" />
+				</Button>
+			),
+			() => slashRender
+		);
+	});
+});

--- a/src/theme/default/index.ts
+++ b/src/theme/default/index.ts
@@ -24,6 +24,7 @@ import * as menu from './menu.m.css';
 import * as menuItem from './menu-item.m.css';
 import * as listBoxItem from './list-box-item.m.css';
 import * as outlinedButton from './outlined-button.m.css';
+import * as passwordInput from './password-input.m.css';
 import * as popup from './popup.m.css';
 import * as progress from './progress.m.css';
 import * as radio from './radio.m.css';
@@ -69,6 +70,7 @@ export default {
 	'@dojo/widgets/menu-item': menuItem,
 	'@dojo/widgets/list-box-item': listBoxItem,
 	'@dojo/widgets/outlined-button': outlinedButton,
+	'@dojo/widget/password-input': passwordInput,
 	'@dojo/widgets/popup': popup,
 	'@dojo/widgets/progress': progress,
 	'@dojo/widgets/radio': radio,

--- a/src/theme/default/password-input.m.css
+++ b/src/theme/default/password-input.m.css
@@ -1,0 +1,22 @@
+.root {
+	composes: root from './text-input.m.css';
+}
+
+.togglePasswordButton {
+	min-width: unset;
+	background: none;
+	border: none;
+}
+
+.togglePasswordButton:hover,
+.togglePasswordButton:focus {
+	box-shadow: none;
+}
+
+.trailing {
+	composes: trailing from './text-input.m.css';
+}
+
+.root .trailing {
+	background: none;
+}

--- a/src/theme/default/password-input.m.css
+++ b/src/theme/default/password-input.m.css
@@ -2,6 +2,9 @@
 	composes: root from './text-input.m.css';
 }
 
+/**
+The button that toggles password visibility
+ */
 .togglePasswordButton {
 	min-width: unset;
 	background: none;

--- a/src/theme/default/password-input.m.css
+++ b/src/theme/default/password-input.m.css
@@ -2,9 +2,7 @@
 	composes: root from './text-input.m.css';
 }
 
-/**
-The button that toggles password visibility
- */
+/* The button that toggles password visibility */
 .togglePasswordButton {
 	min-width: unset;
 	background: none;

--- a/src/theme/default/password-input.m.css.d.ts
+++ b/src/theme/default/password-input.m.css.d.ts
@@ -1,0 +1,3 @@
+export const root: string;
+export const togglePasswordButton: string;
+export const trailing: string;

--- a/src/theme/dojo/index.ts
+++ b/src/theme/dojo/index.ts
@@ -17,6 +17,7 @@ import * as helperText from './helper-text.m.css';
 import * as icon from './icon.m.css';
 import * as label from './label.m.css';
 import * as listbox from './listbox.m.css';
+import * as passwordInput from './password-input.m.css';
 import * as progress from './progress.m.css';
 import * as radio from './radio.m.css';
 import * as raisedButton from './raised-button.m.css';
@@ -54,6 +55,7 @@ export default {
 	'@dojo/widgets/icon': icon,
 	'@dojo/widgets/label': label,
 	'@dojo/widgets/listbox': listbox,
+	'@dojo/widgets/password-input': passwordInput,
 	'@dojo/widgets/progress': progress,
 	'@dojo/widgets/radio': radio,
 	'@dojo/widgets/raised-button': raisedButton,

--- a/src/theme/dojo/password-input.m.css
+++ b/src/theme/dojo/password-input.m.css
@@ -1,0 +1,22 @@
+.root {
+	composes: root from './text-input.m.css';
+}
+
+.togglePasswordButton {
+	min-width: unset;
+	background: none;
+	border: none;
+}
+
+.togglePasswordButton:hover,
+.togglePasswordButton:focus {
+	box-shadow: none;
+}
+
+.trailing {
+	composes: trailing from './text-input.m.css';
+}
+
+.root .trailing {
+	background: none;
+}

--- a/src/theme/dojo/password-input.m.css.d.ts
+++ b/src/theme/dojo/password-input.m.css.d.ts
@@ -1,0 +1,3 @@
+export const root: string;
+export const togglePasswordButton: string;
+export const trailing: string;

--- a/src/theme/dojo/widgets.css
+++ b/src/theme/dojo/widgets.css
@@ -8,6 +8,7 @@
 @import './icon.m.css';
 @import './label.m.css';
 @import './listbox.m.css';
+@import './password-input.m.css';
 @import './progress.m.css';
 @import './radio.m.css';
 @import './range-slider.m.css';


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding password input widget, `PasswordInput`.  Is a regular `ConstrainedInput` widget but with a set type of `password` and a toggle button to see the password.

Resolves #792 

![image](https://user-images.githubusercontent.com/2008858/70343796-28c45200-1826-11ea-9ecb-c4baafb12b1b.png)

![image](https://user-images.githubusercontent.com/2008858/70343809-337ee700-1826-11ea-9875-947aa69e90aa.png)
