### PR TITLE
Dojo Theme for Menu, MenuItem and ListboxItem

### DIFF
--- a/src/common/styles/variables.css.d.ts
+++ b/src/common/styles/variables.css.d.ts
@@ -1,0 +1,2 @@
+declare const styles: {};
+export = styles;

--- a/src/theme/default/variables.css.d.ts
+++ b/src/theme/default/variables.css.d.ts
@@ -1,0 +1,2 @@
+declare const styles: {};
+export = styles;

--- a/src/theme/dojo/index.ts
+++ b/src/theme/dojo/index.ts
@@ -35,6 +35,9 @@ import * as timePicker from './time-picker.m.css';
 import * as titlePane from './title-pane.m.css';
 import * as toolbar from './toolbar.m.css';
 import * as tooltip from './tooltip.m.css';
+import * as menu from './menu.m.css';
+import * as listboxItem from './listbox-item.m.css';
+import * as menuItem from './menu-item.m.css';
 
 export default {
 	'@dojo/widgets/accordion-pane': accordionPane,
@@ -57,6 +60,9 @@ export default {
 	'@dojo/widgets/icon': icon,
 	'@dojo/widgets/label': label,
 	'@dojo/widgets/listbox': listbox,
+	'@dojo/widgets/list-box-item': listboxItem,
+	'@dojo/widgets/menu-item': menuItem,
+	'@dojo/widgets/menu': menu,
 	'@dojo/widgets/password-input': passwordInput,
 	'@dojo/widgets/progress': progress,
 	'@dojo/widgets/radio': radio,

--- a/src/theme/dojo/listbox-item.m.css
+++ b/src/theme/dojo/listbox-item.m.css
@@ -1,0 +1,18 @@
+@import './variables.css';
+
+.root {
+	padding: var(--spacing-regular);
+	border: 1px solid transparent;
+}
+
+.active {
+	border: 1px solid var(--color-highlight-border);
+}
+
+.selected {
+	background: var(--color-background-faded);
+}
+
+.disabled {
+	background: var(--color-text-faded);
+}

--- a/src/theme/dojo/listbox-item.m.css
+++ b/src/theme/dojo/listbox-item.m.css
@@ -14,5 +14,6 @@
 }
 
 .disabled {
-	background: var(--color-text-faded);
+	color: var(--color-text-faded);
+	font-style: italic;
 }

--- a/src/theme/dojo/listbox-item.m.css.d.ts
+++ b/src/theme/dojo/listbox-item.m.css.d.ts
@@ -1,0 +1,4 @@
+export const root: string;
+export const active: string;
+export const selected: string;
+export const disabled: string;

--- a/src/theme/dojo/menu-item.m.css
+++ b/src/theme/dojo/menu-item.m.css
@@ -1,0 +1,10 @@
+@import './variables.css';
+
+.root {
+	padding: var(--spacing-regular);
+	border: 1px solid transparent;
+}
+
+.active {
+	border: 1px solid var(--color-highlight-border);
+}

--- a/src/theme/dojo/menu-item.m.css.d.ts
+++ b/src/theme/dojo/menu-item.m.css.d.ts
@@ -1,0 +1,2 @@
+export const root: string;
+export const active: string;

--- a/src/theme/dojo/menu.m.css
+++ b/src/theme/dojo/menu.m.css
@@ -1,0 +1,8 @@
+@import './variables.css';
+
+.menu {
+	overflow: auto;
+	position: relative;
+	border: var(--border-width) solid var(--color-border);
+	border-radius: 3px;
+}

--- a/src/theme/dojo/menu.m.css
+++ b/src/theme/dojo/menu.m.css
@@ -4,5 +4,4 @@
 	overflow: auto;
 	position: relative;
 	border: var(--border-width) solid var(--color-border);
-	border-radius: 3px;
 }

--- a/src/theme/dojo/menu.m.css.d.ts
+++ b/src/theme/dojo/menu.m.css.d.ts
@@ -1,0 +1,1 @@
+export const menu: string;

--- a/src/theme/dojo/variables.css.d.ts
+++ b/src/theme/dojo/variables.css.d.ts
@@ -1,0 +1,2 @@
+declare const styles: {};
+export = styles;

--- a/src/theme/material/variables.css.d.ts
+++ b/src/theme/material/variables.css.d.ts
@@ -1,0 +1,2 @@
+declare const styles: {};
+export = styles;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds Dojo themeing for the Menu, MenuItem and ListboxItem widgets. This ticks off these widgets for #952 

MenuItem:
![Screenshot_20200103_122346](https://user-images.githubusercontent.com/8822075/71723499-c3638100-2e24-11ea-84ca-9657ddc93ba9.png)

ListboxItem:
![Screenshot_20200103_122916](https://user-images.githubusercontent.com/8822075/71723502-c3fc1780-2e24-11ea-8acc-f96009ede64f.png)

