### PR TITLE
Added missing variables in material theme

### DIFF
--- a/src/theme/material/calendar.m.css
+++ b/src/theme/material/calendar.m.css
@@ -2,44 +2,44 @@
 
 .root {
 	position: relative;
-	width: calc(var(--grid-base) * 32);
+	width: calc(var(--mdc-grid-base) * 32);
 	font-family: var(--mdc-theme-font-family);
-	font-size: var(--font-size-small);
+	font-size: var(--mdc-font-size-small);
 	color: var(--mdc-theme-on-surface);
-	padding-left: calc(var(--grid-base) * 2);
-	padding-right: calc(var(--grid-base) * 2);
+	padding-left: calc(var(--mdc-grid-base) * 2);
+	padding-right: calc(var(--mdc-grid-base) * 2);
 }
 
 .monthTrigger {
-	padding-right: calc(var(--grid-base) * 0.75);
-	padding-left: calc(var(--grid-base) * 1);
+	padding-right: calc(var(--mdc-grid-base) * 0.75);
+	padding-left: calc(var(--mdc-grid-base) * 1);
 }
 
 .datePicker {
-	padding-top: calc(var(--grid-base) * 1.75);
+	padding-top: calc(var(--mdc-grid-base) * 1.75);
 }
 
 .topMatter {
-	padding-bottom: var(--grid-base);
+	padding-bottom: var(--mdc-grid-base);
 }
 
 .weekday,
 .date {
-	width: calc(var(--grid-base) * 4);
-	height: calc(var(--grid-base) * 4);
+	width: calc(var(--mdc-grid-base) * 4);
+	height: calc(var(--mdc-grid-base) * 4);
 	text-align: center;
 	position: relative;
 	z-index: 0;
 }
 
 .inactiveDate {
-	color: var(--disabled-color);
+	color: var(--mdc-disabled-color);
 }
 
 .weekday .abbr {
 	font-weight: 300;
 	text-decoration: none;
-	color: var(--disabled-color);
+	color: var(--mdc-disabled-color);
 }
 
 .selectedDate {
@@ -51,8 +51,8 @@
 	position: absolute;
 	left: 2px;
 	top: 2px;
-	width: calc(var(--grid-base) * 3.5);
-	height: calc(var(--grid-base) * 3.5);
+	width: calc(var(--mdc-grid-base) * 3.5);
+	height: calc(var(--mdc-grid-base) * 3.5);
 	border-radius: 50%;
 	content: '';
 	z-index: -1;
@@ -73,24 +73,24 @@
 .previous,
 .next {
 	position: absolute;
-	top: calc(var(--grid-base) * 2);
+	top: calc(var(--mdc-grid-base) * 2);
 }
 
 .next {
-	right: var(--grid-base);
-	right: calc(var(--grid-base) * 3);
+	right: var(--mdc-grid-base);
+	right: calc(var(--mdc-grid-base) * 3);
 }
 
 .previous {
-	right: calc(var(--grid-base) * 9);
+	right: calc(var(--mdc-grid-base) * 9);
 }
 
 .yearRadio,
 .monthRadio {
-	height: calc(var(--grid-base) * 4);
-	width: calc(var(--grid-base) * 7);
+	height: calc(var(--mdc-grid-base) * 4);
+	width: calc(var(--mdc-grid-base) * 7);
 	display: inline-flex;
-	margin-left: calc(var(--grid-base) * -0.5);
+	margin-left: calc(var(--mdc-grid-base) * -0.5);
 	align-items: center;
 	justify-content: center;
 }
@@ -105,9 +105,9 @@
 	position: absolute;
 	left: 2px;
 	top: 2px;
-	width: calc(var(--grid-base) * 6.5);
-	height: calc(var(--grid-base) * 3.5);
-	border-radius: calc(var(--grid-base) * 2);
+	width: calc(var(--mdc-grid-base) * 6.5);
+	height: calc(var(--mdc-grid-base) * 3.5);
+	border-radius: calc(var(--mdc-grid-base) * 2);
 	content: '';
 	z-index: -1;
 	background-color: var(--mdc-theme-primary);

--- a/src/theme/material/variables.css
+++ b/src/theme/material/variables.css
@@ -47,4 +47,7 @@
 	--mdc-avatar-size-large: 56px;
 	--mdc-theme-heading-font-weight: 500;
 	--mdc-theme-separator: #e0e0e0;
+	--mdc-grid-base: 8px;
+	--mdc-font-size-small: 14px;
+	--mdc-disabled-color: #bbb;
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds missing style variables to calendar widget

Resolves #1113
