### PR TITLE
feat: loading indicator

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -27,6 +27,7 @@
 			"src/icon",
 			"src/label",
 			"src/listbox",
+			"src/loading-indicator",
 			"src/menu",
 			"src/native-select",
 			"src/number-input",

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -182,6 +182,7 @@ import ClickTooltip from './widgets/tooltip/Click';
 import FocusTooltip from './widgets/tooltip/Focus';
 import BasicNativeSelect from './widgets/native-select/Basic';
 import BasicDateInput from './widgets/date-input/Basic';
+import BasicLoadingIndicator from './widgets/loading-indicator/Basic';
 
 `!has('docs')`;
 import testsContext from './tests';
@@ -714,6 +715,15 @@ export const config = {
 					title: 'Secondary Label'
 				}
 			]
+		},
+		'loading-indicator': {
+			filename: 'index',
+			overview: {
+				example: {
+					module: BasicLoadingIndicator,
+					filename: 'Basic'
+				}
+			}
 		},
 		menu: {
 			examples: [

--- a/src/examples/src/widgets/loading-indicator/Basic.tsx
+++ b/src/examples/src/widgets/loading-indicator/Basic.tsx
@@ -1,0 +1,8 @@
+import LoadingIndicator from '@dojo/widgets/loading-indicator';
+import { create, tsx } from '@dojo/framework/core/vdom';
+
+const factory = create();
+
+export default factory(function Basic() {
+	return <LoadingIndicator />;
+});

--- a/src/loading-indicator/README.md
+++ b/src/loading-indicator/README.md
@@ -5,4 +5,3 @@ Dojo's `LoadingIndicator` widget provides an indeterminate progress indicator.
 ### Features
 
 - Render a horizontal loading indicator
-- Provide aria-attributes for accessability

--- a/src/loading-indicator/README.md
+++ b/src/loading-indicator/README.md
@@ -1,0 +1,8 @@
+# @dojo/widgets/loading-indicator
+
+Dojo's `LoadingIndicator` widget provides an indeterminate progress indicator.
+
+### Features
+
+- Render a horizontal loading indicator
+- Provide aria-attributes for accessability

--- a/src/loading-indicator/index.tsx
+++ b/src/loading-indicator/index.tsx
@@ -1,0 +1,37 @@
+import * as css from '../theme/default/loading-indicator.m.css';
+import theme from '../middleware/theme';
+import { ThemedProperties } from '@dojo/framework/core/mixins/Themed';
+import { create, tsx } from '@dojo/framework/core/vdom';
+
+export interface LoadingIndicatorProperties extends ThemedProperties {
+	/** Custom aria attributes */
+	aria?: { [key: string]: string | null };
+}
+
+const factory = create({ theme }).properties<LoadingIndicatorProperties>();
+
+export const LoadingIndicator = factory(function LoadingIndicator({
+	properties,
+	middleware: { theme }
+}) {
+	const classes = theme.classes(css);
+	const { aria = {} } = properties();
+
+	return (
+		<div
+			aria-label={aria.label}
+			aria-valuemax={aria.valuemax}
+			aria-valuemin={aria.valuemin}
+			aria-valuenow={aria.valuenow}
+			classes={classes.root}
+			role="progressbar"
+		>
+			<div classes={classes.buffer} />
+			<div classes={[classes.bar, classes.primary]}>
+				<span classes={classes.inner} />
+			</div>
+		</div>
+	);
+});
+
+export default LoadingIndicator;

--- a/src/loading-indicator/index.tsx
+++ b/src/loading-indicator/index.tsx
@@ -3,29 +3,15 @@ import theme from '../middleware/theme';
 import { ThemedProperties } from '@dojo/framework/core/mixins/Themed';
 import { create, tsx } from '@dojo/framework/core/vdom';
 
-export interface LoadingIndicatorProperties extends ThemedProperties {
-	/** Custom aria attributes */
-	aria?: { [key: string]: string | null };
-}
+export interface LoadingIndicatorProperties extends ThemedProperties {}
 
 const factory = create({ theme }).properties<LoadingIndicatorProperties>();
 
-export const LoadingIndicator = factory(function LoadingIndicator({
-	properties,
-	middleware: { theme }
-}) {
+export const LoadingIndicator = factory(function LoadingIndicator({ middleware: { theme } }) {
 	const classes = theme.classes(css);
-	const { aria = {} } = properties();
 
 	return (
-		<div
-			aria-label={aria.label}
-			aria-valuemax={aria.valuemax}
-			aria-valuemin={aria.valuemin}
-			aria-valuenow={aria.valuenow}
-			classes={classes.root}
-			role="progressbar"
-		>
+		<div classes={classes.root} role="progressbar">
 			<div classes={classes.buffer} />
 			<div classes={[classes.bar, classes.primary]}>
 				<span classes={classes.inner} />

--- a/src/loading-indicator/tests/unit/LoadingIndicator.spec.tsx
+++ b/src/loading-indicator/tests/unit/LoadingIndicator.spec.tsx
@@ -1,0 +1,29 @@
+const { describe, it } = intern.getInterface('bdd');
+import * as classes from '../../../theme/default/loading-indicator.m.css';
+import LoadingIndicator from '../..';
+import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
+import harness from '@dojo/framework/testing/harness';
+import { tsx } from '@dojo/framework/core/vdom';
+
+const baseTemplate = assertionTemplate(() => (
+	<div
+		aria-label={undefined}
+		aria-valuemax={undefined}
+		aria-valuemin={undefined}
+		aria-valuenow={undefined}
+		classes={classes.root}
+		role="progressbar"
+	>
+		<div classes={classes.buffer} />
+		<div classes={classes.primary}>
+			<span classes={classes.inner} />
+		</div>
+	</div>
+));
+
+describe('LoadingIndicator', () => {
+	it('Renders default state', () => {
+		const h = harness(() => <LoadingIndicator />);
+		h.expect(baseTemplate);
+	});
+});

--- a/src/loading-indicator/tests/unit/LoadingIndicator.spec.tsx
+++ b/src/loading-indicator/tests/unit/LoadingIndicator.spec.tsx
@@ -6,14 +6,7 @@ import harness from '@dojo/framework/testing/harness';
 import { tsx } from '@dojo/framework/core/vdom';
 
 const baseTemplate = assertionTemplate(() => (
-	<div
-		aria-label={undefined}
-		aria-valuemax={undefined}
-		aria-valuemin={undefined}
-		aria-valuenow={undefined}
-		classes={classes.root}
-		role="progressbar"
-	>
+	<div classes={classes.root} role="progressbar">
 		<div classes={classes.buffer} />
 		<div classes={[classes.bar, classes.primary]}>
 			<span classes={classes.inner} />

--- a/src/loading-indicator/tests/unit/LoadingIndicator.spec.tsx
+++ b/src/loading-indicator/tests/unit/LoadingIndicator.spec.tsx
@@ -15,7 +15,7 @@ const baseTemplate = assertionTemplate(() => (
 		role="progressbar"
 	>
 		<div classes={classes.buffer} />
-		<div classes={classes.primary}>
+		<div classes={[classes.bar, classes.primary]}>
 			<span classes={classes.inner} />
 		</div>
 	</div>

--- a/src/theme/default/index.ts
+++ b/src/theme/default/index.ts
@@ -46,7 +46,6 @@ import * as textInput from './text-input.m.css';
 import * as timePicker from './time-picker.m.css';
 import * as titlePane from './title-pane.m.css';
 import * as toolbar from './toolbar.m.css';
-v;
 
 export default {
 	'@dojo/widgets/accordion-pane': accordionPane,

--- a/src/theme/default/index.ts
+++ b/src/theme/default/index.ts
@@ -22,6 +22,7 @@ import * as helperText from './helper-text.m.css';
 import * as icon from './icon.m.css';
 import * as label from './label.m.css';
 import * as listbox from './listbox.m.css';
+import * as loadingIndicator from './loading-indicator.m.css';
 import * as menu from './menu.m.css';
 import * as menuItem from './menu-item.m.css';
 import * as nativeSelect from './native-select.m.css';
@@ -45,7 +46,7 @@ import * as textInput from './text-input.m.css';
 import * as timePicker from './time-picker.m.css';
 import * as titlePane from './title-pane.m.css';
 import * as toolbar from './toolbar.m.css';
-import * as tooltip from './tooltip.m.css';
+v;
 
 export default {
 	'@dojo/widgets/accordion-pane': accordionPane,
@@ -72,6 +73,7 @@ export default {
 	'@dojo/widgets/icon': icon,
 	'@dojo/widgets/label': label,
 	'@dojo/widgets/listbox': listbox,
+	'@dojo/widgets/loading-indicator': loadingIndicator,
 	'@dojo/widgets/menu': menu,
 	'@dojo/widgets/menu-item': menuItem,
 	'@dojo/widgets/native-select': nativeSelect,

--- a/src/theme/default/index.ts
+++ b/src/theme/default/index.ts
@@ -46,6 +46,7 @@ import * as textInput from './text-input.m.css';
 import * as timePicker from './time-picker.m.css';
 import * as titlePane from './title-pane.m.css';
 import * as toolbar from './toolbar.m.css';
+import * as tooltip from './tooltip.m.css';
 
 export default {
 	'@dojo/widgets/accordion-pane': accordionPane,

--- a/src/theme/default/loading-indicator.m.css
+++ b/src/theme/default/loading-indicator.m.css
@@ -1,0 +1,19 @@
+/* Outermost container */
+.root {
+}
+
+/* Loading track background */
+.buffer {
+}
+
+/* Loading track bar */
+.bar {
+}
+
+/* Loading track foreground */
+.primary {
+}
+
+/* Loading track foreground inner */
+.inner {
+}

--- a/src/theme/default/loading-indicator.m.css.d.ts
+++ b/src/theme/default/loading-indicator.m.css.d.ts
@@ -1,0 +1,5 @@
+export const root: string;
+export const buffer: string;
+export const bar: string;
+export const primary: string;
+export const inner: string;

--- a/src/theme/dojo/index.ts
+++ b/src/theme/dojo/index.ts
@@ -22,6 +22,7 @@ import * as icon from './icon.m.css';
 import * as label from './label.m.css';
 import * as listbox from './listbox.m.css';
 import * as listboxItem from './listbox-item.m.css';
+import * as loadingIndicator from './loading-indicator.m.css';
 import * as menu from './menu.m.css';
 import * as menuItem from './menu-item.m.css';
 import * as outlinedButton from './outlined-button.m.css';
@@ -70,6 +71,7 @@ export default {
 	'@dojo/widgets/label': label,
 	'@dojo/widgets/listbox': listbox,
 	'@dojo/widgets/list-box-item': listboxItem,
+	'@dojo/widgets/loading-indicator': loadingIndicator,
 	'@dojo/widgets/menu-item': menuItem,
 	'@dojo/widgets/menu': menu,
 	'@dojo/widgets/outlined-button': outlinedButton,

--- a/src/theme/dojo/loading-indicator.m.css
+++ b/src/theme/dojo/loading-indicator.m.css
@@ -1,0 +1,34 @@
+@import './variables.css';
+
+.root {
+	background-color: var(--color-background-faded);
+	height: calc(var(--grid-base) / 2);
+	position: relative;
+}
+
+.buffer {
+}
+
+.bar {
+}
+
+.primary {
+	animation: progress 2s infinite linear;
+	background-color: var(--color-background-inverted);
+	height: 100%;
+	left: -25%;
+	position: relative;
+	width: 25%;
+}
+
+.inner {
+}
+
+@keyframes progress {
+	0% {
+		left: -25%;
+	}
+	100% {
+		left: 100%;
+	}
+}

--- a/src/theme/dojo/loading-indicator.m.css.d.ts
+++ b/src/theme/dojo/loading-indicator.m.css.d.ts
@@ -1,0 +1,6 @@
+export const root: string;
+export const buffer: string;
+export const bar: string;
+export const primary: string;
+export const progress: string;
+export const inner: string;

--- a/src/theme/material/index.ts
+++ b/src/theme/material/index.ts
@@ -21,6 +21,7 @@ import * as icon from './icon.m.css';
 import * as label from './label.m.css';
 import * as listbox from './listbox.m.css';
 import * as listBoxItem from './list-box-item.m.css';
+import * as loadingIndicator from './loading-indicator.m.css';
 import * as menu from './menu.m.css';
 import * as menuItem from './menu-item.m.css';
 import * as nativeSelect from './native-select.m.css';
@@ -66,6 +67,7 @@ export default {
 	'@dojo/widgets/label': label,
 	'@dojo/widgets/listbox': listbox,
 	'@dojo/widgets/list-box-item': listBoxItem,
+	'@dojo/widgets/loading-indicator': loadingIndicator,
 	'@dojo/widgets/menu': menu,
 	'@dojo/widgets/menu-item': menuItem,
 	'@dojo/widgets/native-select': nativeSelect,

--- a/src/theme/material/loading-indicator.m.css
+++ b/src/theme/material/loading-indicator.m.css
@@ -1,0 +1,20 @@
+.root {
+	composes: mdc-linear-progress from '@material/linear-progress/dist/mdc.linear-progress.css';
+	composes: mdc-linear-progress--indeterminate from '@material/linear-progress/dist/mdc.linear-progress.css';
+}
+
+.buffer {
+	composes: mdc-linear-progress__buffer from '@material/linear-progress/dist/mdc.linear-progress.css';
+}
+
+.bar {
+	composes: mdc-linear-progress__bar from '@material/linear-progress/dist/mdc.linear-progress.css';
+}
+
+.primary {
+	composes: mdc-linear-progress__primary-bar from '@material/linear-progress/dist/mdc.linear-progress.css';
+}
+
+.inner {
+	composes: mdc-linear-progress__bar-inner from '@material/linear-progress/dist/mdc.linear-progress.css';
+}

--- a/src/theme/material/loading-indicator.m.css
+++ b/src/theme/material/loading-indicator.m.css
@@ -1,6 +1,5 @@
 .root {
-	composes: mdc-linear-progress from '@material/linear-progress/dist/mdc.linear-progress.css';
-	composes: mdc-linear-progress--indeterminate from '@material/linear-progress/dist/mdc.linear-progress.css';
+	composes: mdc-linear-progress mdc-linear-progress--indeterminate from '@material/linear-progress/dist/mdc.linear-progress.css';
 }
 
 .buffer {

--- a/src/theme/material/loading-indicator.m.css.d.ts
+++ b/src/theme/material/loading-indicator.m.css.d.ts
@@ -1,0 +1,5 @@
+export const root: string;
+export const buffer: string;
+export const bar: string;
+export const primary: string;
+export const inner: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request adds an indeterminate loading indicator widget.

Resolves #1119

**Preview**

![preview](https://i.gyazo.com/3350a42b9321a3f90264f2329f4d39f7.gif)
