### PR TITLE
password input - make rules optional, fix submit, add tests

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -70,6 +70,7 @@ import BasicOutlinedButton from './widgets/outlined-button/Basic';
 import OutlinedDisabledSubmit from './widgets/outlined-button/DisabledSubmit';
 import OutlinedToggleButton from './widgets/outlined-button/ToggleButton';
 import BasicPassword from './widgets/password-input/Basic';
+import NoRules from './widgets/password-input/NoRules';
 import BasicTriggerPopup from './widgets/trigger-popup/Basic';
 import MenuTriggerPopup from './widgets/trigger-popup/MenuPopup';
 import SetWidth from './widgets/trigger-popup/SetWidth';
@@ -602,7 +603,14 @@ export const config = {
 					filename: 'Basic',
 					module: BasicPassword
 				}
-			}
+			},
+			examples: [
+				{
+					title: 'No Rules',
+					filename: 'NoRules',
+					module: NoRules
+				}
+			]
 		},
 		'trigger-popup': {
 			overview: {

--- a/src/examples/src/widgets/password-input/NoRules.tsx
+++ b/src/examples/src/widgets/password-input/NoRules.tsx
@@ -1,0 +1,18 @@
+import icache from '@dojo/framework/core/middleware/icache';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import PasswordInput from '@dojo/widgets/password-input';
+
+const factory = create({ icache });
+
+export default factory(function NoRules({ middleware: { icache } }) {
+	const value = icache.getOrSet('value', '');
+
+	return (
+		<PasswordInput
+			value={value}
+			required
+			onValue={(value) => icache.set('value', value)}
+			label="Enter Password"
+		/>
+	);
+});

--- a/src/password-input/index.tsx
+++ b/src/password-input/index.tsx
@@ -6,11 +6,19 @@ import ConstrainedInput, { ConstrainedInputProperties } from '../constrained-inp
 import theme from '../middleware/theme';
 import * as css from '../theme/default/password-input.m.css';
 import * as textInputCss from '../theme/default/text-input.m.css';
+import TextInput from '../text-input';
+import { ValidationRules } from '../middleware/validation';
 
-export interface PasswordInputProperties extends Exclude<ConstrainedInputProperties, 'type'> {}
+export type Omit<T, E> = Pick<T, Exclude<keyof T, E>>;
+
+export interface PasswordInputProperties
+	extends Omit<ConstrainedInputProperties, 'type' | 'rules'> {
+	rules?: ValidationRules;
+}
 
 export interface PasswordInputState {
 	showPassword: boolean;
+	valid: { valid?: boolean; message?: string } | undefined;
 }
 
 const factory = create({
@@ -26,6 +34,7 @@ export const PasswordInput = factory(function PasswordInput({
 
 	const trailing = (
 		<Button
+			type="button"
 			onClick={() => {
 				icache.set('showPassword', !showPassword);
 			}}
@@ -35,8 +44,25 @@ export const PasswordInput = factory(function PasswordInput({
 		</Button>
 	);
 
-	return (
+	const handleValidation = (valid?: boolean, message?: string) => {
+		icache.set('valid', { valid, message });
+		props.onValidate && props.onValidate(valid);
+	};
+
+	return props.rules ? (
 		<ConstrainedInput
+			{...props}
+			rules={props.rules}
+			key="root"
+			type={showPassword ? 'text' : 'password'}
+			theme={theme.compose(
+				textInputCss,
+				css
+			)}
+			trailing={() => trailing}
+		/>
+	) : (
+		<TextInput
 			{...props}
 			key="root"
 			type={showPassword ? 'text' : 'password'}
@@ -45,6 +71,8 @@ export const PasswordInput = factory(function PasswordInput({
 				css
 			)}
 			trailing={() => trailing}
+			onValidate={handleValidation}
+			valid={icache.get('valid')}
 		/>
 	);
 });

--- a/src/password-input/index.tsx
+++ b/src/password-input/index.tsx
@@ -34,7 +34,6 @@ export const PasswordInput = factory(function PasswordInput({
 
 	const trailing = (
 		<Button
-			type="button"
 			onClick={() => {
 				icache.set('showPassword', !showPassword);
 			}}

--- a/src/password-input/tests/unit/password-input.spec.tsx
+++ b/src/password-input/tests/unit/password-input.spec.tsx
@@ -75,7 +75,6 @@ describe('PasswordInput', () => {
 			() => (
 				<Button
 					onClick={() => {}}
-					type="button"
 					classes={{ '@dojo/widgets/button': { root: [css.togglePasswordButton] } }}
 				>
 					<Icon type="eyeIcon" />
@@ -101,7 +100,6 @@ describe('PasswordInput', () => {
 			() => (
 				<Button
 					onClick={() => {}}
-					type="button"
 					classes={{ '@dojo/widgets/button': { root: [css.togglePasswordButton] } }}
 				>
 					<Icon type="eyeSlashIcon" />

--- a/src/password-input/tests/unit/password-input.spec.tsx
+++ b/src/password-input/tests/unit/password-input.spec.tsx
@@ -8,6 +8,7 @@ import * as css from '../../../theme/default/password-input.m.css';
 import PasswordInput from '../..';
 
 import { tsx } from '@dojo/framework/core/vdom';
+import TextInput from '../../../text-input';
 
 const { describe, it } = intern.getInterface('bdd');
 
@@ -23,6 +24,36 @@ describe('PasswordInput', () => {
 				type={'password'}
 				theme={{ '@dojo/widgets/text-input': textInputCss }}
 				trailing={() => undefined}
+			/>
+		));
+	});
+
+	it('renders a textinput when no rules are passed', () => {
+		const h = harness(() => <PasswordInput />, [compareTheme]);
+		h.expect(() => (
+			<TextInput
+				key="root"
+				type={'password'}
+				theme={{ '@dojo/widgets/text-input': textInputCss }}
+				trailing={() => undefined}
+				onValidate={() => undefined}
+				valid={undefined}
+			/>
+		));
+	});
+
+	it('handles required validation when no rules are passed', () => {
+		const h = harness(() => <PasswordInput required />, [compareTheme]);
+		h.trigger('@root', 'onValidate', false, 'this is required');
+		h.expect(() => (
+			<TextInput
+				key="root"
+				type={'password'}
+				theme={{ '@dojo/widgets/text-input': textInputCss }}
+				trailing={() => undefined}
+				onValidate={() => undefined}
+				required
+				valid={{ valid: false, message: 'this is required' }}
 			/>
 		));
 	});
@@ -44,6 +75,7 @@ describe('PasswordInput', () => {
 			() => (
 				<Button
 					onClick={() => {}}
+					type="button"
 					classes={{ '@dojo/widgets/button': { root: [css.togglePasswordButton] } }}
 				>
 					<Icon type="eyeIcon" />
@@ -69,6 +101,7 @@ describe('PasswordInput', () => {
 			() => (
 				<Button
 					onClick={() => {}}
+					type="button"
 					classes={{ '@dojo/widgets/button': { root: [css.togglePasswordButton] } }}
 				>
 					<Icon type="eyeSlashIcon" />

--- a/src/theme/dojo/password-input.m.css
+++ b/src/theme/dojo/password-input.m.css
@@ -19,4 +19,6 @@
 
 .root .trailing {
 	background: none;
+	padding-top: 0;
+	padding-bottom: 0;
 }


### PR DESCRIPTION
**Type:** enhancement

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

- makes rules optional, renders text-input when no rules present
- handles validation when using only a text-input
- adds tests
- fixes bug where button was submit type so forms would submit

Resolves #1020 
