### PR TITLE
Select displays option label if available (#1164)

### DIFF
--- a/src/examples/src/widgets/select/Basic.tsx
+++ b/src/examples/src/widgets/select/Basic.tsx
@@ -3,7 +3,11 @@ import Select from '@dojo/widgets/select';
 import icache from '@dojo/framework/core/middleware/icache';
 
 const factory = create({ icache });
-const options = [{ value: 'cat' }, { value: 'dog' }, { value: 'fish' }];
+const options = [
+	{ value: 'cat', label: 'Cat' },
+	{ value: 'dog', label: 'Dog' },
+	{ value: 'fish', label: 'Fish' }
+];
 
 export default factory(function Basic({ middleware: { icache } }) {
 	return (

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -17,6 +17,7 @@ import * as labelCss from '../theme/default/label.m.css';
 import * as iconCss from '../theme/default/icon.m.css';
 import * as css from '../theme/default/select.m.css';
 import bundle from './select.nls';
+import { find } from '@dojo/framework/shim/array';
 
 interface SelectProperties {
 	/** Callback called when user selects a value */
@@ -157,6 +158,8 @@ export const Select = factory(function Select({
 							}
 						}
 
+						const valueOption = find(options, (option) => option.value === value);
+
 						return (
 							<button
 								name={name}
@@ -183,7 +186,7 @@ export const Select = factory(function Select({
 								}}
 							>
 								<span classes={themedCss.value}>
-									{value || (
+									{(valueOption && valueOption.label) || value || (
 										<span classes={themedCss.placeholder}>{placeholder}</span>
 									)}
 								</span>

--- a/src/select/tests/Select.spec.tsx
+++ b/src/select/tests/Select.spec.tsx
@@ -59,6 +59,12 @@ const buttonTemplate = assertionTemplate(() => (
 	</button>
 ));
 
+const ignoreMenuTheme = {
+	selector: '@menu',
+	property: 'theme',
+	comparator: () => true
+};
+
 const menuTemplate = assertionTemplate(() => (
 	<div key="menu-wrapper" classes={css.menuWrapper}>
 		<Menu
@@ -198,12 +204,6 @@ describe('Select', () => {
 	it('creates menu content and closes on blur', () => {
 		const closeMenuStub = stub();
 
-		const ignoreMenuTheme = {
-			selector: '@menu',
-			property: 'theme',
-			comparator: () => true
-		};
-
 		const h = harness(() => <Select onValue={() => {}} options={options} />, [
 			compareWidgetId,
 			ignoreMenuTheme
@@ -226,12 +226,6 @@ describe('Select', () => {
 		const onValueStub = stub();
 		const closeMenuStub = stub();
 
-		const ignoreMenuTheme = {
-			selector: '@menu',
-			property: 'theme',
-			comparator: () => true
-		};
-
 		const h = harness(() => <Select onValue={onValueStub} options={options} />, [
 			compareWidgetId,
 			ignoreMenuTheme
@@ -249,5 +243,33 @@ describe('Select', () => {
 		menu.properties.onValue('cat');
 		assert.isTrue(closeMenuStub.calledOnce);
 		assert.isTrue(onValueStub.calledOnceWith('cat'));
+	});
+
+	it('displays an optional label when available', () => {
+		const onValueStub = stub();
+		const toggleOpenStub = stub();
+
+		const options = [{ value: 'dog', label: 'Dog' }, { value: 'cat' }, { value: 'fish' }];
+
+		const h = harness(
+			() => <Select onValue={onValueStub} options={options} initialValue={'dog'} />,
+			[compareAriaControls, compareId]
+		);
+
+		const triggerRenderResult = h.trigger(
+			'@popup',
+			(node) => (node.children as any)[0].trigger,
+			toggleOpenStub
+		);
+
+		h.expect(
+			buttonTemplate.setProperty('@trigger', 'value', 'dog').setChildren('@trigger', () => [
+				<span classes={css.value}>Dog</span>,
+				<span classes={css.arrow}>
+					<Icon type="downIcon" theme={{}} classes={undefined} />
+				</span>
+			]),
+			() => triggerRenderResult
+		);
 	});
 });


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Updating `Select` to display option label instead of value, if available.

![image](https://user-images.githubusercontent.com/2008858/77087011-ebe92900-69d8-11ea-8e9d-060c3c24269b.png)

Resolves #1164