### PR TITLE
Add name property to Form

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -59,6 +59,7 @@ import DisabledForm from './widgets/form/DisabledForm';
 import ResettingForm from './widgets/form/ResettingForm';
 import SubmitForm from './widgets/form/SubmitForm';
 import KitchenSinkForm from './widgets/form/KitchenSinkForm';
+import ActionForm from './widgets/form/ActionForm';
 import BasicGrid from './widgets/grid/Basic';
 import ColumnResize from './widgets/grid/ColumnResize';
 import CustomCellRenderer from './widgets/grid/CustomCellRenderer';
@@ -582,6 +583,11 @@ export const config = {
 					title: 'Form with all available options',
 					module: KitchenSinkForm,
 					filename: 'KitchenSinkForm'
+				},
+				{
+					title: 'Action form with a name',
+					module: ActionForm,
+					filename: 'ActionForm'
 				}
 			],
 			filename: 'index',

--- a/src/examples/src/widgets/form/ActionForm.tsx
+++ b/src/examples/src/widgets/form/ActionForm.tsx
@@ -4,7 +4,6 @@ import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import TextInput from '@dojo/widgets/text-input';
 import Form from '@dojo/widgets/form';
 import { FormMiddleware } from '@dojo/widgets/form/middleware';
-import Button from '@dojo/widgets/button';
 
 const icache = createICacheMiddleware<{
 	basic?: Partial<Fields>;

--- a/src/examples/src/widgets/form/ActionForm.tsx
+++ b/src/examples/src/widgets/form/ActionForm.tsx
@@ -1,0 +1,88 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
+
+import TextInput from '@dojo/widgets/text-input';
+import Form from '@dojo/widgets/form';
+import { FormMiddleware } from '@dojo/widgets/form/middleware';
+import Button from '@dojo/widgets/button';
+
+const icache = createICacheMiddleware<{
+	basic?: Partial<Fields>;
+}>();
+
+const factory = create({ icache });
+
+interface Fields {
+	firstName?: string;
+	middleName?: string;
+	lastName?: string;
+	email?: string;
+}
+
+const App = factory(function({ middleware: { icache } }) {
+	const results = icache.get('basic');
+
+	return (
+		<virtual>
+			<Form
+				name="actionForm"
+				action="action-url"
+				onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}
+			>
+				{({ field }: FormMiddleware<Fields>) => {
+					const firstName = field('firstName');
+					const middleName = field('middleName');
+					const lastName = field('lastName');
+					const email = field('email');
+
+					return (
+						<virtual>
+							<TextInput
+								key="firstName"
+								label="First Name"
+								placeholder="Enter first name"
+								initialValue={firstName.value()}
+								onValue={firstName.value}
+							/>
+							<TextInput
+								key="middleName"
+								label="Middle Name"
+								placeholder="Enter a middle name"
+								initialValue={middleName.value()}
+								onValue={middleName.value}
+							/>
+							<TextInput
+								key="lastName"
+								label="Last Name"
+								placeholder="Enter a last name"
+								initialValue={lastName.value()}
+								onValue={lastName.value}
+							/>
+							<TextInput
+								key="email"
+								label="Email"
+								placeholder="Enter an email address"
+								initialValue={email.value()}
+								onValue={email.value}
+								type="email"
+							/>
+						</virtual>
+					);
+				}}
+			</Form>
+			{results && (
+				<div key="onValueResults">
+					<h2>onValue Results</h2>
+					<ul>
+						<li>First Name: {results.firstName}</li>
+						<li>Middle Name: {results.middleName}</li>
+						<li>Last Name: {results.lastName}</li>
+						<li>Email: {results.email}</li>
+					</ul>
+				</div>
+			)}
+		</virtual>
+	);
+});
+
+export default App;

--- a/src/examples/src/widgets/form/Basic.tsx
+++ b/src/examples/src/widgets/form/Basic.tsx
@@ -23,7 +23,10 @@ const App = factory(function({ middleware: { icache } }) {
 
 	return (
 		<virtual>
-			<Form onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}>
+			<Form
+				name="basicForm"
+				onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}
+			>
 				{({ field }: FormMiddleware<Fields>) => {
 					const firstName = field('firstName');
 					const middleName = field('middleName');

--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -15,6 +15,8 @@ interface BaseFormProperties extends ThemeProperties {
 	initialValue?: FormValue;
 	/** Callback called when a form value changes */
 	onValue?(values: FormValue): void;
+	/** The name property of the form */
+	name?: string;
 
 	onSubmit?: never;
 	action?: never;
@@ -68,6 +70,13 @@ export default factory(function Form({
 	let formProps: Partial<VNodeProperties> = {
 		classes: themedCss.root
 	};
+
+	if (props.name) {
+		formProps = {
+			...formProps,
+			name: props.name
+		};
+	}
 
 	const { initialValue, onValue } = props;
 

--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -68,15 +68,9 @@ export default factory(function Form({
 	const props = properties();
 
 	let formProps: Partial<VNodeProperties> = {
-		classes: themedCss.root
+		classes: themedCss.root,
+		name: props.name
 	};
-
-	if (props.name) {
-		formProps = {
-			...formProps,
-			name: props.name
-		};
-	}
 
 	const { initialValue, onValue } = props;
 

--- a/src/form/tests/unit/Form.spec.tsx
+++ b/src/form/tests/unit/Form.spec.tsx
@@ -25,7 +25,7 @@ interface Fields {
 describe('Form', () => {
 	const noop = () => {};
 	const baseAssertion = assertionTemplate(() => (
-		<form classes={css.root} onsubmit={noop}>
+		<form name="formName" classes={css.root} onsubmit={noop}>
 			<TextInput
 				key="firstName"
 				label="First Name"
@@ -117,6 +117,7 @@ describe('Form', () => {
 			}}
 			onSubmit={onSubmit}
 			onValue={onValue}
+			name="formName"
 		>
 			{({ value, valid, disabled, field, reset }: FormMiddleware<Fields>) => {
 				const firstName = field('firstName', true);

--- a/src/form/tests/unit/Form.spec.tsx
+++ b/src/form/tests/unit/Form.spec.tsx
@@ -512,7 +512,7 @@ describe('Form', () => {
 			</Form>
 		));
 		const actionTemplate = assertionTemplate(() => (
-			<form classes={css.root} action="test-url" method="get">
+			<form name={undefined} classes={css.root} action="test-url" method="get">
 				<div />
 			</form>
 		));
@@ -522,7 +522,7 @@ describe('Form', () => {
 	it('defaults method to post when using an action', () => {
 		const h = harness(() => <Form action="test-url">{() => <div />}</Form>);
 		const actionTemplate = assertionTemplate(() => (
-			<form classes={css.root} action="test-url" method="post">
+			<form name={undefined} classes={css.root} action="test-url" method="post">
 				<div />
 			</form>
 		));


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds a `name` property to the form.

Resolves #1044 

