### PR TITLE
Added native select widget

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -25,6 +25,7 @@
 			"src/label",
 			"src/listbox",
 			"src/menu",
+			"src/native-select",
 			"src/number-input",
 			"src/outlined-button",
 			"src/password-input",

--- a/README.md
+++ b/README.md
@@ -77,6 +77,8 @@ Live examples of current widgets are available in the [widget showcase](https://
 
 [Select](src/select/README.md)
 
+[NativeSelect](src/native-select/README.md)
+
 [Slider](src/slider/README.md)
 
 [TextArea](src/text-area/README.md)

--- a/src/common/styles/variables.css.d.ts
+++ b/src/common/styles/variables.css.d.ts
@@ -1,0 +1,2 @@
+declare const styles: {};
+export = styles;

--- a/src/common/tests/support/test-helpers.ts
+++ b/src/common/tests/support/test-helpers.ts
@@ -29,12 +29,6 @@ export const compareId = {
 	comparator: isStringComparator
 };
 
-export const compareFor = {
-	selector: '*',
-	property: 'for',
-	comparator: isStringComparator
-};
-
 export const compareWidgetId = {
 	selector: '*',
 	property: 'widgetId',

--- a/src/common/tests/support/test-helpers.ts
+++ b/src/common/tests/support/test-helpers.ts
@@ -29,6 +29,12 @@ export const compareId = {
 	comparator: isStringComparator
 };
 
+export const compareFor = {
+	selector: '*',
+	property: 'for',
+	comparator: isStringComparator
+};
+
 export const compareWidgetId = {
 	selector: '*',
 	property: 'widgetId',

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -170,6 +170,7 @@ import HeadingCollapsedToolbar from './widgets/toolbar/HeadingCollapsed';
 import BasicTooltip from './widgets/tooltip/Basic';
 import ClickTooltip from './widgets/tooltip/Click';
 import FocusTooltip from './widgets/tooltip/Focus';
+import BasicNativeSelect from './widgets/native-select/Basic';
 
 `!has('docs')`;
 import testsContext from './tests';
@@ -675,6 +676,14 @@ export const config = {
 				example: {
 					filename: 'Basic',
 					module: BasicMenu
+				}
+			}
+		},
+		'native-select': {
+			overview: {
+				example: {
+					filename: 'Basic',
+					module: BasicNativeSelect
 				}
 			}
 		},

--- a/src/examples/src/widgets/native-select/Basic.tsx
+++ b/src/examples/src/widgets/native-select/Basic.tsx
@@ -1,0 +1,21 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import NativeSelect from '@dojo/widgets/native-select';
+import icache from '@dojo/framework/core/middleware/icache';
+
+const factory = create({ icache });
+const options = [{ value: 'cat' }, { value: 'dog' }, { value: 'fish' }, { value: 'unicorn' }];
+
+export default factory(function Basic({ middleware: { icache } }) {
+	return (
+		<virtual>
+			<NativeSelect
+				label="Basic Select"
+				options={options}
+				onValue={(value) => {
+					icache.set('value', value);
+				}}
+			/>
+			<pre>{icache.getOrSet('value', '')}</pre>
+		</virtual>
+	);
+});

--- a/src/native-select/README.md
+++ b/src/native-select/README.md
@@ -1,0 +1,8 @@
+# @dojo/widgets/native-select
+
+Dojo's `Native Select` provides a dropdown menu form control using the browser's native `<select>` element.
+
+## Features
+
+- Exposes native select interface
+- Optional helpertext property adds text to the bottom the select element

--- a/src/native-select/index.tsx
+++ b/src/native-select/index.tsx
@@ -1,7 +1,6 @@
 import { focus } from '@dojo/framework/core/middleware/focus';
 import { i18n } from '@dojo/framework/core/middleware/i18n';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-import { uuid } from '@dojo/framework/core/util';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import HelperText from '../helper-text';
 import theme from '../middleware/theme';
@@ -38,7 +37,6 @@ export interface NativeSelectProperties {
 
 interface NativeSelectICache {
 	initial: string;
-	selectId: string;
 	value: string;
 }
 
@@ -48,6 +46,7 @@ const factory = create({ icache, focus, theme, i18n }).properties<NativeSelectPr
 
 export const NativeSelect = factory(function NativeSelect({
 	properties,
+	id,
 	middleware: { icache, theme }
 }) {
 	const {
@@ -72,7 +71,6 @@ export const NativeSelect = factory(function NativeSelect({
 	}
 
 	const selectedValue = icache.get('value');
-	const selectId = icache.getOrSet('selectId', uuid());
 	const themedCss = theme.classes(css);
 
 	return (
@@ -88,7 +86,7 @@ export const NativeSelect = factory(function NativeSelect({
 				theme={themeProp}
 				classes={classes}
 				disabled={disabled}
-				forId={selectId}
+				forId={id}
 				required={required}
 			>
 				{label}
@@ -105,7 +103,7 @@ export const NativeSelect = factory(function NativeSelect({
 					disabled={disabled}
 					name={name}
 					required={required}
-					id={selectId}
+					id={id}
 					size={size}
 					onfocus={() => {
 						onFocus && onFocus();

--- a/src/native-select/index.tsx
+++ b/src/native-select/index.tsx
@@ -1,0 +1,128 @@
+import { focus } from '@dojo/framework/core/middleware/focus';
+import { i18n } from '@dojo/framework/core/middleware/i18n';
+import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
+import { uuid } from '@dojo/framework/core/util';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import HelperText from '../helper-text';
+import theme from '../middleware/theme';
+import * as css from '../theme/default/native-select.m.css';
+
+export type MenuOption = { value: string; label?: string; disabled?: boolean };
+
+interface SelectInputEvent extends InputEvent {
+	target: HTMLInputElement;
+}
+
+interface NativeSelectProperties {
+	/** Callback called when user selects a value */
+	onValue?(value: string): void;
+	/** The initial selected value */
+	initialValue?: string;
+	/** Options to display within the menu */
+	options: MenuOption[];
+	/** Property to determine if the input is disabled */
+	disabled?: boolean;
+	/** Sets the helper text of the input */
+	helperText?: string;
+	/** The label to show */
+	label?: string;
+	/** Boolean to indicate if field is required */
+	required?: boolean;
+	/** Used to specify the name of the control */
+	name?: string;
+	/** Represents the number of rows the are visible at one time */
+	size?: number;
+	/** Handler for events triggered by select field losing focus */
+	onBlur?(): void;
+	/** Handler for events triggered by the select element being focused */
+	onFocus?(): void;
+}
+
+interface NativeSelectICache {
+	initial: string;
+	selectId: string;
+	value: string;
+}
+
+const icache = createICacheMiddleware<NativeSelectICache>();
+
+const factory = create({ icache, focus, theme, i18n }).properties<NativeSelectProperties>();
+
+export const NativeSelect = factory(function NativeSelect({
+	properties,
+	middleware: { icache, theme }
+}) {
+	const {
+		disabled,
+		helperText,
+		initialValue,
+		label,
+		onValue,
+		options,
+		required,
+		name,
+		size,
+		onFocus,
+		onBlur
+	} = properties();
+
+	if (initialValue !== undefined && initialValue !== icache.get('initial')) {
+		icache.set('initial', initialValue);
+		icache.set('value', initialValue);
+	}
+
+	const selectedValue = icache.get('value');
+	const selectId = icache.getOrSet('selectId', uuid());
+	const themedCss = theme.classes(css);
+
+	return (
+		<div
+			classes={[
+				themedCss.root,
+				disabled && themedCss.disabled,
+				required && themedCss.required
+			]}
+			key="root"
+		>
+			<label type="select" for={selectId}>
+				{label}
+			</label>
+			<select
+				key="native-select"
+				onchange={(event: SelectInputEvent) => {
+					selectedValue !== icache.get('value') &&
+						icache.set('value', event.target.value);
+					onValue && onValue(event.target.value);
+				}}
+				disabled={disabled}
+				name={name}
+				required={required}
+				id={selectId}
+				size={size}
+				onfocus={() => {
+					onFocus && onFocus();
+				}}
+				onblur={() => {
+					onBlur && onBlur();
+				}}
+				class={themedCss.select}
+			>
+				{options.map(({ value, label, disabled = false }, index) => {
+					return (
+						<option
+							key={`option-${index}`}
+							value={value}
+							disabled={disabled}
+							selected={selectedValue === value}
+						>
+							{label ? label : value}
+						</option>
+					);
+				})}
+			</select>
+			<HelperText key="helperText" text={helperText} />
+		</div>
+	);
+});
+
+export default NativeSelect;

--- a/src/native-select/index.tsx
+++ b/src/native-select/index.tsx
@@ -13,7 +13,7 @@ interface SelectInputEvent extends InputEvent {
 	target: HTMLInputElement;
 }
 
-interface NativeSelectProperties {
+export interface NativeSelectProperties {
 	/** Callback called when user selects a value */
 	onValue?(value: string): void;
 	/** The initial selected value */

--- a/src/native-select/index.tsx
+++ b/src/native-select/index.tsx
@@ -9,10 +9,6 @@ import * as css from '../theme/default/native-select.m.css';
 
 export type MenuOption = { value: string; label?: string; disabled?: boolean };
 
-interface SelectInputEvent extends InputEvent {
-	target: HTMLInputElement;
-}
-
 export interface NativeSelectProperties {
 	/** Callback called when user selects a value */
 	onValue?(value: string): void;
@@ -89,10 +85,11 @@ export const NativeSelect = factory(function NativeSelect({
 			</label>
 			<select
 				key="native-select"
-				onchange={(event: SelectInputEvent) => {
+				onchange={(event: Event) => {
+					const targetElement = event.target as HTMLInputElement;
 					selectedValue !== icache.get('value') &&
-						icache.set('value', event.target.value);
-					onValue && onValue(event.target.value);
+						icache.set('value', targetElement.value);
+					onValue && onValue(targetElement.value);
 				}}
 				disabled={disabled}
 				name={name}

--- a/src/native-select/index.tsx
+++ b/src/native-select/index.tsx
@@ -6,6 +6,7 @@ import { create, tsx } from '@dojo/framework/core/vdom';
 import HelperText from '../helper-text';
 import theme from '../middleware/theme';
 import * as css from '../theme/default/native-select.m.css';
+import Icon from '../icon';
 
 export type MenuOption = { value: string; label?: string; disabled?: boolean };
 
@@ -49,6 +50,7 @@ export const NativeSelect = factory(function NativeSelect({
 	middleware: { icache, theme }
 }) {
 	const {
+		classes,
 		disabled,
 		helperText,
 		initialValue,
@@ -59,7 +61,8 @@ export const NativeSelect = factory(function NativeSelect({
 		name,
 		size,
 		onFocus,
-		onBlur
+		onBlur,
+		theme: themeProp
 	} = properties();
 
 	if (initialValue !== undefined && initialValue !== icache.get('initial')) {
@@ -83,40 +86,45 @@ export const NativeSelect = factory(function NativeSelect({
 			<label type="select" for={selectId}>
 				{label}
 			</label>
-			<select
-				key="native-select"
-				onchange={(event: Event) => {
-					const targetElement = event.target as HTMLInputElement;
-					selectedValue !== icache.get('value') &&
-						icache.set('value', targetElement.value);
-					onValue && onValue(targetElement.value);
-				}}
-				disabled={disabled}
-				name={name}
-				required={required}
-				id={selectId}
-				size={size}
-				onfocus={() => {
-					onFocus && onFocus();
-				}}
-				onblur={() => {
-					onBlur && onBlur();
-				}}
-				class={themedCss.select}
-			>
-				{options.map(({ value, label, disabled = false }, index) => {
-					return (
-						<option
-							key={`option-${index}`}
-							value={value}
-							disabled={disabled}
-							selected={selectedValue === value}
-						>
-							{label ? label : value}
-						</option>
-					);
-				})}
-			</select>
+			<div classes={themedCss.inputWrapper}>
+				<select
+					key="native-select"
+					onchange={(event: Event) => {
+						const targetElement = event.target as HTMLInputElement;
+						selectedValue !== icache.get('value') &&
+							icache.set('value', targetElement.value);
+						onValue && onValue(targetElement.value);
+					}}
+					disabled={disabled}
+					name={name}
+					required={required}
+					id={selectId}
+					size={size}
+					onfocus={() => {
+						onFocus && onFocus();
+					}}
+					onblur={() => {
+						onBlur && onBlur();
+					}}
+					class={themedCss.select}
+				>
+					{options.map(({ value, label, disabled = false }, index) => {
+						return (
+							<option
+								key={`option-${index}`}
+								value={value}
+								disabled={disabled}
+								selected={selectedValue === value}
+							>
+								{label ? label : value}
+							</option>
+						);
+					})}
+				</select>
+				<span classes={themedCss.arrow}>
+					<Icon type="downIcon" theme={themeProp} classes={classes} />
+				</span>
+			</div>
 			<HelperText key="helperText" text={helperText} />
 		</div>
 	);

--- a/src/native-select/index.tsx
+++ b/src/native-select/index.tsx
@@ -7,6 +7,7 @@ import HelperText from '../helper-text';
 import theme from '../middleware/theme';
 import * as css from '../theme/default/native-select.m.css';
 import Icon from '../icon';
+import Label from '../label';
 
 export type MenuOption = { value: string; label?: string; disabled?: boolean };
 
@@ -83,9 +84,15 @@ export const NativeSelect = factory(function NativeSelect({
 			]}
 			key="root"
 		>
-			<label type="select" for={selectId}>
+			<Label
+				theme={themeProp}
+				classes={classes}
+				disabled={disabled}
+				forId={selectId}
+				required={required}
+			>
 				{label}
-			</label>
+			</Label>
 			<div classes={themedCss.inputWrapper}>
 				<select
 					key="native-select"

--- a/src/native-select/tests/NativeSelect.spec.tsx
+++ b/src/native-select/tests/NativeSelect.spec.tsx
@@ -1,0 +1,108 @@
+const { describe, it } = intern.getInterface('bdd');
+import { tsx } from '@dojo/framework/core/vdom';
+import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
+import {
+	compareId,
+	compareTheme,
+	compareFor,
+	createHarness,
+	noop
+} from '../../common/tests/support/test-helpers';
+import HelperText from '../../helper-text';
+import * as css from '../../theme/default/native-select.m.css';
+import { NativeSelect } from '../index';
+import { stub } from 'sinon';
+const { assert } = intern.getPlugin('chai');
+
+const options = [{ value: 'dog' }, { value: 'cat' }, { value: 'fish' }];
+
+const harness = createHarness([compareTheme]);
+
+const baseTemplate = assertionTemplate(() => (
+	<div classes={[css.root, undefined, undefined]} key="root">
+		<label assertion-key="label" type="select" for="something" />
+		<select
+			key="native-select"
+			onchange={noop}
+			disabled={undefined}
+			name={undefined}
+			required={undefined}
+			id="something"
+			size={undefined}
+			onfocus={noop}
+			onblur={noop}
+			class={css.select}
+		>
+			{options.map(({ value }, index) => {
+				return (
+					<option key={`option-${index}`} value={value} disabled={false} selected={false}>
+						{value}
+					</option>
+				);
+			})}
+		</select>
+		<HelperText key="helperText" text={undefined} />
+	</div>
+));
+
+describe('Native Select', () => {
+	it('renders', () => {
+		const h = harness(() => <NativeSelect onValue={() => {}} options={options} />, [
+			compareFor,
+			compareId
+		]);
+		h.expect(baseTemplate);
+	});
+
+	it('takes optional properties', () => {
+		const h = harness(
+			() => (
+				<NativeSelect
+					onValue={() => {}}
+					options={options}
+					initialValue="cat"
+					disabled={true}
+					helperText="Pick a pet type"
+					label="Pets"
+					required={true}
+					name="Pet select"
+					size={3}
+				/>
+			),
+			[compareFor, compareId]
+		);
+
+		const optionalPropertyTemplate = baseTemplate
+			.setProperty('@native-select', 'disabled', true)
+			.setProperty('@native-select', 'required', true)
+			.setProperty('@native-select', 'name', 'Pet select')
+			.setProperty('@native-select', 'size', 3)
+			.setProperty('@helperText', 'text', 'Pick a pet type')
+			.setProperty('@option-1', 'selected', true)
+			.setProperty('@root', 'classes', [css.root, css.disabled, css.required])
+			.replaceChildren('~label', () => {
+				return ['Pets'];
+			});
+
+		h.expect(optionalPropertyTemplate);
+	});
+
+	it('calls onValue when a select item is selected', () => {
+		const changeEvent = {
+			target: {
+				value: 'cat'
+			}
+		};
+
+		const onValueStub = stub();
+
+		const h = harness(() => <NativeSelect onValue={onValueStub} options={options} />, [
+			compareFor,
+			compareId
+		]);
+
+		h.trigger('@native-select', 'onchange', changeEvent);
+
+		assert.isTrue(onValueStub.calledOnceWith('cat'));
+	});
+});

--- a/src/native-select/tests/NativeSelect.spec.tsx
+++ b/src/native-select/tests/NativeSelect.spec.tsx
@@ -4,14 +4,16 @@ import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
 import {
 	compareId,
 	compareTheme,
-	compareFor,
 	createHarness,
-	noop
+	noop,
+	compareForId
 } from '../../common/tests/support/test-helpers';
 import HelperText from '../../helper-text';
 import * as css from '../../theme/default/native-select.m.css';
 import { NativeSelect } from '../index';
 import { stub } from 'sinon';
+import Icon from '../../icon';
+import Label from '../../label';
 const { assert } = intern.getPlugin('chai');
 
 const options = [{ value: 'dog' }, { value: 'cat' }, { value: 'fish' }];
@@ -20,27 +22,44 @@ const harness = createHarness([compareTheme]);
 
 const baseTemplate = assertionTemplate(() => (
 	<div classes={[css.root, undefined, undefined]} key="root">
-		<label assertion-key="label" type="select" for="something" />
-		<select
-			key="native-select"
-			onchange={noop}
+		<Label
+			assertion-key="label"
+			theme={undefined}
+			classes={undefined}
 			disabled={undefined}
-			name={undefined}
+			forId={'something'}
 			required={undefined}
-			id="something"
-			size={undefined}
-			onfocus={noop}
-			onblur={noop}
-			class={css.select}
-		>
-			{options.map(({ value }, index) => {
-				return (
-					<option key={`option-${index}`} value={value} disabled={false} selected={false}>
-						{value}
-					</option>
-				);
-			})}
-		</select>
+		/>
+		<div classes={css.inputWrapper}>
+			<select
+				key="native-select"
+				onchange={noop}
+				disabled={undefined}
+				name={undefined}
+				required={undefined}
+				id="something"
+				size={undefined}
+				onfocus={noop}
+				onblur={noop}
+				class={css.select}
+			>
+				{options.map(({ value }, index) => {
+					return (
+						<option
+							key={`option-${index}`}
+							value={value}
+							disabled={false}
+							selected={false}
+						>
+							{value}
+						</option>
+					);
+				})}
+			</select>
+			<span classes={css.arrow}>
+				<Icon type="downIcon" theme={undefined} classes={undefined} />
+			</span>
+		</div>
 		<HelperText key="helperText" text={undefined} />
 	</div>
 ));
@@ -48,7 +67,7 @@ const baseTemplate = assertionTemplate(() => (
 describe('Native Select', () => {
 	it('renders', () => {
 		const h = harness(() => <NativeSelect onValue={() => {}} options={options} />, [
-			compareFor,
+			compareForId,
 			compareId
 		]);
 		h.expect(baseTemplate);
@@ -69,7 +88,7 @@ describe('Native Select', () => {
 					size={3}
 				/>
 			),
-			[compareFor, compareId]
+			[compareForId, compareId]
 		);
 
 		const optionalPropertyTemplate = baseTemplate
@@ -80,6 +99,8 @@ describe('Native Select', () => {
 			.setProperty('@helperText', 'text', 'Pick a pet type')
 			.setProperty('@option-1', 'selected', true)
 			.setProperty('@root', 'classes', [css.root, css.disabled, css.required])
+			.setProperty('~label', 'disabled', true)
+			.setProperty('~label', 'required', true)
 			.replaceChildren('~label', () => {
 				return ['Pets'];
 			});
@@ -97,7 +118,7 @@ describe('Native Select', () => {
 		const onValueStub = stub();
 
 		const h = harness(() => <NativeSelect onValue={onValueStub} options={options} />, [
-			compareFor,
+			compareForId,
 			compareId
 		]);
 

--- a/src/theme/default/index.ts
+++ b/src/theme/default/index.ts
@@ -23,6 +23,7 @@ import * as label from './label.m.css';
 import * as listbox from './listbox.m.css';
 import * as menu from './menu.m.css';
 import * as menuItem from './menu-item.m.css';
+import * as nativeSelect from './native-select.m.css';
 import * as listBoxItem from './list-box-item.m.css';
 import * as outlinedButton from './outlined-button.m.css';
 import * as passwordInput from './password-input.m.css';
@@ -70,6 +71,7 @@ export default {
 	'@dojo/widgets/listbox': listbox,
 	'@dojo/widgets/menu': menu,
 	'@dojo/widgets/menu-item': menuItem,
+	'@dojo/widgets/native-select': nativeSelect,
 	'@dojo/widgets/list-box-item': listBoxItem,
 	'@dojo/widgets/outlined-button': outlinedButton,
 	'@dojo/widget/password-input': passwordInput,

--- a/src/theme/default/native-select.m.css
+++ b/src/theme/default/native-select.m.css
@@ -1,0 +1,15 @@
+@import './variables.css';
+
+.root {
+	font-size: var(--font-size-base);
+	display: flex;
+	flex-direction: column;
+}
+
+.select {
+	cursor: pointer;
+}
+
+.disabled {
+	cursor: inherit;
+}

--- a/src/theme/default/native-select.m.css
+++ b/src/theme/default/native-select.m.css
@@ -1,11 +1,13 @@
 @import './variables.css';
 
+/* Root class of native select */
 .root {
 	font-size: var(--font-size-base);
 	display: flex;
 	flex-direction: column;
 }
 
+/* Class for select element */
 .select {
 	appearance: none;
 	-webkit-appearance: none;
@@ -14,16 +16,19 @@
 	min-width: 100%;
 }
 
+/* Class for disabled select state */
 .disabled {
 	cursor: inherit;
 }
 
+/* Wrapper class for native select and dropdown arrow */
 .inputWrapper {
 	display: inline-block;
 	position: relative;
 	min-width: 100%;
 }
 
+/* Class for dropdown arrow positioning */
 .arrow {
 	bottom: 0;
 	position: absolute;
@@ -33,5 +38,6 @@
 	pointer-events: none;
 }
 
+/* Class for required select state */
 .required {
 }

--- a/src/theme/default/native-select.m.css
+++ b/src/theme/default/native-select.m.css
@@ -13,3 +13,6 @@
 .disabled {
 	cursor: inherit;
 }
+
+.required {
+}

--- a/src/theme/default/native-select.m.css
+++ b/src/theme/default/native-select.m.css
@@ -30,6 +30,7 @@
 	right: 4px;
 	top: 0;
 	width: 1.5em;
+	pointer-events: none;
 }
 
 .required {

--- a/src/theme/default/native-select.m.css
+++ b/src/theme/default/native-select.m.css
@@ -7,11 +7,29 @@
 }
 
 .select {
+	appearance: none;
+	-webkit-appearance: none;
 	cursor: pointer;
+	border: 1px solid var(--component-color);
+	min-width: 100%;
 }
 
 .disabled {
 	cursor: inherit;
+}
+
+.inputWrapper {
+	display: inline-block;
+	position: relative;
+	min-width: 100%;
+}
+
+.arrow {
+	bottom: 0;
+	position: absolute;
+	right: 4px;
+	top: 0;
+	width: 1.5em;
 }
 
 .required {

--- a/src/theme/default/native-select.m.css.d.ts
+++ b/src/theme/default/native-select.m.css.d.ts
@@ -1,3 +1,6 @@
 export const root: string;
 export const select: string;
 export const disabled: string;
+export const required: string;
+export const inputWrapper: string;
+export const arrow: string;

--- a/src/theme/default/native-select.m.css.d.ts
+++ b/src/theme/default/native-select.m.css.d.ts
@@ -1,0 +1,3 @@
+export const root: string;
+export const select: string;
+export const disabled: string;

--- a/src/theme/default/native-select.m.css.d.ts
+++ b/src/theme/default/native-select.m.css.d.ts
@@ -1,6 +1,6 @@
 export const root: string;
 export const select: string;
 export const disabled: string;
-export const required: string;
 export const inputWrapper: string;
 export const arrow: string;
+export const required: string;

--- a/src/theme/default/variables.css.d.ts
+++ b/src/theme/default/variables.css.d.ts
@@ -1,0 +1,2 @@
+declare const styles: {};
+export = styles;

--- a/src/theme/dojo/index.ts
+++ b/src/theme/dojo/index.ts
@@ -23,6 +23,7 @@ import * as listboxItem from './listbox-item.m.css';
 import * as menu from './menu.m.css';
 import * as menuItem from './menu-item.m.css';
 import * as outlinedButton from './outlined-button.m.css';
+import * as nativeSelect from './native-select.m.css';
 import * as passwordInput from './password-input.m.css';
 import * as progress from './progress.m.css';
 import * as radio from './radio.m.css';
@@ -67,6 +68,7 @@ export default {
 	'@dojo/widgets/menu-item': menuItem,
 	'@dojo/widgets/menu': menu,
 	'@dojo/widgets/outlined-button': outlinedButton,
+	'@dojo/widgets/native-select': nativeSelect,
 	'@dojo/widgets/password-input': passwordInput,
 	'@dojo/widgets/progress': progress,
 	'@dojo/widgets/radio': radio,

--- a/src/theme/dojo/native-select.m.css
+++ b/src/theme/dojo/native-select.m.css
@@ -1,17 +1,20 @@
 @import './variables.css';
 
+/* Root class of native select */
 .root {
 	font-size: var(--font-size-base);
 	display: flex;
 	flex-direction: column;
 }
 
+/* Wrapper class for native select and dropdown arrow */
 .inputWrapper {
 	display: inline-block;
 	position: relative;
 	width: 100%;
 }
 
+/* Class for select element */
 .select {
 	appearance: none;
 	-webkit-appearance: none;
@@ -31,6 +34,7 @@
 	border-bottom-color: var(--color-border-strong);
 }
 
+/* Class for dojo stylized dropdown arrow */
 .arrow {
 	bottom: 0;
 	position: absolute;
@@ -47,6 +51,7 @@
 	pointer-events: none;
 }
 
+/* Class for disabled select state */
 .disabled .select {
 	background-color: var(--color-background-faded);
 }

--- a/src/theme/dojo/native-select.m.css
+++ b/src/theme/dojo/native-select.m.css
@@ -1,0 +1,19 @@
+@import './variables.css';
+
+.root {
+	font-size: var(--font-size-base);
+	display: flex;
+	flex-direction: column;
+}
+
+.select {
+	border: var(--border-width) solid var(--color-border);
+	border-bottom-color: var(--color-border-strong);
+	cursor: pointer;
+	line-height: var(--line-height-base);
+	height: calc(var(--line-height-base) + 2 * var(--grid-base) + 2 * var(--border-width));
+}
+
+.disabled {
+	cursor: inherit;
+}

--- a/src/theme/dojo/native-select.m.css
+++ b/src/theme/dojo/native-select.m.css
@@ -6,14 +6,47 @@
 	flex-direction: column;
 }
 
-.select {
-	border: var(--border-width) solid var(--color-border);
-	border-bottom-color: var(--color-border-strong);
-	cursor: pointer;
-	line-height: var(--line-height-base);
-	height: calc(var(--line-height-base) + 2 * var(--grid-base) + 2 * var(--border-width));
+.inputWrapper {
+	display: inline-block;
+	position: relative;
+	width: 100%;
 }
 
-.disabled {
-	cursor: inherit;
+.select {
+	appearance: none;
+	-webkit-appearance: none;
+	background: var(--component-background);
+	border: 1px solid var(--component-color);
+	border-radius: 0;
+	cursor: pointer;
+	display: block;
+	font-size: inherit;
+	line-height: var(--line-height-base);
+	height: calc(var(--line-height-base) + 2 * var(--grid-base) + 2 * var(--border-width));
+	max-width: 100%;
+	padding: var(--spacing-regular) calc(var(--spacing-regular) * 3) var(--spacing-regular)
+		var(--spacing-regular);
+	width: 100%;
+	border: var(--border-width) solid var(--color-border);
+	border-bottom-color: var(--color-border-strong);
+}
+
+.arrow {
+	bottom: 0;
+	position: absolute;
+	right: 4px;
+	top: 0;
+	width: 1.5em;
+
+	border-left: var(--border-width) solid var(--color-border);
+	bottom: var(--border-width);
+	color: var(--color-text-faded);
+	font-size: var(--font-size-icon);
+	line-height: var(--line-height-base);
+	padding: var(--spacing-regular);
+	pointer-events: none;
+}
+
+.disabled .select {
+	background-color: var(--color-background-faded);
 }

--- a/src/theme/dojo/native-select.m.css.d.ts
+++ b/src/theme/dojo/native-select.m.css.d.ts
@@ -1,3 +1,5 @@
 export const root: string;
+export const inputWrapper: string;
 export const select: string;
+export const arrow: string;
 export const disabled: string;

--- a/src/theme/dojo/native-select.m.css.d.ts
+++ b/src/theme/dojo/native-select.m.css.d.ts
@@ -1,0 +1,3 @@
+export const root: string;
+export const select: string;
+export const disabled: string;

--- a/src/theme/dojo/variables.css.d.ts
+++ b/src/theme/dojo/variables.css.d.ts
@@ -1,0 +1,2 @@
+declare const styles: {};
+export = styles;

--- a/src/theme/material/native-select.m.css
+++ b/src/theme/material/native-select.m.css
@@ -1,0 +1,5 @@
+.root {
+}
+
+.disabled {
+}

--- a/src/theme/material/variables.css.d.ts
+++ b/src/theme/material/variables.css.d.ts
@@ -1,0 +1,2 @@
+declare const styles: {};
+export = styles;

--- a/src/theme/material/widgets.css
+++ b/src/theme/material/widgets.css
@@ -7,6 +7,7 @@
 @import './icon.m.css';
 @import './label.m.css';
 @import './listbox.m.css';
+@import './native-select.m.css';
 @import './progress.m.css';
 @import './radio.m.css';
 @import './select.m.css';


### PR DESCRIPTION
**Type:** Feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [NA] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:** 
Added a native select component so users have the option other than our current custom built select.

<img width="700" alt="Screen Shot 2020-01-03 at 10 53 52 AM" src="https://user-images.githubusercontent.com/3914018/71742754-99f02880-2e17-11ea-8a06-d3d10e01b133.png">

Resolves #973 
