### PR TITLE
Fix material styling of track

### DIFF
--- a/src/theme/material/range-slider.m.css
+++ b/src/theme/material/range-slider.m.css
@@ -5,14 +5,18 @@
 }
 
 .inputWrapper {
-	margin: calc(var(--spacing-regular) * 1.5) 0;
+	composes: mdc-slider__track-container from '@material/slider/dist/mdc.slider.css';
 	height: calc(var(--border-width) * 2);
+	margin: calc(var(--spacing-regular) * 1.5) 0;
+	overflow: inherit;
 	position: relative;
+	top: auto;
+	width: auto;
 }
 
 .filled {
+	composes: mdc-slider__track from '@material/slider/dist/mdc.slider.css';
 	position: relative;
-	composes: mdc-slider__track-container from '@material/slider/dist/mdc.slider.css';
 }
 
 .root .filled {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixes material styling of the`RangeSlider` widget. Adds styling for the missing track and appropriate fill.

Resolves #1144 

![Screen Shot 2020-03-18 at 12 44 18 PM](https://user-images.githubusercontent.com/1054198/76991228-399d5d00-6917-11ea-808c-efe3add53645.png)
![Screen Shot 2020-03-18 at 12 44 04 PM](https://user-images.githubusercontent.com/1054198/76991230-3a35f380-6917-11ea-911d-42c2d175fdb2.png)

