### PR TITLE
Update cli-test-intern and build default theme with build-widget command

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -1,7 +1,7 @@
 {
 	"extends": "./node_modules/@dojo/parade/parade.json",
 	"build-theme": {
-		"themes": ["default", "dojo", "material"]
+		"themes": ["dojo", "material"]
 	},
 	"build-widget": {
 		"prefix": "dojo",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1600,12 +1600,12 @@
       }
     },
     "@dojo/cli-test-intern": {
-      "version": "7.0.0-alpha.3",
-      "resolved": "https://registry.npmjs.org/@dojo/cli-test-intern/-/cli-test-intern-7.0.0-alpha.3.tgz",
-      "integrity": "sha512-Q87MAh33SNfku9pUBKM7BDIqA1AdWAOxiUqrODmjO3UlHrqVENps9FdRV8NFVFagMlRYNgOpcgdQ/rQ7QfCrwg==",
+      "version": "7.0.0-alpha.4",
+      "resolved": "https://registry.npmjs.org/@dojo/cli-test-intern/-/cli-test-intern-7.0.0-alpha.4.tgz",
+      "integrity": "sha512-5UUcrfQEEz91FNTEBaep1HuJzH4C5c2riyhc1j0RrAmYND7pXRohSAmYDGzc75HGaZbRDo1L1+/yqmAUgWjeWQ==",
       "dev": true,
       "requires": {
-        "@dojo/framework": "7.0.0-alpha.3",
+        "@dojo/framework": "7.0.0-alpha.5",
         "chalk": "2.4.1",
         "cross-spawn": "4.0.2",
         "css-modules-require-hook": "4.2.3",
@@ -1618,28 +1618,6 @@
         "typescript": "~3.4.5"
       },
       "dependencies": {
-        "@dojo/framework": {
-          "version": "7.0.0-alpha.3",
-          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.3.tgz",
-          "integrity": "sha512-NbagpENJR0sArFopGUFXF/iqyVM8q8y2QXEzTTIz8Z1IG8taOYntqehITB0fcdt7K7jV0YzC6ScoG1LC1hS5lw==",
-          "dev": true,
-          "requires": {
-            "@types/cldrjs": "0.4.20",
-            "@types/globalize": "0.0.34",
-            "@webcomponents/webcomponentsjs": "1.1.0",
-            "cldrjs": "0.5.0",
-            "cross-fetch": "3.0.2",
-            "css-select-umd": "1.3.0-rc0",
-            "diff": "3.5.0",
-            "globalize": "1.4.0",
-            "immutable": "3.8.2",
-            "intersection-observer": "0.4.2",
-            "pepjs": "0.4.2",
-            "resize-observer-polyfill": "1.5.0",
-            "tslib": "1.9.3",
-            "web-animations-js": "2.3.1"
-          }
-        },
         "abab": {
           "version": "1.0.4",
           "resolved": "https://registry.npmjs.org/abab/-/abab-1.0.4.tgz",
@@ -7668,9 +7646,9 @@
       }
     },
     "es-abstract": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.3.tgz",
-      "integrity": "sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==",
+      "version": "1.17.0-next.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.0-next.1.tgz",
+      "integrity": "sha512-7MmGr03N7Rnuid6+wyhD9sHNE2n4tFSwExnU2lQl3lIo2ShXWGePY80zYaoMOmILWv57H0amMjZGHNzzGG70Rw==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
@@ -7681,6 +7659,7 @@
         "is-regex": "^1.0.4",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
+        "object.assign": "^4.1.0",
         "string.prototype.trimleft": "^2.1.0",
         "string.prototype.trimright": "^2.1.0"
       }
@@ -13715,14 +13694,26 @@
         "isobject": "^3.0.0"
       }
     },
-    "object.getownpropertydescriptors": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.0.3.tgz",
-      "integrity": "sha1-h1jIRvW0B62rDyNuCYbxSwUcqhY=",
+    "object.assign": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/object.assign/-/object.assign-4.1.0.tgz",
+      "integrity": "sha512-exHJeq6kBKj58mqGyTQ9DFvrZC/eR6OwxzoM9YRoGBqrXYonaFyGiFMuc9VZrXf7DarreEwMpurG3dd+CNyW5w==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.2",
-        "es-abstract": "^1.5.1"
+        "function-bind": "^1.1.1",
+        "has-symbols": "^1.0.0",
+        "object-keys": "^1.0.11"
+      }
+    },
+    "object.getownpropertydescriptors": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/object.getownpropertydescriptors/-/object.getownpropertydescriptors-2.1.0.tgz",
+      "integrity": "sha512-Z53Oah9A3TdLoblT7VKJaTDdXdT+lQO+cNpKVnya5JDe9uLvzu1YyY1yFDFrcxrlRgWrEFH0jJtD/IbuwjcEVg==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3",
+        "es-abstract": "^1.17.0-next.1"
       }
     },
     "object.omit": {
@@ -13745,13 +13736,13 @@
       }
     },
     "object.values": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.0.tgz",
-      "integrity": "sha512-8mf0nKLAoFX6VlNVdhGj31SVYpaNFtUnuoOXWyFEstsWRgU837AK+JYM0iAxwkSzGRbwn8cbFmgbyxj1j4VbXg==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/object.values/-/object.values-1.1.1.tgz",
+      "integrity": "sha512-WTa54g2K8iu0kmS/us18jEmdv1a4Wi//BZ/DTVYEcH0XhLM5NYdpDHja3gt57VrZLcNAO2WGA+KpWsDBaHt6eA==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.12.0",
+        "es-abstract": "^1.17.0-next.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3"
       }
@@ -17771,9 +17762,9 @@
       }
     },
     "stream-shift": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.0.tgz",
-      "integrity": "sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
+      "integrity": "sha512-AiisoFqQ0vbGcZgQPY1cdP2I76glaVA/RauYR4G4thNFgkTqr90yXTo4LYX60Jl+sIlPNHHdGSwo01AvbKUSVQ==",
       "dev": true
     },
     "stream-to": {
@@ -17839,6 +17830,26 @@
         "define-properties": "^1.1.2",
         "es-abstract": "^1.4.3",
         "function-bind": "^1.0.2"
+      },
+      "dependencies": {
+        "es-abstract": {
+          "version": "1.16.3",
+          "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.16.3.tgz",
+          "integrity": "sha512-WtY7Fx5LiOnSYgF5eg/1T+GONaGmpvpPdCpSnYij+U2gDTL0UPfWrhDw7b2IYb+9NQJsYpCA0wOQvZfsd6YwRw==",
+          "dev": true,
+          "requires": {
+            "es-to-primitive": "^1.2.1",
+            "function-bind": "^1.1.1",
+            "has": "^1.0.3",
+            "has-symbols": "^1.0.1",
+            "is-callable": "^1.1.4",
+            "is-regex": "^1.0.4",
+            "object-inspect": "^1.7.0",
+            "object-keys": "^1.1.1",
+            "string.prototype.trimleft": "^2.1.0",
+            "string.prototype.trimright": "^2.1.0"
+          }
+        }
       }
     },
     "string.prototype.trimleft": {

--- a/package.json
+++ b/package.json
@@ -46,14 +46,14 @@
     }
   },
   "peerDependencies": {
-    "@dojo/framework": "7.0.0-alpha.4"
+    "@dojo/framework": "7.0.0-alpha.5"
   },
   "devDependencies": {
     "@dojo/cli": "7.0.0-alpha.1",
     "@dojo/cli-build-app": "7.0.0-alpha.6",
     "@dojo/cli-build-theme": "7.0.0-alpha.2",
     "@dojo/cli-build-widget": "7.0.0-alpha.5",
-    "@dojo/cli-test-intern": "7.0.0-alpha.3",
+    "@dojo/cli-test-intern": "7.0.0-alpha.4",
     "@dojo/framework": "7.0.0-alpha.5",
     "@dojo/parade": "0.0.5",
     "@dojo/scripts": "^4.0.2",


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

* Updates to the latest cli-test-intern, tests should start passing
* Uses cli-build-widget to build the default theme over cli-build-theme
