### PR TITLE
Add name and value to trigger button on select component

### DIFF
--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -43,6 +43,8 @@ interface SelectProperties {
 	required?: boolean;
 	/** Callabck when valid state has changed */
 	onValidate?(valid: boolean): void;
+	/** The name property of the input */
+	name?: string;
 }
 
 interface SelectICache {
@@ -77,7 +79,8 @@ export const Select = factory(function Select({
 		options,
 		placeholder = '',
 		position,
-		required
+		required,
+		name
 	} = properties();
 
 	if (initialValue !== undefined && initialValue !== icache.get('initial')) {
@@ -156,6 +159,8 @@ export const Select = factory(function Select({
 
 						return (
 							<button
+								name={name}
+								value={icache.get('value')}
 								focus={() => focusNode === 'trigger' && shouldFocus}
 								aria-controls={menuId}
 								aria-haspopup="listbox"

--- a/src/select/tests/Select.spec.tsx
+++ b/src/select/tests/Select.spec.tsx
@@ -47,6 +47,8 @@ const buttonTemplate = assertionTemplate(() => (
 		classes={css.trigger}
 		onclick={() => {}}
 		onkeydown={() => {}}
+		name={undefined}
+		value={undefined}
 	>
 		<span classes={css.value}>
 			<span classes={css.placeholder} />


### PR DESCRIPTION
**Type:** Feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds name and value to the trigger button on the select component

Resolves #1045 
