### PR TITLE
Convert Card to functional widget

### DIFF
--- a/src/card/index.tsx
+++ b/src/card/index.tsx
@@ -1,29 +1,26 @@
-import { WidgetBase } from '@dojo/framework/core/WidgetBase';
-import { tsx } from '@dojo/framework/core/vdom';
+import { tsx, create } from '@dojo/framework/core/vdom';
 import { RenderResult } from '@dojo/framework/core/interfaces';
-import { alwaysRender } from '@dojo/framework/core/decorators/alwaysRender';
-import { ThemedMixin, theme, ThemedProperties } from '@dojo/framework/core/mixins/Themed';
 import * as css from '../theme/default/card.m.css';
-import { DNode } from '@dojo/framework/core/interfaces';
+import theme from '../middleware/theme';
+import { ThemedProperties } from '@dojo/framework/core/mixins/Themed';
 
 export interface CardProperties extends ThemedProperties {
 	/** Renderer for action available from the card */
 	actionsRenderer?(): RenderResult;
 }
 
-@theme(css)
-@alwaysRender()
-export class Card extends ThemedMixin(WidgetBase)<CardProperties> {
-	protected render(): DNode {
-		const { actionsRenderer } = this.properties;
-		const actionsResult = actionsRenderer && actionsRenderer();
-		return (
-			<div key="root" classes={this.theme(css.root)}>
-				{this.children}
-				{actionsResult && <div classes={this.theme(css.actions)}>{actionsResult}</div>}
-			</div>
-		);
-	}
-}
+const factory = create({ theme }).properties<CardProperties>();
+
+export const Card = factory(function Card({ children, properties, middleware: { theme } }) {
+	const { actionsRenderer } = properties();
+	const classes = theme.classes(css);
+
+	return (
+		<div key="root" classes={[classes.root]}>
+			{children()}
+			{actionsRenderer && <div classes={[classes.actions]}>{actionsRenderer()}</div>}
+		</div>
+	);
+});
 
 export default Card;

--- a/src/card/tests/unit/Card.spec.tsx
+++ b/src/card/tests/unit/Card.spec.tsx
@@ -7,7 +7,7 @@ import Button from '../../../button/index';
 import * as css from '../../../theme/default/card.m.css';
 
 describe('Card', () => {
-	const template = assertionTemplate(() => <div key="root" classes={css.root} />);
+	const template = assertionTemplate(() => <div key="root" classes={[css.root]} />);
 
 	it('renders', () => {
 		const h = harness(() => <Card />);
@@ -24,9 +24,9 @@ describe('Card', () => {
 		const h = harness(() => (
 			<Card actionsRenderer={() => <Button>test</Button>}>Hello, World</Card>
 		));
-		const childrenTemplate = template.setChildren('@root', [
+		const childrenTemplate = template.setChildren('@root', () => [
 			'Hello, World',
-			<div classes={css.actions}>
+			<div classes={[css.actions]}>
 				<Button>test</Button>
 			</div>
 		]);


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Converts the `Card` widget to a functional component