### PR TITLE
Updating grid material filter styles

### DIFF
--- a/src/grid/Header.tsx
+++ b/src/grid/Header.tsx
@@ -98,6 +98,8 @@ export default class Header extends ThemedMixin(WidgetBase)<HeaderProperties> {
 				...classes,
 				'@dojo/widgets/text-input': {
 					root: [this.theme(css.filter)],
+					input: [this.theme(css.filterInput)],
+					noLabel: [this.theme(css.filterNoLabel)],
 					...passedInputClasses
 				}
 			},

--- a/src/grid/tests/unit/Header.spec.tsx
+++ b/src/grid/tests/unit/Header.spec.tsx
@@ -147,7 +147,13 @@ describe('Header', () => {
 						),
 						w(TextInput, {
 							key: 'filter',
-							classes: { '@dojo/widgets/text-input': { root: [css.filter] } },
+							classes: {
+								'@dojo/widgets/text-input': {
+									root: [css.filter],
+									input: [css.filterInput],
+									noLabel: [css.filterNoLabel]
+								}
+							},
 							label: 'Filter by Custom Title',
 							labelHidden: true,
 							type: 'search',
@@ -225,7 +231,13 @@ describe('Header', () => {
 						),
 						w(TextInput, {
 							key: 'filter',
-							classes: { '@dojo/widgets/text-input': { root: [css.filter] } },
+							classes: {
+								'@dojo/widgets/text-input': {
+									root: [css.filter],
+									input: [css.filterInput],
+									noLabel: [css.filterNoLabel]
+								}
+							},
 							label: 'Filter by Custom Title',
 							labelHidden: true,
 							type: 'search',
@@ -309,7 +321,13 @@ describe('Header', () => {
 						),
 						w(TextInput, {
 							key: 'filter',
-							classes: { '@dojo/widgets/text-input': { root: [css.filter] } },
+							classes: {
+								'@dojo/widgets/text-input': {
+									root: [css.filter],
+									input: [css.filterInput],
+									noLabel: [css.filterNoLabel]
+								}
+							},
 							label: 'Filter by Custom Title',
 							labelHidden: true,
 							type: 'search',
@@ -386,7 +404,13 @@ describe('Header', () => {
 						),
 						w(TextInput, {
 							key: 'filter',
-							classes: { '@dojo/widgets/text-input': { root: [css.filter] } },
+							classes: {
+								'@dojo/widgets/text-input': {
+									root: [css.filter],
+									input: [css.filterInput],
+									noLabel: [css.filterNoLabel]
+								}
+							},
 							label: 'Filter by Custom Title',
 							labelHidden: true,
 							type: 'search',
@@ -550,7 +574,13 @@ describe('Header', () => {
 							),
 							w(TextInput, {
 								key: 'filter',
-								classes: { '@dojo/widgets/text-input': { root: [css.filter] } },
+								classes: {
+									'@dojo/widgets/text-input': {
+										root: [css.filter],
+										input: [css.filterInput],
+										noLabel: [css.filterNoLabel]
+									}
+								},
 								label: 'Filter by Custom Title',
 								labelHidden: true,
 								type: 'search',
@@ -629,7 +659,13 @@ describe('Header', () => {
 							),
 							w(TextInput, {
 								key: 'filter',
-								classes: { '@dojo/widgets/text-input': { root: [css.filter] } },
+								classes: {
+									'@dojo/widgets/text-input': {
+										root: [css.filter],
+										input: [css.filterInput],
+										noLabel: [css.filterNoLabel]
+									}
+								},
 								label: 'Filter by Custom Title',
 								labelHidden: true,
 								type: 'search',

--- a/src/theme/default/grid-header.m.css
+++ b/src/theme/default/grid-header.m.css
@@ -56,3 +56,9 @@
 	color: var(--component-color);
 	padding: 2px 4px;
 }
+
+.filterInput {
+}
+
+.filterNoLabel {
+}

--- a/src/theme/default/grid-header.m.css.d.ts
+++ b/src/theme/default/grid-header.m.css.d.ts
@@ -6,3 +6,5 @@ export const desc: string;
 export const asc: string;
 export const sort: string;
 export const filter: string;
+export const filterInput: string;
+export const filterNoLabel: string;

--- a/src/theme/material/grid-header.m.css
+++ b/src/theme/material/grid-header.m.css
@@ -26,3 +26,11 @@
 .sorted .sort {
 	opacity: 1;
 }
+
+.root .cell .filter .filterNoLabel .filterInput {
+	padding: 8px;
+}
+
+.root .filter .filterNoLabel {
+	height: auto;
+}

--- a/src/theme/material/grid-header.m.css.d.ts
+++ b/src/theme/material/grid-header.m.css.d.ts
@@ -3,3 +3,6 @@ export const cell: string;
 export const sort: string;
 export const sortable: string;
 export const sorted: string;
+export const filter: string;
+export const filterNoLabel: string;
+export const filterInput: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Taming the grid filter styles on the material theme. Had to add some extra classes to `Header` so I could theme them.

![image](https://user-images.githubusercontent.com/2008858/75689227-d4870d80-5c6e-11ea-9e7e-4ae6cc225779.png)

Resolves #1117 
