### PR TITLE
Adding grid material styles

### DIFF
--- a/src/grid/Row.tsx
+++ b/src/grid/Row.tsx
@@ -73,7 +73,8 @@ export default class Row extends ThemedMixin(WidgetBase)<RowProperties> {
 				classes: [
 					this.theme(css.root),
 					selected && this.theme(css.selected),
-					fixedCss.rootFixed
+					fixedCss.rootFixed,
+					onRowSelect && this.theme(css.selectable)
 				],
 				role: 'row',
 				onclick: onRowSelect ? this._onRowSelect : undefined,

--- a/src/grid/tests/unit/Row.spec.tsx
+++ b/src/grid/tests/unit/Row.spec.tsx
@@ -23,7 +23,7 @@ describe('Row', () => {
 				'div',
 				{
 					key: 'root',
-					classes: [css.root, undefined, fixedCss.rootFixed],
+					classes: [css.root, undefined, fixedCss.rootFixed, undefined],
 					role: 'row',
 					'aria-rowindex': '2',
 					onclick: undefined
@@ -52,7 +52,7 @@ describe('Row', () => {
 				'div',
 				{
 					key: 'root',
-					classes: [css.root, undefined, fixedCss.rootFixed],
+					classes: [css.root, undefined, fixedCss.rootFixed, undefined],
 					role: 'row',
 					'aria-rowindex': '2',
 					onclick: undefined
@@ -93,7 +93,7 @@ describe('Row', () => {
 				'div',
 				{
 					key: 'root',
-					classes: [css.root, undefined, fixedCss.rootFixed],
+					classes: [css.root, undefined, fixedCss.rootFixed, undefined],
 					role: 'row',
 					'aria-rowindex': '2',
 					onclick: undefined
@@ -138,7 +138,7 @@ describe('Row', () => {
 				'div',
 				{
 					key: 'root',
-					classes: [css.root, css.selected, fixedCss.rootFixed],
+					classes: [css.root, css.selected, fixedCss.rootFixed, css.selectable],
 					role: 'row',
 					'aria-rowindex': '2',
 					onclick: noop

--- a/src/theme/default/grid-row.m.css
+++ b/src/theme/default/grid-row.m.css
@@ -9,3 +9,6 @@
 .selected {
 	background: rgba(0, 0, 0, 0.05);
 }
+
+.selectable {
+}

--- a/src/theme/default/grid-row.m.css.d.ts
+++ b/src/theme/default/grid-row.m.css.d.ts
@@ -1,2 +1,3 @@
 export const root: string;
 export const selected: string;
+export const selectable: string;

--- a/src/theme/material/grid-cell.m.css
+++ b/src/theme/material/grid-cell.m.css
@@ -1,2 +1,9 @@
+@import './variables.css';
+
 .root {
+	padding: 16px;
+	color: var(--mdc-theme-text-primary-on-background);
+	font-size: var(--mdc-theme-font-size-small);
+	font-family: var(--mdc-theme-font-family);
+	border-top: 1px solid var(--mdc-theme-separator);
 }

--- a/src/theme/material/grid-footer.m.css
+++ b/src/theme/material/grid-footer.m.css
@@ -1,2 +1,15 @@
+@import './variables.css';
+
 .root {
+	min-height: 52px;
+	padding-right: 24px;
+	padding-left: 24px;
+	display: flex;
+	position: relative;
+	align-items: center;
+	justify-content: flex-end;
+	color: var(--mdc-theme-text-primary-on-background);
+	font-size: var(--mdc-theme-font-size-small);
+	font-family: var(--mdc-theme-font-family);
+	border-top: 1px solid var(--mdc-theme-separator);
 }

--- a/src/theme/material/grid-header.m.css
+++ b/src/theme/material/grid-header.m.css
@@ -10,8 +10,7 @@
 	border: none;
 	font-weight: var(--mdc-theme-heading-font-weight);
 	padding: 16px;
-	background-color: var(--mdc-theme-on-surface);
-	color: var(--mdc-theme-text-primary-on-dark);
+	color: var(--mdc-theme-text-primary-on-light);
 }
 
 .sort {

--- a/src/theme/material/grid-header.m.css
+++ b/src/theme/material/grid-header.m.css
@@ -1,2 +1,29 @@
+@import './variables.css';
+
 .root {
+}
+
+.cell {
+	font-size: var(--mdc-theme-font-size-small);
+	font-family: var(--mdc-theme-font-family);
+	display: table-cell;
+	border: none;
+	font-weight: var(--mdc-theme-heading-font-weight);
+	padding: 16px;
+	background-color: var(--mdc-theme-on-surface);
+	color: var(--mdc-theme-text-primary-on-dark);
+}
+
+.sort {
+	display: flex;
+	align-items: center;
+	opacity: 0;
+}
+
+.sortable {
+	display: flex;
+}
+
+.sorted .sort {
+	opacity: 1;
 }

--- a/src/theme/material/grid-header.m.css.d.ts
+++ b/src/theme/material/grid-header.m.css.d.ts
@@ -1,1 +1,5 @@
 export const root: string;
+export const cell: string;
+export const sort: string;
+export const sortable: string;
+export const sorted: string;

--- a/src/theme/material/grid-paginated-footer.m.css
+++ b/src/theme/material/grid-paginated-footer.m.css
@@ -1,0 +1,38 @@
+.root {
+	min-height: 52px;
+	padding-right: 24px;
+	padding-left: 24px;
+	display: flex;
+	position: relative;
+	align-items: center;
+	justify-content: flex-end;
+	color: var(--mdc-theme-text-primary-on-background);
+	font-size: var(--mdc-theme-font-size-small);
+	font-family: var(--mdc-theme-font-family);
+	border-top: 1px solid var(--mdc-theme-separator);
+}
+
+.root .details {
+	width: auto;
+	margin-right: 16px;
+	justify-content: flex-end;
+	font-weight: var(--mdc-theme-heading-font-weight);
+}
+
+.pageNav {
+	color: var(--mdc-theme-text-secondary-on-background);
+	font-size: var(--mdc-theme-font-size-small);
+	font-family: var(--mdc-theme-font-family);
+	margin: 0 16px;
+}
+
+.pageNumber {
+	color: var(--mdc-theme-text-secondary-on-background);
+	font-size: var(--mdc-theme-font-size-small);
+	font-family: var(--mdc-theme-font-family);
+	margin: 0 4px;
+}
+
+.active {
+	color: var(--mdc-theme-text-primary-on-background);
+}

--- a/src/theme/material/grid-paginated-footer.m.css.d.ts
+++ b/src/theme/material/grid-paginated-footer.m.css.d.ts
@@ -1,0 +1,5 @@
+export const root: string;
+export const details: string;
+export const pageNav: string;
+export const pageNumber: string;
+export const active: string;

--- a/src/theme/material/grid-row.m.css
+++ b/src/theme/material/grid-row.m.css
@@ -1,2 +1,12 @@
+@import './variables.css';
+
 .root {
+}
+
+.selected {
+	background-color: var(--mdc-theme-background-selected);
+}
+
+.selectable:hover {
+	background-color: var(--mdc-theme-background-active);
 }

--- a/src/theme/material/grid-row.m.css.d.ts
+++ b/src/theme/material/grid-row.m.css.d.ts
@@ -1,1 +1,3 @@
 export const root: string;
+export const selected: string;
+export const selectable: string;

--- a/src/theme/material/grid.m.css
+++ b/src/theme/material/grid.m.css
@@ -1,2 +1,13 @@
+@import './variables.css';
+
 .root {
+	box-shadow: var(--mdc-theme-elevation-1);
+	border-radius: var(--mdc-theme-border-radius);
+}
+
+.header {
+	border: none;
+}
+
+.filterGroup {
 }

--- a/src/theme/material/grid.m.css.d.ts
+++ b/src/theme/material/grid.m.css.d.ts
@@ -1,1 +1,3 @@
 export const root: string;
+export const header: string;
+export const filterGroup: string;

--- a/src/theme/material/index.ts
+++ b/src/theme/material/index.ts
@@ -12,6 +12,7 @@ import * as gridBody from './grid-body.m.css';
 import * as gridCell from './grid-cell.m.css';
 import * as gridFooter from './grid-footer.m.css';
 import * as gridHeader from './grid-header.m.css';
+import * as gridPaginatedFooter from './grid-paginated-footer.m.css';
 import * as gridPlaceholderRow from './grid-placeholder-row.m.css';
 import * as gridRow from './grid-row.m.css';
 import * as grid from './grid.m.css';
@@ -56,6 +57,7 @@ export default {
 	'@dojo/widgets/grid-cell': gridCell,
 	'@dojo/widgets/grid-footer': gridFooter,
 	'@dojo/widgets/grid-header': gridHeader,
+	'@dojo/widgets/grid-paginated-footer': gridPaginatedFooter,
 	'@dojo/widgets/grid-placeholder-row': gridPlaceholderRow,
 	'@dojo/widgets/grid-row': gridRow,
 	'@dojo/widgets/grid': grid,

--- a/src/theme/material/variables.css
+++ b/src/theme/material/variables.css
@@ -45,4 +45,6 @@
 	--mdc-avatar-size-small: 24px;
 	--mdc-avatar-size-medium: 40px;
 	--mdc-avatar-size-large: 56px;
+	--mdc-theme-heading-font-weight: 500;
+	--mdc-theme-separator: #e0e0e0;
 }

--- a/src/theme/material/widgets.css
+++ b/src/theme/material/widgets.css
@@ -25,6 +25,7 @@
 @import './grid-cell.m.css';
 @import './grid-footer.m.css';
 @import './grid-header.m.css';
+@import './grid-paginated-footer.m.css';
 @import './grid-placeholder-row.m.css';
 @import './grid-row.m.css';
 @import './grid.m.css';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding some materialesque styles for the grid!  Still might need a little work, but the bulk of it is here.  The only bits that look odd are when filtering is involved, since the material text boxes are so large.

![image](https://user-images.githubusercontent.com/2008858/74664453-b946d900-516b-11ea-8900-90284c7eacc2.png)

![image](https://user-images.githubusercontent.com/2008858/74664479-c368d780-516b-11ea-993b-15c1b2eb5f2a.png)

![image](https://user-images.githubusercontent.com/2008858/74664489-cbc11280-516b-11ea-977b-cafb722d1d33.png)


Resolves #1078
