### PR TITLE
Menu dividers

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -54,6 +54,7 @@ import BasicIcons from './widgets/icon/Basic';
 import BasicLabel from './widgets/label/Basic';
 import BasicListbox from './widgets/listbox/Basic';
 import BasicMenu from './widgets/menu/Basic';
+import DividedMenu from './widgets/menu/Dividers';
 import ControlledMenu from './widgets/menu/Controlled';
 import ItemRenderer from './widgets/menu/ItemRenderer';
 import LargeOptionSet from './widgets/menu/LargeOptionSet';
@@ -510,6 +511,13 @@ export const config = {
 					filename: 'LargeOptionSet',
 					module: LargeOptionSet,
 					title: '100,000 options'
+				},
+				{
+					description:
+						'This example shows usage of the divider property on a menu item to trigger the menu to render with a divider after that item',
+					filename: 'Dividers',
+					module: DividedMenu,
+					title: 'Dividers'
 				}
 			],
 			overview: {

--- a/src/examples/src/widgets/menu/Dividers.tsx
+++ b/src/examples/src/widgets/menu/Dividers.tsx
@@ -1,0 +1,27 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Menu from '@dojo/widgets/menu';
+import icache from '@dojo/framework/core/middleware/icache';
+
+const factory = create({ icache });
+
+export default factory(function Dividers({ middleware: { icache } }) {
+	const options = [
+		{ value: 'Save' },
+		{ value: 'Delete', divider: true },
+		{ value: 'copy', label: 'Copy' },
+		{ value: 'Paste', disabled: true, divider: true },
+		{ value: 'Edit' }
+	];
+
+	return (
+		<virtual>
+			<Menu
+				options={options}
+				onValue={(value) => {
+					icache.set('value', value);
+				}}
+			/>
+			<p>{`Clicked on: ${icache.getOrSet('value', '')}`}</p>{' '}
+		</virtual>
+	);
+});

--- a/src/examples/src/widgets/menu/Dividers.tsx
+++ b/src/examples/src/widgets/menu/Dividers.tsx
@@ -20,6 +20,7 @@ export default factory(function Dividers({ middleware: { icache } }) {
 				onValue={(value) => {
 					icache.set('value', value);
 				}}
+				total={options.length}
 			/>
 			<p>{`Clicked on: ${icache.getOrSet('value', '')}`}</p>{' '}
 		</virtual>

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -16,7 +16,7 @@ import MenuItem from './MenuItem';
 export type MenuOption = { value: string; label?: string; disabled?: boolean; divider?: boolean };
 
 export interface MenuProperties {
-	/** Options to display within the menu. An option with `divider: true` will have a divider rendered after it in the menu */
+	/** Options to display within the menu. The `value` of the option will be passed to `onValue` when it is selected. The label is an optional display string to be used instead of the `value`. If `disabled` is true the option will have a disabled style and will not be selectable. An option with `divider: true` will have a divider rendered after it in the menu */
 	options: MenuOption[];
 	/** The total number of options provided */
 	total: number;

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -239,7 +239,7 @@ export const Menu = factory(function Menu({
 			</MenuItem>
 		);
 
-		return divider ? item : [item, <hr classes={classes.divider} />];
+		return divider ? [item, <hr classes={classes.divider} />] : item;
 	}
 
 	if (initialValue !== undefined && initialValue !== icache.get('initial')) {

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -13,7 +13,7 @@ import * as fixedCss from './menu.m.css';
 import ListBoxItem from './ListBoxItem';
 import MenuItem from './MenuItem';
 
-export type MenuOption = { value: string; label?: string; disabled?: boolean };
+export type MenuOption = { value: string; label?: string; disabled?: boolean; divider?: boolean };
 
 export interface MenuProperties {
 	/** Options to display within the menu */
@@ -214,7 +214,7 @@ export const Menu = factory(function Menu({
 			  })
 			: label || value;
 
-		return listBox ? (
+		const item = listBox ? (
 			<ListBoxItem
 				{...itemProps}
 				selected={selected}
@@ -238,6 +238,8 @@ export const Menu = factory(function Menu({
 				{children}
 			</MenuItem>
 		);
+
+		return divider ? item : [item, <hr classes={classes.divider} />];
 	}
 
 	if (initialValue !== undefined && initialValue !== icache.get('initial')) {

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -16,7 +16,7 @@ import MenuItem from './MenuItem';
 export type MenuOption = { value: string; label?: string; disabled?: boolean; divider?: boolean };
 
 export interface MenuProperties {
-	/** Options to display within the menu */
+	/** Options to display within the menu. An option with `divider: true` will have a divider rendered after it in the menu */
 	options: MenuOption[];
 	/** The total number of options provided */
 	total: number;
@@ -188,7 +188,7 @@ export const Menu = factory(function Menu({
 	}
 
 	function renderItem(index: number) {
-		const { value, label, disabled = false } = options[index];
+		const { value, label, divider, disabled = false } = options[index];
 		const selected = value === selectedValue;
 		const active = index === computedActiveIndex;
 		const itemProps = {

--- a/src/menu/tests/Menu.spec.tsx
+++ b/src/menu/tests/Menu.spec.tsx
@@ -295,6 +295,7 @@ describe('Menu - ListBox', () => {
 			<Menu
 				onValue={noop}
 				listBox
+				total={animalOptions.length}
 				options={[{ ...animalOptions[0], divider: true }, ...animalOptions.slice(1)]}
 			/>
 		));

--- a/src/menu/tests/Menu.spec.tsx
+++ b/src/menu/tests/Menu.spec.tsx
@@ -290,6 +290,17 @@ describe('Menu - ListBox', () => {
 		h.expect(template);
 	});
 
+	it('renders options with dividers', () => {
+		const h = harness(() => (
+			<Menu
+				onValue={noop}
+				listBox
+				options={[{ ...animalOptions[0], divider: true }, ...animalOptions.slice(1)]}
+			/>
+		));
+		h.expect(template.insertAfter('@item-0', () => [<hr classes={css.divider} />]));
+	});
+
 	it('takes a custom renderer', () => {
 		const h = harness(() => (
 			<Menu

--- a/src/theme/default/menu.m.css
+++ b/src/theme/default/menu.m.css
@@ -4,5 +4,6 @@
 	position: relative;
 }
 
+/* Class for dividers between menu options */
 .divider {
 }

--- a/src/theme/default/menu.m.css
+++ b/src/theme/default/menu.m.css
@@ -3,3 +3,6 @@
 	overflow: auto;
 	position: relative;
 }
+
+.divider {
+}

--- a/src/theme/default/menu.m.css.d.ts
+++ b/src/theme/default/menu.m.css.d.ts
@@ -1,1 +1,2 @@
 export const menu: string;
+export const divider: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds a `divider` property to menu items that renders an `hr` element after the item if true.
Resolves #939 