### PR TITLE
Fix: header card styling

### DIFF
--- a/src/examples/src/widgets/header-card/ActionCard.tsx
+++ b/src/examples/src/widgets/header-card/ActionCard.tsx
@@ -18,7 +18,7 @@ export default factory(function Basic() {
 				mediaSrc={mediaSrc}
 			>
 				{{
-					content: () => <p>Lorem ipsum</p>,
+					content: () => <p styles={{ margin: '0' }}>Lorem ipsum</p>,
 					actionButtons: () => <Button>Action</Button>,
 					actionIcons: () => (
 						<virtual>

--- a/src/examples/src/widgets/header-card/Basic.tsx
+++ b/src/examples/src/widgets/header-card/Basic.tsx
@@ -13,7 +13,7 @@ export default factory(function Basic() {
 				avatar={() => <Avatar>D</Avatar>}
 			>
 				{{
-					content: () => <p>Lorem ipsum</p>
+					content: () => <p styles={{ margin: '0' }}>Lorem ipsum</p>
 				}}
 			</HeaderCard>
 		</div>

--- a/src/examples/src/widgets/header-card/MediaCard.tsx
+++ b/src/examples/src/widgets/header-card/MediaCard.tsx
@@ -16,7 +16,7 @@ export default factory(function Basic() {
 				mediaSrc={mediaSrc}
 			>
 				{{
-					content: () => <p>Lorem ipsum</p>
+					content: () => <p styles={{ margin: '0' }}>Lorem ipsum</p>
 				}}
 			</HeaderCard>
 		</div>

--- a/src/theme/dojo/header-card.m.css
+++ b/src/theme/dojo/header-card.m.css
@@ -16,6 +16,12 @@
 	flex: 0 0 auto;
 }
 
+.title,
+.subtitle {
+	font-weight: inherit;
+	margin: 0;
+}
+
 .title {
 	font-size: var(--font-size-title);
 }

--- a/src/theme/material/header-card.m.css
+++ b/src/theme/material/header-card.m.css
@@ -18,9 +18,11 @@
 
 .title {
 	composes: mdc-typography mdc-typography--headline6 from '@material/typography/dist/mdc.typography.css';
+	margin: 0;
 }
 
 .subtitle {
 	composes: mdc-typography mdc-typography--subtitle2 from '@material/typography/dist/mdc.typography.css';
 	color: var(--mdc-theme-text-secondary-on-background);
+	margin: 0;
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #1143 

Strip the margin and reset the font weight for the header card's title and subtitle.