### PR TITLE
Fix: Dojo & Material theme styles

### DIFF
--- a/src/examples/src/widgets/card/ActionButtons.tsx
+++ b/src/examples/src/widgets/card/ActionButtons.tsx
@@ -18,7 +18,7 @@ export default factory(function ActionButtons({ middleware: { icache } }) {
 								: `Clicked: ${clickCount} time${clickCount > 1 ? 's' : ''}`}
 						</Button>
 					),
-					content: () => <p>Lorem ipsum</p>
+					content: () => <span>Lorem ipsum</span>
 				}}
 			</Card>
 		</div>

--- a/src/examples/src/widgets/card/ActionButtonsAndIcons.tsx
+++ b/src/examples/src/widgets/card/ActionButtonsAndIcons.tsx
@@ -12,7 +12,7 @@ export default factory(function ActionButtonsAndIcons({ middleware: { icache } }
 		<div styles={{ width: '400px' }}>
 			<Card title="Hello, World">
 				{{
-					content: () => <p>Lorem ipsum</p>,
+					content: () => <span>Lorem ipsum</span>,
 					actionButtons: () => (
 						<Button onClick={() => icache.set('clickCount', clickCount + 1)}>
 							{clickCount === 0

--- a/src/examples/src/widgets/card/Basic.tsx
+++ b/src/examples/src/widgets/card/Basic.tsx
@@ -8,7 +8,7 @@ export default factory(function Basic() {
 		<div styles={{ width: '400px' }}>
 			<Card title="Hello, World">
 				{{
-					content: () => <p>Lorem ipsum</p>
+					content: () => <span>Lorem ipsum</span>
 				}}
 			</Card>
 		</div>

--- a/src/examples/src/widgets/card/CardCombined.tsx
+++ b/src/examples/src/widgets/card/CardCombined.tsx
@@ -17,7 +17,7 @@ export default factory(function CardWithMediaContent() {
 			>
 				{{
 					header: () => <div>Header Content</div>,
-					content: () => <p>Travel the world today.</p>,
+					content: () => <span>Travel the world today.</span>,
 					actionButtons: () => (
 						<virtual>
 							<Button>Read</Button>

--- a/src/examples/src/widgets/card/CardWithMediaContent.tsx
+++ b/src/examples/src/widgets/card/CardWithMediaContent.tsx
@@ -9,7 +9,7 @@ export default factory(function CardWithMediaContent() {
 		<div styles={{ width: '400px' }}>
 			<Card title="Hello, World" mediaSrc={mediaSrc}>
 				{{
-					content: () => <p>Lorem ipsum</p>
+					content: () => <span>Lorem ipsum</span>
 				}}
 			</Card>
 		</div>

--- a/src/examples/src/widgets/card/CardWithMediaRectangle.tsx
+++ b/src/examples/src/widgets/card/CardWithMediaRectangle.tsx
@@ -9,7 +9,7 @@ export default factory(function CardWithMediaRectangle() {
 		<div styles={{ width: '400px' }}>
 			<Card mediaSrc={mediaSrc} title="Hello, World" subtitle="Lorem ipsum">
 				{{
-					content: () => <p>Content goes here.</p>
+					content: () => <span>Content goes here.</span>
 				}}
 			</Card>
 		</div>

--- a/src/examples/src/widgets/card/CardWithMediaSquare.tsx
+++ b/src/examples/src/widgets/card/CardWithMediaSquare.tsx
@@ -9,7 +9,7 @@ export default factory(function CardWithMediaSquare() {
 		<div styles={{ width: '200px' }}>
 			<Card title="Hello, World" square mediaSrc={mediaSrc}>
 				{{
-					content: () => <p>Lorem ipsum</p>
+					content: () => <span>Lorem ipsum</span>
 				}}
 			</Card>
 		</div>

--- a/src/examples/src/widgets/checkbox-group/CustomRenderer.tsx
+++ b/src/examples/src/widgets/checkbox-group/CustomRenderer.tsx
@@ -5,7 +5,7 @@ import { icache } from '@dojo/framework/core/middleware/icache';
 
 const factory = create({ icache });
 
-const App = factory(function({ properties, middleware: { icache } }) {
+const App = factory(function({ middleware: { icache } }) {
 	const { get, set } = icache;
 
 	return (
@@ -30,7 +30,16 @@ const App = factory(function({ properties, middleware: { icache } }) {
 									checked={checked()}
 									onValue={checked}
 								/>
-								<hr />
+								<hr
+									styles={{
+										borderColor: '#d6dde2',
+										borderStyle: 'solid',
+										borderWidth: '1px 0 0',
+										height: '0',
+										margin: '0',
+										overflow: 'hidden'
+									}}
+								/>
 							</virtual>
 						);
 					});

--- a/src/examples/src/widgets/radio-group/CustomRenderer.tsx
+++ b/src/examples/src/widgets/radio-group/CustomRenderer.tsx
@@ -30,7 +30,16 @@ const App = factory(function({ properties, middleware: { icache } }) {
 									onValue={checked}
 									value={value}
 								/>
-								<hr />
+								<hr
+									styles={{
+										borderColor: '#d6dde2',
+										borderStyle: 'solid',
+										borderWidth: '1px 0 0',
+										height: '0',
+										margin: '0',
+										overflow: 'hidden'
+									}}
+								/>
 							</virtual>
 						);
 					});

--- a/src/theme/dojo/card.m.css
+++ b/src/theme/dojo/card.m.css
@@ -87,8 +87,12 @@
 
 .title {
 	font-size: var(--font-size-title);
+	font-weight: inherit;
+	margin: 0;
 }
 
 .subtitle {
 	font-size: var(--font-size-small);
+	font-weight: inherit;
+	margin: 0;
 }

--- a/src/theme/dojo/checkbox-group.m.css
+++ b/src/theme/dojo/checkbox-group.m.css
@@ -1,10 +1,12 @@
 @import './variables.css';
 
 .root {
-	padding-top: var(--spacing-regular);
-	padding-bottom: var(--spacing-regular);
+	border: 0;
+	margin: 0;
+	padding: var(--spacing-regular) 0;
 }
 
 .legend {
 	composes: root from './label.m.css';
+	padding: 0;
 }

--- a/src/theme/dojo/date-input.m.css
+++ b/src/theme/dojo/date-input.m.css
@@ -7,9 +7,12 @@
 }
 
 .toggleCalendarButton {
-	min-width: unset;
 	background: none;
 	border: none;
+	color: inherit;
+	font-size: inherit;
+	min-width: unset;
+	padding: 0;
 }
 
 .toggleCalendarButton:hover,

--- a/src/theme/dojo/grid-paginated-footer.m.css
+++ b/src/theme/dojo/grid-paginated-footer.m.css
@@ -21,14 +21,16 @@
 
 .pageNav,
 .pageNumber {
-	border: 0;
-	cursor: pointer;
-	border-radius: 4px;
-	height: 26px;
-	min-width: 26px;
-	margin: 2px;
-	color: var(--color-text-primary);
 	background-color: var(--color-background-faded);
+	border-radius: 4px;
+	border: 0;
+	color: var(--color-text-primary);
+	cursor: pointer;
+	font-size: inherit;
+	height: 26px;
+	margin: 2px;
+	min-width: 26px;
+	padding: 0;
 	text-align: center;
 }
 

--- a/src/theme/dojo/index.ts
+++ b/src/theme/dojo/index.ts
@@ -31,6 +31,7 @@ import * as outlinedButton from './outlined-button.m.css';
 import * as nativeSelect from './native-select.m.css';
 import * as passwordInput from './password-input.m.css';
 import * as progress from './progress.m.css';
+import * as radioGroup from './radio-group.m.css';
 import * as radio from './radio.m.css';
 import * as raisedButton from './raised-button.m.css';
 import * as rangeSlider from './range-slider.m.css';
@@ -82,6 +83,7 @@ export default {
 	'@dojo/widgets/native-select': nativeSelect,
 	'@dojo/widgets/password-input': passwordInput,
 	'@dojo/widgets/progress': progress,
+	'@dojo/widgets/radio-group': radioGroup,
 	'@dojo/widgets/radio': radio,
 	'@dojo/widgets/raised-button': raisedButton,
 	'@dojo/widgets/range-slider': rangeSlider,

--- a/src/theme/dojo/menu.m.css
+++ b/src/theme/dojo/menu.m.css
@@ -6,3 +6,10 @@
 	border: var(--border-width) solid var(--color-border);
 	background: var(--component-background);
 }
+
+.divider {
+	border-color: var(--color-border);
+	border-style: solid;
+	border-width: 1px 0 0;
+	margin: 0;
+}

--- a/src/theme/dojo/menu.m.css.d.ts
+++ b/src/theme/dojo/menu.m.css.d.ts
@@ -1,1 +1,2 @@
 export const menu: string;
+export const divider: string;

--- a/src/theme/dojo/radio-group.m.css
+++ b/src/theme/dojo/radio-group.m.css
@@ -1,0 +1,9 @@
+.root {
+	border: 0;
+	margin: 0;
+	padding: 0;
+}
+
+.legend {
+	padding: 0;
+}

--- a/src/theme/dojo/radio-group.m.css.d.ts
+++ b/src/theme/dojo/radio-group.m.css.d.ts
@@ -1,0 +1,2 @@
+export const root: string;
+export const legend: string;

--- a/src/theme/dojo/raised-button.m.css
+++ b/src/theme/dojo/raised-button.m.css
@@ -1,7 +1,21 @@
 @import './variables.css';
 
 .root {
+	border: 0;
 	box-shadow: var(--box-shadow-dimensions-small) var(--color-box-shadow);
+	font-size: inherit;
+	line-height: var(--line-height-base);
+	min-width: calc(var(--grid-base) * 20);
+	padding: var(--spacing-regular);
+}
+
+.root:not(.pressed) {
+	background: none;
+	color: inherit;
+}
+
+.pressed {
+	composes: pressed from './button.m.css';
 }
 
 .root:hover,

--- a/src/theme/dojo/raised-button.m.css.d.ts
+++ b/src/theme/dojo/raised-button.m.css.d.ts
@@ -1,2 +1,3 @@
 export const root: string;
+export const pressed: string;
 export const disabled: string;

--- a/src/theme/dojo/tab-controller.m.css
+++ b/src/theme/dojo/tab-controller.m.css
@@ -60,6 +60,7 @@
 .close {
 	background: none;
 	border: none;
+	color: inherit;
 	cursor: pointer;
 	font-size: 0;
 	padding: 1px 3px;

--- a/src/theme/dojo/text-area.m.css
+++ b/src/theme/dojo/text-area.m.css
@@ -13,6 +13,7 @@
 .input {
 	border: var(--border-width) solid var(--color-border);
 	border-bottom-color: var(--color-border-strong);
+	font-family: inherit;
 	font-size: inherit;
 	padding: var(--grid-base) calc(var(--grid-base) * 3) var(--grid-base) var(--grid-base);
 	transition: box-shadow var(--transition-duration) var(--transition-easing);

--- a/src/theme/dojo/title-pane.m.css
+++ b/src/theme/dojo/title-pane.m.css
@@ -15,6 +15,7 @@
 	color: var(--color-text-faded);
 	cursor: pointer;
 	font-size: var(--font-size-base);
+	line-height: var(--line-height-base);
 	padding: var(--grid-base) var(--grid-base) var(--grid-base) calc(var(--grid-base) * 4);
 	position: relative;
 	width: 100%;

--- a/src/theme/material/button.m.css
+++ b/src/theme/material/button.m.css
@@ -1,5 +1,15 @@
 @import './variables.css';
 
+.nativeResetRoot {
+	background: none;
+	border: none;
+	color: inherit;
+	font-family: inherit;
+	font-size: inherit;
+	line-height: inherit;
+	padding: 0;
+}
+
 .root {
 	composes: mdc-button from '@material/button/dist/mdc.button.css';
 }

--- a/src/theme/material/button.m.css.d.ts
+++ b/src/theme/material/button.m.css.d.ts
@@ -1,2 +1,3 @@
+export const nativeResetRoot: string;
 export const root: string;
 export const pressed: string;

--- a/src/theme/material/calendar.m.css
+++ b/src/theme/material/calendar.m.css
@@ -10,6 +10,19 @@
 	padding-right: calc(var(--mdc-grid-base) * 2);
 }
 
+.monthTrigger,
+.yearTrigger,
+.previous,
+.next {
+	background: inherit;
+	border: 0;
+	color: inherit;
+	font-family: inherit;
+	font-size: inherit;
+	line-height: inherit;
+	padding: 0;
+}
+
 .monthTrigger {
 	padding-right: calc(var(--mdc-grid-base) * 0.75);
 	padding-left: calc(var(--mdc-grid-base) * 1);

--- a/src/theme/material/calendar.m.css.d.ts
+++ b/src/theme/material/calendar.m.css.d.ts
@@ -1,5 +1,8 @@
 export const root: string;
 export const monthTrigger: string;
+export const yearTrigger: string;
+export const previous: string;
+export const next: string;
 export const datePicker: string;
 export const topMatter: string;
 export const weekday: string;
@@ -9,8 +12,6 @@ export const abbr: string;
 export const selectedDate: string;
 export const todayDate: string;
 export const controls: string;
-export const previous: string;
-export const next: string;
 export const yearRadio: string;
 export const monthRadio: string;
 export const yearRadioChecked: string;

--- a/src/theme/material/card.m.css
+++ b/src/theme/material/card.m.css
@@ -79,9 +79,11 @@
 
 .title {
 	composes: mdc-typography mdc-typography--headline6 from '@material/typography/dist/mdc.typography.css';
+	margin: 0;
 }
 
 .subtitle {
 	composes: mdc-typography mdc-typography--subtitle2 from '@material/typography/dist/mdc.typography.css';
 	color: var(--mdc-theme-text-secondary-on-background);
+	margin: 0;
 }

--- a/src/theme/material/checkbox-group.m.css
+++ b/src/theme/material/checkbox-group.m.css
@@ -1,0 +1,9 @@
+.root {
+	border: 0;
+	margin: 0;
+	padding: 0;
+}
+
+.legend {
+	padding: 0;
+}

--- a/src/theme/material/checkbox-group.m.css.d.ts
+++ b/src/theme/material/checkbox-group.m.css.d.ts
@@ -1,0 +1,2 @@
+export const root: string;
+export const legend: string;

--- a/src/theme/material/date-input.m.css
+++ b/src/theme/material/date-input.m.css
@@ -1,6 +1,7 @@
 @import './variables.css';
 
 .toggleCalendarButton {
+	composes: nativeResetRoot from './button.m.css';
 	cursor: pointer;
 	display: flex;
 	pointer-events: all;

--- a/src/theme/material/grid-header.m.css
+++ b/src/theme/material/grid-header.m.css
@@ -14,6 +14,7 @@
 }
 
 .sort {
+	composes: nativeResetRoot from './button.m.css';
 	display: flex;
 	align-items: center;
 	opacity: 0;

--- a/src/theme/material/grid-paginated-footer.m.css
+++ b/src/theme/material/grid-paginated-footer.m.css
@@ -19,6 +19,18 @@
 	font-weight: var(--mdc-theme-heading-font-weight);
 }
 
+.paginationList {
+	padding-left: 0;
+}
+
+.pageNav,
+.pageNumber {
+	background: none;
+	border: 0;
+	font-size: inherit;
+	padding: 0;
+}
+
 .pageNav {
 	color: var(--mdc-theme-text-secondary-on-background);
 	font-size: var(--mdc-theme-font-size-small);

--- a/src/theme/material/grid-paginated-footer.m.css.d.ts
+++ b/src/theme/material/grid-paginated-footer.m.css.d.ts
@@ -1,5 +1,6 @@
 export const root: string;
 export const details: string;
+export const paginationList: string;
 export const pageNav: string;
 export const pageNumber: string;
 export const active: string;

--- a/src/theme/material/index.ts
+++ b/src/theme/material/index.ts
@@ -3,6 +3,7 @@ import * as avatar from './avatar.m.css';
 import * as button from './button.m.css';
 import * as card from './card.m.css';
 import * as calendar from './calendar.m.css';
+import * as checkboxGroup from './checkbox-group.m.css';
 import * as checkbox from './checkbox.m.css';
 import * as chip from './chip.m.css';
 import * as combobox from './combobox.m.css';
@@ -29,6 +30,7 @@ import * as menuItem from './menu-item.m.css';
 import * as nativeSelect from './native-select.m.css';
 import * as outlinedButton from './outlined-button.m.css';
 import * as progress from './progress.m.css';
+import * as radioGroup from './radio-group.m.css';
 import * as radio from './radio.m.css';
 import * as raisedButton from './raised-button.m.css';
 import * as rangeSlider from './range-slider.m.css';
@@ -51,6 +53,7 @@ export default {
 	'@dojo/widgets/avatar': avatar,
 	'@dojo/widgets/button': button,
 	'@dojo/widgets/calendar': calendar,
+	'@dojo/widgets/checkbox-group': checkboxGroup,
 	'@dojo/widgets/checkbox': checkbox,
 	'@dojo/widgets/card': card,
 	'@dojo/widgets/chip': chip,
@@ -78,6 +81,7 @@ export default {
 	'@dojo/widgets/native-select': nativeSelect,
 	'@dojo/widgets/outlined-button': outlinedButton,
 	'@dojo/widgets/progress': progress,
+	'@dojo/widgets/radio-group': radioGroup,
 	'@dojo/widgets/radio': radio,
 	'@dojo/widgets/raised-button': raisedButton,
 	'@dojo/widgets/range-slider': rangeSlider,

--- a/src/theme/material/radio-group.m.css
+++ b/src/theme/material/radio-group.m.css
@@ -1,0 +1,9 @@
+.root {
+	border: 0;
+	margin: 0;
+	padding: 0;
+}
+
+.legend {
+	padding: 0;
+}

--- a/src/theme/material/radio-group.m.css.d.ts
+++ b/src/theme/material/radio-group.m.css.d.ts
@@ -1,0 +1,2 @@
+export const root: string;
+export const legend: string;

--- a/src/theme/material/select.m.css
+++ b/src/theme/material/select.m.css
@@ -18,6 +18,8 @@
 
 .trigger {
 	composes: mdc-select__anchor from '@material/select/dist/mdc.select.css';
+	border: 0;
+	padding: 0;
 	width: 100%;
 }
 

--- a/src/theme/material/tab-controller.m.css
+++ b/src/theme/material/tab-controller.m.css
@@ -30,14 +30,12 @@
 }
 
 .close {
+	composes: nativeResetRoot from './button.m.css';
 	position: absolute;
 	top: 50%;
 	transform: translateY(-50%);
 	right: 5px;
 	cursor: pointer;
-	font-size: 0;
-	border: none;
-	background: none;
 	padding: 1px 3px;
 	margin-top: -1px;
 }

--- a/src/theme/material/title-pane.m.css
+++ b/src/theme/material/title-pane.m.css
@@ -7,6 +7,8 @@
 }
 
 .titleButton {
+	composes: nativeResetRoot from './button.m.css';
+
 	background-color: var(--mdc-theme-surface);
 	cursor: pointer;
 	position: relative;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #1138 

- Fixes `<button>`, `<fieldset>`, and `<hr />` styles that previously were masked by the tailwind `reset.css` included with `@dojo/parade`. Certain discrepancies are left alone since the change post-reset is an improvement (e.g., the positioning of the dialog close button, previously adversely affected by resetting the `button` `line-height`).
- In a few cases, example files include manual style updates in order to improve look and feel, even though the styles are not specific to the demonstrated widget.