### PR TITLE
fix: remove unnecessary box-sizing rules

### DIFF
--- a/src/grid/styles/body.m.css
+++ b/src/grid/styles/body.m.css
@@ -1,5 +1,4 @@
 .rootFixed {
-	box-sizing: border-box;
 	height: 100%;
 	overflow-x: auto;
 	overflow-y: scroll;

--- a/src/grid/styles/grid.m.css
+++ b/src/grid/styles/grid.m.css
@@ -1,10 +1,8 @@
 .rootFixed {
 	height: 100%;
-	box-sizing: border-box;
 }
 
 .headerFixed {
 	overflow-y: scroll;
 	overflow-x: hidden;
-	box-sizing: border-box;
 }

--- a/src/grid/styles/row.m.css
+++ b/src/grid/styles/row.m.css
@@ -1,5 +1,4 @@
 .rootFixed {
 	border-left-style: none;
-	box-sizing: border-box;
 	display: flex;
 }

--- a/src/slide-pane/styles/slide-pane.m.css
+++ b/src/slide-pane/styles/slide-pane.m.css
@@ -8,7 +8,6 @@
 
 .paneFixed {
 	position: fixed;
-	box-sizing: border-box;
 	display: flex;
 	flex-direction: column;
 }

--- a/src/theme/default/button.m.css
+++ b/src/theme/default/button.m.css
@@ -11,7 +11,6 @@
 .pressed::before {
 	border-bottom: 2px solid black;
 	border-right: 2px solid black;
-	box-sizing: border-box;
 	content: '';
 	display: inline-block;
 	height: 1em;

--- a/src/theme/default/calendar.m.css
+++ b/src/theme/default/calendar.m.css
@@ -2,7 +2,6 @@
 
 /* The root class of the calendar */
 .root {
-	box-sizing: border-box;
 	display: inline-block;
 }
 

--- a/src/theme/default/combobox.m.css
+++ b/src/theme/default/combobox.m.css
@@ -4,7 +4,6 @@
 .root {
 	position: relative;
 	display: inline-block;
-	box-sizing: border-box;
 	width: 200px;
 }
 

--- a/src/theme/default/grid-footer.m.css
+++ b/src/theme/default/grid-footer.m.css
@@ -8,5 +8,4 @@
 	border-left: 1px solid var(--component-color);
 	border-right: 1px solid var(--component-color);
 	height: 20px;
-	box-sizing: border-box;
 }

--- a/src/theme/default/grid-header.m.css
+++ b/src/theme/default/grid-header.m.css
@@ -52,7 +52,6 @@
 .filter {
 	margin-top: 4px;
 	width: 100%;
-	box-sizing: border-box;
 	color: var(--component-color);
 	padding: 2px 4px;
 }

--- a/src/theme/default/grid-row.m.css
+++ b/src/theme/default/grid-row.m.css
@@ -1,6 +1,5 @@
 /* The root class of the grid Row */
 .root {
-	box-sizing: border-box;
 	height: 30px;
 	border-left-style: none;
 }

--- a/src/theme/default/list-box-item.m.css
+++ b/src/theme/default/list-box-item.m.css
@@ -3,7 +3,6 @@
 	background: white;
 	padding: 10px;
 	border: 1px solid transparent;
-	box-sizing: border-box;
 	height: 45px;
 }
 

--- a/src/theme/default/menu-item.m.css
+++ b/src/theme/default/menu-item.m.css
@@ -3,7 +3,6 @@
 	background: white;
 	padding: 10px;
 	border: 1px solid transparent;
-	box-sizing: border-box;
 	height: 45px;
 }
 

--- a/src/theme/default/tab-controller.m.css
+++ b/src/theme/default/tab-controller.m.css
@@ -62,7 +62,6 @@
 
 /* The root class of the TabController */
 .root {
-	box-sizing: border-box;
 }
 
 /* The root class of the TabButton */

--- a/src/theme/default/time-picker.m.css
+++ b/src/theme/default/time-picker.m.css
@@ -2,7 +2,6 @@
 
 /* The root class of the TimePicker */
 .root {
-	box-sizing: border-box;
 	display: inline-block;
 }
 

--- a/src/theme/dojo/button.m.css
+++ b/src/theme/dojo/button.m.css
@@ -1,11 +1,5 @@
 @import './variables.css';
 
-.root,
-.root:before,
-.root:after {
-	box-sizing: border-box;
-}
-
 .root {
 	background-color: var(--color-background);
 	border: var(--border-width) solid var(--color-border);

--- a/src/theme/dojo/calendar.m.css
+++ b/src/theme/dojo/calendar.m.css
@@ -1,10 +1,6 @@
 @import './variables.css';
 
 .root {
-	box-sizing: border-box;
-}
-
-.root {
 	border: var(--border-width) solid var(--color-border);
 	display: inline-block;
 	font-size: var(--font-size-base);

--- a/src/theme/dojo/card.m.css
+++ b/src/theme/dojo/card.m.css
@@ -13,20 +13,17 @@
 	flex-direction: row;
 	padding: var(--grid-base);
 	align-items: center;
-	box-sizing: border-box;
 	min-height: 52px;
 }
 
 .actionButtons {
 	display: flex;
 	align-items: center;
-	box-sizing: border-box;
 }
 
 .actionIcons {
 	display: flex;
 	align-items: center;
-	box-sizing: border-box;
 	flex-grow: 1;
 	justify-content: flex-end;
 }
@@ -54,7 +51,6 @@
 	background-repeat: no-repeat;
 	background-position: 50%;
 	background-size: cover;
-	box-sizing: border-box;
 	margin-bottom: calc(2 * var(--grid-base));
 }
 

--- a/src/theme/dojo/checkbox.m.css
+++ b/src/theme/dojo/checkbox.m.css
@@ -1,10 +1,6 @@
 @import './variables.css';
 
 .root {
-	box-sizing: border-box;
-}
-
-.root {
 	display: block;
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);

--- a/src/theme/dojo/combobox.m.css
+++ b/src/theme/dojo/combobox.m.css
@@ -1,7 +1,6 @@
 @import './variables.css';
 
 .root {
-	box-sizing: border-box;
 	color: var(--color-text-primary);
 	display: inline-block;
 	font-size: var(--font-size-base);

--- a/src/theme/dojo/dialog.m.css
+++ b/src/theme/dojo/dialog.m.css
@@ -6,10 +6,6 @@
 	line-height: var(--line-height-base);
 }
 
-.root {
-	box-sizing: border-box;
-}
-
 .main {
 	background: #fff;
 	border: var(--border-width) solid var(--color-border);
@@ -35,7 +31,6 @@
 
 .title {
 	border-bottom: var(--border-width) solid var(--color-border);
-	box-sizing: border-box;
 	flex: 0 0 auto;
 	font-size: var(--font-size-title);
 	height: calc(7 * var(--grid-base));

--- a/src/theme/dojo/grid-footer.m.css
+++ b/src/theme/dojo/grid-footer.m.css
@@ -2,7 +2,6 @@
 
 .root {
 	background-color: var(--color-background-faded);
-	box-sizing: border-box;
 	color: var(--color-text-primary);
 	padding: var(--grid-base) calc(var(--grid-base) / 2);
 	border-top: var(--border-width) solid var(--color-border);

--- a/src/theme/dojo/grid-row.m.css
+++ b/src/theme/dojo/grid-row.m.css
@@ -1,7 +1,6 @@
 @import './variables.css';
 
 .root {
-	box-sizing: border-box;
 	height: calc(var(--grid-base) * 5);
 	border-top: var(--border-width) solid var(--color-border);
 }

--- a/src/theme/dojo/radio.m.css
+++ b/src/theme/dojo/radio.m.css
@@ -1,10 +1,6 @@
 @import './variables.css';
 
 .root {
-	box-sizing: border-box;
-}
-
-.root {
 	display: block;
 	min-height: var(--line-height-base);
 	padding: 0 0 0 calc(var(--grid-base) * 3);
@@ -35,7 +31,6 @@
 .radioOuter,
 .radioInner {
 	border-radius: 50%;
-	box-sizing: border-box;
 	content: '';
 	display: block;
 	transition: transform var(--transition-duration) var(--transition-easing),

--- a/src/theme/dojo/range-slider.m.css
+++ b/src/theme/dojo/range-slider.m.css
@@ -1,10 +1,6 @@
 @import './variables.css';
 
 .root {
-	box-sizing: border-box;
-}
-
-.root {
 	display: block;
 	font: var(--font-size-base);
 	line-height: var(--line-height-base);

--- a/src/theme/dojo/slide-pane.m.css
+++ b/src/theme/dojo/slide-pane.m.css
@@ -1,7 +1,6 @@
 @import './variables.css';
 
 .root {
-	box-sizing: border-box;
 	color: var(--color-text-primary);
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);
@@ -25,7 +24,6 @@
 
 .title {
 	border-bottom: var(--border-width) solid var(--color-border);
-	box-sizing: border-box;
 	flex: 0 0 auto;
 	font-size: var(--font-size-title);
 	height: calc(7 * var(--grid-base));

--- a/src/theme/dojo/slider.m.css
+++ b/src/theme/dojo/slider.m.css
@@ -1,10 +1,6 @@
 @import './variables.css';
 
 .root {
-	box-sizing: border-box;
-}
-
-.root {
 	display: block;
 	font: var(--font-size-base);
 	line-height: var(--line-height-base);

--- a/src/theme/dojo/snackbar.m.css
+++ b/src/theme/dojo/snackbar.m.css
@@ -8,7 +8,6 @@
 	left: 0;
 	align-items: center;
 	justify-content: center;
-	box-sizing: border-box;
 	pointer-events: none;
 	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 	margin: var(--spacing-regular);
@@ -20,7 +19,6 @@
 	align-items: center;
 	flex-direction: row;
 	justify-content: flex-start;
-	box-sizing: border-box;
 	opacity: 0;
 	color: var(--color-text-inverted);
 	background-color: var(--color-dark);
@@ -32,7 +30,6 @@
 
 .label {
 	flex-grow: 1;
-	box-sizing: border-box;
 	margin: 0;
 	padding: var(--spacing-regular);
 }
@@ -41,7 +38,6 @@
 	display: flex;
 	flex-shrink: 0;
 	align-items: center;
-	box-sizing: border-box;
 }
 
 .open {

--- a/src/theme/dojo/split-pane.m.css
+++ b/src/theme/dojo/split-pane.m.css
@@ -1,7 +1,6 @@
 @import './variables.css';
 
 .root {
-	box-sizing: border-box;
 	color: var(--color-text-primary);
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);

--- a/src/theme/dojo/tab-controller.m.css
+++ b/src/theme/dojo/tab-controller.m.css
@@ -5,7 +5,6 @@
 }
 
 .root {
-	box-sizing: border-box;
 	color: var(--color-text-primary);
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);

--- a/src/theme/dojo/text-area.m.css
+++ b/src/theme/dojo/text-area.m.css
@@ -1,10 +1,6 @@
 @import './variables.css';
 
 .root {
-	box-sizing: border-box;
-}
-
-.root {
 	display: block;
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);

--- a/src/theme/dojo/text-input.m.css
+++ b/src/theme/dojo/text-input.m.css
@@ -7,7 +7,6 @@
 	display: block;
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);
-	box-sizing: border-box;
 }
 
 .input {
@@ -21,7 +20,6 @@
 	); /* for IE 11 */
 	line-height: var(--line-height-base);
 	padding: var(--grid-base);
-	box-sizing: border-box;
 }
 
 .input:focus {
@@ -40,7 +38,6 @@
 	flex-direction: row;
 	align-items: center;
 	transition: box-shadow var(--transition-duration) var(--transition-easing);
-	box-sizing: border-box;
 }
 
 .focused .inputWrapper {
@@ -99,5 +96,4 @@
 	line-height: var(--line-height-base);
 	padding: var(--grid-base);
 	transition: border var(--transition-duration) var(--transition-easing);
-	box-sizing: border-box;
 }

--- a/src/theme/dojo/time-picker.m.css
+++ b/src/theme/dojo/time-picker.m.css
@@ -7,7 +7,6 @@
 .input {
 	border: var(--border-width) solid var(--color-border);
 	border-bottom-color: var(--color-border-strong);
-	box-sizing: border-box;
 	font-size: inherit;
 	line-height: var(--line-height-base);
 	padding: var(--grid-base) calc(var(--grid-base) * 3) var(--grid-base) var(--grid-base);

--- a/src/theme/dojo/title-pane.m.css
+++ b/src/theme/dojo/title-pane.m.css
@@ -1,7 +1,6 @@
 @import './variables.css';
 
 .root {
-	box-sizing: border-box;
 	color: var(--color-text-primary);
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);

--- a/src/theme/dojo/toolbar.m.css
+++ b/src/theme/dojo/toolbar.m.css
@@ -4,7 +4,6 @@
 	background: var(--color-background);
 	border-top: var(--border-width) solid var(--color-border);
 	border-bottom: var(--border-width) solid var(--color-border);
-	box-sizing: border-box;
 	height: calc(7 * var(--grid-base));
 	padding: calc(2 * var(--grid-base));
 	text-align: left;

--- a/src/theme/dojo/tooltip.m.css
+++ b/src/theme/dojo/tooltip.m.css
@@ -6,10 +6,6 @@
 	line-height: var(--line-height-base);
 }
 
-.root {
-	box-sizing: border-box;
-}
-
 .content {
 	background-color: var(--color-background-inverted);
 	color: var(--color-text-inverted);

--- a/src/theme/material/checkbox.m.css
+++ b/src/theme/material/checkbox.m.css
@@ -33,7 +33,6 @@
 	border-left: none;
 	border-top: none;
 	transform: translate(3.5px, -0.5px) rotate(45deg);
-	box-sizing: border-box;
 }
 
 .disabled,

--- a/src/theme/material/title-pane.m.css
+++ b/src/theme/material/title-pane.m.css
@@ -2,7 +2,6 @@
 
 .root {
 	font-family: var(--mdc-theme-font-family);
-	box-sizing: border-box;
 	box-shadow: var(--mdc-theme-elevation-1);
 }
 

--- a/src/title-pane/styles/title-pane.m.css
+++ b/src/title-pane/styles/title-pane.m.css
@@ -1,7 +1,6 @@
 .rootFixed {
 	overflow: hidden;
 	position: relative;
-	box-sizing: border-box;
 }
 
 .titleFixed {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request removes unnecessary `border-sizing` rules.

Resolves #1009 
