### PR TITLE
Refactor radio as functional widget

### DIFF
--- a/src/radio/index.tsx
+++ b/src/radio/index.tsx
@@ -1,15 +1,14 @@
-import { WidgetBase } from '@dojo/framework/core/WidgetBase';
-import { DNode } from '@dojo/framework/core/interfaces';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
-import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
-import Focus from '../meta/Focus';
-import Label from '../label/index';
-import { formatAriaProperties } from '../common/util';
-import { v, w } from '@dojo/framework/core/vdom';
+import { focus } from '@dojo/framework/core/middleware/focus';
+import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { uuid } from '@dojo/framework/core/util';
+import { create, tsx } from '@dojo/framework/core/vdom';
+
+import { formatAriaProperties } from '../common/util';
+import Label from '../label';
+import theme, { ThemeProperties } from '../middleware/theme';
 import * as css from '../theme/default/radio.m.css';
 
-export interface RadioProperties extends ThemedProperties, FocusProperties {
+interface RadioProperties extends ThemeProperties, FocusProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Checked/unchecked property of the radio */
@@ -46,125 +45,114 @@ export interface RadioProperties extends ThemedProperties, FocusProperties {
 	widgetId?: string;
 }
 
-@theme(css)
-export class Radio extends ThemedMixin(FocusMixin(WidgetBase))<RadioProperties> {
-	private _uuid = uuid();
+const factory = create({ focus, theme }).properties<RadioProperties>();
 
-	private _onChange(event: Event) {
-		event.stopPropagation();
-		const radio = event.target as HTMLInputElement;
-		this.properties.onValue && this.properties.onValue(radio.checked);
-	}
+export const Radio = factory(function Radio({ properties, middleware: { focus, theme } }) {
+	const _uuid = uuid();
+	const {
+		aria = {},
+		checked = false,
+		classes,
+		disabled,
+		label,
+		labelAfter = true,
+		labelHidden,
+		name,
+		onBlur,
+		onFocus,
+		onOut,
+		onOver,
+		onValue,
+		readOnly,
+		required,
+		theme: themeProp,
+		valid,
+		value,
+		widgetId = _uuid
+	} = properties();
 
-	protected getRootClasses(): (string | null)[] {
-		const { checked = false, disabled, valid, readOnly, required } = this.properties;
-		const focus = this.meta(Focus).get('root');
+	const themeCss = theme.classes(css);
 
-		return [
-			css.root,
-			checked ? css.checked : null,
-			disabled ? css.disabled : null,
-			focus.containsFocus ? css.focused : null,
-			valid === true ? css.valid : null,
-			valid === false ? css.invalid : null,
-			readOnly ? css.readonly : null,
-			required ? css.required : null
-		];
-	}
-
-	render(): DNode {
-		const {
-			aria = {},
-			checked = false,
-			disabled,
-			widgetId = this._uuid,
-			valid,
-			label,
-			labelAfter = true,
-			labelHidden,
-			theme,
-			classes,
-			name,
-			readOnly,
-			required,
-			value,
-			onOut,
-			onOver,
-			onBlur,
-			onFocus
-		} = this.properties;
-		const focus = this.meta(Focus).get('root');
-
-		const children = [
-			v('div', { classes: this.theme(css.inputWrapper) }, [
-				v('input', {
-					id: widgetId,
-					...formatAriaProperties(aria),
-					classes: this.theme(css.input),
-					checked,
-					disabled,
-					focus: this.shouldFocus,
-					'aria-invalid': valid === false ? 'true' : null,
-					name,
-					readOnly,
-					'aria-readonly': readOnly === true ? 'true' : null,
-					required,
-					type: 'radio',
-					value,
-					onblur: () => {
-						onBlur && onBlur();
-					},
-					onchange: this._onChange,
-					onfocus: () => {
-						onFocus && onFocus();
-					},
-					onpointerenter: () => {
-						onOver && onOver();
-					},
-					onpointerleave: () => {
-						onOut && onOut();
-					}
-				}),
-				v(
-					'div',
-					{
-						classes: this.theme(css.radioBackground)
-					},
-					[
-						v('div', { classes: this.theme(css.radioOuter) }),
-						v('div', { classes: this.theme(css.radioInner) })
-					]
-				)
-			]),
-			label
-				? w(
-						Label,
-						{
-							theme,
-							classes,
-							disabled,
-							focused: focus.containsFocus,
-							valid,
-							readOnly,
-							required,
-							hidden: labelHidden,
-							forId: widgetId,
-							secondary: true
-						},
-						[label]
-				  )
-				: null
-		];
-
-		return v(
-			'div',
-			{
-				key: 'root',
-				classes: this.theme(this.getRootClasses())
-			},
-			labelAfter ? children : children.reverse()
-		);
-	}
-}
+	return (
+		<div
+			key="root"
+			classes={[
+				themeCss.root,
+				checked ? themeCss.checked : null,
+				disabled ? themeCss.disabled : null,
+				focus.isFocused('root') ? themeCss.focused : null,
+				valid === false ? themeCss.invalid : null,
+				valid === true ? themeCss.valid : null,
+				readOnly ? themeCss.readonly : null,
+				required ? themeCss.required : null
+			]}
+		>
+			{!labelAfter && label ? (
+				<Label
+					key="label"
+					classes={classes}
+					theme={themeProp}
+					disabled={disabled}
+					focused={focus.isFocused('root')}
+					forId={widgetId}
+					valid={valid}
+					readOnly={readOnly}
+					hidden={labelHidden}
+					required={required}
+					secondary={true}
+				>
+					{label}
+				</Label>
+			) : null}
+			<div classes={themeCss.inputWrapper}>
+				<input
+					id={widgetId}
+					{...formatAriaProperties(aria)}
+					classes={themeCss.input}
+					checked={checked}
+					disabled={disabled}
+					focus={focus.shouldFocus()}
+					aria-invalid={valid === false ? 'true' : null}
+					name={name}
+					readonly={readOnly}
+					aria-readonly={readOnly === true ? 'true' : null}
+					required={required}
+					type="radio"
+					value={value}
+					onblur={() => onBlur && onBlur()}
+					onchange={(event: Event) => {
+						event.stopPropagation();
+						const radio = event.target as HTMLInputElement;
+						onValue && onValue(radio.checked);
+					}}
+					onfocus={() => onFocus && onFocus()}
+					onpointerenter={() => onOver && onOver()}
+					onpointerleave={() => onOut && onOut()}
+				/>
+				<div classes={themeCss.radioBackground}>
+					<div classes={themeCss.radioOuter} />
+					<div classes={themeCss.radioInner} />
+				</div>
+			</div>
+			{labelAfter && label ? (
+				<Label
+					key="labelAfter"
+					classes={classes}
+					theme={themeProp}
+					disabled={disabled}
+					focused={focus.isFocused('root')}
+					forId={widgetId}
+					valid={valid}
+					readOnly={readOnly}
+					hidden={labelHidden}
+					required={required}
+					secondary={true}
+				>
+					{label}
+				</Label>
+			) : null}
+		</div>
+	);
+});
 
 export default Radio;

--- a/src/radio/index.tsx
+++ b/src/radio/index.tsx
@@ -1,6 +1,5 @@
 import { focus } from '@dojo/framework/core/middleware/focus';
 import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
-import { uuid } from '@dojo/framework/core/util';
 import { create, tsx } from '@dojo/framework/core/vdom';
 
 import { formatAriaProperties } from '../common/util';
@@ -8,7 +7,7 @@ import Label from '../label';
 import theme, { ThemeProperties } from '../middleware/theme';
 import * as css from '../theme/default/radio.m.css';
 
-interface RadioProperties extends ThemeProperties, FocusProperties {
+export interface RadioProperties extends ThemeProperties, FocusProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Checked/unchecked property of the radio */
@@ -17,8 +16,6 @@ interface RadioProperties extends ThemeProperties, FocusProperties {
 	disabled?: boolean;
 	/** Adds a <label> element with the supplied text */
 	label?: string;
-	/** Adds the label element after (true) or before (false) */
-	labelAfter?: boolean;
 	/** Hides the label from view while still remaining accessible for screen readers */
 	labelHidden?: boolean;
 	/** The name of the radio button */
@@ -41,21 +38,19 @@ interface RadioProperties extends ThemeProperties, FocusProperties {
 	valid?: boolean;
 	/** The current value */
 	value?: string;
-	/** The id used for the form input element */
+	/** The id used for the form input element. If not passed, one will be generated. */
 	widgetId?: string;
 }
 
 const factory = create({ focus, theme }).properties<RadioProperties>();
 
-export const Radio = factory(function Radio({ properties, middleware: { focus, theme } }) {
-	const _uuid = uuid();
+export const Radio = factory(function Radio({ properties, id, middleware: { focus, theme } }) {
 	const {
 		aria = {},
 		checked = false,
 		classes,
 		disabled,
 		label,
-		labelAfter = true,
 		labelHidden,
 		name,
 		onBlur,
@@ -68,10 +63,11 @@ export const Radio = factory(function Radio({ properties, middleware: { focus, t
 		theme: themeProp,
 		valid,
 		value,
-		widgetId = _uuid
+		widgetId
 	} = properties();
 
 	const themeCss = theme.classes(css);
+	const idBase = widgetId || `radio-${id}`;
 
 	return (
 		<div
@@ -87,26 +83,9 @@ export const Radio = factory(function Radio({ properties, middleware: { focus, t
 				required ? themeCss.required : null
 			]}
 		>
-			{!labelAfter && label ? (
-				<Label
-					key="label"
-					classes={classes}
-					theme={themeProp}
-					disabled={disabled}
-					focused={focus.isFocused('root')}
-					forId={widgetId}
-					valid={valid}
-					readOnly={readOnly}
-					hidden={labelHidden}
-					required={required}
-					secondary={true}
-				>
-					{label}
-				</Label>
-			) : null}
 			<div classes={themeCss.inputWrapper}>
 				<input
-					id={widgetId}
+					id={idBase}
 					{...formatAriaProperties(aria)}
 					classes={themeCss.input}
 					checked={checked}
@@ -134,14 +113,14 @@ export const Radio = factory(function Radio({ properties, middleware: { focus, t
 					<div classes={themeCss.radioInner} />
 				</div>
 			</div>
-			{labelAfter && label ? (
+			{label && (
 				<Label
 					key="labelAfter"
 					classes={classes}
 					theme={themeProp}
 					disabled={disabled}
 					focused={focus.isFocused('root')}
-					forId={widgetId}
+					forId={idBase}
 					valid={valid}
 					readOnly={readOnly}
 					hidden={labelHidden}
@@ -150,7 +129,7 @@ export const Radio = factory(function Radio({ properties, middleware: { focus, t
 				>
 					{label}
 				</Label>
-			) : null}
+			)}
 		</div>
 	);
 });


### PR DESCRIPTION
**Type:**  feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Converts `Radio` to a function based widget. 

Resolves #1148 
