### PR TITLE
Add chip to material theme

### DIFF
--- a/src/theme/material/index.ts
+++ b/src/theme/material/index.ts
@@ -4,6 +4,7 @@ import * as raisedButton from './raised-button.m.css';
 import * as outlinedButton from './outlined-button.m.css';
 import * as calendar from './calendar.m.css';
 import * as checkbox from './checkbox.m.css';
+import * as chip from './chip.m.css';
 import * as combobox from './combobox.m.css';
 import * as dialog from './dialog.m.css';
 import * as icon from './icon.m.css';
@@ -36,6 +37,7 @@ export default {
 	'@dojo/widgets/button': button,
 	'@dojo/widgets/calendar': calendar,
 	'@dojo/widgets/checkbox': checkbox,
+	'@dojo/widgets/chip': chip,
 	'@dojo/widgets/combobox': combobox,
 	'@dojo/widgets/dialog': dialog,
 	'@dojo/widgets/icon': icon,


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
I missed this when adding the material theme for chips