### PR TITLE
Upgrade parade to support selecting theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1826,9 +1826,9 @@
       }
     },
     "@dojo/parade": {
-      "version": "0.0.4",
-      "resolved": "https://registry.npmjs.org/@dojo/parade/-/parade-0.0.4.tgz",
-      "integrity": "sha512-oQWSWjVYX0aFqDN3I5EM6hWhP0x444Nj8K963Ce2GSx3KIWTNRew/eMUcRyZs/CeO2OHRB7pO8XvlSTOrLgqIg==",
+      "version": "0.0.5",
+      "resolved": "https://registry.npmjs.org/@dojo/parade/-/parade-0.0.5.tgz",
+      "integrity": "sha512-rgRVIqtBnPtvPZysRjqtiLiFPv9XqNYEKPKM8Hy1IPiHLVPAZW2wrlCKVKt9xbUmNtBzZ+60PpwvuLfoCMfbWw==",
       "dev": true,
       "requires": {
         "canonical-path": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
     "@dojo/cli-build-widget": "7.0.0-alpha.5",
     "@dojo/cli-test-intern": "7.0.0-alpha.3",
     "@dojo/framework": "7.0.0-alpha.4",
-    "@dojo/parade": "0.0.4",
+    "@dojo/parade": "0.0.5",
     "@dojo/scripts": "^4.0.2",
     "@material/button": "2.1.1",
     "@material/checkbox": "4.0.0",

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -1,4 +1,5 @@
 import dojoTheme from '@dojo/widgets/theme/dojo';
+import materialTheme from '@dojo/widgets/theme/material';
 
 import BasicAccordionPane from './widgets/accordion-pane/Basic';
 import Exclusive from './widgets/accordion-pane/Exclusive';
@@ -118,7 +119,11 @@ const tests = typeof testsContext !== 'undefined' ? testsContext : { keys: () =>
 export const config = {
 	name: '@dojo/widgets',
 	home: 'src/examples/README.md',
-	themes: [dojoTheme],
+	themes: [
+		{ label: 'dojo', theme: dojoTheme },
+		{ label: 'material', theme: materialTheme },
+		{ label: 'default', theme: {} }
+	],
 	tests,
 	readmePath: (widget: string) => `src/${widget}/README.md`,
 	widgetPath: (widget: string, filename: string) => `src/${widget}/${filename || 'index'}.tsx`,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**
Upgrades parade to 0.0.5, which now supports theme selection.
