### PR TITLE
Dojo Theme for Checkbox Group

### DIFF
--- a/src/theme/dojo/checkbox-group.m.css
+++ b/src/theme/dojo/checkbox-group.m.css
@@ -1,0 +1,9 @@
+@import './variables.css';
+
+.root {
+	padding-top: var(--spacing-regular);
+	padding-bottom: var(--spacing-regular);
+}
+
+.legend {
+}

--- a/src/theme/dojo/checkbox-group.m.css
+++ b/src/theme/dojo/checkbox-group.m.css
@@ -6,4 +6,5 @@
 }
 
 .legend {
+	composes: root from './label.m.css';
 }

--- a/src/theme/dojo/checkbox-group.m.css.d.ts
+++ b/src/theme/dojo/checkbox-group.m.css.d.ts
@@ -1,0 +1,2 @@
+export const root: string;
+export const legend: string;

--- a/src/theme/dojo/index.ts
+++ b/src/theme/dojo/index.ts
@@ -2,6 +2,7 @@ import * as accordionPane from './accordion-pane.m.css';
 import * as button from './button.m.css';
 import * as calendar from './calendar.m.css';
 import * as card from './card.m.css';
+import * as checkboxGroup from './checkbox-group.m.css';
 import * as checkbox from './checkbox.m.css';
 import * as chip from './chip.m.css';
 import * as combobox from './combobox.m.css';
@@ -45,6 +46,7 @@ export default {
 	'@dojo/widgets/button': button,
 	'@dojo/widgets/calendar': calendar,
 	'@dojo/widgets/card': card,
+	'@dojo/widgets/checkbox-group': checkboxGroup,
 	'@dojo/widgets/checkbox': checkbox,
 	'@dojo/widgets/chip': chip,
 	'@dojo/widgets/combobox': combobox,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

This PR adds the Dojo themining for the CheckboxGroup widget (tickbox of #952) . The styling is fairly minimal as the widget is a container for Checkboxs which are already styled.

![Screenshot_20200103_121612](https://user-images.githubusercontent.com/8822075/71723102-44ba1400-2e23-11ea-9546-dd209841f98f.png)
