### PR TITLE
Fixing material dialog animation

### DIFF
--- a/src/theme/material/dialog.m.css
+++ b/src/theme/material/dialog.m.css
@@ -2,11 +2,11 @@
 
 /* The root class for the Dialog */
 .root {
-	composes: mdc-dialog from '@material/dialog/dist/mdc.dialog.css';
 }
 
 /* Added to `.root` for an open dialog */
 .open {
+	composes: mdc-dialog from '@material/dialog/dist/mdc.dialog.css';
 	composes: mdc-dialog--open from '@material/dialog/dist/mdc.dialog.css';
 }
 


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

There was a problem with the dialog exit animation using the material theme. The material theme had a `display: none` on the root of the dialog, so as soon as the dialog would close, the parent would be hidden, and thus the exit animation could never start, and therefore finish. This would leave the vdom in a weird state in that it was keeping the old nodes around waiting for the animation to finish.

