### PR TITLE
Removing certain functional widget property extends

### DIFF
--- a/src/avatar/index.tsx
+++ b/src/avatar/index.tsx
@@ -1,8 +1,8 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import theme, { ThemeProperties } from '../middleware/theme';
+import theme from '../middleware/theme';
 import * as css from '../theme/default/avatar.m.css';
 
-export interface AvatarProperties extends ThemeProperties {
+export interface AvatarProperties {
 	variant?: 'square' | 'rounded' | 'circle';
 	secondary?: boolean;
 	src?: string;

--- a/src/card/index.tsx
+++ b/src/card/index.tsx
@@ -1,9 +1,9 @@
 import { tsx, create } from '@dojo/framework/core/vdom';
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import * as css from '../theme/default/card.m.css';
-import theme, { ThemeProperties } from '../middleware/theme';
+import theme from '../middleware/theme';
 
-export interface CardProperties extends ThemeProperties {
+export interface CardProperties {
 	onAction?: () => void;
 	mediaSrc?: string;
 	mediaTitle?: string;

--- a/src/checkbox-group/index.tsx
+++ b/src/checkbox-group/index.tsx
@@ -2,12 +2,12 @@ import { create, tsx } from '@dojo/framework/core/vdom';
 import { checkboxGroup } from './middleware';
 import { Checkbox } from '../checkbox/index';
 import { RenderResult } from '@dojo/framework/core/interfaces';
-import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
+import theme from '@dojo/framework/core/middleware/theme';
 import * as css from '../theme/default/checkbox-group.m.css';
 
 type CheckboxOptions = { value: string; label?: string }[];
 
-interface CheckboxGroupProperties extends ThemeProperties {
+interface CheckboxGroupProperties {
 	/** The name attribute for this form group */
 	name: string;
 	/** The label to be displayed in the legend */

--- a/src/checkbox/index.tsx
+++ b/src/checkbox/index.tsx
@@ -1,13 +1,12 @@
 import { tsx, create } from '@dojo/framework/core/vdom';
 import * as css from '../theme/default/checkbox.m.css';
-import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
+import theme from '@dojo/framework/core/middleware/theme';
 import focus from '@dojo/framework/core/middleware/focus';
-import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import Label from '../label/index';
 import { formatAriaProperties } from '../common/util';
 import { uuid } from '@dojo/framework/core/util';
 
-export interface CheckboxProperties extends ThemeProperties, FocusProperties {
+export interface CheckboxProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/**  Checked/unchecked property of the control */

--- a/src/chip/index.tsx
+++ b/src/chip/index.tsx
@@ -1,11 +1,11 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import { RenderResult } from '@dojo/framework/core/interfaces';
-import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
+import theme from '@dojo/framework/core/middleware/theme';
 import * as css from '../theme/default/chip.m.css';
 import Icon from '../icon/index';
 import { Keys } from '../common/util';
 
-export interface ChipProperties extends ThemeProperties {
+export interface ChipProperties {
 	/** Renders an icon, provided with the value of the checked property */
 	iconRenderer?(checked?: boolean): RenderResult;
 	/** The label to be displayed in the widget */

--- a/src/context-menu/index.tsx
+++ b/src/context-menu/index.tsx
@@ -1,11 +1,11 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import theme, { ThemeProperties } from '../middleware/theme';
+import theme from '../middleware/theme';
 import Menu, { MenuOption } from '../menu/index';
 import * as menuCss from '../theme/default/menu.m.css';
 import * as css from '../theme/default/context-menu.m.css';
 import ContextPopup from '../context-popup';
 
-export interface ContextMenuProperties extends ThemeProperties {
+export interface ContextMenuProperties {
 	/* Menu options for the context menu. Uses the same API as the menu widget */
 	options: MenuOption[];
 	/* A callback that will be called with the value of whatever item is selected */

--- a/src/context-popup/index.tsx
+++ b/src/context-popup/index.tsx
@@ -1,13 +1,12 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import focus from '@dojo/framework/core/middleware/focus';
-import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import Popup from '../popup';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 
 import * as css from '../theme/default/context-popup.m.css';
 
-export interface ContextPopupProperties extends FocusProperties {
+export interface ContextPopupProperties {
 	onClose?(): void;
 	onOpen?(): void;
 }

--- a/src/dialog/index.tsx
+++ b/src/dialog/index.tsx
@@ -5,7 +5,7 @@ import { uuid } from '@dojo/framework/core/util';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import { formatAriaProperties, Keys } from '../common/util';
 import Icon from '../icon';
-import theme, { ThemeProperties } from '../middleware/theme';
+import theme from '../middleware/theme';
 import bodyScroll from '../middleware/bodyScroll';
 import * as css from '../theme/default/dialog.m.css';
 import * as fixedCss from './styles/dialog.m.css';
@@ -13,7 +13,7 @@ import commonBundle from '../common/nls/common';
 import GlobalEvent from '../global-event';
 import inert from '@dojo/framework/core/middleware/inert';
 
-export interface DialogPropertiesBase extends ThemeProperties {
+export interface DialogPropertiesBase {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Determines whether the dialog can be closed */

--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -1,6 +1,6 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import icache from '@dojo/framework/core/middleware/icache';
-import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
+import theme from '@dojo/framework/core/middleware/theme';
 import { RenderResult, VNodeProperties } from '@dojo/framework/core/interfaces';
 
 import createFormMiddleware, { FormMiddleware, FormValue } from './middleware';
@@ -10,7 +10,7 @@ const form = createFormMiddleware();
 
 type Omit<T, E> = Pick<T, Exclude<keyof T, E>>;
 
-interface BaseFormProperties extends ThemeProperties {
+interface BaseFormProperties {
 	/** The initial form value */
 	initialValue?: FormValue;
 	/** Callback called when a form value changes */

--- a/src/helper-text/index.tsx
+++ b/src/helper-text/index.tsx
@@ -1,8 +1,8 @@
-import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
+import theme from '@dojo/framework/core/middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import * as css from '../theme/default/helper-text.m.css';
 
-export interface HelperTextProperties extends ThemeProperties {
+export interface HelperTextProperties {
 	/** The supplied helper text */
 	text?: string;
 	/** If `HelperText` indicates a valid condition */

--- a/src/icon/index.tsx
+++ b/src/icon/index.tsx
@@ -1,12 +1,12 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import theme, { ThemeProperties } from '../middleware/theme';
+import theme from '../middleware/theme';
 import { formatAriaProperties } from '../common/util';
 import * as css from '../theme/default/icon.m.css';
 import * as baseCss from '../common/styles/base.m.css';
 
 export type IconType = keyof typeof css;
 
-export interface IconProperties extends ThemeProperties {
+export interface IconProperties {
 	/** An optional, visually hidden label for the icon */
 	altText?: string;
 	/** Custom aria attributes */

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -1,12 +1,11 @@
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import { focus } from '@dojo/framework/core/middleware/focus';
-import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, renderer, tsx } from '@dojo/framework/core/vdom';
 import { findIndex } from '@dojo/framework/shim/array';
 import global from '@dojo/framework/shim/global';
 import { Keys } from '../common/util';
-import theme, { ThemeProperties } from '../middleware/theme';
+import theme from '../middleware/theme';
 import * as listBoxItemCss from '../theme/default/list-box-item.m.css';
 import * as menuItemCss from '../theme/default/menu-item.m.css';
 import * as css from '../theme/default/menu.m.css';
@@ -16,7 +15,7 @@ import MenuItem from './MenuItem';
 
 export type MenuOption = { value: string; label?: string; disabled?: boolean; divider?: boolean };
 
-export interface MenuProperties extends ThemeProperties, FocusProperties {
+export interface MenuProperties {
 	/** Options to display within the menu. The `value` of the option will be passed to `onValue` when it is selected. The label is an optional display string to be used instead of the `value`. If `disabled` is true the option will have a disabled style and will not be selectable. An option with `divider: true` will have a divider rendered after it in the menu */
 	options: MenuOption[];
 	/** The total number of options provided */

--- a/src/native-select/index.tsx
+++ b/src/native-select/index.tsx
@@ -1,10 +1,9 @@
 import { focus } from '@dojo/framework/core/middleware/focus';
-import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { i18n } from '@dojo/framework/core/middleware/i18n';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import HelperText from '../helper-text';
-import theme, { ThemeProperties } from '../middleware/theme';
+import theme from '../middleware/theme';
 import * as css from '../theme/default/native-select.m.css';
 import * as labelCss from '../theme/default/label.m.css';
 import * as iconCss from '../theme/default/icon.m.css';
@@ -13,7 +12,7 @@ import Label from '../label';
 
 export type MenuOption = { value: string; label?: string; disabled?: boolean };
 
-export interface NativeSelectProperties extends FocusProperties, ThemeProperties {
+export interface NativeSelectProperties {
 	/** Callback called when user selects a value */
 	onValue?(value: string): void;
 	/** The initial selected value */

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -1,5 +1,5 @@
 import { dimensions } from '@dojo/framework/core/middleware/dimensions';
-import { theme, ThemeProperties } from '@dojo/framework/core/middleware/theme';
+import { theme } from '@dojo/framework/core/middleware/theme';
 import { bodyScroll } from '../middleware/bodyScroll';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import * as css from '../theme/default/popup.m.css';
@@ -8,7 +8,7 @@ import { RenderResult } from '@dojo/framework/core/interfaces';
 
 export type PopupPosition = 'above' | 'below';
 
-export interface BasePopupProperties extends ThemeProperties {
+export interface BasePopupProperties {
 	/** Preferred position where the popup should render relative to the provided position (defaults to "below"). If the popup does not have room to fully render in the preferred position it will switch to the opposite side. */
 	position?: PopupPosition;
 	/** If the underlay should be visible (defaults to false) */

--- a/src/radio-group/index.tsx
+++ b/src/radio-group/index.tsx
@@ -1,5 +1,5 @@
 import * as css from '../theme/default/radio-group.m.css';
-import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
+import theme from '@dojo/framework/core/middleware/theme';
 import { Radio } from '../radio/index';
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import { create, tsx } from '@dojo/framework/core/vdom';
@@ -7,7 +7,7 @@ import { radioGroup } from './middleware';
 
 type RadioOptions = { value: string; label?: string }[];
 
-interface RadioGroupProperties extends ThemeProperties {
+interface RadioGroupProperties {
 	/** Initial value of the radio group */
 	initialValue?: string;
 	/** The label to be displayed in the legend */

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -1,6 +1,5 @@
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import { focus } from '@dojo/framework/core/middleware/focus';
-import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { i18n } from '@dojo/framework/core/middleware/i18n';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { uuid } from '@dojo/framework/core/util';
@@ -10,7 +9,7 @@ import HelperText from '../helper-text';
 import Icon from '../icon';
 import Label from '../label';
 import { ItemRendererProperties, Menu, MenuOption } from '../menu';
-import theme, { ThemeProperties } from '../middleware/theme';
+import theme from '../middleware/theme';
 import { PopupPosition } from '../popup';
 import TriggerPopup from '../trigger-popup';
 import * as menuCss from '../theme/default/menu.m.css';
@@ -19,7 +18,7 @@ import * as iconCss from '../theme/default/icon.m.css';
 import * as css from '../theme/default/select.m.css';
 import bundle from './select.nls';
 
-interface SelectProperties extends ThemeProperties, FocusProperties {
+interface SelectProperties {
 	/** Callback called when user selects a value */
 	onValue(value: string): void;
 	/** The initial selected value */

--- a/src/slider/index.tsx
+++ b/src/slider/index.tsx
@@ -1,15 +1,14 @@
 import { DNode } from '@dojo/framework/core/interfaces';
 import focus from '@dojo/framework/core/middleware/focus';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
-import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
+import theme from '@dojo/framework/core/middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import { formatAriaProperties } from '../common/util';
 import Label from '../label/index';
 import * as css from '../theme/default/slider.m.css';
 import * as fixedCss from './styles/slider.m.css';
 
-export interface SliderProperties extends ThemeProperties, FocusProperties {
+export interface SliderProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Set the disabled property of the control */

--- a/src/snackbar/index.tsx
+++ b/src/snackbar/index.tsx
@@ -1,9 +1,9 @@
 import { RenderResult } from '@dojo/framework/core/interfaces';
-import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
+import theme from '@dojo/framework/core/middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import * as css from '../theme/default/snackbar.m.css';
 
-export interface SnackbarProperties extends ThemeProperties {
+export interface SnackbarProperties {
 	/** If the snackbar is displayed */
 	open: boolean;
 	/** Renders the message portion of the snackbar */

--- a/src/switch/index.tsx
+++ b/src/switch/index.tsx
@@ -1,14 +1,13 @@
 import { DNode } from '@dojo/framework/core/interfaces';
 import focus from '@dojo/framework/core/middleware/focus';
-import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
-import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
+import theme from '@dojo/framework/core/middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
 
 import { formatAriaProperties } from '../common/util';
 import Label from '../label';
 import * as css from '../theme/default/switch.m.css';
 
-interface SwitchProperties extends ThemeProperties, FocusProperties {
+interface SwitchProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Whether the switch is disabled or clickable */

--- a/src/text-area/index.tsx
+++ b/src/text-area/index.tsx
@@ -5,13 +5,11 @@ import * as css from '../theme/default/text-area.m.css';
 import * as labelCss from '../theme/default/label.m.css';
 import HelperText from '../helper-text/index';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-import { ThemeProperties } from '@dojo/framework/core/middleware/theme';
 import theme from '../middleware/theme';
 import focus from '@dojo/framework/core/middleware/focus';
-import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import validity from '@dojo/framework/core/middleware/validity';
 
-export interface TextAreaProperties extends ThemeProperties, FocusProperties {
+export interface TextAreaProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Number of columns, controls the width of the textarea */

--- a/src/text-input/index.tsx
+++ b/src/text-input/index.tsx
@@ -1,8 +1,7 @@
 import { DNode } from '@dojo/framework/core/interfaces';
 import focus from '@dojo/framework/core/middleware/focus';
-import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-import theme, { ThemeProperties } from '@dojo/framework/core/middleware/theme';
+import theme from '@dojo/framework/core/middleware/theme';
 import validity from '@dojo/framework/core/middleware/validity';
 import { create, diffProperty, invalidator, tsx } from '@dojo/framework/core/vdom';
 import { formatAriaProperties } from '../common/util';
@@ -20,9 +19,7 @@ export type TextInputType =
 	| 'url'
 	| 'date';
 
-export interface BaseInputProperties<T extends { value: any } = { value: string }>
-	extends ThemeProperties,
-		FocusProperties {
+export interface BaseInputProperties<T extends { value: any } = { value: string }> {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Should the field autocomplete */

--- a/src/tooltip/index.tsx
+++ b/src/tooltip/index.tsx
@@ -1,12 +1,12 @@
 import { DNode } from '@dojo/framework/core/interfaces';
 import { create, tsx } from '@dojo/framework/core/vdom';
-import theme, { ThemeProperties } from '../middleware/theme';
+import theme from '../middleware/theme';
 
 import * as fixedCss from './styles/tooltip.m.css';
 import * as css from '../theme/default/tooltip.m.css';
 import { formatAriaProperties } from '../common/util';
 
-export interface TooltipProperties extends ThemeProperties {
+export interface TooltipProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Information to show within the tooltip */


### PR DESCRIPTION
There does not appear to be difference when we remove the `ThemeMixin` or `FocusedProperties` extends clauses from the functional widgets... I manually verified a few widgets with and without the extends and the results were the same.

As such, I removed all the `ThemeMixin` and `FocusedProperty` extensions from the functional widgets.