### PR TITLE
Replace reset with resetHistory to remove Sinon deprecation warning

### DIFF
--- a/src/chip/tests/Chip.spec.tsx
+++ b/src/chip/tests/Chip.spec.tsx
@@ -242,8 +242,8 @@ describe('Chip', () => {
 		);
 
 		[Keys.Enter, Keys.Space, Keys.Left].forEach((which) => {
-			onClose.reset();
-			onClick.reset();
+			onClose.resetHistory();
+			onClick.resetHistory();
 			const closeEvent = {
 				which,
 				preventDefault: sinon.spy(),

--- a/src/combobox/tests/unit/ComboBox.spec.tsx
+++ b/src/combobox/tests/unit/ComboBox.spec.tsx
@@ -515,7 +515,7 @@ registerSuite('ComboBox', {
 				onResultSelect.calledTwice,
 				'enter does not trigger onResultSelect when menu is closed'
 			);
-			onValue.reset();
+			onValue.resetHistory();
 
 			h.trigger(`.${css.trigger}`, 'onclick', stubEvent);
 			h.trigger('@textinput', 'onKeyDown', Keys.Space, () => {});

--- a/src/dialog/tests/unit/Dialog.spec.tsx
+++ b/src/dialog/tests/unit/Dialog.spec.tsx
@@ -557,7 +557,7 @@ registerSuite('Dialog', {
 					active: true,
 					containsFocus: true
 				});
-				mockFocusSet.reset();
+				mockFocusSet.resetHistory();
 				h.expect(() => expected(true, true));
 				assert.isFalse(
 					mockFocusSet.called,
@@ -608,7 +608,7 @@ registerSuite('Dialog', {
 					active: true,
 					containsFocus: true
 				});
-				mockFocusSet.reset();
+				mockFocusSet.resetHistory();
 				h.expect(() => expected(true, true));
 				assert.isFalse(
 					mockFocusSet.called,

--- a/src/form/tests/unit/Form.spec.tsx
+++ b/src/form/tests/unit/Form.spec.tsx
@@ -219,7 +219,7 @@ describe('Form', () => {
 	);
 
 	beforeEach(() => {
-		onSubmit.reset();
+		onSubmit.resetHistory();
 	});
 
 	it('renders', () => {

--- a/src/form/tests/unit/FormMiddleware.spec.tsx
+++ b/src/form/tests/unit/FormMiddleware.spec.tsx
@@ -23,8 +23,8 @@ describe('Form Middleware', () => {
 	let form: ReturnType<typeof formMiddleware>['api'];
 
 	beforeEach(() => {
-		onSubmit.reset();
-		onValue.reset();
+		onSubmit.resetHistory();
+		onValue.resetHistory();
 
 		const { callback: iCacheCallback } = iCacheMiddleware();
 		const icache = iCacheCallback({

--- a/src/grid/tests/unit/Header.spec.tsx
+++ b/src/grid/tests/unit/Header.spec.tsx
@@ -435,7 +435,7 @@ describe('Header', () => {
 
 			h.trigger(`.${css.sort}`, 'onclick', {});
 			assert.isTrue(sorterStub.calledWith('firstName', 'desc'));
-			sorterStub.reset();
+			sorterStub.resetHistory();
 
 			h.trigger(`.${css.sortable}`, 'onclick', {});
 			assert.isTrue(sorterStub.calledWith('firstName', 'desc'));
@@ -459,7 +459,7 @@ describe('Header', () => {
 
 			h.trigger(`.${css.sort}`, 'onclick', {});
 			assert.isTrue(sorterStub.calledWith('firstName', 'asc'));
-			sorterStub.reset();
+			sorterStub.resetHistory();
 
 			h.trigger(`.${css.sortable}`, 'onclick', {});
 			assert.isTrue(sorterStub.calledWith('firstName', 'asc'));
@@ -483,7 +483,7 @@ describe('Header', () => {
 
 			h.trigger(`.${css.sort}`, 'onclick', {});
 			assert.isTrue(sorterStub.calledWith('firstName', 'desc'));
-			sorterStub.reset();
+			sorterStub.resetHistory();
 
 			h.trigger(`.${css.sortable}`, 'onclick', {});
 			assert.isTrue(sorterStub.calledWith('firstName', 'desc'));

--- a/src/select/tests/Select.spec.tsx
+++ b/src/select/tests/Select.spec.tsx
@@ -175,15 +175,15 @@ describe('Select', () => {
 
 		triggerRenderResult.properties.onkeydown({ which: Keys.Down, preventDefault: stub() });
 		assert.isTrue(toggleOpenStub.calledOnce);
-		toggleOpenStub.reset();
+		toggleOpenStub.resetHistory();
 
 		triggerRenderResult.properties.onkeydown({ which: Keys.Space, preventDefault: stub() });
 		assert.isTrue(toggleOpenStub.calledOnce);
-		toggleOpenStub.reset();
+		toggleOpenStub.resetHistory();
 
 		triggerRenderResult.properties.onkeydown({ which: Keys.Enter, preventDefault: stub() });
 		assert.isTrue(toggleOpenStub.calledOnce);
-		toggleOpenStub.reset();
+		toggleOpenStub.resetHistory();
 
 		triggerRenderResult.properties.onkeydown({ which: Keys.Left });
 		triggerRenderResult.properties.onkeydown({ which: Keys.Right });


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

In Sinon 5, `reset` is deprecated and `resetHistory` is preferred. This PR silences the deprecation warnings whilst testing.

Example warnings:
![Screenshot_20200113_200955](https://user-images.githubusercontent.com/8822075/72288303-ac046f00-3640-11ea-8e15-64396e4262b4.png)

