### PR TITLE
Added default background color menu widget

### DIFF
--- a/src/theme/default/menu.m.css
+++ b/src/theme/default/menu.m.css
@@ -2,6 +2,7 @@
 .menu {
 	overflow: auto;
 	position: relative;
+	background: var(--component-background);
 }
 
 /* Class for dividers between menu options */

--- a/src/theme/dojo/menu.m.css
+++ b/src/theme/dojo/menu.m.css
@@ -4,4 +4,5 @@
 	overflow: auto;
 	position: relative;
 	border: var(--border-width) solid var(--color-border);
+	background: var(--component-background);
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
In the select widget update the background color for the select widget was lost. This PR adds in  the default background color the was previously used in widget version 6 before the update: https://github.com/dojo/widgets/blob/v6.1.0/src/theme/select.m.css

<img width="745" alt="Screen Shot 2020-01-03 at 2 57 13 PM" src="https://user-images.githubusercontent.com/3914018/71754020-57d7de80-2e39-11ea-87c3-6486bd6d5cff.png">


Resolves #1002
