### PR TITLE
Add ThemeProperties, FocusProperties to functional widgets using those middleware

### DIFF
--- a/src/card/index.tsx
+++ b/src/card/index.tsx
@@ -1,10 +1,9 @@
 import { tsx, create } from '@dojo/framework/core/vdom';
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import * as css from '../theme/default/card.m.css';
-import theme from '../middleware/theme';
-import { ThemedProperties } from '@dojo/framework/core/mixins/Themed';
+import theme, { ThemeProperties } from '../middleware/theme';
 
-export interface CardProperties extends ThemedProperties {
+export interface CardProperties extends ThemeProperties {
 	/** Renderer for action available from the card */
 	actionsRenderer?(): RenderResult;
 }

--- a/src/checkbox-group/index.tsx
+++ b/src/checkbox-group/index.tsx
@@ -2,12 +2,12 @@ import { create, tsx } from '@dojo/framework/core/vdom';
 import { checkboxGroup } from './middleware';
 import { Checkbox } from '../checkbox/index';
 import { RenderResult } from '@dojo/framework/core/interfaces';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
 import * as css from '../theme/default/checkbox-group.m.css';
 
 type CheckboxOptions = { value: string; label?: string }[];
 
-interface CheckboxGroupProperties {
+interface CheckboxGroupProperties extends ThemeProperties {
 	/** The name attribute for this form group */
 	name: string;
 	/** The label to be displayed in the legend */

--- a/src/checkbox/index.tsx
+++ b/src/checkbox/index.tsx
@@ -1,14 +1,13 @@
 import { tsx, create } from '@dojo/framework/core/vdom';
 import * as css from '../theme/default/checkbox.m.css';
-import coreTheme from '@dojo/framework/core/middleware/theme';
+import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
 import focus from '@dojo/framework/core/middleware/focus';
-import { ThemedProperties } from '@dojo/framework/core/mixins/Themed';
 import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import Label from '../label/index';
 import { formatAriaProperties } from '../common/util';
 import { uuid } from '@dojo/framework/core/util';
 
-export interface CheckboxProperties extends ThemedProperties, FocusProperties {
+export interface CheckboxProperties extends ThemeProperties, FocusProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/**  Checked/unchecked property of the control */
@@ -45,12 +44,9 @@ export interface CheckboxProperties extends ThemedProperties, FocusProperties {
 	widgetId?: string;
 }
 
-const factory = create({ coreTheme, focus }).properties<CheckboxProperties>();
+const factory = create({ theme, focus }).properties<CheckboxProperties>();
 
-export const Checkbox = factory(function Checkbox({
-	properties,
-	middleware: { coreTheme, focus }
-}) {
+export const Checkbox = factory(function Checkbox({ properties, middleware: { theme, focus } }) {
 	const _uuid = uuid();
 	const {
 		aria = {},
@@ -67,13 +63,13 @@ export const Checkbox = factory(function Checkbox({
 		onOver,
 		readOnly,
 		required,
-		theme,
+		theme: themeProp,
 		valid,
 		value,
 		widgetId = _uuid
 	} = properties();
 
-	const themeCss = coreTheme.classes(css);
+	const themeCss = theme.classes(css);
 
 	return (
 		<div
@@ -120,7 +116,7 @@ export const Checkbox = factory(function Checkbox({
 				<Label
 					key="label"
 					classes={classes}
-					theme={theme}
+					theme={themeProp}
 					disabled={disabled}
 					focused={focus.isFocused('root')}
 					valid={valid}

--- a/src/chip/index.tsx
+++ b/src/chip/index.tsx
@@ -1,11 +1,11 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import { RenderResult } from '@dojo/framework/core/interfaces';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
 import * as css from '../theme/default/chip.m.css';
 import Icon from '../icon/index';
 import { Keys } from '../common/util';
 
-export interface ChipProperties {
+export interface ChipProperties extends ThemeProperties {
 	/** Renders an icon, provided with the value of the checked property */
 	iconRenderer?(checked?: boolean): RenderResult;
 	/** The label to be displayed in the widget */

--- a/src/constrained-input/index.tsx
+++ b/src/constrained-input/index.tsx
@@ -2,15 +2,13 @@ import TextInput, { TextInputProperties } from '../text-input';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import validation, { ValidationRules } from '../middleware/validation';
-import theme from '../middleware/theme';
+import theme, { ThemeProperties } from '../middleware/theme';
 import * as constrainedInputCss from '../theme/default/constrained-input.m.css';
 import * as textInputCss from '../theme/default/text-input.m.css';
 
 export interface ConstrainedInputProperties
-	extends Exclude<
-		TextInputProperties,
-		'onValidate' | 'valid' | 'helperText' | 'customValidator'
-	> {
+	extends ThemeProperties,
+		Exclude<TextInputProperties, 'onValidate' | 'valid' | 'helperText' | 'customValidator'> {
 	/** Validation rules applied to this input */
 	rules: ValidationRules;
 	/** Callback fired when the input validation changes */

--- a/src/context-menu/index.tsx
+++ b/src/context-menu/index.tsx
@@ -1,11 +1,11 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import theme from '../middleware/theme';
+import theme, { ThemeProperties } from '../middleware/theme';
 import Menu, { MenuOption } from '../menu/index';
 import * as menuCss from '../theme/default/menu.m.css';
 import * as css from '../theme/default/context-menu.m.css';
 import ContextPopup from '../context-popup';
 
-export interface ContextMenuProperties {
+export interface ContextMenuProperties extends ThemeProperties {
 	/* Menu options for the context menu. Uses the same API as the menu widget */
 	options: MenuOption[];
 	/* A callback that will be called with the value of whatever item is selected */

--- a/src/context-popup/index.tsx
+++ b/src/context-popup/index.tsx
@@ -1,12 +1,13 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import focus from '@dojo/framework/core/middleware/focus';
+import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import Popup from '../popup';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 
 import * as css from '../theme/default/context-popup.m.css';
 
-export interface ContextPopupProperties {
+export interface ContextPopupProperties extends FocusProperties {
 	onClose?(): void;
 	onOpen?(): void;
 }

--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -2,10 +2,11 @@ import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { i18n } from '@dojo/framework/core/middleware/i18n';
 import { focus } from '@dojo/framework/core/middleware/focus';
+import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 
 import { parseDate, formatDateISO, formatDate } from './date-utils';
 import { Keys } from '../common/util';
-import theme from '../middleware/theme';
+import theme, { ThemeProperties } from '../middleware/theme';
 import Calendar from '../calendar';
 import TextInput from '../text-input';
 import Button from '../button';
@@ -15,7 +16,7 @@ import * as css from '../theme/default/date-input.m.css';
 
 import bundle from './nls/DateInput';
 
-export interface DateInputProperties {
+export interface DateInputProperties extends ThemeProperties, FocusProperties {
 	/** The initial value */
 	initialValue?: string;
 	/** Set the latest date the calendar will display in (it will show the whole month but not allow previous selections) */

--- a/src/dialog/index.tsx
+++ b/src/dialog/index.tsx
@@ -5,14 +5,14 @@ import { uuid } from '@dojo/framework/core/util';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import { formatAriaProperties, Keys } from '../common/util';
 import Icon from '../icon';
-import theme from '../middleware/theme';
+import theme, { ThemeProperties } from '../middleware/theme';
 import * as css from '../theme/default/dialog.m.css';
 import * as fixedCss from './styles/dialog.m.css';
 import commonBundle from '../common/nls/common';
 import GlobalEvent from '../global-event';
 import inert from '@dojo/framework/core/middleware/inert';
 
-export interface DialogPropertiesBase {
+export interface DialogPropertiesBase extends ThemeProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Determines whether the dialog can be closed */

--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -1,6 +1,6 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import icache from '@dojo/framework/core/middleware/icache';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
 import { RenderResult, VNodeProperties } from '@dojo/framework/core/interfaces';
 
 import createFormMiddleware, { FormMiddleware, FormValue } from './middleware';
@@ -10,7 +10,7 @@ const form = createFormMiddleware();
 
 type Omit<T, E> = Pick<T, Exclude<keyof T, E>>;
 
-interface BaseFormProperties {
+interface BaseFormProperties extends ThemeProperties {
 	/** The initial form value */
 	initialValue?: FormValue;
 	/** Callback called when a form value changes */

--- a/src/icon/index.tsx
+++ b/src/icon/index.tsx
@@ -1,12 +1,12 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import theme from '../middleware/theme';
+import theme, { ThemeProperties } from '../middleware/theme';
 import { formatAriaProperties } from '../common/util';
 import * as css from '../theme/default/icon.m.css';
 import * as baseCss from '../common/styles/base.m.css';
 
 export type IconType = keyof typeof css;
 
-export interface IconProperties {
+export interface IconProperties extends ThemeProperties {
 	/** An optional, visually hidden label for the icon */
 	altText?: string;
 	/** Custom aria attributes */

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -1,11 +1,12 @@
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import { focus } from '@dojo/framework/core/middleware/focus';
+import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, renderer, tsx } from '@dojo/framework/core/vdom';
 import { findIndex } from '@dojo/framework/shim/array';
 import global from '@dojo/framework/shim/global';
 import { Keys } from '../common/util';
-import theme from '../middleware/theme';
+import theme, { ThemeProperties } from '../middleware/theme';
 import * as listBoxItemCss from '../theme/default/list-box-item.m.css';
 import * as menuItemCss from '../theme/default/menu-item.m.css';
 import * as css from '../theme/default/menu.m.css';
@@ -15,7 +16,7 @@ import MenuItem from './MenuItem';
 
 export type MenuOption = { value: string; label?: string; disabled?: boolean; divider?: boolean };
 
-export interface MenuProperties {
+export interface MenuProperties extends ThemeProperties, FocusProperties {
 	/** Options to display within the menu. The `value` of the option will be passed to `onValue` when it is selected. The label is an optional display string to be used instead of the `value`. If `disabled` is true the option will have a disabled style and will not be selectable. An option with `divider: true` will have a divider rendered after it in the menu */
 	options: MenuOption[];
 	/** The total number of options provided */

--- a/src/middleware/theme.tsx
+++ b/src/middleware/theme.tsx
@@ -1,5 +1,7 @@
 import { create } from '@dojo/framework/core/vdom';
-import coreTheme from '@dojo/framework/core/middleware/theme';
+import coreTheme, {
+	ThemeProperties as CoreThemeProperties
+} from '@dojo/framework/core/middleware/theme';
 import { ClassNames, Theme } from '@dojo/framework/core/mixins/Themed';
 
 const factory = create({ coreTheme });
@@ -13,7 +15,9 @@ function lowercaseFirstChar(value: string) {
 	return `${value.charAt(0).toLowerCase()}${value.slice(1)}`;
 }
 
-const theme = factory(function({ middleware: { coreTheme }, properties }) {
+export interface ThemeProperties extends CoreThemeProperties {}
+
+export const theme = factory(function({ middleware: { coreTheme }, properties }) {
 	return {
 		compose: <T extends ClassNames, B extends ClassNames>(
 			baseCss: B,

--- a/src/native-select/index.tsx
+++ b/src/native-select/index.tsx
@@ -1,9 +1,10 @@
 import { focus } from '@dojo/framework/core/middleware/focus';
+import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { i18n } from '@dojo/framework/core/middleware/i18n';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import HelperText from '../helper-text';
-import theme from '../middleware/theme';
+import theme, { ThemeProperties } from '../middleware/theme';
 import * as css from '../theme/default/native-select.m.css';
 import * as labelCss from '../theme/default/label.m.css';
 import * as iconCss from '../theme/default/icon.m.css';
@@ -12,7 +13,7 @@ import Label from '../label';
 
 export type MenuOption = { value: string; label?: string; disabled?: boolean };
 
-export interface NativeSelectProperties {
+export interface NativeSelectProperties extends FocusProperties, ThemeProperties {
 	/** Callback called when user selects a value */
 	onValue?(value: string): void;
 	/** The initial selected value */

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -1,5 +1,5 @@
 import { dimensions } from '@dojo/framework/core/middleware/dimensions';
-import { theme } from '@dojo/framework/core/middleware/theme';
+import { theme, ThemeProperties } from '@dojo/framework/core/middleware/theme';
 import { bodyScroll } from '../middleware/bodyScroll';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import * as css from '../theme/default/popup.m.css';
@@ -8,7 +8,7 @@ import { RenderResult } from '@dojo/framework/core/interfaces';
 
 export type PopupPosition = 'above' | 'below';
 
-export interface PopupProperties {
+export interface PopupProperties extends ThemeProperties {
 	/** Where the popup should render relative to the provided position (defaults to "below") */
 	position?: PopupPosition;
 	/** If the underlay should be visible (defaults to false) */

--- a/src/radio-group/index.tsx
+++ b/src/radio-group/index.tsx
@@ -1,5 +1,5 @@
 import * as css from '../theme/radio-group.m.css';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
 import { Radio } from '../radio/index';
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import { create, tsx } from '@dojo/framework/core/vdom';
@@ -7,7 +7,7 @@ import { radioGroup } from './middleware';
 
 type RadioOptions = { value: string; label?: string }[];
 
-interface RadioGroupProperties {
+interface RadioGroupProperties extends ThemeProperties {
 	/** Initial value of the radio group */
 	initialValue?: string;
 	/** The label to be displayed in the legend */

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -1,5 +1,6 @@
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import { focus } from '@dojo/framework/core/middleware/focus';
+import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { i18n } from '@dojo/framework/core/middleware/i18n';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { uuid } from '@dojo/framework/core/util';
@@ -9,7 +10,7 @@ import HelperText from '../helper-text';
 import Icon from '../icon';
 import Label from '../label';
 import { ItemRendererProperties, Menu, MenuOption } from '../menu';
-import theme from '../middleware/theme';
+import theme, { ThemeProperties } from '../middleware/theme';
 import { PopupPosition } from '../popup';
 import TriggerPopup from '../trigger-popup';
 import * as menuCss from '../theme/default/menu.m.css';
@@ -18,7 +19,7 @@ import * as iconCss from '../theme/default/icon.m.css';
 import * as css from '../theme/default/select.m.css';
 import bundle from './select.nls';
 
-interface SelectProperties {
+interface SelectProperties extends ThemeProperties, FocusProperties {
 	/** Callback called when user selects a value */
 	onValue(value: string): void;
 	/** The initial selected value */

--- a/src/snackbar/index.tsx
+++ b/src/snackbar/index.tsx
@@ -1,10 +1,9 @@
 import { RenderResult } from '@dojo/framework/core/interfaces';
-import theme from '@dojo/framework/core/middleware/theme';
-import { ThemedProperties } from '@dojo/framework/core/mixins/Themed';
+import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import * as css from '../theme/default/snackbar.m.css';
 
-export interface SnackbarProperties extends ThemedProperties {
+export interface SnackbarProperties extends ThemeProperties {
 	/** If the snackbar is displayed */
 	open: boolean;
 	/** Renders the message portion of the snackbar */

--- a/src/switch/index.tsx
+++ b/src/switch/index.tsx
@@ -1,13 +1,14 @@
 import { DNode } from '@dojo/framework/core/interfaces';
 import focus from '@dojo/framework/core/middleware/focus';
-import coreTheme from '@dojo/framework/core/middleware/theme';
+import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
+import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
 
 import { formatAriaProperties } from '../common/util';
 import Label from '../label';
 import * as css from '../theme/default/switch.m.css';
 
-interface SwitchProperties {
+interface SwitchProperties extends ThemeProperties, FocusProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Whether the switch is disabled or clickable */
@@ -42,9 +43,9 @@ interface SwitchProperties {
 	value?: boolean;
 }
 
-const factory = create({ coreTheme, focus }).properties<SwitchProperties>();
+const factory = create({ theme, focus }).properties<SwitchProperties>();
 
-export default factory(function Switch({ properties, id, middleware: { coreTheme, focus } }) {
+export default factory(function Switch({ properties, id, middleware: { theme, focus } }) {
 	const {
 		aria = {},
 		classes,
@@ -61,12 +62,12 @@ export default factory(function Switch({ properties, id, middleware: { coreTheme
 		onOver,
 		readOnly,
 		required,
-		theme,
+		theme: themeProp,
 		valid,
 		value = false
 	} = properties();
 
-	const themedCss = coreTheme.classes(css);
+	const themedCss = theme.classes(css);
 	const idBase = `switch-${id}`;
 
 	return (
@@ -134,7 +135,7 @@ export default factory(function Switch({ properties, id, middleware: { coreTheme
 				<Label
 					key="label"
 					classes={classes}
-					theme={theme}
+					theme={themeProp}
 					disabled={disabled}
 					focused={focus.isFocused('root')}
 					valid={valid}

--- a/src/text-area/index.tsx
+++ b/src/text-area/index.tsx
@@ -6,9 +6,10 @@ import HelperText from '../helper-text/index';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
 import focus from '@dojo/framework/core/middleware/focus';
+import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import validity from '@dojo/framework/core/middleware/validity';
 
-export interface TextAreaProperties extends ThemeProperties {
+export interface TextAreaProperties extends ThemeProperties, FocusProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Number of columns, controls the width of the textarea */

--- a/src/text-input/index.tsx
+++ b/src/text-input/index.tsx
@@ -1,5 +1,6 @@
 import { DNode } from '@dojo/framework/core/interfaces';
 import focus from '@dojo/framework/core/middleware/focus';
+import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
 import validity from '@dojo/framework/core/middleware/validity';
@@ -20,7 +21,8 @@ export type TextInputType =
 	| 'date';
 
 export interface BaseInputProperties<T extends { value: any } = { value: string }>
-	extends ThemeProperties {
+	extends ThemeProperties,
+		FocusProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Should the field autocomplete */

--- a/src/text-input/index.tsx
+++ b/src/text-input/index.tsx
@@ -1,7 +1,7 @@
 import { DNode } from '@dojo/framework/core/interfaces';
 import focus from '@dojo/framework/core/middleware/focus';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
 import validity from '@dojo/framework/core/middleware/validity';
 import { create, diffProperty, invalidator, tsx } from '@dojo/framework/core/vdom';
 import { formatAriaProperties } from '../common/util';
@@ -19,7 +19,8 @@ export type TextInputType =
 	| 'url'
 	| 'date';
 
-export interface BaseInputProperties<T extends { value: any } = { value: string }> {
+export interface BaseInputProperties<T extends { value: any } = { value: string }>
+	extends ThemeProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Should the field autocomplete */

--- a/src/tooltip/index.tsx
+++ b/src/tooltip/index.tsx
@@ -1,13 +1,12 @@
 import { DNode } from '@dojo/framework/core/interfaces';
 import { create, tsx } from '@dojo/framework/core/vdom';
-import { ThemedProperties } from '@dojo/framework/core/mixins/Themed';
-import theme from '../middleware/theme';
+import theme, { ThemeProperties } from '../middleware/theme';
 
 import * as fixedCss from './styles/tooltip.m.css';
 import * as css from '../theme/default/tooltip.m.css';
 import { formatAriaProperties } from '../common/util';
 
-export interface TooltipProperties extends ThemedProperties {
+export interface TooltipProperties extends ThemeProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Information to show within the tooltip */


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Extend `ThemeProperties` and `FocusProperties` where the respective middleware is used in fucntional widgets.

Resolves #1080 
