### PR TITLE
Add Header Card widget

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -23,6 +23,7 @@
 			"src/email-input",
 			"src/form",
 			"src/grid",
+			"src/header-card",
 			"src/helper-text",
 			"src/icon",
 			"src/label",

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -23,6 +23,8 @@ import CardWithMediaContent from './widgets/card/CardWithMediaContent';
 import CardWithMediaRectangle from './widgets/card/CardWithMediaRectangle';
 import CardWithMediaSquare from './widgets/card/CardWithMediaSquare';
 import BasicHeaderCard from './widgets/header-card/Basic';
+import MediaHeaderCard from './widgets/header-card/MediaCard';
+import ActionHeaderCard from './widgets/header-card/ActionCard';
 import BasicCheckboxGroup from './widgets/checkbox-group/Basic';
 import CustomLabelCheckboxGroup from './widgets/checkbox-group/CustomLabel';
 import CustomRendererCheckboxGroup from './widgets/checkbox-group/CustomRenderer';
@@ -352,39 +354,14 @@ export const config = {
 			examples: [
 				{
 					title: 'Basic HeaderCard with Action Buttons',
-					module: ActionButtons,
-					filename: 'ActionButtons'
+					module: ActionHeaderCard,
+					filename: 'ActionHeaderCard'
+				},
+				{
+					title: 'Header Card with media',
+					module: MediaHeaderCard,
+					filename: 'MediaHeaderCard'
 				}
-				// {
-				// 	title: 'Basic HeaderCard with Action Icons',
-				// 	module: ActionIcons,
-				// 	filename: 'ActionIcons'
-				// },
-				// {
-				// 	title: 'Basic HeaderCard with Actions and Icons',
-				// 	module: ActionButtonsAndIcons,
-				// 	filename: 'ActionButtonsAndIcons'
-				// },
-				// {
-				// 	title: 'Basic HeaderCard with 16x9 Media',
-				// 	module: CardWithMediaRectangle,
-				// 	filename: 'CardWithMediaRectangle'
-				// },
-				// {
-				// 	title: 'Basic HeaderCard with Square Media',
-				// 	module: CardWithMediaSquare,
-				// 	filename: 'CardWithMediaSquare'
-				// },
-				// {
-				// 	title: 'Basic card with Content Media',
-				// 	module: CardWithMediaContent,
-				// 	filename: 'CardWithMediaContent'
-				// },
-				// {
-				// 	title: 'Combined Card',
-				// 	module: CardCombined,
-				// 	filename: 'CardCombined'
-				// }
 			],
 			filename: 'index',
 			overview: {

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -22,6 +22,7 @@ import CardCombined from './widgets/card/CardCombined';
 import CardWithMediaContent from './widgets/card/CardWithMediaContent';
 import CardWithMediaRectangle from './widgets/card/CardWithMediaRectangle';
 import CardWithMediaSquare from './widgets/card/CardWithMediaSquare';
+import BasicHeaderCard from './widgets/header-card/Basic';
 import BasicCheckboxGroup from './widgets/checkbox-group/Basic';
 import CustomLabelCheckboxGroup from './widgets/checkbox-group/CustomLabel';
 import CustomRendererCheckboxGroup from './widgets/checkbox-group/CustomRenderer';
@@ -344,6 +345,52 @@ export const config = {
 				example: {
 					filename: 'Basic',
 					module: BasicCard
+				}
+			}
+		},
+		'header-card': {
+			examples: [
+				{
+					title: 'Basic HeaderCard with Action Buttons',
+					module: ActionButtons,
+					filename: 'ActionButtons'
+				}
+				// {
+				// 	title: 'Basic HeaderCard with Action Icons',
+				// 	module: ActionIcons,
+				// 	filename: 'ActionIcons'
+				// },
+				// {
+				// 	title: 'Basic HeaderCard with Actions and Icons',
+				// 	module: ActionButtonsAndIcons,
+				// 	filename: 'ActionButtonsAndIcons'
+				// },
+				// {
+				// 	title: 'Basic HeaderCard with 16x9 Media',
+				// 	module: CardWithMediaRectangle,
+				// 	filename: 'CardWithMediaRectangle'
+				// },
+				// {
+				// 	title: 'Basic HeaderCard with Square Media',
+				// 	module: CardWithMediaSquare,
+				// 	filename: 'CardWithMediaSquare'
+				// },
+				// {
+				// 	title: 'Basic card with Content Media',
+				// 	module: CardWithMediaContent,
+				// 	filename: 'CardWithMediaContent'
+				// },
+				// {
+				// 	title: 'Combined Card',
+				// 	module: CardCombined,
+				// 	filename: 'CardCombined'
+				// }
+			],
+			filename: 'index',
+			overview: {
+				example: {
+					filename: 'Basic',
+					module: BasicHeaderCard
 				}
 			}
 		},

--- a/src/examples/src/widgets/header-card/ActionCard.tsx
+++ b/src/examples/src/widgets/header-card/ActionCard.tsx
@@ -1,0 +1,33 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import HeaderCard from '@dojo/widgets/header-card';
+import Avatar from '@dojo/widgets/avatar';
+import Button from '@dojo/widgets/button';
+import Icon from '@dojo/widgets/icon';
+const mediaSrc = require('../card/img/card-photo.jpg');
+const avatar = require('../avatar/img/dojo.jpg');
+
+const factory = create();
+
+export default factory(function Basic() {
+	return (
+		<div styles={{ width: '400px' }}>
+			<HeaderCard
+				avatar={() => <Avatar src={avatar} />}
+				title="Hello, World"
+				subtitle="Lorem ipsum"
+				mediaSrc={mediaSrc}
+			>
+				{{
+					content: () => <p>Lorem ipsum</p>,
+					actionButtons: () => <Button>Action</Button>,
+					actionIcons: () => (
+						<virtual>
+							<Icon type="upIcon" />
+							<Icon type="downIcon" />
+						</virtual>
+					)
+				}}
+			</HeaderCard>
+		</div>
+	);
+});

--- a/src/examples/src/widgets/header-card/Basic.tsx
+++ b/src/examples/src/widgets/header-card/Basic.tsx
@@ -1,0 +1,21 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import HeaderCard from '@dojo/widgets/header-card';
+import Avatar from '@dojo/widgets/avatar';
+
+const factory = create();
+
+export default factory(function Basic() {
+	return (
+		<div styles={{ width: '400px' }}>
+			<HeaderCard
+				title="Hello, World"
+				subtitle="Lorem ipsum"
+				avatar={() => <Avatar>D</Avatar>}
+			>
+				{{
+					content: () => <p>Lorem ipsum</p>
+				}}
+			</HeaderCard>
+		</div>
+	);
+});

--- a/src/examples/src/widgets/header-card/MediaCard.tsx
+++ b/src/examples/src/widgets/header-card/MediaCard.tsx
@@ -1,0 +1,24 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import HeaderCard from '@dojo/widgets/header-card';
+import Avatar from '@dojo/widgets/avatar';
+const mediaSrc = require('../card/img/card-photo.jpg');
+const avatar = require('../avatar/img/dojo.jpg');
+
+const factory = create();
+
+export default factory(function Basic() {
+	return (
+		<div styles={{ width: '400px' }}>
+			<HeaderCard
+				avatar={() => <Avatar src={avatar} />}
+				title="Hello, World"
+				subtitle="Lorem ipsum"
+				mediaSrc={mediaSrc}
+			>
+				{{
+					content: () => <p>Lorem ipsum</p>
+				}}
+			</HeaderCard>
+		</div>
+	);
+});

--- a/src/header-card/README.md
+++ b/src/header-card/README.md
@@ -1,0 +1,9 @@
+# @dojo/widgets/header-card
+
+Dojo's `HeaderCard` widget is a wrapper around `@dojo/widgets/card` that adds common styling for title, subtitle, and avatar properties in the card's header .
+
+## Feautres
+
+- Wrap content with a consistent style
+- Consistently style the header section of a card
+- Include actions within the card

--- a/src/header-card/index.tsx
+++ b/src/header-card/index.tsx
@@ -1,0 +1,48 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import theme from '../middleware/theme';
+import Card, { CardProperties, CardChildren } from '../card';
+import { RenderResult } from '@dojo/framework/core/interfaces';
+import * as css from '../theme/default/header-card.m.css';
+
+type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
+
+export interface HeaderCardProperties extends CardProperties {
+	title: string;
+	avatar?: () => RenderResult;
+}
+
+export interface HeaderCardChildren extends Omit<CardChildren, 'header'> {}
+
+const factory = create({ theme })
+	.properties<HeaderCardProperties>()
+	.children<HeaderCardChildren>();
+
+export const HeaderCard = factory(function HeaderCard({
+	middleware: { theme },
+	properties,
+	children
+}) {
+	const themeCss = theme.classes(css);
+	const { title, subtitle, avatar, ...cardProps } = properties();
+	const cardChildren = children()[0];
+	return (
+		<Card {...cardProps}>
+			{{
+				header: () => (
+					<virtual>
+						<div classes={themeCss.header}>
+							{avatar && <div classes={themeCss.avatar}>{avatar()}</div>}
+							<div classes={themeCss.headerContent}>
+								{<h2 classes={themeCss.title}>{title}</h2>}
+								{subtitle && <h3 classes={themeCss.subtitle}>{subtitle}</h3>}
+							</div>
+						</div>
+					</virtual>
+				),
+				...cardChildren
+			}}
+		</Card>
+	);
+});
+
+export default HeaderCard;

--- a/src/header-card/index.tsx
+++ b/src/header-card/index.tsx
@@ -24,7 +24,7 @@ export const HeaderCard = factory(function HeaderCard({
 }) {
 	const themeCss = theme.classes(css);
 	const { title, subtitle, avatar, ...cardProps } = properties();
-	const cardChildren = children()[0];
+	const [ cardChildren ] = children();
 	return (
 		<Card key="root" {...cardProps}>
 			{{

--- a/src/header-card/index.tsx
+++ b/src/header-card/index.tsx
@@ -15,7 +15,7 @@ export interface HeaderCardChildren extends Omit<CardChildren, 'header'> {}
 
 const factory = create({ theme })
 	.properties<HeaderCardProperties>()
-	.children<HeaderCardChildren>();
+	.children<HeaderCardChildren | undefined>();
 
 export const HeaderCard = factory(function HeaderCard({
 	middleware: { theme },
@@ -26,18 +26,16 @@ export const HeaderCard = factory(function HeaderCard({
 	const { title, subtitle, avatar, ...cardProps } = properties();
 	const cardChildren = children()[0];
 	return (
-		<Card {...cardProps}>
+		<Card key="root" {...cardProps}>
 			{{
 				header: () => (
-					<virtual>
-						<div classes={themeCss.header}>
-							{avatar && <div classes={themeCss.avatar}>{avatar()}</div>}
-							<div classes={themeCss.headerContent}>
-								{<h2 classes={themeCss.title}>{title}</h2>}
-								{subtitle && <h3 classes={themeCss.subtitle}>{subtitle}</h3>}
-							</div>
+					<div key="header" classes={themeCss.header}>
+						{avatar && <div classes={themeCss.avatar}>{avatar()}</div>}
+						<div key="headerContent" classes={themeCss.headerContent}>
+							{<h2 classes={themeCss.title}>{title}</h2>}
+							{subtitle && <h3 classes={themeCss.subtitle}>{subtitle}</h3>}
 						</div>
-					</virtual>
+					</div>
 				),
 				...cardChildren
 			}}

--- a/src/header-card/tests/unit/HeaderCard.spec.tsx
+++ b/src/header-card/tests/unit/HeaderCard.spec.tsx
@@ -1,0 +1,77 @@
+const { describe, it } = intern.getInterface('bdd');
+import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
+import harness from '@dojo/framework/testing/harness';
+import { tsx } from '@dojo/framework/core/vdom';
+import HeaderCard from '../../index';
+import Card from '../../../card';
+import Avatar from '../../../avatar';
+import * as css from '../../../theme/default/header-card.m.css';
+
+describe('HeaderCard', () => {
+	const template = assertionTemplate(() => (
+		<Card key="root">
+			{{
+				header: () => (
+					<div key="header" classes={css.header}>
+						<div key="headerContent" classes={css.headerContent}>
+							<h2 classes={css.title}>title</h2>
+						</div>
+					</div>
+				)
+			}}
+		</Card>
+	));
+
+	it('renders', () => {
+		const h = harness(() => <HeaderCard title="title" />);
+		h.expect(template);
+	});
+
+	it('renders with a subtitle', () => {
+		const h = harness(() => <HeaderCard title="title" subtitle="subtitle" />);
+		h.expect(
+			template.setChildren(
+				'@root',
+				() =>
+					[
+						{
+							header: () => (
+								<div key="header" classes={css.header}>
+									<div key="headerContent" classes={css.headerContent}>
+										{<h2 classes={css.title}>title</h2>}
+										<h3 classes={css.subtitle}>subtitle</h3>
+									</div>
+								</div>
+							)
+						}
+					] as any
+			)
+		);
+	});
+
+	it('renders with a an avatar', () => {
+		const avatar = <Avatar>D</Avatar>;
+		const h = harness(() => (
+			<HeaderCard square title="title" subtitle="subtitle" avatar={() => avatar} />
+		));
+		h.expect(
+			template.setProperty('@root', 'square', true).setChildren(
+				'@root',
+				() =>
+					[
+						{
+							header: () => (
+								<div key="header" classes={css.header}>
+									<div classes={css.avatar}>avatar</div>
+									<div key="headerContent" classes={css.headerContent}>
+										{<h2 classes={css.title}>title</h2>}
+										<h3 classes={css.subtitle}>subtitle</h3>
+									</div>
+								</div>
+							)
+						}
+					] as any
+			)
+		);
+	});
+});

--- a/src/theme/default/header-card.m.css
+++ b/src/theme/default/header-card.m.css
@@ -1,0 +1,15 @@
+/* The wrapper around a header */
+.header {
+}
+
+.headerContent {
+}
+
+.avatar {
+}
+
+.title {
+}
+
+.subtitle {
+}

--- a/src/theme/default/header-card.m.css.d.ts
+++ b/src/theme/default/header-card.m.css.d.ts
@@ -1,0 +1,5 @@
+export const header: string;
+export const headerContent: string;
+export const avatar: string;
+export const title: string;
+export const subtitle: string;

--- a/src/theme/dojo/header-card.m.css
+++ b/src/theme/dojo/header-card.m.css
@@ -1,0 +1,25 @@
+@import './variables.css';
+
+/* The wrapper around a header */
+.header {
+	display: flex;
+	padding-top: calc(2 * var(--spacing-regular));
+	align-items: center;
+}
+
+.headerContent {
+	flex: 1 1 auto;
+}
+
+.avatar {
+	margin-right: calc(2 * var(--spacing-regular));
+	flex: 0 0 auto;
+}
+
+.title {
+	font-size: var(--font-size-title);
+}
+
+.subtitle {
+	font-size: var(--font-size-small);
+}

--- a/src/theme/dojo/header-card.m.css.d.ts
+++ b/src/theme/dojo/header-card.m.css.d.ts
@@ -1,0 +1,5 @@
+export const header: string;
+export const headerContent: string;
+export const avatar: string;
+export const title: string;
+export const subtitle: string;

--- a/src/theme/dojo/index.ts
+++ b/src/theme/dojo/index.ts
@@ -17,6 +17,7 @@ import * as gridHeader from './grid-header.m.css';
 import * as gridPlaceholderRow from './grid-placeholder-row.m.css';
 import * as gridPaginatedFooter from './grid-paginated-footer.m.css';
 import * as gridRow from './grid-row.m.css';
+import * as headerCard from './header-card.m.css';
 import * as helperText from './helper-text.m.css';
 import * as icon from './icon.m.css';
 import * as label from './label.m.css';
@@ -65,6 +66,7 @@ export default {
 	'@dojo/widgets/grid-paginated-footer': gridPaginatedFooter,
 	'@dojo/widgets/grid-row': gridRow,
 	'@dojo/widgets/grid': grid,
+	'@dojo/widgets/header-card': headerCard,
 	'@dojo/widgets/helper-text': helperText,
 	'@dojo/widgets/icon': icon,
 	'@dojo/widgets/label': label,

--- a/src/theme/material/header-card.m.css
+++ b/src/theme/material/header-card.m.css
@@ -1,0 +1,26 @@
+@import './variables.css';
+
+/* The wrapper around a header */
+.header {
+	display: flex;
+	padding-top: 1rem;
+	align-items: center;
+}
+
+.headerContent {
+	flex: 1 1 auto;
+}
+
+.avatar {
+	margin-right: 1rem;
+	flex: 0 0 auto;
+}
+
+.title {
+	composes: mdc-typography mdc-typography--headline6 from '@material/typography/dist/mdc.typography.css';
+}
+
+.subtitle {
+	composes: mdc-typography mdc-typography--subtitle2 from '@material/typography/dist/mdc.typography.css';
+	color: var(--mdc-theme-text-secondary-on-background);
+}

--- a/src/theme/material/header-card.m.css.d.ts
+++ b/src/theme/material/header-card.m.css.d.ts
@@ -1,0 +1,5 @@
+export const header: string;
+export const headerContent: string;
+export const avatar: string;
+export const title: string;
+export const subtitle: string;

--- a/src/theme/material/index.ts
+++ b/src/theme/material/index.ts
@@ -16,6 +16,7 @@ import * as gridPaginatedFooter from './grid-paginated-footer.m.css';
 import * as gridPlaceholderRow from './grid-placeholder-row.m.css';
 import * as gridRow from './grid-row.m.css';
 import * as grid from './grid.m.css';
+import * as headerCard from './header-card.m.css';
 import * as helperText from './helper-text.m.css';
 import * as icon from './icon.m.css';
 import * as label from './label.m.css';
@@ -62,6 +63,7 @@ export default {
 	'@dojo/widgets/grid-placeholder-row': gridPlaceholderRow,
 	'@dojo/widgets/grid-row': gridRow,
 	'@dojo/widgets/grid': grid,
+	'@dojo/widgets/header-card': headerCard,
 	'@dojo/widgets/helper-text': helperText,
 	'@dojo/widgets/icon': icon,
 	'@dojo/widgets/label': label,


### PR DESCRIPTION
**Type:** feature

**Note:** This PR relies on #1105 and #1104 being merged. Please review those first.

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This adds a new card, a header card, that wraps the card implementation and takes over rendering of the card's `header` named child to provide a consistently-styled header for the card. The header-card takes all the same properties and children (minus `header` named child). It takes over rendering the `title` and `subtitle` if provided and will render them in the header (and prevent them from being passed to the underlying card). It also adds an `avatar` property which will render an avatar in the header next to the title/subtitle.

Resolves #978 

**Example**
```tsx
<HeaderCard
	avatar={() => <Avatar src={avatar} />}
	title="Hello, World"
	subtitle="Lorem ipsum"
	mediaSrc={mediaSrc}
>
	{{
		content: () => <p>Lorem ipsum</p>,
		actionButtons: () => <Button>Action</Button>,
		actionIcons: () => (
			<virtual>
				<Icon type="upIcon" />
				<Icon type="downIcon" />
			</virtual>
		)
	}}
</HeaderCard>
```
![image](https://user-images.githubusercontent.com/293805/74691397-4f98f000-51a8-11ea-8b21-72550c426ac4.png)
