### PR TITLE
Material theme for tooltip

### DIFF
--- a/src/theme/material/tooltip.m.css
+++ b/src/theme/material/tooltip.m.css
@@ -1,2 +1,38 @@
+@import './variables.css';
+
+:root {
+	--mdc-tooltip-font-size: 0.975rem;
+}
+
 .root {
+	font-family: Roboto, sans-serif;
+}
+
+.content {
+	background-color: var(--mdc-theme-grey-background);
+	border-radius: var(--border-radius);
+	color: var(--mdc-theme-surface);
+	padding: calc(var(--spacing-regular) * 0.5) var(--spacing-regular);
+	font-size: 0.875rem;
+	line-height: calc(var(--mdc-tooltip-font-size) * 1.6);
+}
+
+.bottom .content {
+	margin: var(--spacing-regular) 0 0;
+	transform: translate(-50%, calc(100% + var(--grid-base)));
+}
+
+.top .content {
+	margin: 0 0 var(--spacing-regular);
+	transform: translate(-50%, calc(-100% - var(--grid-base)));
+}
+
+.left .content {
+	margin: 0 var(--spacing-regular) 0 0;
+	transform: translate(calc(-100% - var(--grid-base)), -50%);
+}
+
+.right .content {
+	margin: 0 0 0 var(--spacing-regular);
+	transform: translate(calc(100% + var(--grid-base)), -50%);
 }

--- a/src/theme/material/tooltip.m.css
+++ b/src/theme/material/tooltip.m.css
@@ -1,38 +1,47 @@
 @import './variables.css';
 
 :root {
-	--mdc-tooltip-font-size: 0.975rem;
+	/* Spacing */
+	--mdc-tooltip-grid-base: 8px;
+	--mdc-tooltip-spacing-regular: var(--grid-base);
+
+	/* Color */
+	--mdc-tooltip-grey-background: rgba(97, 97, 97, 0.9); /* The theme grey background color */
+
+	/* Border */
+	--mdc-tooltip-border-radius: 6px;
 }
 
 .root {
-	font-family: Roboto, sans-serif;
+	font-family: var(--mdc-theme-font-family);
 }
 
 .content {
-	background-color: var(--mdc-theme-grey-background);
-	border-radius: var(--border-radius);
+	background-color: var(--mdc-tooltip-grey-background);
+	border-radius: var(--mdc-tooltip-border-radius);
 	color: var(--mdc-theme-surface);
-	padding: calc(var(--spacing-regular) * 0.5) var(--spacing-regular);
-	font-size: 0.875rem;
+	padding: var(--mdc-tooltip-spacing-regular) calc(var(--mdc-tooltip-spacing-regular) * 2);
+	font-size: var(--mdc-theme-font-size-small);
 	line-height: calc(var(--mdc-tooltip-font-size) * 1.6);
+	z-index: var(--zindex-tooltip);
 }
 
 .bottom .content {
-	margin: var(--spacing-regular) 0 0;
-	transform: translate(-50%, calc(100% + var(--grid-base)));
+	margin: var(--mdc-tooltip-spacing-regular) 0 0;
+	transform: translate(-50%, calc(100% + var(--mdc-tooltip-grid-base)));
 }
 
 .top .content {
-	margin: 0 0 var(--spacing-regular);
-	transform: translate(-50%, calc(-100% - var(--grid-base)));
+	margin: 0 0 var(--mdc-tooltip-spacing-regular);
+	transform: translate(-50%, calc(-100% - var(--mdc-tooltip-grid-base)));
 }
 
 .left .content {
-	margin: 0 var(--spacing-regular) 0 0;
-	transform: translate(calc(-100% - var(--grid-base)), -50%);
+	margin: 0 var(--mdc-tooltip-spacing-regular) 0 0;
+	transform: translate(calc(-100% - var(--mdc-tooltip-grid-base)), -50%);
 }
 
 .right .content {
-	margin: 0 0 0 var(--spacing-regular);
-	transform: translate(calc(100% + var(--grid-base)), -50%);
+	margin: 0 0 0 var(--mdc-tooltip-spacing-regular);
+	transform: translate(calc(100% + var(--mdc-tooltip-grid-base)), -50%);
 }

--- a/src/theme/material/tooltip.m.css.d.ts
+++ b/src/theme/material/tooltip.m.css.d.ts
@@ -1,1 +1,6 @@
 export const root: string;
+export const content: string;
+export const bottom: string;
+export const top: string;
+export const left: string;
+export const right: string;

--- a/src/theme/material/variables.css
+++ b/src/theme/material/variables.css
@@ -1,4 +1,9 @@
 :root {
+	/* Spacing */
+	--grid-base: 8px;
+	--spacing-regular: var(--grid-base);
+
+	/* Color */
 	--mdc-theme-primary: rgb(0, 142, 231); /* The theme primary color */
 	--mdc-theme-secondary: rgb(169, 49, 182); /* The theme secondary color */
 	--mdc-theme-background: #fff; /* The theme background color */
@@ -6,6 +11,10 @@
 	--mdc-theme-on-primary: #fff; /* Text color on top of a primary background */
 	--mdc-theme-on-secondary: #fff; /* Text color on top of a secondary background */
 	--mdc-theme-on-surface: #000; /* Text color on top of a surface background */
+	--mdc-theme-grey-background: rgba(97, 97, 97, 0.9); /* The theme grey background color */
+
+	/* Border */
+	--border-radius: 6px;
 
 	--zindex-dialog: 400;
 }

--- a/src/theme/material/variables.css
+++ b/src/theme/material/variables.css
@@ -1,8 +1,4 @@
 :root {
-	/* Spacing */
-	--grid-base: 8px;
-	--spacing-regular: var(--grid-base);
-
 	/* Color */
 	--mdc-theme-primary: rgb(0, 142, 231); /* The theme primary color */
 	--mdc-theme-secondary: rgb(169, 49, 182); /* The theme secondary color */
@@ -11,10 +7,10 @@
 	--mdc-theme-on-primary: #fff; /* Text color on top of a primary background */
 	--mdc-theme-on-secondary: #fff; /* Text color on top of a secondary background */
 	--mdc-theme-on-surface: #000; /* Text color on top of a surface background */
-	--mdc-theme-grey-background: rgba(97, 97, 97, 0.9); /* The theme grey background color */
 
-	/* Border */
-	--border-radius: 6px;
+	--mdc-theme-font-family: Roboto, sans-serif;
+	--mdc-theme-font-size-small: 0.875rem;
 
+	--zindex-tooltip: 100;
 	--zindex-dialog: 400;
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds basic material theme for the Tooltip widget.

Resolves #1041

![Jan-17-2020 16-23-41](https://user-images.githubusercontent.com/1054198/72650656-bc6d6000-3946-11ea-838b-df1208062357.gif)
