### PR TITLE
Fix issues with pagination on small data sets

### DIFF
--- a/src/examples/src/widgets/grid/Paginated.tsx
+++ b/src/examples/src/widgets/grid/Paginated.tsx
@@ -13,7 +13,8 @@ const columnConfig: ColumnConfig[] = [
 	},
 	{
 		id: 'firstName',
-		title: 'First Name'
+		title: 'First Name',
+		filterable: true
 	},
 	{
 		id: 'middleName',
@@ -21,7 +22,8 @@ const columnConfig: ColumnConfig[] = [
 	},
 	{
 		id: 'lastName',
-		title: 'Last Name'
+		title: 'Last Name',
+		filterable: true
 	},
 	{
 		id: 'otherName',

--- a/src/grid/PaginatedBody.tsx
+++ b/src/grid/PaginatedBody.tsx
@@ -67,13 +67,14 @@ export default class PaginatedBody<S> extends ThemedMixin(WidgetBase)<PaginatedB
 			classes,
 			columnWidths
 		} = this.properties;
-		let data = pages[`page-${pageNumber}`] || [];
-		if (!data.length) {
+		let data = pages[`page-${pageNumber}`];
+		if (!data) {
 			fetcher(pageNumber, pageSize);
 		}
 		let rows: DNode[] = [];
-		for (let i = 0; i < pageSize; i++) {
-			if (!data.length) {
+		const rowCount = data ? data.length : pageSize;
+		for (let i = 0; i < rowCount; i++) {
+			if (!data) {
 				rows.push(placeholderRowRenderer(i));
 			} else {
 				rows.push(

--- a/src/grid/PaginatedFooter.tsx
+++ b/src/grid/PaginatedFooter.tsx
@@ -39,20 +39,21 @@ export default class PaginatedFooter extends ThemedMixin(WidgetBase)<PaginatedFo
 		if (page < 4) {
 			return [
 				this._renderPageControl(1),
-				this._renderPageControl(2),
-				this._renderPageControl(3),
-				this._renderPageControl(4),
-				this._renderPageControl(5),
-				v(
-					'span',
-					{
-						key: 'more',
-						'aria-hidden': true,
-						classes: [this.theme(css.more), fixedCss.moreFixed]
-					},
-					['...']
-				),
-				this._renderPageControl(totalPages)
+				totalPages > 1 && this._renderPageControl(2),
+				totalPages > 2 && this._renderPageControl(3),
+				totalPages > 3 && this._renderPageControl(4),
+				totalPages > 4 && this._renderPageControl(5),
+				totalPages > 5 &&
+					v(
+						'span',
+						{
+							key: 'more',
+							'aria-hidden': true,
+							classes: [this.theme(css.more), fixedCss.moreFixed]
+						},
+						['...']
+					),
+				totalPages > 5 && this._renderPageControl(totalPages)
 			];
 		} else if (page > totalPages - 3) {
 			return [
@@ -103,12 +104,14 @@ export default class PaginatedFooter extends ThemedMixin(WidgetBase)<PaginatedFo
 
 	protected render() {
 		const { onPageChange, page, total, pageSize } = this.properties;
-		if (!total) {
+		if (total === undefined) {
 			return null;
 		}
 		const totalPages = Math.ceil(total / pageSize);
 		const from = page === 1 ? '1' : `${(page - 1) * pageSize + 1}`;
 		const to = page === 1 ? pageSize : page * pageSize;
+
+		const controls = total ? this._renderPaginationControls(totalPages) : [];
 		return v('div', { classes: [this.theme(css.root), fixedCss.rootFixed] }, [
 			v(
 				'div',
@@ -119,7 +122,7 @@ export default class PaginatedFooter extends ThemedMixin(WidgetBase)<PaginatedFo
 						fixedCss.detailsFixed
 					]
 				},
-				[`${from} - ${to} of ${total} Results`]
+				[total ? `${from} - ${total < to ? total : to} of ${total} Results` : '0 Results']
 			),
 			v(
 				'nav',
@@ -140,33 +143,41 @@ export default class PaginatedFooter extends ThemedMixin(WidgetBase)<PaginatedFo
 						},
 						[
 							v('li', { classes: [fixedCss.itemFixed, this.theme(css.item)] }, [
-								v(
-									'button',
-									{
-										key: 'previous',
-										disabled: page === 1,
-										onclick: () => {
-											onPageChange(page - 1);
+								totalPages > 1 &&
+									v(
+										'button',
+										{
+											key: 'previous',
+											disabled: page === 1,
+											onclick: () => {
+												onPageChange(page - 1);
+											},
+											'aria-label': `Goto Page ${page - 1}`,
+											classes: [
+												this.theme(css.pageNav),
+												fixedCss.pageNavFixed
+											]
 										},
-										'aria-label': `Goto Page ${page - 1}`,
-										classes: [this.theme(css.pageNav), fixedCss.pageNavFixed]
-									},
-									['<']
-								),
-								...this._renderPaginationControls(totalPages),
-								v(
-									'button',
-									{
-										key: 'next',
-										disabled: page === totalPages,
-										onclick: () => {
-											onPageChange(page + 1);
+										['<']
+									),
+								...controls,
+								totalPages > 1 &&
+									v(
+										'button',
+										{
+											key: 'next',
+											disabled: page === totalPages,
+											onclick: () => {
+												onPageChange(page + 1);
+											},
+											'aria-label': `Goto Page ${page + 1}`,
+											classes: [
+												this.theme(css.pageNav),
+												fixedCss.pageNavFixed
+											]
 										},
-										'aria-label': `Goto Page ${page + 1}`,
-										classes: [this.theme(css.pageNav), fixedCss.pageNavFixed]
-									},
-									['>']
-								)
+										['>']
+									)
 							])
 						]
 					)

--- a/src/grid/tests/unit/PaginatedBody.spec.tsx
+++ b/src/grid/tests/unit/PaginatedBody.spec.tsx
@@ -152,4 +152,60 @@ describe('PaginatedBody', () => {
 			)
 		);
 	});
+
+	it('should only render based on the total page length', () => {
+		const columnConfig = [
+			{
+				id: 'id',
+				title: 'Id'
+			}
+		];
+		const rows: any[] = [];
+		const page: any[] = [];
+		for (let i = 0; i < 57; i++) {
+			const item = { id: 'id' };
+			page.push(item);
+			rows.push(
+				w(Row, {
+					id: i,
+					key: i,
+					item,
+					columnConfig,
+					updater: noop,
+					classes: undefined,
+					theme: undefined,
+					columnWidths: undefined
+				})
+			);
+		}
+
+		const h = harness(() =>
+			w(PaginatedBody, {
+				pageSize: 100,
+				height: 400,
+				pageNumber: 1,
+				pages: {
+					'page-1': page
+				},
+				columnConfig,
+				fetcher: noop,
+				updater: noop,
+				onScroll: noop
+			})
+		);
+
+		h.expect(() =>
+			v(
+				'div',
+				{
+					key: 'root',
+					classes: [css.root, fixedCss.rootFixed],
+					role: 'rowgroup',
+					onscroll: noop,
+					styles: { height: '400px' }
+				},
+				[v('div', { styles: {} }, [v('div'), ...rows])]
+			)
+		);
+	});
 });

--- a/src/grid/tests/unit/PaginatedFooter.spec.tsx
+++ b/src/grid/tests/unit/PaginatedFooter.spec.tsx
@@ -416,4 +416,151 @@ describe('PaginatedFooter', () => {
 			});
 		h.expect(middlePageControlsTemplate);
 	});
+
+	it('should render limited controls when total is less than page size', () => {
+		const h = harness(() =>
+			w(PaginatedFooter, {
+				page: 1,
+				pageSize: 100,
+				total: 90,
+				onPageChange: noop
+			})
+		);
+		const middlePageControlsTemplate = baseTemplate
+			.setChildren('~details', () => ['1 - 90 of 90 Results'])
+			.setChildren('~pagination-item', () => {
+				return [
+					v(
+						'button',
+						{
+							key: 'current',
+							disabled: true,
+							onclick: noop,
+							'aria-current': 'page',
+							'aria-label': 'Current Page, Page 1',
+							classes: [css.pageNumber, css.active]
+						},
+						['1']
+					)
+				];
+			});
+		h.expect(middlePageControlsTemplate);
+	});
+
+	it('should render limited controls when total is less than 6 pages', () => {
+		const h = harness(() =>
+			w(PaginatedFooter, {
+				page: 1,
+				pageSize: 100,
+				total: 401,
+				onPageChange: noop
+			})
+		);
+		const middlePageControlsTemplate = baseTemplate
+			.setChildren('~details', () => ['1 - 100 of 401 Results'])
+			.setChildren('~pagination-item', () => {
+				return [
+					v(
+						'button',
+						{
+							key: 'previous',
+							disabled: true,
+							onclick: noop,
+							'aria-label': `Goto Page 0`,
+							classes: [css.pageNav, fixedCss.pageNavFixed]
+						},
+						['<']
+					),
+					v(
+						'button',
+						{
+							key: 'current',
+							disabled: true,
+							onclick: noop,
+							'aria-current': 'page',
+							'aria-label': 'Current Page, Page 1',
+							classes: [css.pageNumber, css.active]
+						},
+						['1']
+					),
+					v(
+						'button',
+						{
+							key: '2',
+							disabled: false,
+							onclick: noop,
+							'aria-current': undefined,
+							'aria-label': 'Goto Page 2',
+							classes: [css.pageNumber, false]
+						},
+						['2']
+					),
+					v(
+						'button',
+						{
+							key: '3',
+							disabled: false,
+							onclick: noop,
+							'aria-current': undefined,
+							'aria-label': 'Goto Page 3',
+							classes: [css.pageNumber, false]
+						},
+						['3']
+					),
+					v(
+						'button',
+						{
+							key: '4',
+							disabled: false,
+							onclick: noop,
+							'aria-current': undefined,
+							'aria-label': 'Goto Page 4',
+							classes: [css.pageNumber, false]
+						},
+						['4']
+					),
+					v(
+						'button',
+						{
+							key: '5',
+							disabled: false,
+							onclick: noop,
+							'aria-current': undefined,
+							'aria-label': 'Goto Page 5',
+							classes: [css.pageNumber, false]
+						},
+						['5']
+					),
+					v(
+						'button',
+						{
+							key: 'next',
+							disabled: false,
+							onclick: noop,
+							'aria-label': `Goto Page 2`,
+							classes: [css.pageNav, fixedCss.pageNavFixed]
+						},
+						['>']
+					)
+				];
+			});
+		h.expect(middlePageControlsTemplate);
+	});
+
+	it('should not render controls when there are zero results', () => {
+		const h = harness(() =>
+			w(PaginatedFooter, {
+				page: 1,
+				pageSize: 100,
+				total: 0,
+				onPageChange: noop
+			})
+		);
+		const middlePageControlsTemplate = baseTemplate
+			.setChildren('~details', () => ['0 Results'])
+			.setChildren('~pagination-item', () => {
+				return [];
+			});
+		h.expect(middlePageControlsTemplate);
+	});
 });

--- a/src/grid/tests/unit/PaginatedFooter.spec.tsx
+++ b/src/grid/tests/unit/PaginatedFooter.spec.tsx
@@ -187,7 +187,7 @@ describe('PaginatedFooter', () => {
 				onPageChange: noop
 			})
 		);
-		const middlePageControlsTemplate = baseTemplate
+		const pageControlsTemplate = baseTemplate
 			.setChildren('~details', () => ['1101 - 1200 of 10500 Results'])
 			.setChildren('~pagination-item', () => {
 				return [
@@ -293,7 +293,7 @@ describe('PaginatedFooter', () => {
 					)
 				];
 			});
-		h.expect(middlePageControlsTemplate);
+		h.expect(pageControlsTemplate);
 	});
 
 	it('should render the controls for the last page', () => {
@@ -305,7 +305,7 @@ describe('PaginatedFooter', () => {
 				onPageChange: noop
 			})
 		);
-		const middlePageControlsTemplate = baseTemplate
+		const pageControlsTemplate = baseTemplate
 			.setChildren('~details', () => ['10401 - 10500 of 10500 Results'])
 			.setChildren('~pagination-item', () => {
 				return [
@@ -414,7 +414,7 @@ describe('PaginatedFooter', () => {
 					)
 				];
 			});
-		h.expect(middlePageControlsTemplate);
+		h.expect(pageControlsTemplate);
 	});
 
 	it('should render limited controls when total is less than page size', () => {
@@ -426,7 +426,7 @@ describe('PaginatedFooter', () => {
 				onPageChange: noop
 			})
 		);
-		const middlePageControlsTemplate = baseTemplate
+		const pageControlsTemplate = baseTemplate
 			.setChildren('~details', () => ['1 - 90 of 90 Results'])
 			.setChildren('~pagination-item', () => {
 				return [
@@ -444,7 +444,7 @@ describe('PaginatedFooter', () => {
 					)
 				];
 			});
-		h.expect(middlePageControlsTemplate);
+		h.expect(pageControlsTemplate);
 	});
 
 	it('should render limited controls when total is less than 6 pages', () => {
@@ -456,7 +456,7 @@ describe('PaginatedFooter', () => {
 				onPageChange: noop
 			})
 		);
-		const middlePageControlsTemplate = baseTemplate
+		const pageControlsTemplate = baseTemplate
 			.setChildren('~details', () => ['1 - 100 of 401 Results'])
 			.setChildren('~pagination-item', () => {
 				return [
@@ -544,7 +544,7 @@ describe('PaginatedFooter', () => {
 					)
 				];
 			});
-		h.expect(middlePageControlsTemplate);
+		h.expect(pageControlsTemplate);
 	});
 
 	it('should not render controls when there are zero results', () => {
@@ -556,11 +556,11 @@ describe('PaginatedFooter', () => {
 				onPageChange: noop
 			})
 		);
-		const middlePageControlsTemplate = baseTemplate
+		const pageControlsTemplate = baseTemplate
 			.setChildren('~details', () => ['0 Results'])
 			.setChildren('~pagination-item', () => {
 				return [];
 			});
-		h.expect(middlePageControlsTemplate);
+		h.expect(pageControlsTemplate);
 	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Fixes issues with rendering the grid and pagination controls with a limited dataset.

Resolves #968 
