### PR TITLE
Adding managed text area value

### DIFF
--- a/src/examples/src/widgets/text-area/Basic.tsx
+++ b/src/examples/src/widgets/text-area/Basic.tsx
@@ -1,17 +1,8 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import icache from '@dojo/framework/core/middleware/icache';
 import TextArea from '@dojo/widgets/text-area';
 
-const factory = create({ icache });
+const factory = create();
 
-export default factory(function Basic({ middleware: { icache } }) {
-	const value = icache.getOrSet('value', '');
-	return (
-		<TextArea
-			value={value}
-			onValue={(value) => {
-				icache.set('value', value);
-			}}
-		/>
-	);
+export default factory(function Basic() {
+	return <TextArea />;
 });

--- a/src/examples/src/widgets/text-area/Disabled.tsx
+++ b/src/examples/src/widgets/text-area/Disabled.tsx
@@ -6,5 +6,5 @@ const factory = create({ icache });
 
 export default factory(function Disabled({ middleware: { icache } }) {
 	const value = icache.getOrSet('value', 'Initial value');
-	return <TextArea value={value} label="Can't type here" disabled={true} />;
+	return <TextArea initialValue={value} label="Can't type here" disabled={true} />;
 });

--- a/src/examples/src/widgets/text-area/HelperText.tsx
+++ b/src/examples/src/widgets/text-area/HelperText.tsx
@@ -1,19 +1,8 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import icache from '@dojo/framework/core/middleware/icache';
 import TextArea from '@dojo/widgets/text-area';
 
-const factory = create({ icache });
+const factory = create();
 
-export default factory(function HelperText({ middleware: { icache } }) {
-	const value = icache.getOrSet('value', '');
-	return (
-		<TextArea
-			value={value}
-			label="Has helper text"
-			helperText="Hi there, enter some text"
-			onValue={(value) => {
-				icache.set('value', value);
-			}}
-		/>
-	);
+export default factory(function HelperText() {
+	return <TextArea label="Has helper text" helperText="Hi there, enter some text" />;
 });

--- a/src/examples/src/widgets/text-area/HiddenLabel.tsx
+++ b/src/examples/src/widgets/text-area/HiddenLabel.tsx
@@ -1,10 +1,8 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import icache from '@dojo/framework/core/middleware/icache';
 import TextArea from '@dojo/widgets/text-area';
 
-const factory = create({ icache });
+const factory = create();
 
-export default factory(function HiddenLabel({ middleware: { icache } }) {
-	const value = icache.getOrSet('value', '');
-	return <TextArea value={value} label="Hidden label" labelHidden={true} />;
+export default factory(function HiddenLabel() {
+	return <TextArea label="Hidden label" labelHidden={true} />;
 });

--- a/src/examples/src/widgets/text-area/ValidatedCustom.tsx
+++ b/src/examples/src/widgets/text-area/ValidatedCustom.tsx
@@ -5,11 +5,9 @@ import TextArea from '@dojo/widgets/text-area';
 const factory = create({ icache });
 
 export default factory(function ValidateCustom({ middleware: { icache } }) {
-	const value = icache.getOrSet('value', '');
 	const valid = icache.getOrSet('valid', {});
 	return (
 		<TextArea
-			value={value}
 			valid={valid}
 			label="Custom Validated"
 			helperText='Enter "valid" to be valid'
@@ -28,9 +26,6 @@ export default factory(function ValidateCustom({ middleware: { icache } }) {
 						message: 'Only "valid" is a valid input'
 					};
 				}
-			}}
-			onValue={(value) => {
-				icache.set('value', value);
 			}}
 			onValidate={(valid?: boolean, message?: string) => {
 				icache.set('valid', { valid, message });

--- a/src/examples/src/widgets/text-area/ValidatedRequired.tsx
+++ b/src/examples/src/widgets/text-area/ValidatedRequired.tsx
@@ -5,17 +5,12 @@ import TextArea from '@dojo/widgets/text-area';
 const factory = create({ icache });
 
 export default factory(function ValidateRequired({ middleware: { icache } }) {
-	const value = icache.getOrSet('value', '');
 	const valid = icache.getOrSet('valid', {});
 	return (
 		<TextArea
-			value={value}
 			valid={valid}
 			label="Required"
 			required={true}
-			onValue={(value) => {
-				icache.set('value', value);
-			}}
 			onValidate={(valid?: boolean, message?: string) => {
 				icache.set('valid', { valid, message });
 			}}

--- a/src/text-area/tests/unit/TextArea.spec.tsx
+++ b/src/text-area/tests/unit/TextArea.spec.tsx
@@ -184,7 +184,7 @@ registerSuite('Textarea', {
 					name: 'bar',
 					placeholder: 'baz',
 					rows: 42,
-					value: 'qux',
+					initialValue: 'qux',
 					wrapText: 'soft'
 				})
 			);
@@ -294,7 +294,7 @@ registerSuite('Textarea', {
 
 			mockValidity('input', { valid: false, message: 'test' });
 
-			let h = harness(() => <TextArea value="test value" onValidate={validateSpy} />, {
+			let h = harness(() => <TextArea initialValue="test value" onValidate={validateSpy} />, {
 				middleware: [[validity, mockValidity]]
 			});
 
@@ -303,7 +303,7 @@ registerSuite('Textarea', {
 
 			mockValidity = createValidityMock();
 
-			h = harness(() => <TextArea value="test value" onValidate={validateSpy} />, {
+			h = harness(() => <TextArea initialValue="test value" onValidate={validateSpy} />, {
 				middleware: [[validity, mockValidity]]
 			});
 			mockValidity('input', { valid: true, message: 'test' });
@@ -321,7 +321,7 @@ registerSuite('Textarea', {
 			harness(
 				() => (
 					<TextArea
-						value="test value"
+						initialValue="test value"
 						valid={{ valid: false, message: 'test' }}
 						onValidate={validateSpy}
 					/>
@@ -344,7 +344,7 @@ registerSuite('Textarea', {
 			harness(
 				() => (
 					<TextArea
-						value="test value"
+						initialValue="test value"
 						onValidate={validateSpy}
 						customValidator={customValidatorSpy}
 					/>
@@ -367,7 +367,7 @@ registerSuite('Textarea', {
 			const h = harness(
 				() => (
 					<TextArea
-						value="test value"
+						initialValue="test value"
 						onValidate={validateSpy}
 						customValidator={customValidatorSpy}
 					/>
@@ -394,7 +394,7 @@ registerSuite('Textarea', {
 			const h = harness(
 				() => (
 					<TextArea
-						value="test value"
+						initialValue="test value"
 						onValidate={validateSpy}
 						customValidator={customValidatorSpy}
 					/>


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Making `TextArea` use the `initialValue` pattern.

Resolves #1028
