### PR TITLE
Set page size on preFetch so it's ready for initial filter

### DIFF
--- a/src/grid/processes.ts
+++ b/src/grid/processes.ts
@@ -25,12 +25,13 @@ const pageChangeCommand = commandFactory<PageChangeCommandPayload>(
 );
 
 const preFetcherCommand = commandFactory<FetcherCommandPayload>(
-	({ path, get, payload: { id, page } }) => {
+	({ path, get, payload: { id, page, pageSize } }) => {
 		const fetchedPages = get(path(id, 'meta', 'fetchedPages')) || [];
 		if (fetchedPages.indexOf(page) === -1) {
 			return [
 				replace(path(id, 'meta', 'fetchedPages'), [...fetchedPages, page]),
-				replace(path(id, 'meta', 'page'), page)
+				replace(path(id, 'meta', 'page'), page),
+				replace(path(id, 'meta', 'pageSize'), pageSize)
 			];
 		}
 		throw Error('The page has already been requested');
@@ -54,8 +55,7 @@ const fetcherCommand = commandFactory<FetcherCommandPayload>(
 			}
 			return [
 				replace(path(id, 'data', 'pages', `page-${page}`), result.data),
-				replace(path(id, 'meta', 'total'), result.meta.total),
-				replace(path(id, 'meta', 'pageSize'), pageSize)
+				replace(path(id, 'meta', 'total'), result.meta.total)
 			];
 		} else {
 			throw Error('The grid is being sorted or filtered');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:
On the first render the `onValue` of the filter textbox is triggered with `""`. This triggered the filter process before the fetch process resolved so the `pageSize` had not been set. Moving the setting of `pageSize` to the `preFetcher` makes it available for the first filter command. 
* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #1083 
