### PR TITLE
Expanded DateInput example sandbox to large

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -420,7 +420,7 @@ export const config = {
 					filename: 'Basic',
 					module: BasicDateInput,
 					sandbox: true,
-					size: 'medium'
+					size: 'large'
 				}
 			}
 		},


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Sandbox medium height of 300px is ~55px short of containing the DateInput with the calendar expanded. Increased the sandbox size to large to prevent unexpected popup placement.

![image](https://user-images.githubusercontent.com/41762295/74545182-67f1dc00-4f16-11ea-9eca-911cbc08e298.png)

Resolves #1094 
