### PR TITLE
Add helper-text pass through and tests

### DIFF
--- a/src/constrained-input/index.tsx
+++ b/src/constrained-input/index.tsx
@@ -28,16 +28,18 @@ export const ConstrainedInput = factory(function ConstrainedInput({
 	middleware: { icache, validation, theme },
 	properties
 }) {
-	const { rules, onValidate, ...props } = properties();
+	const { rules, onValidate, helperText, ...props } = properties();
 	const valid = icache.get('valid');
 
 	const validator = validation(rules);
 
 	const handleValidation = (valid?: boolean, message?: string) => {
 		icache.set('valid', { valid, message });
-
 		onValidate && onValidate(valid);
 	};
+
+	const generatedDescribeHelperText =
+		valid && valid.valid === true ? undefined : validator.describe().join(' ');
 
 	return (
 		<TextInput
@@ -50,7 +52,7 @@ export const ConstrainedInput = factory(function ConstrainedInput({
 			customValidator={validator}
 			valid={valid}
 			onValidate={handleValidation}
-			helperText={valid && valid.valid === true ? undefined : validator.describe().join(' ')}
+			helperText={helperText ? helperText : generatedDescribeHelperText}
 		/>
 	);
 });

--- a/src/constrained-input/tests/unit/ConstrainedInput.spec.tsx
+++ b/src/constrained-input/tests/unit/ConstrainedInput.spec.tsx
@@ -62,6 +62,29 @@ describe('ConstrainedInput', () => {
 		));
 	});
 
+	it('will display user helperText if passed instead of generated description', () => {
+		const h = harness(
+			() => (
+				<ConstrainedInput rules={rules} label="Test Label" helperText="test helper text" />
+			),
+			{
+				middleware: [[validation, createMockValidationMiddleware(() => true)]],
+				customComparator: [compareTheme]
+			}
+		);
+		h.expect(() => (
+			<TextInput
+				key="root"
+				theme={{ '@dojo/widgets/text-input': textInputCss }}
+				customValidator={() => {}}
+				valid={undefined}
+				onValidate={() => {}}
+				helperText="test helper text"
+				label="Test Label"
+			/>
+		));
+	});
+
 	it('handles validation and messaging', () => {
 		const h = harness(
 			() => (


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Allows constrained input to accept a helper text property which overrides the generated description.

Resolves #1108 
