### PR TITLE
Adding functional text area

### DIFF
--- a/src/text-area/index.tsx
+++ b/src/text-area/index.tsx
@@ -1,17 +1,15 @@
-import { WidgetBase } from '@dojo/framework/core/WidgetBase';
-import { DNode } from '@dojo/framework/core/interfaces';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
-import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
-import { v, w } from '@dojo/framework/core/vdom';
-import Focus from '../meta/Focus';
+import { create, tsx } from '@dojo/framework/core/vdom';
 import Label from '../label/index';
 import { formatAriaProperties } from '../common/util';
 import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/default/text-area.m.css';
 import HelperText from '../helper-text/index';
-import { InputValidity } from '@dojo/framework/core/meta/InputValidity';
+import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
+import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
+import focus from '@dojo/framework/core/middleware/focus';
+import validity from '@dojo/framework/core/middleware/validity';
 
-export interface TextAreaProperties extends ThemedProperties, FocusProperties {
+export interface TextAreaProperties extends ThemeProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Number of columns, controls the width of the textarea */
@@ -32,24 +30,34 @@ export interface TextAreaProperties extends ThemedProperties, FocusProperties {
 	minLength?: number | string;
 	/** The name of the field */
 	name?: string;
+
 	/** Handler for when the element is blurred */
 	onBlur?(): void;
+
 	/** Handler of when the element is clicked */
 	onClick?(): void;
+
 	/** Handler for when the element is focused */
 	onFocus?(): void;
+
 	/** Handler for when a key is depressed in the element */
 	onKeyDown?(key: number, preventDefault: () => void): void;
+
 	/** Handler for when a key is released in the element */
 	onKeyUp?(key: number, preventDefault: () => void): void;
+
 	/** Handler for when the pointer moves out of the element */
 	onOut?(): void;
+
 	/** Handler for when the pointer moves over the element */
 	onOver?(): void;
+
 	/** Called when TextArea's state is validated */
 	onValidate?: (valid: boolean | undefined, message: string) => void;
+
 	/** Handler for when the value of the widget changes */
 	onValue?(value?: string): void;
+
 	/** Placeholder text displayed in an empty TextArea */
 	placeholder?: string;
 	/** Makes the field readonly (it may be focused but not changed) */
@@ -68,34 +76,25 @@ export interface TextAreaProperties extends ThemedProperties, FocusProperties {
 	wrapText?: 'hard' | 'soft' | 'off';
 }
 
-@theme(css)
-export class TextArea extends ThemedMixin(FocusMixin(WidgetBase))<TextAreaProperties> {
-	private _dirty = false;
+export interface TextAreaICache {
+	dirty: boolean;
+	uuid: string;
+}
 
-	private _onInput(event: Event) {
-		event.stopPropagation();
-		this.properties.onValue &&
-			this.properties.onValue((event.target as HTMLInputElement).value);
-	}
+const factory = create({
+	icache: createICacheMiddleware<TextAreaICache>(),
+	theme,
+	focus,
+	validity
+}).properties<TextAreaProperties>();
+export const TextArea = factory(function TextArea({
+	middleware: { icache, theme, focus, validity },
+	properties
+}) {
+	const themeCss = theme.classes(css);
 
-	private _onKeyDown(event: KeyboardEvent) {
-		event.stopPropagation();
-		this.properties.onKeyDown &&
-			this.properties.onKeyDown(event.which, () => {
-				event.preventDefault();
-			});
-	}
-
-	private _onKeyUp(event: KeyboardEvent) {
-		event.stopPropagation();
-		this.properties.onKeyUp &&
-			this.properties.onKeyUp(event.which, () => {
-				event.preventDefault();
-			});
-	}
-
-	private _callOnValidate(valid: boolean | undefined, message: string) {
-		let { valid: previousValid } = this.properties;
+	function callOnValidate(valid: boolean | undefined, message: string) {
+		let { valid: previousValid, onValidate } = properties();
 		let previousMessage: string | undefined;
 
 		if (typeof previousValid === 'object') {
@@ -104,20 +103,22 @@ export class TextArea extends ThemedMixin(FocusMixin(WidgetBase))<TextAreaProper
 		}
 
 		if (valid !== previousValid || message !== previousMessage) {
-			this.properties.onValidate && this.properties.onValidate(valid, message);
+			onValidate && onValidate(valid, message);
 		}
 	}
 
-	private _validate() {
-		const { customValidator, value = '' } = this.properties;
+	function validate() {
+		const { customValidator, value = '' } = properties();
+		const dirty = icache.getOrSet('dirty', false);
 
-		if (value === '' && !this._dirty) {
-			this._callOnValidate(undefined, '');
+		if (value === '' && !dirty) {
+			callOnValidate(undefined, '');
 			return;
 		}
 
-		this._dirty = true;
-		let { valid, message = '' } = this.meta(InputValidity).get('input', value);
+		icache.set('dirty', true);
+
+		let { valid, message = '' } = validity.get('input', value || '');
 		if (valid && customValidator) {
 			const customValid = customValidator(value);
 			if (customValid) {
@@ -125,11 +126,12 @@ export class TextArea extends ThemedMixin(FocusMixin(WidgetBase))<TextAreaProper
 				message = customValid.message || '';
 			}
 		}
-		this._callOnValidate(valid, message);
+
+		callOnValidate(valid, message);
 	}
 
-	protected get validity() {
-		const { valid = { valid: undefined, message: undefined } } = this.properties;
+	function getValidity() {
+		const { valid = { valid: undefined, message: undefined } } = properties();
 
 		if (typeof valid === 'boolean') {
 			return { valid, message: undefined };
@@ -141,130 +143,132 @@ export class TextArea extends ThemedMixin(FocusMixin(WidgetBase))<TextAreaProper
 		};
 	}
 
-	private _uuid = uuid();
-
-	protected getRootClasses(): (string | null)[] {
-		const { disabled, readOnly, required } = this.properties;
-		const focus = this.meta(Focus).get('root');
-		const { valid } = this.validity;
+	function getRootClasses(): (string | null)[] {
+		const { disabled, readOnly, required } = properties();
+		const { valid } = getValidity();
 		return [
-			css.root,
-			disabled ? css.disabled : null,
-			focus.containsFocus ? css.focused : null,
-			valid === false ? css.invalid : null,
-			valid === true ? css.valid : null,
-			readOnly ? css.readonly : null,
-			required ? css.required : null
+			themeCss.root,
+			disabled ? themeCss.disabled : null,
+			valid === false ? themeCss.invalid : null,
+			valid === true ? themeCss.valid : null,
+			readOnly ? themeCss.readonly : null,
+			required ? themeCss.required : null
 		];
 	}
 
-	render(): DNode {
-		const {
-			aria = {},
-			columns = 20,
-			disabled,
-			widgetId = this._uuid,
-			label,
-			maxLength,
-			minLength,
-			name,
-			placeholder,
-			readOnly,
-			required,
-			rows = 2,
-			value,
-			wrapText,
-			theme,
-			classes,
-			labelHidden,
-			helperText,
-			onValidate,
-			onBlur,
-			onFocus,
-			onClick,
-			onOver,
-			onOut
-		} = this.properties;
-		const focus = this.meta(Focus).get('root');
+	const {
+		aria = {},
+		columns = 20,
+		disabled,
+		widgetId = icache.getOrSet('uuid', uuid()),
+		label,
+		maxLength,
+		minLength,
+		name,
+		placeholder,
+		readOnly,
+		required,
+		rows = 2,
+		value,
+		wrapText,
+		theme: themeProp,
+		classes,
+		labelHidden,
+		helperText,
+		onValidate,
+		onBlur,
+		onFocus,
+		onClick,
+		onOver,
+		onOut
+	} = properties();
+	onValidate && validate();
+	const { valid, message } = getValidity();
 
-		onValidate && this._validate();
-		const { valid, message } = this.validity;
+	const computedHelperText = (valid === false && message) || helperText;
 
-		const computedHelperText = (valid === false && message) || helperText;
-
-		return v(
-			'div',
-			{
-				key: 'root',
-				classes: this.theme(this.getRootClasses())
-			},
-			[
-				label
-					? w(
-							Label,
-							{
-								theme,
-								classes,
-								disabled,
-								focused: focus.containsFocus,
-								valid,
-								readOnly,
-								required,
-								hidden: labelHidden,
-								forId: widgetId
-							},
-							[label]
-					  )
-					: null,
-				v('div', { classes: this.theme(css.inputWrapper) }, [
-					v('textarea', {
-						id: widgetId,
-						key: 'input',
-						...formatAriaProperties(aria),
-						classes: this.theme(css.input),
-						cols: `${columns}`,
-						disabled,
-						focus: this.shouldFocus,
-						'aria-invalid': valid === false ? 'true' : null,
-						maxlength: maxLength ? `${maxLength}` : null,
-						minlength: minLength ? `${minLength}` : null,
-						name,
-						placeholder,
-						readOnly,
-						'aria-readonly': readOnly ? 'true' : null,
-						required,
-						rows: `${rows}`,
-						value,
-						wrap: wrapText,
-						onblur: () => {
-							onBlur && onBlur();
-						},
-						onfocus: () => {
-							onFocus && onFocus();
-						},
-						oninput: this._onInput,
-						onkeydown: this._onKeyDown,
-						onkeyup: this._onKeyUp,
-						onclick: () => {
-							onClick && onClick();
-						},
-						onpointerenter: () => {
-							onOver && onOver();
-						},
-						onpointerleave: () => {
-							onOut && onOut();
-						}
-					})
-				]),
-				w(HelperText, {
-					text: computedHelperText,
-					valid,
-					classes,
-					theme
-				})
-			]
-		);
-	}
-}
+	return (
+		<div key="root" classes={getRootClasses()}>
+			{label ? (
+				<Label
+					theme={themeProp}
+					classes={classes}
+					disabled={disabled}
+					valid={valid}
+					readOnly={readOnly}
+					required={required}
+					hidden={labelHidden}
+					forId={widgetId}
+				>
+					{label}
+				</Label>
+			) : null}
+			<div classes={themeCss.inputWrapper}>
+				<textarea
+					id={widgetId}
+					key="input"
+					{...formatAriaProperties(aria)}
+					classes={themeCss.input}
+					cols={`${columns}`}
+					disabled={disabled}
+					focus={focus.shouldFocus}
+					aria-invalid={valid === false ? 'true' : null}
+					maxlength={maxLength ? `${maxLength}` : null}
+					minlength={minLength ? `${minLength}` : null}
+					name={name}
+					placeholder={placeholder}
+					readOnly={readOnly}
+					aria-readonly={readOnly ? 'true' : null}
+					required={required}
+					rows={`${rows}`}
+					value={value}
+					wrap={wrapText}
+					onblur={() => {
+						onBlur && onBlur();
+					}}
+					onfocus={() => {
+						onFocus && onFocus();
+					}}
+					oninput={(event: Event) => {
+						const { onValue } = properties();
+						event.stopPropagation();
+						onValue && onValue((event.target as HTMLInputElement).value);
+					}}
+					onkeydown={(event: KeyboardEvent) => {
+						const { onKeyDown } = properties();
+						event.stopPropagation();
+						onKeyDown &&
+							onKeyDown(event.which, () => {
+								event.preventDefault();
+							});
+					}}
+					onkeyup={(event: KeyboardEvent) => {
+						const { onKeyUp } = properties();
+						event.stopPropagation();
+						onKeyUp &&
+							onKeyUp(event.which, () => {
+								event.preventDefault();
+							});
+					}}
+					onclick={() => {
+						onClick && onClick();
+					}}
+					onpointerenter={() => {
+						onOver && onOver();
+					}}
+					onpointerleave={() => {
+						onOut && onOut();
+					}}
+				/>
+			</div>
+			<HelperText
+				text={computedHelperText}
+				valid={valid}
+				classes={classes}
+				theme={themeProp}
+			/>
+		</div>
+	);
+});
 
 export default TextArea;

--- a/src/text-area/index.tsx
+++ b/src/text-area/index.tsx
@@ -152,7 +152,8 @@ export const TextArea = factory(function TextArea({
 			valid === false ? themeCss.invalid : null,
 			valid === true ? themeCss.valid : null,
 			readOnly ? themeCss.readonly : null,
-			required ? themeCss.required : null
+			required ? themeCss.required : null,
+			focus.isFocused('input') ? themeCss.focused : null
 		];
 	}
 
@@ -199,6 +200,8 @@ export const TextArea = factory(function TextArea({
 					required={required}
 					hidden={labelHidden}
 					forId={widgetId}
+					focused={focus.isFocused('input')}
+					active={!!value || focus.isFocused('input')}
 				>
 					{label}
 				</Label>

--- a/src/text-area/index.tsx
+++ b/src/text-area/index.tsx
@@ -1,7 +1,6 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Label from '../label/index';
 import { formatAriaProperties } from '../common/util';
-import { uuid } from '@dojo/framework/core/util';
 import * as css from '../theme/default/text-area.m.css';
 import HelperText from '../helper-text/index';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
@@ -78,7 +77,6 @@ export interface TextAreaProperties extends ThemeProperties {
 
 export interface TextAreaICache {
 	dirty: boolean;
-	uuid: string;
 }
 
 const factory = create({
@@ -88,6 +86,7 @@ const factory = create({
 	validity
 }).properties<TextAreaProperties>();
 export const TextArea = factory(function TextArea({
+	id,
 	middleware: { icache, theme, focus, validity },
 	properties
 }) {
@@ -143,25 +142,11 @@ export const TextArea = factory(function TextArea({
 		};
 	}
 
-	function getRootClasses(): (string | null)[] {
-		const { disabled, readOnly, required } = properties();
-		const { valid } = getValidity();
-		return [
-			themeCss.root,
-			disabled ? themeCss.disabled : null,
-			valid === false ? themeCss.invalid : null,
-			valid === true ? themeCss.valid : null,
-			readOnly ? themeCss.readonly : null,
-			required ? themeCss.required : null,
-			focus.isFocused('input') ? themeCss.focused : null
-		];
-	}
-
 	const {
 		aria = {},
 		columns = 20,
 		disabled,
-		widgetId = icache.getOrSet('uuid', uuid()),
+		widgetId = `textarea-${id}`,
 		label,
 		maxLength,
 		minLength,
@@ -183,13 +168,25 @@ export const TextArea = factory(function TextArea({
 		onOver,
 		onOut
 	} = properties();
+
 	onValidate && validate();
 	const { valid, message } = getValidity();
 
 	const computedHelperText = (valid === false && message) || helperText;
 
 	return (
-		<div key="root" classes={getRootClasses()}>
+		<div
+			key="root"
+			classes={[
+				themeCss.root,
+				disabled ? themeCss.disabled : null,
+				valid === false ? themeCss.invalid : null,
+				valid === true ? themeCss.valid : null,
+				readOnly ? themeCss.readonly : null,
+				required ? themeCss.required : null,
+				focus.isFocused('input') ? themeCss.focused : null
+			]}
+		>
 			{label ? (
 				<Label
 					theme={themeProp}

--- a/src/text-area/tests/unit/TextArea.spec.tsx
+++ b/src/text-area/tests/unit/TextArea.spec.tsx
@@ -27,6 +27,7 @@ interface States {
 	required?: boolean;
 	readOnly?: boolean;
 	valid?: { valid?: boolean; message?: string } | boolean;
+	focused?: boolean;
 }
 
 const expected = function(
@@ -35,7 +36,7 @@ const expected = function(
 	states: States = {},
 	helperText?: string
 ) {
-	const { disabled, required, readOnly, valid: validState } = states;
+	const { disabled, required, readOnly, valid: validState, focused } = states;
 	let valid: boolean | undefined;
 	let message: string | undefined;
 
@@ -58,7 +59,8 @@ const expected = function(
 				valid === false ? css.invalid : null,
 				valid === true ? css.valid : null,
 				readOnly ? css.readonly : null,
-				required ? css.required : null
+				required ? css.required : null,
+				focused ? css.focused : null
 			]
 		},
 		[
@@ -73,7 +75,9 @@ const expected = function(
 							valid,
 							readOnly,
 							required,
-							forId: ''
+							forId: '',
+							active: false,
+							focused: false
 						},
 						['foo']
 				  )
@@ -114,7 +118,7 @@ const expected = function(
 };
 
 const baseAssertion = assertionTemplate(() => (
-	<div key="root" classes={[css.root, null, null, null, null, null]}>
+	<div key="root" classes={[css.root, null, null, null, null, null, null]}>
 		{textarea()}
 		<HelperText
 			assertion-key="helperText"
@@ -229,7 +233,8 @@ registerSuite('Textarea', {
 						css.invalid,
 						null,
 						css.readonly,
-						css.required
+						css.required,
+						null
 					])
 					.setProperty('@input', 'aria-invalid', 'true')
 					.setProperty('@input', 'aria-readonly', 'true')
@@ -247,7 +252,7 @@ registerSuite('Textarea', {
 			};
 			h.expect(
 				baseAssertion
-					.setProperty(':root', 'classes', [css.root, null, null, null, null, null])
+					.setProperty(':root', 'classes', [css.root, null, null, null, null, null, null])
 					.setProperty('@input', 'aria-invalid', null)
 					.setProperty('@input', 'aria-readonly', null)
 					.setProperty('@input', 'disabled', false)


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Converting `TextArea` to a functional widget. Next up is managed `value` support like the recent changes for `TextInput`.