### PR TITLE
Add Virtual scrolling / rendering to the Menu

### DIFF
--- a/src/common/styles/variables.css.d.ts
+++ b/src/common/styles/variables.css.d.ts
@@ -1,2 +1,0 @@
-declare const styles: {};
-export = styles;

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -126,6 +126,7 @@ import FocusTooltip from './widgets/tooltip/Focus';
 
 `!has('docs')`;
 import testsContext from './tests';
+import LargeOptionSet from './widgets/menu/LargeOptionSet';
 
 const tests = typeof testsContext !== 'undefined' ? testsContext : { keys: () => [] };
 
@@ -502,6 +503,12 @@ export const config = {
 					filename: 'ListBox',
 					module: ListBox,
 					title: 'List Box'
+				},
+				{
+					description: 'This example shows the menu rendering 100,000 options.',
+					filename: 'LargeOptionSet',
+					module: LargeOptionSet,
+					title: '100,000 options'
 				}
 			],
 			overview: {

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -56,6 +56,7 @@ import BasicListbox from './widgets/listbox/Basic';
 import BasicMenu from './widgets/menu/Basic';
 import ControlledMenu from './widgets/menu/Controlled';
 import ItemRenderer from './widgets/menu/ItemRenderer';
+import LargeOptionSet from './widgets/menu/LargeOptionSet';
 import ListBox from './widgets/menu/ListBox';
 import BasicNumberInput from './widgets/number-input/Basic';
 import BasicOutlinedButton from './widgets/outlined-button/Basic';
@@ -126,7 +127,6 @@ import FocusTooltip from './widgets/tooltip/Focus';
 
 `!has('docs')`;
 import testsContext from './tests';
-import LargeOptionSet from './widgets/menu/LargeOptionSet';
 
 const tests = typeof testsContext !== 'undefined' ? testsContext : { keys: () => [] };
 
@@ -505,7 +505,8 @@ export const config = {
 					title: 'List Box'
 				},
 				{
-					description: 'This example shows the menu rendering 100,000 options.',
+					description:
+						'This example shows the menu handling being passed 100,000 options. The menu will only render the items in view along with a buffer albove / below. When scrolling up / down, the menu will render the appropriate items.',
 					filename: 'LargeOptionSet',
 					module: LargeOptionSet,
 					title: '100,000 options'

--- a/src/examples/src/widgets/menu/Basic.tsx
+++ b/src/examples/src/widgets/menu/Basic.tsx
@@ -15,7 +15,6 @@ export default factory(function Basic({ middleware: { icache } }) {
 					icache.set('value', value);
 				}}
 				total={options.length}
-				itemsInView={10}
 			/>
 			<p>{`Clicked on: ${icache.getOrSet('value', '')}`}</p>{' '}
 		</virtual>

--- a/src/examples/src/widgets/menu/Basic.tsx
+++ b/src/examples/src/widgets/menu/Basic.tsx
@@ -1,15 +1,15 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Menu from '@dojo/widgets/menu';
+import Menu, { MenuOption } from '@dojo/widgets/menu';
 import icache from '@dojo/framework/core/middleware/icache';
 
 const factory = create({ icache });
 
 export default factory(function Basic({ middleware: { icache } }) {
-	const options = [
-		{ value: 'Save' },
-		{ value: 'copy', label: 'Copy' },
-		{ value: 'Paste', disabled: true }
-	];
+	const options: MenuOption[] = [];
+	const total = 10000;
+	for (let i = 0; i < total; i++) {
+		options[i] = { value: `test-${i}` };
+	}
 
 	return (
 		<virtual>
@@ -18,6 +18,8 @@ export default factory(function Basic({ middleware: { icache } }) {
 				onValue={(value) => {
 					icache.set('value', value);
 				}}
+				total={total}
+				itemsInView={10}
 			/>
 			<p>{`Clicked on: ${icache.getOrSet('value', '')}`}</p>{' '}
 		</virtual>

--- a/src/examples/src/widgets/menu/Controlled.tsx
+++ b/src/examples/src/widgets/menu/Controlled.tsx
@@ -57,6 +57,7 @@ export default factory(function Controlled({ middleware: { icache } }) {
 				onValue={(value) => {
 					icache.set('value', value);
 				}}
+				total={options.length}
 			/>
 			<p>{`Clicked on: ${icache.getOrSet('value', '')}`}</p>{' '}
 		</virtual>

--- a/src/examples/src/widgets/menu/ItemRenderer.tsx
+++ b/src/examples/src/widgets/menu/ItemRenderer.tsx
@@ -18,6 +18,7 @@ export default factory(function ItemRenderer({ middleware: { icache } }) {
 					return <div styles={{ color: color }}>{value}</div>;
 				}}
 				itemsInView={8}
+				total={states.length}
 			/>
 			<p>{`Clicked On: ${icache.getOrSet('value', '')}`}</p>
 		</virtual>

--- a/src/examples/src/widgets/menu/LargeOptionSet.tsx
+++ b/src/examples/src/widgets/menu/LargeOptionSet.tsx
@@ -4,13 +4,13 @@ import icache from '@dojo/framework/core/middleware/icache';
 
 const factory = create({ icache });
 
-export default factory(function LargeOptionSet({ middleware: { icache } }) {
-	const options: MenuOption[] = [];
-	const total = 100000;
-	for (let i = 0; i < total; i++) {
-		options[i] = { value: `test-${i}` };
-	}
+const options: MenuOption[] = [];
+const total = 100000;
+for (let i = 0; i < total; i++) {
+	options[i] = { value: `test-${i}` };
+}
 
+export default factory(function LargeOptionSet({ middleware: { icache } }) {
 	return (
 		<virtual>
 			<Menu

--- a/src/examples/src/widgets/menu/LargeOptionSet.tsx
+++ b/src/examples/src/widgets/menu/LargeOptionSet.tsx
@@ -1,11 +1,15 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Menu from '@dojo/widgets/menu';
+import Menu, { MenuOption } from '@dojo/widgets/menu';
 import icache from '@dojo/framework/core/middleware/icache';
 
 const factory = create({ icache });
 
-export default factory(function Basic({ middleware: { icache } }) {
-	const options = [{ value: 'Save' }, { value: 'Copy' }, { value: 'Paste' }];
+export default factory(function LargeOptionSet({ middleware: { icache } }) {
+	const options: MenuOption[] = [];
+	const total = 100000;
+	for (let i = 0; i < total; i++) {
+		options[i] = { value: `test-${i}` };
+	}
 
 	return (
 		<virtual>
@@ -14,7 +18,7 @@ export default factory(function Basic({ middleware: { icache } }) {
 				onValue={(value) => {
 					icache.set('value', value);
 				}}
-				total={options.length}
+				total={total}
 				itemsInView={10}
 			/>
 			<p>{`Clicked on: ${icache.getOrSet('value', '')}`}</p>{' '}

--- a/src/examples/src/widgets/menu/ListBox.tsx
+++ b/src/examples/src/widgets/menu/ListBox.tsx
@@ -15,6 +15,7 @@ export default factory(function ListBox({ middleware: { icache } }) {
 					icache.set('value', value);
 				}}
 				itemsInView={8}
+				total={states.length}
 			/>
 			<p>{`Selected: ${icache.getOrSet('value', '')}`}</p>
 		</virtual>

--- a/src/examples/src/widgets/popup/MenuPopup.tsx
+++ b/src/examples/src/widgets/popup/MenuPopup.tsx
@@ -18,7 +18,7 @@ export default factory(function MenuPopup() {
 				trigger: (onToggleOpen) => <Button onClick={onToggleOpen}>Menu Popup</Button>,
 				content: (onClose) => (
 					<div styles={{ border: '1px solid black' }}>
-						<Menu options={options} onValue={onClose} />
+						<Menu options={options} onValue={onClose} total={options.length} />
 					</div>
 				)
 			}}

--- a/src/examples/src/widgets/progress/ProgressWithChangingValues.tsx
+++ b/src/examples/src/widgets/progress/ProgressWithChangingValues.tsx
@@ -16,9 +16,7 @@ export default factory(function ProgressWithChangingvalues({ middleware: { icach
 				<Button onClick={() => icache.set('value', Math.max(0, value - step))}>
 					Decrease
 				</Button>
-				<Button
-					onClick={() => icache.set('value', Math.min(value + step, max))}
-				>
+				<Button onClick={() => icache.set('value', Math.min(value + step, max))}>
 					Increase
 				</Button>
 			</div>

--- a/src/menu/ListBoxItem.tsx
+++ b/src/menu/ListBoxItem.tsx
@@ -1,6 +1,3 @@
-import { DimensionResults } from '@dojo/framework/core/meta/Dimensions';
-import { dimensions } from '@dojo/framework/core/middleware/dimensions';
-import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import theme from '@dojo/framework/core/middleware/theme';
 import { throttle } from '@dojo/framework/core/util';
 import { create, tsx } from '@dojo/framework/core/vdom';
@@ -15,44 +12,23 @@ export interface ListBoxItemProperties {
 	active?: boolean;
 	/** Callback used when the item wants to request it be made active, to example on pointer move */
 	onRequestActive(): void;
-	/** Callback used when an item is set to active, allows parent menu to scroll appropriate item into view */
-	onActive(dimensions: DimensionResults): void;
-	/** When set to true, the item will set `scrollIntoView` on it's root dom node */
-	scrollIntoView?: boolean;
 	/** Property to set the disabled state of the item */
 	disabled?: boolean;
 	/** The id to apply to this widget top level for a11y */
 	widgetId: string;
 }
 
-interface ListBoxItemICache {
-	active: boolean;
-}
+const factory = create({ theme }).properties<ListBoxItemProperties>();
 
-const icache = createICacheMiddleware<ListBoxItemICache>();
-
-const factory = create({ dimensions, icache, theme }).properties<ListBoxItemProperties>();
-
-export const ListBoxItem = factory(function({
-	properties,
-	children,
-	middleware: { dimensions, icache, theme }
-}) {
+export const ListBoxItem = factory(function({ properties, children, middleware: { theme } }) {
 	const {
 		onSelect,
 		active = false,
 		onRequestActive,
-		onActive,
-		scrollIntoView = false,
 		selected = false,
 		disabled = false,
 		widgetId
 	} = properties();
-
-	if (icache.get('active') !== active) {
-		icache.set('active', active);
-		active && onActive(dimensions.get('root'));
-	}
 
 	const classes = theme.classes(css);
 
@@ -72,7 +48,6 @@ export const ListBoxItem = factory(function({
 			onpointerdown={() => {
 				!disabled && onSelect();
 			}}
-			scrollIntoView={scrollIntoView}
 			role="option"
 			aria-disabled={disabled}
 			aria-selected={selected}

--- a/src/menu/ListBoxItem.tsx
+++ b/src/menu/ListBoxItem.tsx
@@ -20,7 +20,11 @@ export interface ListBoxItemProperties {
 
 const factory = create({ theme }).properties<ListBoxItemProperties>();
 
-export const ListBoxItem = factory(function({ properties, children, middleware: { theme } }) {
+export const ListBoxItem = factory(function ListBoxItem({
+	properties,
+	children,
+	middleware: { theme }
+}) {
 	const {
 		onSelect,
 		active = false,

--- a/src/menu/ListBoxItem.tsx
+++ b/src/menu/ListBoxItem.tsx
@@ -36,12 +36,20 @@ export const ListBoxItem = factory(function ListBoxItem({
 
 	const classes = theme.classes(css);
 
+	function select() {
+		!disabled && onSelect();
+	}
+
+	function requestActive() {
+		!disabled && !active && onRequestActive();
+	}
+
 	return (
 		<div
 			id={widgetId}
 			key="root"
 			onpointermove={throttle(() => {
-				!disabled && !active && onRequestActive();
+				requestActive();
 			}, 500)}
 			classes={[
 				classes.root,
@@ -50,7 +58,8 @@ export const ListBoxItem = factory(function ListBoxItem({
 				disabled && classes.disabled
 			]}
 			onpointerdown={() => {
-				!disabled && onSelect();
+				requestActive();
+				select();
 			}}
 			role="option"
 			aria-disabled={disabled}

--- a/src/menu/MenuItem.tsx
+++ b/src/menu/MenuItem.tsx
@@ -23,16 +23,25 @@ export const MenuItem = factory(function MenuItem({ properties, children, middle
 
 	const classes = theme.classes(css);
 
+	function select() {
+		!disabled && onSelect();
+	}
+
+	function requestActive() {
+		!disabled && !active && onRequestActive();
+	}
+
 	return (
 		<div
 			id={widgetId}
 			key="root"
 			onpointermove={throttle(() => {
-				!disabled && !active && onRequestActive();
+				requestActive();
 			}, 500)}
 			classes={[classes.root, active && classes.active, disabled && classes.disabled]}
 			onpointerdown={() => {
-				!disabled && onSelect();
+				requestActive();
+				select();
 			}}
 			role="menuitem"
 			aria-disabled={disabled}

--- a/src/menu/MenuItem.tsx
+++ b/src/menu/MenuItem.tsx
@@ -18,7 +18,7 @@ export interface MenuItemProperties {
 
 const factory = create({ theme }).properties<MenuItemProperties>();
 
-export const MenuItem = factory(function({ properties, children, middleware: { theme } }) {
+export const MenuItem = factory(function MenuItem({ properties, children, middleware: { theme } }) {
 	const { onSelect, active = false, onRequestActive, disabled = false, widgetId } = properties();
 
 	const classes = theme.classes(css);

--- a/src/menu/MenuItem.tsx
+++ b/src/menu/MenuItem.tsx
@@ -1,6 +1,3 @@
-import { DimensionResults } from '@dojo/framework/core/meta/Dimensions';
-import { dimensions } from '@dojo/framework/core/middleware/dimensions';
-import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import theme from '@dojo/framework/core/middleware/theme';
 import { throttle } from '@dojo/framework/core/util';
 import { create, tsx } from '@dojo/framework/core/vdom';
@@ -13,43 +10,16 @@ export interface MenuItemProperties {
 	active?: boolean;
 	/** Callback used when the item wants to request it be made active, to example on pointer move */
 	onRequestActive(): void;
-	/** Callback used when an item is set to active, allows parent menu to scroll appropriate item into view */
-	onActive(dimensions: DimensionResults): void;
-	/** When set to true, the item will set `scrollIntoView` on it's root dom node */
-	scrollIntoView?: boolean;
 	/** Property to set the disabled state of the item */
 	disabled?: boolean;
 	/** The id to apply to this widget top level for a11y */
 	widgetId: string;
 }
 
-interface MenuItemICache {
-	active: boolean;
-}
+const factory = create({ theme }).properties<MenuItemProperties>();
 
-const icache = createICacheMiddleware<MenuItemICache>();
-
-const factory = create({ dimensions, icache, theme }).properties<MenuItemProperties>();
-
-export const MenuItem = factory(function({
-	properties,
-	children,
-	middleware: { dimensions, icache, theme }
-}) {
-	const {
-		onSelect,
-		active = false,
-		onRequestActive,
-		onActive,
-		scrollIntoView = false,
-		disabled = false,
-		widgetId
-	} = properties();
-
-	if (icache.get('active') !== active) {
-		icache.set('active', active);
-		active && onActive(dimensions.get('root'));
-	}
+export const MenuItem = factory(function({ properties, children, middleware: { theme } }) {
+	const { onSelect, active = false, onRequestActive, disabled = false, widgetId } = properties();
 
 	const classes = theme.classes(css);
 
@@ -64,7 +34,6 @@ export const MenuItem = factory(function({
 			onpointerdown={() => {
 				!disabled && onSelect();
 			}}
-			scrollIntoView={scrollIntoView}
 			role="menuitem"
 			aria-disabled={disabled}
 		>

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -343,12 +343,14 @@ export const Menu = factory(function({ properties, id, middleware: { icache, foc
 				styles={{
 					height: `${totalContentHeight}px`
 				}}
+				key="wrapper"
 			>
 				<div
 					classes={fixedCss.transformer}
 					styles={{
 						transform: `translateY(${offsetY}px)`
 					}}
+					key="transformer"
 				>
 					{renderedItems}
 				</div>

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -84,7 +84,11 @@ const factory = create({
 	theme
 }).properties<MenuProperties>();
 
-export const Menu = factory(function({ properties, id, middleware: { icache, focus, theme } }) {
+export const Menu = factory(function Menu({
+	properties,
+	id,
+	middleware: { icache, focus, theme }
+}) {
 	const {
 		activeIndex,
 		focusable = true,
@@ -266,7 +270,11 @@ export const Menu = factory(function({ properties, id, middleware: { icache, foc
 			  })
 			: 'offscreen';
 
-		const offscreenMenuItem = <MenuItem {...offscreenItemProps}>{menuItemChild}</MenuItem>;
+		const offscreenMenuItem = listBox ? (
+			<ListBoxItem {...offscreenItemProps}>{menuItemChild}</ListBoxItem>
+		) : (
+			<MenuItem {...offscreenItemProps}>{menuItemChild}</MenuItem>
+		);
 
 		const itemHeight = icache.getOrSet('itemHeight', offscreenHeight(offscreenMenuItem));
 

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -244,7 +244,7 @@ export const Menu = factory(function({ properties, id, middleware: { icache, foc
 		icache.set('activeIndex', findIndex(options, (option) => option.value === initialValue));
 	}
 
-	if (itemsInView && itemsInView !== icache.get('itemsInView')) {
+	if (itemsInView !== icache.get('itemsInView')) {
 		icache.set('itemsInView', itemsInView);
 
 		const offscreenItemProps = {

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -199,9 +199,7 @@ export const Menu = factory(function Menu({
 			},
 			active,
 			onRequestActive: () => {
-				if (focus.isFocused('root') || !focusable) {
-					setActiveIndex(index);
-				}
+				setActiveIndex(index);
 			},
 			disabled
 		};

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -127,11 +127,19 @@ export const Menu = factory(function({ properties, id, middleware: { icache, foc
 				break;
 			case Keys.Down:
 				event.preventDefault();
-				setActiveIndex((computedActiveIndex + 1) % total);
+				if (event.metaKey || event.ctrlKey) {
+					setActiveIndex(total - 1);
+				} else {
+					setActiveIndex((computedActiveIndex + 1) % total);
+				}
 				break;
 			case Keys.Up:
 				event.preventDefault();
-				setActiveIndex((computedActiveIndex - 1 + total) % total);
+				if (event.metaKey || event.ctrlKey) {
+					setActiveIndex(0);
+				} else {
+					setActiveIndex((computedActiveIndex - 1 + total) % total);
+				}
 				break;
 			case Keys.Escape:
 				event.preventDefault();
@@ -146,6 +154,9 @@ export const Menu = factory(function({ properties, id, middleware: { icache, foc
 				setActiveIndex(total - 1);
 				break;
 			default:
+				if (event.metaKey || event.ctrlKey) {
+					return;
+				}
 				const newIndex = getComputedIndexFromInput(event.key);
 				if (newIndex !== undefined) {
 					setActiveIndex(newIndex);

--- a/src/menu/menu.m.css
+++ b/src/menu/menu.m.css
@@ -1,0 +1,9 @@
+.wrapper {
+	overflow: hidden;
+	will-change: transform;
+	position: relative;
+}
+
+.transformer {
+	will-change: transform;
+}

--- a/src/menu/menu.m.css.d.ts
+++ b/src/menu/menu.m.css.d.ts
@@ -1,0 +1,2 @@
+export const wrapper: string;
+export const transformer: string;

--- a/src/menu/tests/ListBoxItem.spec.tsx
+++ b/src/menu/tests/ListBoxItem.spec.tsx
@@ -16,7 +16,6 @@ describe('ListBoxItem', () => {
 			onpointermove={noop}
 			classes={[css.root, false, false, false]}
 			onpointerdown={noop}
-			scrollIntoView={false}
 			role="option"
 			aria-selected={false}
 			aria-disabled={false}
@@ -34,7 +33,7 @@ describe('ListBoxItem', () => {
 
 	it('renders with a label', () => {
 		const h = harness(() => (
-			<ListBoxItem widgetId="test" onActive={noop} onRequestActive={noop} onSelect={noop}>
+			<ListBoxItem widgetId="test" onRequestActive={noop} onSelect={noop}>
 				test
 			</ListBoxItem>
 		));
@@ -43,13 +42,7 @@ describe('ListBoxItem', () => {
 
 	it('renders selected', () => {
 		const h = harness(() => (
-			<ListBoxItem
-				widgetId="test"
-				onActive={noop}
-				selected
-				onRequestActive={noop}
-				onSelect={noop}
-			>
+			<ListBoxItem widgetId="test" selected onRequestActive={noop} onSelect={noop}>
 				test
 			</ListBoxItem>
 		));
@@ -61,13 +54,7 @@ describe('ListBoxItem', () => {
 
 	it('renders disabled', () => {
 		const h = harness(() => (
-			<ListBoxItem
-				widgetId="test"
-				onActive={noop}
-				disabled
-				onRequestActive={noop}
-				onSelect={noop}
-			>
+			<ListBoxItem widgetId="test" disabled onRequestActive={noop} onSelect={noop}>
 				test
 			</ListBoxItem>
 		));
@@ -77,54 +64,25 @@ describe('ListBoxItem', () => {
 		h.expect(disabledTemplate);
 	});
 
-	it('renders with scroll into view', () => {
-		const h = harness(() => (
-			<ListBoxItem
-				widgetId="test"
-				onActive={noop}
-				scrollIntoView
-				onRequestActive={noop}
-				onSelect={noop}
-			>
-				test
-			</ListBoxItem>
-		));
-		const scrollIntoViewTemplate = template.setProperty('@root', 'scrollIntoView', true);
-		h.expect(scrollIntoViewTemplate);
-	});
-
 	it('renders active', () => {
-		const onActive = sb.stub();
 		const h = harness(() => (
-			<ListBoxItem
-				widgetId="test"
-				onActive={onActive}
-				active
-				onRequestActive={noop}
-				onSelect={noop}
-			>
+			<ListBoxItem widgetId="test" active onRequestActive={noop} onSelect={noop}>
 				test
 			</ListBoxItem>
 		));
-		const disabledTemplate = template.setProperty('@root', 'classes', [
+		const activeTemplate = template.setProperty('@root', 'classes', [
 			css.root,
 			false,
 			css.active,
 			false
 		]);
-		h.expect(disabledTemplate);
-		assert.isTrue(onActive.calledOnce);
+		h.expect(activeTemplate);
 	});
 
 	it('requests active onpointermove', () => {
 		const onRequestActive = sb.stub();
 		const h = harness(() => (
-			<ListBoxItem
-				widgetId="test"
-				onActive={noop}
-				onRequestActive={onRequestActive}
-				onSelect={noop}
-			>
+			<ListBoxItem widgetId="test" onRequestActive={onRequestActive} onSelect={noop}>
 				test
 			</ListBoxItem>
 		));
@@ -135,13 +93,7 @@ describe('ListBoxItem', () => {
 	it('does not request active onpointermove when disabled', () => {
 		const onRequestActive = sb.stub();
 		const h = harness(() => (
-			<ListBoxItem
-				widgetId="test"
-				onActive={noop}
-				disabled
-				onRequestActive={onRequestActive}
-				onSelect={noop}
-			>
+			<ListBoxItem widgetId="test" disabled onRequestActive={onRequestActive} onSelect={noop}>
 				test
 			</ListBoxItem>
 		));
@@ -152,7 +104,7 @@ describe('ListBoxItem', () => {
 	it('calls onSelect onpointerdown', () => {
 		const onSelect = sb.stub();
 		const h = harness(() => (
-			<ListBoxItem widgetId="test" onActive={noop} onRequestActive={noop} onSelect={onSelect}>
+			<ListBoxItem widgetId="test" onRequestActive={noop} onSelect={onSelect}>
 				test
 			</ListBoxItem>
 		));
@@ -163,13 +115,7 @@ describe('ListBoxItem', () => {
 	it('does not call onSelect onpointerdown when disabled', () => {
 		const onSelect = sb.stub();
 		const h = harness(() => (
-			<ListBoxItem
-				widgetId="test"
-				onActive={noop}
-				disabled
-				onRequestActive={noop}
-				onSelect={onSelect}
-			>
+			<ListBoxItem widgetId="test" disabled onRequestActive={noop} onSelect={onSelect}>
 				test
 			</ListBoxItem>
 		));

--- a/src/menu/tests/Menu.spec.tsx
+++ b/src/menu/tests/Menu.spec.tsx
@@ -6,6 +6,7 @@ import Menu, { MenuOption } from '../';
 import { compareId, createHarness, compareTheme } from '../../common/tests/support/test-helpers';
 import { Keys } from '../../common/util';
 import * as css from '../../theme/default/menu.m.css';
+import * as fixedCss from '../menu.m.css';
 import MenuItem from '../MenuItem';
 import ListBoxItem from '../ListBoxItem';
 const { assert } = intern.getPlugin('chai');
@@ -37,27 +38,43 @@ describe('Menu - Menu', () => {
 			focus={noop}
 			onfocus={undefined}
 			onblur={undefined}
-			styles={{}}
+			styles={{ maxHeight: '450px' }}
 			id="test"
 			role="menu"
 			aria-activedescendant="test"
 			aria-orientation="vertical"
+			scrollTop={0}
+			onscroll={() => {}}
 		>
-			{animalOptions.map(({ value, label, disabled = false }, index) => (
-				<MenuItem
-					key={`item-${index}`}
-					onSelect={noop}
-					active={index === 0}
-					onRequestActive={noop}
-					onActive={noop}
-					scrollIntoView={false}
-					disabled={disabled}
-					theme={{}}
-					widgetId={`menu-test-item-${index}`}
+			<div
+				classes={fixedCss.wrapper}
+				styles={{
+					height: `135px`
+				}}
+				key="wrapper"
+			>
+				<div
+					classes={fixedCss.transformer}
+					styles={{
+						transform: `translateY(0px)`
+					}}
+					key="transformer"
 				>
-					{label || value}
-				</MenuItem>
-			))}
+					{animalOptions.map(({ value, label, disabled = false }, index) => (
+						<MenuItem
+							key={`item-${index}`}
+							onSelect={noop}
+							active={index === 0}
+							onRequestActive={noop}
+							disabled={disabled}
+							theme={{}}
+							widgetId={`menu-test-item-${index}`}
+						>
+							{label || value}
+						</MenuItem>
+					))}
+				</div>
+			</div>
 		</div>
 	));
 
@@ -74,7 +91,9 @@ describe('Menu - Menu', () => {
 	});
 
 	it('renders options', () => {
-		const h = harness(() => <Menu onValue={noop} options={animalOptions} />);
+		const h = harness(() => (
+			<Menu onValue={noop} options={animalOptions} total={animalOptions.length} />
+		));
 		h.expect(template);
 	});
 
@@ -84,9 +103,10 @@ describe('Menu - Menu', () => {
 				onValue={noop}
 				options={animalOptions}
 				itemRenderer={({ label, value }) => <span>label is {label || value}</span>}
+				total={animalOptions.length}
 			/>
 		));
-		const itemRendererTemplate = template.setChildren('@root', () =>
+		const itemRendererTemplate = template.setChildren('@transformer', () =>
 			animalOptions.map(({ value, label, disabled = false }, index) => {
 				return (
 					<MenuItem
@@ -94,8 +114,6 @@ describe('Menu - Menu', () => {
 						onSelect={noop}
 						active={index === 0}
 						onRequestActive={noop}
-						onActive={noop}
-						scrollIntoView={false}
 						disabled={disabled}
 						theme={{}}
 						widgetId={`menu-test-item-${index}`}
@@ -109,7 +127,14 @@ describe('Menu - Menu', () => {
 	});
 
 	it('takes a number in view property', () => {
-		const h = harness(() => <Menu onValue={noop} options={animalOptions} itemsInView={2} />);
+		const h = harness(() => (
+			<Menu
+				onValue={noop}
+				options={animalOptions}
+				itemsInView={2}
+				total={animalOptions.length}
+			/>
+		));
 		const numberInViewTemplate = template.setProperty('@root', 'styles', {
 			maxHeight: '90px'
 		});
@@ -117,7 +142,9 @@ describe('Menu - Menu', () => {
 	});
 
 	it('changes active item on arrow key down', () => {
-		const h = harness(() => <Menu onValue={noop} options={animalOptions} />);
+		const h = harness(() => (
+			<Menu onValue={noop} options={animalOptions} total={animalOptions.length} />
+		));
 		const mockArrowDownEvent = {
 			stopPropagation: sb.stub(),
 			preventDefault: sb.stub(),
@@ -132,7 +159,9 @@ describe('Menu - Menu', () => {
 	});
 
 	it('changes active item on arrow key up and loops to last item', () => {
-		const h = harness(() => <Menu onValue={noop} options={animalOptions} />);
+		const h = harness(() => (
+			<Menu onValue={noop} options={animalOptions} total={animalOptions.length} />
+		));
 		const mockArrowUpEvent = {
 			stopPropagation: sb.stub(),
 			preventDefault: sb.stub(),
@@ -153,6 +182,7 @@ describe('Menu - Menu', () => {
 				onValue={noop}
 				options={animalOptions}
 				onActiveIndexChange={onActiveIndexChange}
+				total={animalOptions.length}
 			/>
 		));
 		const mockArrowDownEvent = {
@@ -167,7 +197,9 @@ describe('Menu - Menu', () => {
 	});
 
 	it('sets active item to be the one starting with letter key pressed', () => {
-		const h = harness(() => <Menu onValue={noop} options={animalOptions} />);
+		const h = harness(() => (
+			<Menu onValue={noop} options={animalOptions} total={animalOptions.length} />
+		));
 		const mockCPressEvent = {
 			stopPropagation: sb.stub(),
 			preventDefault: sb.stub(),
@@ -198,28 +230,44 @@ describe('Menu - ListBox', () => {
 			focus={noop}
 			onfocus={undefined}
 			onblur={undefined}
-			styles={{}}
+			styles={{ maxHeight: '450px' }}
 			id="test"
 			role="listbox"
 			aria-activedescendant="test"
 			aria-orientation="vertical"
+			scrollTop={0}
+			onscroll={() => {}}
 		>
-			{animalOptions.map(({ value, label, disabled = false }, index) => (
-				<ListBoxItem
-					key={`item-${index}`}
-					onSelect={noop}
-					active={index === 0}
-					onRequestActive={noop}
-					onActive={noop}
-					scrollIntoView={false}
-					disabled={disabled}
-					selected={false}
-					theme={{}}
-					widgetId={`menu-test-item-${index}`}
+			<div
+				classes={fixedCss.wrapper}
+				styles={{
+					height: `135px`
+				}}
+				key="wrapper"
+			>
+				<div
+					classes={fixedCss.transformer}
+					styles={{
+						transform: `translateY(0px)`
+					}}
+					key="transformer"
 				>
-					{label || value}
-				</ListBoxItem>
-			))}
+					{animalOptions.map(({ value, label, disabled = false }, index) => (
+						<ListBoxItem
+							key={`item-${index}`}
+							onSelect={noop}
+							active={index === 0}
+							onRequestActive={noop}
+							disabled={disabled}
+							selected={false}
+							theme={{}}
+							widgetId={`menu-test-item-${index}`}
+						>
+							{label || value}
+						</ListBoxItem>
+					))}
+				</div>
+			</div>
 		</div>
 	));
 
@@ -236,7 +284,9 @@ describe('Menu - ListBox', () => {
 	});
 
 	it('renders options', () => {
-		const h = harness(() => <Menu onValue={noop} listBox options={animalOptions} />);
+		const h = harness(() => (
+			<Menu onValue={noop} listBox options={animalOptions} total={animalOptions.length} />
+		));
 		h.expect(template);
 	});
 
@@ -245,11 +295,12 @@ describe('Menu - ListBox', () => {
 			<Menu
 				onValue={noop}
 				options={animalOptions}
+				total={animalOptions.length}
 				listBox
 				itemRenderer={({ label, value }) => <span>label is {label || value}</span>}
 			/>
 		));
-		const itemRendererTemplate = template.setChildren('@root', () =>
+		const itemRendererTemplate = template.setChildren('@transformer', () =>
 			animalOptions.map(({ value, label, disabled = false }, index) => {
 				return (
 					<ListBoxItem
@@ -257,8 +308,6 @@ describe('Menu - ListBox', () => {
 						onSelect={noop}
 						active={index === 0}
 						onRequestActive={noop}
-						onActive={noop}
-						scrollIntoView={false}
 						disabled={disabled}
 						selected={false}
 						theme={{}}
@@ -274,7 +323,9 @@ describe('Menu - ListBox', () => {
 
 	it('selects item on key press', () => {
 		const onValue = sb.stub();
-		const h = harness(() => <Menu listBox onValue={onValue} options={animalOptions} />);
+		const h = harness(() => (
+			<Menu listBox onValue={onValue} options={animalOptions} total={animalOptions.length} />
+		));
 
 		const mockArrowDownEvent = {
 			stopPropagation: sb.stub(),

--- a/src/menu/tests/MenuItem.spec.tsx
+++ b/src/menu/tests/MenuItem.spec.tsx
@@ -16,7 +16,6 @@ describe('MenuItem', () => {
 			onpointermove={noop}
 			classes={[css.root, false, false]}
 			onpointerdown={noop}
-			scrollIntoView={false}
 			role="menuitem"
 			aria-disabled={false}
 			id="test"
@@ -33,7 +32,7 @@ describe('MenuItem', () => {
 
 	it('renders with a label', () => {
 		const h = harness(() => (
-			<MenuItem widgetId="test" onActive={noop} onRequestActive={noop} onSelect={noop}>
+			<MenuItem widgetId="test" onRequestActive={noop} onSelect={noop}>
 				test
 			</MenuItem>
 		));
@@ -42,13 +41,7 @@ describe('MenuItem', () => {
 
 	it('renders disabled', () => {
 		const h = harness(() => (
-			<MenuItem
-				widgetId="test"
-				onActive={noop}
-				disabled
-				onRequestActive={noop}
-				onSelect={noop}
-			>
+			<MenuItem widgetId="test" disabled onRequestActive={noop} onSelect={noop}>
 				test
 			</MenuItem>
 		));
@@ -58,53 +51,24 @@ describe('MenuItem', () => {
 		h.expect(disabledTemplate);
 	});
 
-	it('renders with scroll into view', () => {
-		const h = harness(() => (
-			<MenuItem
-				widgetId="test"
-				onActive={noop}
-				scrollIntoView
-				onRequestActive={noop}
-				onSelect={noop}
-			>
-				test
-			</MenuItem>
-		));
-		const scrollIntoViewTemplate = template.setProperty('@root', 'scrollIntoView', true);
-		h.expect(scrollIntoViewTemplate);
-	});
-
 	it('renders active', () => {
-		const onActive = sb.stub();
 		const h = harness(() => (
-			<MenuItem
-				widgetId="test"
-				onActive={onActive}
-				active
-				onRequestActive={noop}
-				onSelect={noop}
-			>
+			<MenuItem widgetId="test" active onRequestActive={noop} onSelect={noop}>
 				test
 			</MenuItem>
 		));
-		const disabledTemplate = template.setProperty('@root', 'classes', [
+		const activeTemplate = template.setProperty('@root', 'classes', [
 			css.root,
 			css.active,
 			false
 		]);
-		h.expect(disabledTemplate);
-		assert.isTrue(onActive.calledOnce);
+		h.expect(activeTemplate);
 	});
 
 	it('requests active onpointermove', () => {
 		const onRequestActive = sb.stub();
 		const h = harness(() => (
-			<MenuItem
-				widgetId="test"
-				onActive={noop}
-				onRequestActive={onRequestActive}
-				onSelect={noop}
-			>
+			<MenuItem widgetId="test" onRequestActive={onRequestActive} onSelect={noop}>
 				test
 			</MenuItem>
 		));
@@ -115,13 +79,7 @@ describe('MenuItem', () => {
 	it('does not request active onpointermove when disabled', () => {
 		const onRequestActive = sb.stub();
 		const h = harness(() => (
-			<MenuItem
-				widgetId="test"
-				onActive={noop}
-				disabled
-				onRequestActive={onRequestActive}
-				onSelect={noop}
-			>
+			<MenuItem widgetId="test" disabled onRequestActive={onRequestActive} onSelect={noop}>
 				test
 			</MenuItem>
 		));
@@ -132,7 +90,7 @@ describe('MenuItem', () => {
 	it('calls onSelect onpointerdown', () => {
 		const onSelect = sb.stub();
 		const h = harness(() => (
-			<MenuItem widgetId="test" onActive={noop} onRequestActive={noop} onSelect={onSelect}>
+			<MenuItem widgetId="test" onRequestActive={noop} onSelect={onSelect}>
 				test
 			</MenuItem>
 		));
@@ -143,13 +101,7 @@ describe('MenuItem', () => {
 	it('does not call onSelect onpointerdown when disabled', () => {
 		const onSelect = sb.stub();
 		const h = harness(() => (
-			<MenuItem
-				widgetId="test"
-				onActive={noop}
-				disabled
-				onRequestActive={noop}
-				onSelect={onSelect}
-			>
+			<MenuItem widgetId="test" disabled onRequestActive={noop} onSelect={onSelect}>
 				test
 			</MenuItem>
 		));

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -193,6 +193,7 @@ export const Select = factory(function Select({
 									key="menu"
 									focus={() => focusNode === 'menu' && shouldFocus}
 									options={options}
+									total={options.length}
 									onValue={(value: string) => {
 										focus.focus();
 										closeMenu();

--- a/src/select/tests/Select.spec.tsx
+++ b/src/select/tests/Select.spec.tsx
@@ -73,6 +73,7 @@ const menuTemplate = assertionTemplate(() => (
 			classes={undefined}
 			listBox
 			widgetId={'test'}
+			total={options.length}
 		/>
 	</div>
 ));

--- a/src/theme/default/variables.css.d.ts
+++ b/src/theme/default/variables.css.d.ts
@@ -1,2 +1,0 @@
-declare const styles: {};
-export = styles;

--- a/src/theme/dojo/variables.css.d.ts
+++ b/src/theme/dojo/variables.css.d.ts
@@ -1,2 +1,0 @@
-declare const styles: {};
-export = styles;

--- a/src/theme/material/variables.css.d.ts
+++ b/src/theme/material/variables.css.d.ts
@@ -1,2 +1,0 @@
-declare const styles: {};
-export = styles;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

- Adds scrolling virtual window
- adds required `total` property required
   - This will be used for future enhancements around pagination

Resolves #983 
