### PR TITLE
Material theme for DateInput

### DIFF
--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -134,8 +134,12 @@ export default factory(function({ properties, middleware: { theme, icache, i18n,
 									trailing={() => (
 										<button
 											key="dateIcon"
-											onclick={openCalendar}
+											onclick={(e) => {
+												e.stopPropagation();
+												openCalendar();
+											}}
 											classes={classes.toggleCalendarButton}
+											type="button"
 										>
 											<Icon type="dateIcon" />
 										</button>

--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -9,7 +9,6 @@ import { Keys } from '../common/util';
 import theme, { ThemeProperties } from '../middleware/theme';
 import Calendar from '../calendar';
 import TextInput from '../text-input';
-import Button from '../button';
 import Icon from '../icon';
 import TriggerPopup from '../trigger-popup';
 import * as css from '../theme/default/date-input.m.css';

--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -133,17 +133,13 @@ export default factory(function({ properties, middleware: { theme, icache, i18n,
 										}
 									}}
 									trailing={() => (
-										<Button
+										<button
 											key="dateIcon"
-											onClick={openCalendar}
-											classes={{
-												'@dojo/widgets/button': {
-													root: [classes.toggleCalendarButton]
-												}
-											}}
+											onclick={openCalendar}
+											classes={classes.toggleCalendarButton}
 										>
 											<Icon type="dateIcon" />
-										</Button>
+										</button>
 									)}
 									type="text"
 									initialValue={icache.get('inputValue')}

--- a/src/date-input/tests/unit/DateInput.spec.tsx
+++ b/src/date-input/tests/unit/DateInput.spec.tsx
@@ -9,6 +9,7 @@ import { harness } from '@dojo/framework/testing/harness';
 import select from '@dojo/framework/testing/support/selector';
 import focus from '@dojo/framework/core/middleware/focus';
 
+import { stubEvent } from '../../../common/tests/support/test-helpers';
 import { Keys } from '../../../common/util';
 import Calendar from '../../../calendar';
 import TriggerPopup from '../../../trigger-popup';
@@ -144,7 +145,7 @@ describe('DateInput', () => {
 			'@dateIcon',
 			select('@input', triggerResult)[0].properties.trailing()
 		);
-		dateIcon.properties.onclick();
+		dateIcon.properties.onclick(stubEvent);
 		h.expect(baseTemplate());
 
 		// If `toggleOpen` is called, the popup content (i.e., the calendar) is shown

--- a/src/date-input/tests/unit/DateInput.spec.tsx
+++ b/src/date-input/tests/unit/DateInput.spec.tsx
@@ -144,7 +144,7 @@ describe('DateInput', () => {
 			'@dateIcon',
 			select('@input', triggerResult)[0].properties.trailing()
 		);
-		dateIcon.properties.onClick();
+		dateIcon.properties.onclick();
 		h.expect(baseTemplate());
 
 		// If `toggleOpen` is called, the popup content (i.e., the calendar) is shown

--- a/src/theme/material/date-input.m.css
+++ b/src/theme/material/date-input.m.css
@@ -9,6 +9,6 @@
 .popup {
 	display: inline-block;
 	background: var(--mdc-theme-background);
-	border-radius: var(--mdc-theme-popup-border-radius);
-	box-shadow: var(--mdc-theme-popup-box-shadow);
+	border-radius: var(--mdc-theme-border-radius);
+	box-shadow: var(--mdc-theme-elevation-2);
 }

--- a/src/theme/material/date-input.m.css
+++ b/src/theme/material/date-input.m.css
@@ -1,43 +1,14 @@
 @import './variables.css';
 
-.root {
-}
-
-.input {
-}
-
-.root .toggleCalendarButton {
-	min-width: unset;
-	background: none;
-	border: none;
-	position: relative;
-	right: -6px;
+.toggleCalendarButton {
 	cursor: pointer;
+	display: flex;
 	pointer-events: all;
-}
-
-.root .toggleCalendarButton:hover,
-.root .toggleCalendarButton:focus {
-	box-shadow: none;
-	background: none;
-}
-
-.root .toggleCalendarButton:hover::before,
-.root .toggleCalendarButton:hover::after,
-.root .toggleCalendarButton:focus::before,
-.root .toggleCalendarButton:focus::after {
-	display: none;
 }
 
 .popup {
 	display: inline-block;
 	background: var(--mdc-theme-background);
-	box-shadow: 0px 3px 2px 0px rgba(0, 0, 0, 0.4);
-}
-
-/* include .root prefix to ensure this overrides the default styling */
-.root .inputTrailing {
-	background: none;
-	padding-bottom: 0;
-	padding-top: 0;
+	border-radius: var(--mdc-theme-popup-border-radius);
+	box-shadow: var(--mdc-theme-popup-box-shadow);
 }

--- a/src/theme/material/date-input.m.css
+++ b/src/theme/material/date-input.m.css
@@ -1,0 +1,43 @@
+@import './variables.css';
+
+.root {
+}
+
+.input {
+}
+
+.root .toggleCalendarButton {
+	min-width: unset;
+	background: none;
+	border: none;
+	position: relative;
+	right: -6px;
+	cursor: pointer;
+	pointer-events: all;
+}
+
+.root .toggleCalendarButton:hover,
+.root .toggleCalendarButton:focus {
+	box-shadow: none;
+	background: none;
+}
+
+.root .toggleCalendarButton:hover::before,
+.root .toggleCalendarButton:hover::after,
+.root .toggleCalendarButton:focus::before,
+.root .toggleCalendarButton:focus::after {
+	display: none;
+}
+
+.popup {
+	display: inline-block;
+	background: var(--mdc-theme-background);
+	box-shadow: 0px 3px 2px 0px rgba(0, 0, 0, 0.4);
+}
+
+/* include .root prefix to ensure this overrides the default styling */
+.root .inputTrailing {
+	background: none;
+	padding-bottom: 0;
+	padding-top: 0;
+}

--- a/src/theme/material/date-input.m.css.d.ts
+++ b/src/theme/material/date-input.m.css.d.ts
@@ -1,5 +1,2 @@
-export const root: string;
-export const input: string;
 export const toggleCalendarButton: string;
 export const popup: string;
-export const inputTrailing: string;

--- a/src/theme/material/date-input.m.css.d.ts
+++ b/src/theme/material/date-input.m.css.d.ts
@@ -1,0 +1,5 @@
+export const root: string;
+export const input: string;
+export const toggleCalendarButton: string;
+export const popup: string;
+export const inputTrailing: string;

--- a/src/theme/material/index.ts
+++ b/src/theme/material/index.ts
@@ -5,6 +5,7 @@ import * as calendar from './calendar.m.css';
 import * as checkbox from './checkbox.m.css';
 import * as chip from './chip.m.css';
 import * as combobox from './combobox.m.css';
+import * as dateInput from './date-input.m.css';
 import * as dialog from './dialog.m.css';
 import * as gridBody from './grid-body.m.css';
 import * as gridCell from './grid-cell.m.css';
@@ -47,6 +48,7 @@ export default {
 	'@dojo/widgets/card': card,
 	'@dojo/widgets/chip': chip,
 	'@dojo/widgets/combobox': combobox,
+	'@dojo/widgets/date-input': dateInput,
 	'@dojo/widgets/dialog': dialog,
 	'@dojo/widgets/grid-body': gridBody,
 	'@dojo/widgets/grid-cell': gridCell,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

Material theme for DateInput

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #1073 

![image](https://user-images.githubusercontent.com/41762295/74668362-11cda480-5173-11ea-8f51-c35c87521a9a.png)

![image](https://user-images.githubusercontent.com/41762295/74668406-23af4780-5173-11ea-88d4-f43a142175e5.png)

