### PR TITLE
Pass action and method to form

### DIFF
--- a/src/form/middleware.ts
+++ b/src/form/middleware.ts
@@ -33,6 +33,7 @@ export interface Field<S, K extends keyof S> {
 	valid(valid?: boolean, message?: string): Validity;
 	required(required?: boolean): boolean;
 	disabled(required?: boolean): boolean;
+	name: string;
 }
 
 function compareValidity(a: Validity, b: Validity) {
@@ -131,6 +132,7 @@ export const createFormMiddleware = <S extends FormValue = any>() => {
 					});
 				}
 				return {
+					name,
 					value: (newValue?: any): any => {
 						const values = icache.getOrSet('values', {}) as S;
 						if (newValue !== undefined && values[name] !== newValue) {

--- a/src/form/tests/unit/Form.spec.tsx
+++ b/src/form/tests/unit/Form.spec.tsx
@@ -503,4 +503,28 @@ describe('Form', () => {
 				.setProperty('@lastName', 'value', 'Bob')
 		);
 	});
+
+	it('sets action and method when passed', () => {
+		const h = harness(() => (
+			<Form action="test-url" method="get">
+				{() => <div />}
+			</Form>
+		));
+		const actionTemplate = assertionTemplate(() => (
+			<form classes={css.root} action="test-url" method="get">
+				<div />
+			</form>
+		));
+		h.expect(actionTemplate);
+	});
+
+	it('defaults method to post when using an action', () => {
+		const h = harness(() => <Form action="test-url">{() => <div />}</Form>);
+		const actionTemplate = assertionTemplate(() => (
+			<form classes={css.root} action="test-url" method="post">
+				<div />
+			</form>
+		));
+		h.expect(actionTemplate);
+	});
 });


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Allows the form widget to take an action and method to perform a standard web form post.

Resolves #1034 
