### PR TITLE
Adding no-label class when label is hidden

### DIFF
--- a/src/text-input/index.tsx
+++ b/src/text-input/index.tsx
@@ -244,7 +244,7 @@ export const TextInput = factory(function TextInput({
 					required ? themeCss.required : null,
 					leading ? themeCss.hasLeading : null,
 					trailing ? themeCss.hasTrailing : null,
-					!label ? themeCss.noLabel : null
+					!label || labelHidden ? themeCss.noLabel : null
 				]}
 				role="presentation"
 			>

--- a/src/text-input/tests/unit/TextInput.spec.tsx
+++ b/src/text-input/tests/unit/TextInput.spec.tsx
@@ -33,6 +33,7 @@ interface States {
 
 interface ExpectedOptions {
 	label?: boolean;
+	labelHidden?: boolean;
 	inputOverrides?: any;
 	states?: States;
 	focused?: boolean;
@@ -46,7 +47,8 @@ const expected = function({
 	states = {},
 	focused = false,
 	helperText,
-	value
+	value,
+	labelHidden = false
 }: ExpectedOptions = {}) {
 	const { disabled, required, readOnly, valid: validState } = states;
 	let valid: boolean | undefined;
@@ -75,7 +77,7 @@ const expected = function({
 					required ? css.required : null,
 					null,
 					null,
-					!label ? css.noLabel : null
+					!label || labelHidden ? css.noLabel : null
 				]}
 				role="presentation"
 			>
@@ -87,7 +89,7 @@ const expected = function({
 						focused={focused}
 						readOnly={readOnly}
 						required={required}
-						hidden={false}
+						hidden={labelHidden}
 						forId={''}
 						active={false}
 					>
@@ -708,6 +710,11 @@ registerSuite('TextInput', {
 					.setProperty('~helperText', 'valid', true)
 			);
 			clock.restore();
+		},
+		hiddenLabel() {
+			const h = harness(() => <TextInput label="foo" labelHidden={true} />);
+
+			h.expect(() => expected({ label: true, labelHidden: true }));
 		}
 	}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Applying the `noLabel` class when the label exists, but is hidden!

Resolves #1115
