### PR TITLE
Use child renderer functions where possible

### DIFF
--- a/src/checkbox-group/index.tsx
+++ b/src/checkbox-group/index.tsx
@@ -7,7 +7,7 @@ import * as css from '../theme/default/checkbox-group.m.css';
 
 type CheckboxOptions = { value: string; label?: string }[];
 
-interface CheckboxGroupProperties {
+export interface CheckboxGroupProperties {
 	/** The name attribute for this form group */
 	name: string;
 	/** The label to be displayed in the legend */
@@ -16,29 +16,36 @@ interface CheckboxGroupProperties {
 	options: CheckboxOptions;
 	/** Callback for the current value */
 	onValue(value: string[]): void;
-	/** Custom renderer for the checkboxes, receives the checkbox group middleware and options */
-	renderer?(
-		name: string,
-		middleware: ReturnType<ReturnType<typeof checkboxGroup>['api']>,
-		options: CheckboxOptions
-	): RenderResult;
 	/** Initial value of the checkbox group */
 	initialValue?: string[];
 }
 
-const factory = create({ checkboxGroup, theme }).properties<CheckboxGroupProperties>();
+export interface CheckboxGroupChildren {
+	/** Custom renderer for the checkboxes, receives the checkbox group middleware and options */
+	(
+		name: string,
+		middleware: ReturnType<ReturnType<typeof checkboxGroup>['api']>,
+		options: CheckboxOptions
+	): RenderResult;
+}
+
+const factory = create({ checkboxGroup, theme })
+	.properties<CheckboxGroupProperties>()
+	.children<CheckboxGroupChildren | undefined>();
 
 export const CheckboxGroup = factory(function({
+	children,
 	properties,
 	middleware: { checkboxGroup, theme }
 }) {
-	const { name, label, options, renderer, onValue, initialValue } = properties();
+	const { name, label, options, onValue, initialValue } = properties();
+	const [renderer] = children();
 
 	const checkbox = checkboxGroup(onValue, initialValue);
 	const { root, legend } = theme.classes(css);
 
 	function renderCheckboxes() {
-		if (renderer) {
+		if (typeof renderer === 'function') {
 			return renderer(name, checkbox, options);
 		}
 		return options.map(({ value, label }) => {

--- a/src/checkbox-group/tests/CheckboxGroup.spec.tsx
+++ b/src/checkbox-group/tests/CheckboxGroup.spec.tsx
@@ -69,7 +69,8 @@ describe('CheckboxGroup', () => {
 				name="test"
 				label="custom render label"
 				options={[{ value: 'cat' }]}
-				renderer={() => {
+			>
+				{() => {
 					return [
 						<span>custom label</span>,
 						<Checkbox
@@ -82,7 +83,7 @@ describe('CheckboxGroup', () => {
 						<hr />
 					];
 				}}
-			/>
+			</CheckboxGroup>
 		));
 		const customTemplate = template.setChildren('@root', () => [
 			<legend classes={css.legend}>custom render label</legend>,

--- a/src/examples/src/widgets/checkbox-group/CustomRenderer.tsx
+++ b/src/examples/src/widgets/checkbox-group/CustomRenderer.tsx
@@ -17,7 +17,8 @@ const App = factory(function({ middleware: { icache } }) {
 				onValue={(value) => {
 					set('custom', value);
 				}}
-				renderer={(name, checkboxGroup, options) => {
+			>
+				{(name, checkboxGroup, options) => {
 					return options.map(({ value, label }) => {
 						const { checked } = checkboxGroup(value);
 						return (
@@ -44,7 +45,7 @@ const App = factory(function({ middleware: { icache } }) {
 						);
 					});
 				}}
-			/>
+			</CheckboxGroup>
 			<pre>{`${get('custom')}`}</pre>
 		</virtual>
 	);

--- a/src/examples/src/widgets/menu/ItemRenderer.tsx
+++ b/src/examples/src/widgets/menu/ItemRenderer.tsx
@@ -13,13 +13,14 @@ export default factory(function ItemRenderer({ middleware: { icache } }) {
 				onValue={(value) => {
 					icache.set('value', value);
 				}}
-				itemRenderer={({ value }) => {
+				itemsInView={8}
+				total={states.length}
+			>
+				{({ value }) => {
 					const color = value.length > 7 ? 'red' : 'blue';
 					return <div styles={{ color: color }}>{value}</div>;
 				}}
-				itemsInView={8}
-				total={states.length}
-			/>
+			</Menu>
 			<p>{`Clicked On: ${icache.getOrSet('value', '')}`}</p>
 		</virtual>
 	);

--- a/src/examples/src/widgets/radio-group/CustomRenderer.tsx
+++ b/src/examples/src/widgets/radio-group/CustomRenderer.tsx
@@ -5,7 +5,7 @@ import { icache } from '@dojo/framework/core/middleware/icache';
 
 const factory = create({ icache });
 
-const App = factory(function({ properties, middleware: { icache } }) {
+const App = factory(function({ middleware: { icache } }) {
 	const { get, set } = icache;
 
 	return (
@@ -17,7 +17,8 @@ const App = factory(function({ properties, middleware: { icache } }) {
 				onValue={(value) => {
 					set('custom', value);
 				}}
-				renderer={(name, radioGroup, options) => {
+			>
+				{(name, radioGroup, options) => {
 					return options.map(({ value, label }) => {
 						const { checked } = radioGroup(value);
 						return (
@@ -44,7 +45,7 @@ const App = factory(function({ properties, middleware: { icache } }) {
 						);
 					});
 				}}
-			/>
+			</RadioGroup>
 			<pre>{`${get('custom')}`}</pre>
 		</virtual>
 	);

--- a/src/examples/src/widgets/select/CustomRenderer.tsx
+++ b/src/examples/src/widgets/select/CustomRenderer.tsx
@@ -14,7 +14,8 @@ export default factory(function CustomRenderer({ middleware: { icache } }) {
 				onValue={(value) => {
 					icache.set('value', value);
 				}}
-				itemRenderer={({ selected, value }) => {
+			>
+				{({ selected, value }) => {
 					return (
 						<div>
 							{selected && <span>✅ </span>}
@@ -22,7 +23,7 @@ export default factory(function CustomRenderer({ middleware: { icache } }) {
 						</div>
 					);
 				}}
-			/>
+			</Select>
 			<pre>{icache.getOrSet('value', '')}</pre>
 		</virtual>
 	);

--- a/src/menu/index.tsx
+++ b/src/menu/index.tsx
@@ -38,12 +38,15 @@ export interface MenuProperties {
 	onBlur?(): void;
 	/** Property to determine how many items to render. Not passing a number will render all results */
 	itemsInView?: number;
-	/** Custom renderer for item contents */
-	itemRenderer?(properties: ItemRendererProperties): RenderResult;
 	/** Property to determine if this menu is being used as a listbox, changes a11y and item type */
 	listBox?: boolean;
 	/** The id to be applied to the root of this widget, if not passed, one will be generated for a11y reasons */
 	widgetId?: string;
+}
+
+export interface MenuChildren {
+	/** Custom renderer for item contents */
+	(properties: ItemRendererProperties): RenderResult;
 }
 
 export interface ItemRendererProperties {
@@ -82,9 +85,12 @@ const factory = create({
 	icache: createICacheMiddleware<MenuICache>(),
 	focus,
 	theme
-}).properties<MenuProperties>();
+})
+	.properties<MenuProperties>()
+	.children<MenuChildren | undefined>();
 
 export const Menu = factory(function Menu({
+	children,
 	properties,
 	id,
 	middleware: { icache, focus, theme }
@@ -93,7 +99,6 @@ export const Menu = factory(function Menu({
 		activeIndex,
 		focusable = true,
 		initialValue,
-		itemRenderer,
 		itemsInView = 10,
 		listBox = false,
 		onActiveIndexChange,
@@ -106,6 +111,7 @@ export const Menu = factory(function Menu({
 		total,
 		theme: themeProp
 	} = properties();
+	const [itemRenderer] = children();
 
 	function setActiveIndex(index: number) {
 		if (onActiveIndexChange) {

--- a/src/menu/tests/Menu.spec.tsx
+++ b/src/menu/tests/Menu.spec.tsx
@@ -99,12 +99,9 @@ describe('Menu - Menu', () => {
 
 	it('takes a custom renderer', () => {
 		const h = harness(() => (
-			<Menu
-				onValue={noop}
-				options={animalOptions}
-				itemRenderer={({ label, value }) => <span>label is {label || value}</span>}
-				total={animalOptions.length}
-			/>
+			<Menu onValue={noop} options={animalOptions} total={animalOptions.length}>
+				{({ label, value }) => <span>label is {label || value}</span>}
+			</Menu>
 		));
 		const itemRendererTemplate = template.setChildren('@transformer', () =>
 			animalOptions.map(({ value, label, disabled = false }, index) => {
@@ -304,13 +301,9 @@ describe('Menu - ListBox', () => {
 
 	it('takes a custom renderer', () => {
 		const h = harness(() => (
-			<Menu
-				onValue={noop}
-				options={animalOptions}
-				total={animalOptions.length}
-				listBox
-				itemRenderer={({ label, value }) => <span>label is {label || value}</span>}
-			/>
+			<Menu onValue={noop} options={animalOptions} total={animalOptions.length} listBox>
+				{({ label, value }) => <span>label is {label || value}</span>}
+			</Menu>
 		));
 		const itemRendererTemplate = template.setChildren('@transformer', () =>
 			animalOptions.map(({ value, label, disabled = false }, index) => {

--- a/src/radio-group/index.tsx
+++ b/src/radio-group/index.tsx
@@ -7,7 +7,7 @@ import { radioGroup } from './middleware';
 
 type RadioOptions = { value: string; label?: string }[];
 
-interface RadioGroupProperties {
+export interface RadioGroupProperties {
 	/** Initial value of the radio group */
 	initialValue?: string;
 	/** The label to be displayed in the legend */
@@ -18,18 +18,28 @@ interface RadioGroupProperties {
 	onValue(value: string): void;
 	/** Object containing the values / labels to create radios for */
 	options: RadioOptions;
+}
+
+export interface RadioGroupChildren {
 	/** Custom renderer for the radios, receives the radio group middleware and options */
-	renderer?(
+	(
 		name: string,
 		middleware: ReturnType<ReturnType<typeof radioGroup>['api']>,
 		options: RadioOptions
 	): RenderResult;
 }
 
-const factory = create({ radioGroup, theme }).properties<RadioGroupProperties>();
+const factory = create({ radioGroup, theme })
+	.properties<RadioGroupProperties>()
+	.children<RadioGroupChildren | undefined>();
 
-export const RadioGroup = factory(function({ properties, middleware: { radioGroup, theme } }) {
-	const { name, label, options, renderer, onValue, initialValue } = properties();
+export const RadioGroup = factory(function({
+	children,
+	properties,
+	middleware: { radioGroup, theme }
+}) {
+	const { name, label, options, onValue, initialValue } = properties();
+	const [renderer] = children();
 	const radio = radioGroup(onValue, initialValue || '');
 	const { root, legend } = theme.classes(css);
 

--- a/src/radio-group/tests/RadioGroup.spec.tsx
+++ b/src/radio-group/tests/RadioGroup.spec.tsx
@@ -69,7 +69,8 @@ describe('RadioGroup', () => {
 				name="test"
 				onValue={noop}
 				options={[{ value: 'cat' }]}
-				renderer={() => {
+			>
+				{() => {
 					return [
 						<span>custom label</span>,
 						<Radio
@@ -82,7 +83,7 @@ describe('RadioGroup', () => {
 						<hr />
 					];
 				}}
-			/>
+			</RadioGroup>
 		));
 		const customTemplate = template.setChildren('@root', () => [
 			<legend classes={css.legend}>custom render label</legend>,

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -18,7 +18,7 @@ import * as iconCss from '../theme/default/icon.m.css';
 import * as css from '../theme/default/select.m.css';
 import bundle from './select.nls';
 
-interface SelectProperties {
+export interface SelectProperties {
 	/** Callback called when user selects a value */
 	onValue(value: string): void;
 	/** The initial selected value */
@@ -27,8 +27,6 @@ interface SelectProperties {
 	options: MenuOption[];
 	/** Property to determine how many items to render. Defaults to 6 */
 	itemsInView?: number;
-	/** Custom renderer for item contents */
-	itemRenderer?(properties: ItemRendererProperties): RenderResult;
 	/** placement of the select menu; 'above' or 'below' */
 	position?: PopupPosition;
 	/** Placeholder value to show when nothing has been selected */
@@ -47,6 +45,11 @@ interface SelectProperties {
 	name?: string;
 }
 
+export interface SelectChildren {
+	/** Custom renderer for item contents */
+	(properties: ItemRendererProperties): RenderResult;
+}
+
 interface SelectICache {
 	dirty: boolean;
 	expanded: boolean;
@@ -60,9 +63,12 @@ interface SelectICache {
 
 const icache = createICacheMiddleware<SelectICache>();
 
-const factory = create({ icache, focus, theme, i18n }).properties<SelectProperties>();
+const factory = create({ icache, focus, theme, i18n })
+	.properties<SelectProperties>()
+	.children<SelectChildren | undefined>();
 
 export const Select = factory(function Select({
+	children,
 	properties,
 	middleware: { icache, focus, theme, i18n }
 }) {
@@ -71,7 +77,6 @@ export const Select = factory(function Select({
 		disabled,
 		helperText,
 		initialValue,
-		itemRenderer,
 		itemsInView = 6,
 		label,
 		onValidate,
@@ -82,6 +87,7 @@ export const Select = factory(function Select({
 		required,
 		name
 	} = properties();
+	const [itemRenderer] = children();
 
 	if (initialValue !== undefined && initialValue !== icache.get('initial')) {
 		icache.set('initial', initialValue);
@@ -224,7 +230,6 @@ export const Select = factory(function Select({
 									onBlur={closeMenu}
 									initialValue={value}
 									itemsInView={itemsInView}
-									itemRenderer={itemRenderer}
 									theme={theme.compose(
 										menuCss,
 										css,
@@ -233,7 +238,9 @@ export const Select = factory(function Select({
 									classes={classes}
 									listBox
 									widgetId={menuId}
-								/>
+								>
+									{itemRenderer}
+								</Menu>
 							</div>
 						);
 					}

--- a/src/select/tests/Select.spec.tsx
+++ b/src/select/tests/Select.spec.tsx
@@ -70,7 +70,6 @@ const menuTemplate = assertionTemplate(() => (
 			onBlur={() => {}}
 			initialValue={undefined}
 			itemsInView={6}
-			itemRenderer={undefined}
 			theme={{}}
 			classes={undefined}
 			listBox


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #1150 

Update the `CheckboxGroup`, `RadioGroup`, `Menu`, and `Select` widgets to use child renderer functions instead of relying on `renderer`/`itemRenderer` properties. Other widgets still accept custom renderer properties, but accept multiple properties for rendering different portions of the widget and therefore were left alone.
