### PR TITLE
Fixing issue with date input and new text input changes

### DIFF
--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -145,7 +145,7 @@ export default factory(function({ properties, middleware: { theme, icache, i18n,
 										</Button>
 									)}
 									type="text"
-									value={icache.get('inputValue')}
+									initialValue={icache.get('inputValue')}
 									onBlur={() => icache.set('shouldValidate', true)}
 									onValue={(v) => icache.set('inputValue', v || '')}
 									helperText={icache.get('validationMessage')}

--- a/src/date-input/tests/unit/DateInput.spec.tsx
+++ b/src/date-input/tests/unit/DateInput.spec.tsx
@@ -75,7 +75,7 @@ const buttonTemplate = assertionTemplate(() => {
 				onBlur={noop}
 				onValue={noop}
 				trailing={() => undefined}
-				value={formatDate(today)}
+				initialValue={formatDate(today)}
 				helperText=""
 				onKeyDown={noop}
 			/>
@@ -245,7 +245,7 @@ describe('DateInput', () => {
 			'@input',
 			h.trigger('@popup', (node) => (node.children as any)[0].trigger)
 		);
-		assert(input.properties.value, formatDate(expected));
+		assert(input.properties.initialValue, formatDate(expected));
 
 		// If `onValue` is called, the input was accepted & validated
 		sinon.assert.calledWith(onValue, formatDateISO(expected));


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

It looks like text input was merged after a new widget was added, and this new widget used a text input.  This PR is changing `value` of `DateInput` to use `initialValue` instead.