### PR TITLE
Do not deploy if the build fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,7 @@ addons:
 script:
 - npm run build
 - npm run test:ci
-- npm run build:examples
-- ./deploy.sh
-- ./comment-deployments.sh
+- npm run build:examples && ./deploy.sh && ./comment-deployments.sh
 - npm run uploadCoverage
 notifications:
   slack:


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Do not deploy documentation if build fails.