### PR TITLE
Stop body scrolling whilst dialog open

### DIFF
--- a/src/dialog/index.tsx
+++ b/src/dialog/index.tsx
@@ -6,6 +6,7 @@ import { create, tsx } from '@dojo/framework/core/vdom';
 import { formatAriaProperties, Keys } from '../common/util';
 import Icon from '../icon';
 import theme, { ThemeProperties } from '../middleware/theme';
+import bodyScroll from '../middleware/bodyScroll';
 import * as css from '../theme/default/dialog.m.css';
 import * as fixedCss from './styles/dialog.m.css';
 import commonBundle from '../common/nls/common';
@@ -55,11 +56,17 @@ export interface DialogState {
 	contentId: string;
 }
 
-const factory = create({ theme, i18n, icache: createICacheMiddleware<DialogState>(), inert })
+const factory = create({
+	theme,
+	i18n,
+	icache: createICacheMiddleware<DialogState>(),
+	inert,
+	bodyScroll
+})
 	.properties<DialogProperties>()
 	.children<DialogChild>();
 export const Dialog = factory(function Dialog({
-	middleware: { theme, i18n, icache, inert },
+	middleware: { theme, i18n, icache, inert, bodyScroll },
 	properties,
 	children
 }) {
@@ -109,6 +116,8 @@ export const Dialog = factory(function Dialog({
 			close();
 		}
 	};
+
+	bodyScroll(!open);
 
 	return (
 		<body>


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Uses the body scroll middleware with dialog

Resolves #669 
