### PR TITLE
Convert Tooltip to functional widget

### DIFF
--- a/src/tooltip/tests/unit/Tooltip.spec.tsx
+++ b/src/tooltip/tests/unit/Tooltip.spec.tsx
@@ -1,6 +1,6 @@
 const { registerSuite } = intern.getInterface('object');
 
-import { w, tsx } from '@dojo/framework/core/vdom';
+import { tsx } from '@dojo/framework/core/vdom';
 import harness from '@dojo/framework/testing/harness';
 
 import Tooltip, { Orientation } from '../../index';

--- a/src/tooltip/tests/unit/Tooltip.spec.tsx
+++ b/src/tooltip/tests/unit/Tooltip.spec.tsx
@@ -1,6 +1,6 @@
 const { registerSuite } = intern.getInterface('object');
 
-import { v, w } from '@dojo/framework/core/vdom';
+import { w, tsx } from '@dojo/framework/core/vdom';
 import harness from '@dojo/framework/testing/harness';
 
 import Tooltip, { Orientation } from '../../index';
@@ -10,95 +10,56 @@ import * as fixedCss from '../../styles/tooltip.m.css';
 registerSuite('Tooltip', {
 	tests: {
 		'should construct Tooltip'() {
-			const h = harness(() => w(Tooltip, { content: '' }));
-			h.expect(() =>
-				v(
-					'div',
-					{
-						classes: [css.right, fixedCss.rootFixed, fixedCss.rightFixed]
-					},
-					[v('div', { key: 'target' }, []), null]
-				)
-			);
+			const h = harness(() => <Tooltip content="" />);
+			h.expect(() => (
+				<div classes={[css.right, fixedCss.rootFixed, fixedCss.rightFixed]}>
+					<div key="target" />
+				</div>
+			));
 		},
 
 		'should render content if open'() {
-			const h = harness(() =>
-				w(Tooltip, {
-					content: 'foobar',
-					open: true
-				})
-			);
+			const h = harness(() => <Tooltip content="foobar" open />);
 
-			h.expect(() =>
-				v(
-					'div',
-					{
-						classes: [css.right, fixedCss.rootFixed, fixedCss.rightFixed]
-					},
-					[
-						v('div', { key: 'target' }, []),
-						v(
-							'div',
-							{
-								key: 'content',
-								classes: [css.content, fixedCss.contentFixed]
-							},
-							['foobar']
-						)
-					]
-				)
-			);
+			h.expect(() => (
+				<div classes={[css.right, fixedCss.rootFixed, fixedCss.rightFixed]}>
+					<div key="target">
+						<div key="content" classes={[css.content, fixedCss.contentFixed]}>
+							foobar
+						</div>
+					</div>
+				</div>
+			));
 		},
 
 		'should render correct orientation'() {
-			const h = harness(() =>
-				w(Tooltip, {
-					orientation: Orientation.bottom,
-					content: 'foobar'
-				})
-			);
+			const h = harness(() => (
+				<Tooltip orientation={Orientation.bottom} content={'foobar'} />
+			));
 
-			h.expect(() =>
-				v(
-					'div',
-					{
-						classes: [css.bottom, fixedCss.rootFixed, fixedCss.bottomFixed]
-					},
-					[v('div', { key: 'target' }, []), null]
-				)
-			);
+			h.expect(() => (
+				<div classes={[css.bottom, fixedCss.rootFixed, fixedCss.bottomFixed]}>
+					<div key="target" />
+				</div>
+			));
 		},
 
 		'should render aria properties'() {
-			const h = harness(() =>
-				w(Tooltip, {
-					aria: { describedBy: 'foo' },
-					content: 'bar',
-					open: true
-				})
-			);
+			const h = harness(() => <Tooltip content="bar" open aria={{ describedBy: 'foo' }} />);
 
-			h.expect(() =>
-				v(
-					'div',
-					{
-						classes: [css.right, fixedCss.rootFixed, fixedCss.rightFixed]
-					},
-					[
-						v('div', { key: 'target' }, []),
-						v(
-							'div',
-							{
-								key: 'content',
-								'aria-describedby': 'foo',
-								classes: [css.content, fixedCss.contentFixed]
-							},
-							['bar']
-						)
-					]
-				)
-			);
+			h.expect(() => (
+				<div classes={[css.right, fixedCss.rootFixed, fixedCss.rightFixed]}>
+					<div key="target">
+						<div
+							key="content"
+							aria-describedby="foo"
+							classes={[css.content, fixedCss.contentFixed]}
+						>
+							bar
+						</div>
+					</div>
+				</div>
+			));
 		}
 	}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Converts the Tooltip widget to a functional widget along with the unit test. In turn this simplifies the widget slightly.
