### PR TITLE
Dojo Theme for OutlinedButton

### DIFF
--- a/src/theme/default/button.m.css
+++ b/src/theme/default/button.m.css
@@ -23,9 +23,6 @@
 .popup {
 }
 
-.addon {
-}
-
 /* Addded to a disabled button */
 .disabled,
 .disabled:hover {

--- a/src/theme/default/button.m.css.d.ts
+++ b/src/theme/default/button.m.css.d.ts
@@ -1,5 +1,4 @@
 export const root: string;
 export const pressed: string;
 export const popup: string;
-export const addon: string;
 export const disabled: string;

--- a/src/theme/dojo/button.m.css
+++ b/src/theme/dojo/button.m.css
@@ -29,11 +29,6 @@
 	outline: none;
 }
 
-.root:hover .addon,
-.root:focus .addon {
-	border-left-color: var(--color-highlight);
-}
-
 .pressed {
 	background-color: var(--color-highlight);
 	border-color: var(--color-highlight);

--- a/src/theme/dojo/button.m.css
+++ b/src/theme/dojo/button.m.css
@@ -35,27 +35,6 @@
 	color: var(--color-text-inverted);
 }
 
-.pressed .addon {
-	border-left-color: var(--color-highlight-border);
-}
-
-.popup {
-	padding-right: calc(var(--line-height-base) + 3 * var(--spacing-regular));
-	position: relative;
-}
-
-.addon {
-	border-left: var(--border-width) solid var(--color-border);
-	line-height: var(--line-height-base);
-	padding: var(--spacing-regular);
-	position: absolute;
-	right: 0;
-	text-align: center;
-	top: 0;
-	width: calc(var(--line-height-base) + 2 * var(--spacing-regular)); /* square icon addons */
-	transition: border var(--transition-duration) var(--transition-easing);
-}
-
 .disabled,
 .disabled:hover {
 	background-color: var(--color-background-faded);

--- a/src/theme/dojo/button.m.css.d.ts
+++ b/src/theme/dojo/button.m.css.d.ts
@@ -1,5 +1,3 @@
 export const root: string;
 export const pressed: string;
-export const addon: string;
-export const popup: string;
 export const disabled: string;

--- a/src/theme/dojo/button.m.css.d.ts
+++ b/src/theme/dojo/button.m.css.d.ts
@@ -1,5 +1,5 @@
 export const root: string;
-export const addon: string;
 export const pressed: string;
+export const addon: string;
 export const popup: string;
 export const disabled: string;

--- a/src/theme/dojo/index.ts
+++ b/src/theme/dojo/index.ts
@@ -18,6 +18,9 @@ import * as helperText from './helper-text.m.css';
 import * as icon from './icon.m.css';
 import * as label from './label.m.css';
 import * as listbox from './listbox.m.css';
+import * as listboxItem from './listbox-item.m.css';
+import * as menu from './menu.m.css';
+import * as menuItem from './menu-item.m.css';
 import * as outlinedButton from './outlined-button.m.css';
 import * as passwordInput from './password-input.m.css';
 import * as progress from './progress.m.css';
@@ -36,9 +39,6 @@ import * as timePicker from './time-picker.m.css';
 import * as titlePane from './title-pane.m.css';
 import * as toolbar from './toolbar.m.css';
 import * as tooltip from './tooltip.m.css';
-import * as menu from './menu.m.css';
-import * as listboxItem from './listbox-item.m.css';
-import * as menuItem from './menu-item.m.css';
 
 export default {
 	'@dojo/widgets/accordion-pane': accordionPane,

--- a/src/theme/dojo/index.ts
+++ b/src/theme/dojo/index.ts
@@ -18,6 +18,7 @@ import * as helperText from './helper-text.m.css';
 import * as icon from './icon.m.css';
 import * as label from './label.m.css';
 import * as listbox from './listbox.m.css';
+import * as outlinedButton from './outlined-button.m.css';
 import * as passwordInput from './password-input.m.css';
 import * as progress from './progress.m.css';
 import * as radio from './radio.m.css';
@@ -63,6 +64,7 @@ export default {
 	'@dojo/widgets/list-box-item': listboxItem,
 	'@dojo/widgets/menu-item': menuItem,
 	'@dojo/widgets/menu': menu,
+	'@dojo/widgets/outlined-button': outlinedButton,
 	'@dojo/widgets/password-input': passwordInput,
 	'@dojo/widgets/progress': progress,
 	'@dojo/widgets/radio': radio,

--- a/src/theme/dojo/outlined-button.m.css
+++ b/src/theme/dojo/outlined-button.m.css
@@ -1,0 +1,63 @@
+@import './variables.css';
+
+.root {
+	background-color: var(--color-background);
+	border: var(--border-width) solid var(--color-highlight);
+	color: var(--color-highlight);
+	cursor: pointer;
+	display: inline-block;
+	font-size: var(--font-size-base);
+	font-weight: bold;
+	line-height: var(--line-height-base);
+	min-width: calc(var(--grid-base) * 20);
+	padding: var(--spacing-regular);
+	transition: box-shadow var(--transition-duration) var(--transition-easing);
+	margin: 0;
+}
+
+.root:hover {
+	background-color: var(--color-highlight);
+	color: var(--color-text-inverted);
+	outline: none;
+}
+
+.root:hover .addon,
+.root:focus .addon {
+	border-left-color: var(--color-highlight);
+}
+
+.pressed {
+	background-color: var(--color-highlight);
+	border-color: var(--color-highlight);
+	color: var(--color-text-inverted);
+}
+
+.pressed .addon {
+	border-left-color: var(--color-highlight-border);
+}
+
+.popup {
+	padding-right: calc(var(--line-height-base) + 3 * var(--spacing-regular));
+	position: relative;
+}
+
+.addon {
+	border-left: var(--border-width) solid var(--color-border);
+	line-height: var(--line-height-base);
+	padding: var(--spacing-regular);
+	position: absolute;
+	right: 0;
+	text-align: center;
+	top: 0;
+	width: calc(var(--line-height-base) + 2 * var(--spacing-regular)); /* square icon addons */
+	transition: border var(--transition-duration) var(--transition-easing);
+}
+
+.disabled,
+.disabled:hover {
+	background-color: initial;
+	border-color: var(--color-border);
+	box-shadow: none;
+	color: var(--color-text-faded);
+	cursor: default;
+}

--- a/src/theme/dojo/outlined-button.m.css
+++ b/src/theme/dojo/outlined-button.m.css
@@ -26,11 +26,6 @@
 	color: var(--color-text-inverted);
 }
 
-.popup {
-	padding-right: calc(var(--line-height-base) + 3 * var(--spacing-regular));
-	position: relative;
-}
-
 .disabled,
 .disabled:hover {
 	background-color: initial;

--- a/src/theme/dojo/outlined-button.m.css
+++ b/src/theme/dojo/outlined-button.m.css
@@ -11,7 +11,6 @@
 	line-height: var(--line-height-base);
 	min-width: calc(var(--grid-base) * 20);
 	padding: var(--spacing-regular);
-	transition: box-shadow var(--transition-duration) var(--transition-easing);
 	margin: 0;
 }
 
@@ -21,19 +20,10 @@
 	outline: none;
 }
 
-.root:hover .addon,
-.root:focus .addon {
-	border-left-color: var(--color-highlight);
-}
-
 .pressed {
 	background-color: var(--color-highlight);
 	border-color: var(--color-highlight);
 	color: var(--color-text-inverted);
-}
-
-.pressed .addon {
-	border-left-color: var(--color-highlight-border);
 }
 
 .popup {
@@ -41,23 +31,10 @@
 	position: relative;
 }
 
-.addon {
-	border-left: var(--border-width) solid var(--color-border);
-	line-height: var(--line-height-base);
-	padding: var(--spacing-regular);
-	position: absolute;
-	right: 0;
-	text-align: center;
-	top: 0;
-	width: calc(var(--line-height-base) + 2 * var(--spacing-regular)); /* square icon addons */
-	transition: border var(--transition-duration) var(--transition-easing);
-}
-
 .disabled,
 .disabled:hover {
 	background-color: initial;
 	border-color: var(--color-border);
-	box-shadow: none;
 	color: var(--color-text-faded);
 	cursor: default;
 }

--- a/src/theme/dojo/outlined-button.m.css.d.ts
+++ b/src/theme/dojo/outlined-button.m.css.d.ts
@@ -1,0 +1,5 @@
+export const root: string;
+export const addon: string;
+export const pressed: string;
+export const popup: string;
+export const disabled: string;

--- a/src/theme/dojo/outlined-button.m.css.d.ts
+++ b/src/theme/dojo/outlined-button.m.css.d.ts
@@ -1,5 +1,4 @@
 export const root: string;
-export const addon: string;
 export const pressed: string;
 export const popup: string;
 export const disabled: string;

--- a/src/theme/dojo/outlined-button.m.css.d.ts
+++ b/src/theme/dojo/outlined-button.m.css.d.ts
@@ -1,4 +1,3 @@
 export const root: string;
 export const pressed: string;
-export const popup: string;
 export const disabled: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR adds the Dojo theme for the OutlinedButton widget. It ticks a box for #952 which aims to add a Dojo theme for all the widgets.

![Screenshot_20200103_123604](https://user-images.githubusercontent.com/8822075/71723790-daef3980-2e25-11ea-9481-a711a386d0ef.png)

![Screenshot_20200103_123616](https://user-images.githubusercontent.com/8822075/71723769-d034a480-2e25-11ea-88fc-89c2d9aeb1bf.png)
![Screenshot_20200103_123628](https://user-images.githubusercontent.com/8822075/71723774-d32f9500-2e25-11ea-9456-9672ad4e63d5.png)

