### PR TITLE
Add confirm flag to now deployments

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -5,14 +5,14 @@ cp ./now.json ./output/dev
 name="dojo.widgets"
 
 if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
-	nowurl=$(npx now ./output/dist --token=$PUBLIC_NOW_TOKEN --public --name=$name)
+	nowurl=$(npx now ./output/dist --token=$PUBLIC_NOW_TOKEN --public --name=$name --confirm)
 	if [ "$nowurl" = "" ] ; then
 		echo "Now deployment failed"
 		exit 1
 	fi
 
 	echo "* Docs Deployment: $nowurl" &>> deployments.txt
-	nowurl=$(npx now ./output/dev --token=$PUBLIC_NOW_TOKEN --public --name=$name)
+	nowurl=$(npx now ./output/dev --token=$PUBLIC_NOW_TOKEN --public --name=$name --confirm)
 	if [ "$nowurl" = "" ] ; then
 		echo "Now deployment failed"
 		exit 1
@@ -21,7 +21,7 @@ if [ "$TRAVIS_PULL_REQUEST" != "false" ] ; then
 	echo "* Tests Deployment: $nowurl" &>> deployments.txt
 else
 	if [ "$TRAVIS_BRANCH" = "master" ] ; then
-		nowurl=$(npx now ./output/dist --token=$NOW_TOKEN --public --name=$name --scope=dojo --target=production)
+		nowurl=$(npx now ./output/dist --token=$NOW_TOKEN --public --name=$name --scope=dojo --target=production --confirm)
 		if [ "$nowurl" = "" ] ; then
 			echo "Now deployment failed"
 			exit 1


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixes deployment issue to now by adding `--confirm` flag.

Related issue: https://github.com/zeit/now/pull/3690
