### PR TITLE
fix: convert RangeSlider to functional widget

### DIFF
--- a/src/examples/src/widgets/range-slider/Basic.tsx
+++ b/src/examples/src/widgets/range-slider/Basic.tsx
@@ -1,19 +1,14 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
-import icache from '@dojo/framework/core/middleware/icache';
 import RangeSlider from '@dojo/widgets/range-slider';
+import { create, tsx } from '@dojo/framework/core/vdom';
 
-const factory = create({ icache });
+const factory = create();
 
-export default factory(function Basic({ middleware: { icache } }) {
-	const min = 0;
-	const max = 100;
-	const value = icache.getOrSet('value', { min, max });
-
+export default factory(function Basic() {
 	return (
 		<RangeSlider
-			value={value}
-			onValue={(newValue) => {
-				icache.set('value', newValue);
+			initialValue={{
+				min: 0,
+				max: 100
 			}}
 		/>
 	);

--- a/src/examples/src/widgets/range-slider/Disabled.tsx
+++ b/src/examples/src/widgets/range-slider/Disabled.tsx
@@ -1,9 +1,8 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
-import icache from '@dojo/framework/core/middleware/icache';
 import RangeSlider from '@dojo/widgets/range-slider';
+import { create, tsx } from '@dojo/framework/core/vdom';
 
-const factory = create({ icache });
+const factory = create();
 
-export default factory(function DisabledRangeSlider({ middleware: { icache } }) {
-	return <RangeSlider min={0} max={100} value={{ min: 20, max: 80 }} disabled />;
+export default factory(function DisabledRangeSlider() {
+	return <RangeSlider initialValue={{ min: 20, max: 80 }} disabled />;
 });

--- a/src/examples/src/widgets/range-slider/Events.tsx
+++ b/src/examples/src/widgets/range-slider/Events.tsx
@@ -1,24 +1,18 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
-import icache from '@dojo/framework/core/middleware/icache';
 import RangeSlider from '@dojo/widgets/range-slider';
+import icache from '@dojo/framework/core/middleware/icache';
+import { create, tsx } from '@dojo/framework/core/vdom';
 
 const factory = create({ icache });
 
 export default factory(function EventsRangeSlider({ middleware: { icache } }) {
-	const min = 0;
-	const max = 100;
-	const value = icache.getOrSet('value', { min, max });
-
 	return (
 		<virtual>
 			<RangeSlider
-				min={0}
-				max={100}
-				value={value}
-				onValue={(newValue) => {
-					icache.set('value', newValue);
-					icache.set('event', 'onValue');
+				initialValue={{
+					min: 0,
+					max: 100
 				}}
+				onValue={() => icache.set('event', 'onValue')}
 				onBlur={() => icache.set('event', 'onBlur')}
 				onFocus={() => icache.set('event', 'onFocus')}
 				onOut={() => icache.set('event', 'onOut')}

--- a/src/examples/src/widgets/range-slider/Labelled.tsx
+++ b/src/examples/src/widgets/range-slider/Labelled.tsx
@@ -1,21 +1,16 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
-import icache from '@dojo/framework/core/middleware/icache';
 import RangeSlider from '@dojo/widgets/range-slider';
+import { create, tsx } from '@dojo/framework/core/vdom';
 
-const factory = create({ icache });
+const factory = create();
 
-export default factory(function LabelledRangeSlider({ middleware: { icache } }) {
-	const min = 0;
-	const max = 100;
-	const value = icache.getOrSet('value', { min, max });
-
+export default factory(function LabelledRangeSlider() {
 	return (
 		<RangeSlider
-			value={value}
-			onValue={(newValue) => {
-				icache.set('value', newValue);
+			initialValue={{
+				min: 0,
+				max: 100
 			}}
-			label={'A Labelled Slider'}
+			label="A Labelled Slider"
 		/>
 	);
 });

--- a/src/examples/src/widgets/range-slider/MinMax.tsx
+++ b/src/examples/src/widgets/range-slider/MinMax.tsx
@@ -1,21 +1,16 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
-import icache from '@dojo/framework/core/middleware/icache';
 import RangeSlider from '@dojo/widgets/range-slider';
+import { create, tsx } from '@dojo/framework/core/vdom';
 
-const factory = create({ icache });
+const factory = create();
 
-export default factory(function MinMaxRangeSlider({ middleware: { icache } }) {
-	const min = 0;
-	const max = 100;
-	const value = icache.getOrSet('value', { min, max });
-
+export default factory(function MinMaxRangeSlider() {
 	return (
 		<RangeSlider
 			min={0}
 			max={100}
-			value={value}
-			onValue={(newValue) => {
-				icache.set('value', newValue);
+			initialValue={{
+				min: 0,
+				max: 100
 			}}
 		/>
 	);

--- a/src/examples/src/widgets/range-slider/Required.tsx
+++ b/src/examples/src/widgets/range-slider/Required.tsx
@@ -1,23 +1,16 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
-import icache from '@dojo/framework/core/middleware/icache';
 import RangeSlider from '@dojo/widgets/range-slider';
+import { create, tsx } from '@dojo/framework/core/vdom';
 
-const factory = create({ icache });
+const factory = create();
 
-export default factory(function RequiredRangeSlider({ middleware: { icache } }) {
-	const min = 0;
-	const max = 100;
-	const value = icache.getOrSet('value', { min, max });
-
+export default factory(function RequiredRangeSlider() {
 	return (
 		<RangeSlider
-			min={0}
-			max={100}
-			value={value}
-			onValue={(newValue) => {
-				icache.set('value', newValue);
+			initialValue={{
+				min: 0,
+				max: 100
 			}}
-			label={'A Required Slider'}
+			label="A Required Slider"
 			required
 		/>
 	);

--- a/src/examples/src/widgets/range-slider/Tooltip.tsx
+++ b/src/examples/src/widgets/range-slider/Tooltip.tsx
@@ -1,21 +1,14 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
-import icache from '@dojo/framework/core/middleware/icache';
 import RangeSlider from '@dojo/widgets/range-slider';
+import { create, tsx } from '@dojo/framework/core/vdom';
 
-const factory = create({ icache });
+const factory = create();
 
-export default factory(function TooltipRangeSlider({ middleware: { icache } }) {
-	const min = 0;
-	const max = 100;
-	const value = icache.getOrSet('value', { min, max });
-
+export default factory(function TooltipRangeSlider() {
 	return (
 		<RangeSlider
-			min={0}
-			max={100}
-			value={value}
-			onValue={(newValue) => {
-				icache.set('value', newValue);
+			initialValue={{
+				min: 0,
+				max: 100
 			}}
 			showOutput={true}
 			outputIsTooltip={true}

--- a/src/range-slider/index.tsx
+++ b/src/range-slider/index.tsx
@@ -1,19 +1,18 @@
-import { uuid } from '@dojo/framework/core/util';
-import { v, w } from '@dojo/framework/core/vdom';
-import { DNode } from '@dojo/framework/core/interfaces';
-import Dimensions from '@dojo/framework/core/meta/Dimensions';
-import Focus from '../meta/Focus';
-import { theme, ThemedMixin, ThemedProperties } from '@dojo/framework/core/mixins/Themed';
-import { WidgetBase } from '@dojo/framework/core/WidgetBase';
-import { formatAriaProperties } from '../common/util';
-import Label from '../label/index';
-import * as fixedCss from './styles/range-slider.m.css';
-import * as css from '../theme/default/range-slider.m.css';
 import * as baseCss from '../common/styles/base.m.css';
+import * as css from '../theme/default/range-slider.m.css';
+import * as fixedCss from './styles/range-slider.m.css';
+import Label from '../label/index';
+import dimensions from '@dojo/framework/core/middleware/dimensions';
+import focus from '@dojo/framework/core/middleware/focus';
+import theme from '@dojo/framework/core/middleware/theme';
+import { DNode } from '@dojo/framework/core/interfaces';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
+import { formatAriaProperties } from '../common/util';
 
 type RangeValue = { min: number; max: number };
 
-export interface RangeSliderProperties extends ThemedProperties {
+export interface RangeSliderProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Set the disabled property of the control */
@@ -68,32 +67,96 @@ export interface RangeSliderProperties extends ThemedProperties {
 	widgetId?: string;
 }
 
-@theme(css)
-export class RangeSlider extends ThemedMixin(WidgetBase)<RangeSliderProperties> {
-	// id used to associate input with output
-	private _widgetId = uuid();
-	private _minLabelId = uuid();
-	private _maxLabelId = uuid();
+export interface RangeSliderICache {
+	initialValue?: RangeValue;
+	value?: RangeValue;
+}
 
-	protected getRootClasses(): (string | null)[] {
-		const { disabled, valid, readOnly, showOutput } = this.properties;
-		const focus = this.meta(Focus).get('root');
+const factory = create({
+	dimensions,
+	focus,
+	icache: createICacheMiddleware<RangeSliderICache>(),
+	theme
+}).properties<RangeSliderProperties>();
 
-		return [
-			css.root,
-			disabled ? css.disabled : null,
-			focus.containsFocus ? css.focused : null,
-			valid === false ? css.invalid : null,
-			valid === true ? css.valid : null,
-			readOnly ? css.readonly : null,
-			showOutput ? css.hasOutput : null
-		];
-	}
+export const RangeSlider = factory(function RangeSlider({
+	id,
+	middleware: { dimensions, focus, icache, theme },
+	properties
+}) {
+	const {
+		name = '',
+		aria = {},
+		classes,
+		disabled,
+		label,
+		labelAfter,
+		labelHidden,
+		max: maxRestraint = 100,
+		maxName = `${name}_max`,
+		maximumLabel = 'Maximum',
+		min: minRestraint = 0,
+		minName = `${name}_min`,
+		minimumLabel = 'Minimum',
+		onBlur,
+		onFocus,
+		onOut,
+		onOver,
+		onValue,
+		output,
+		outputIsTooltip,
+		readOnly,
+		required,
+		showOutput = false,
+		step = 1,
+		valid,
+		value = {
+			max: maxRestraint,
+			min: minRestraint
+		},
+		widgetId = `range-slider-${id}`
+	} = properties();
 
-	private _onInput(event: Event, isMinEvent: boolean) {
-		const { min: minRestraint = 0, max: maxRestraint = 100, onValue } = this.properties;
-		const { value: { min, max } = { min: minRestraint, max: maxRestraint } } = this.properties;
+	const themeCss = theme.classes(css);
+	const size = dimensions.get('root');
 
+	const maxLabelId = `max-label-${id}`;
+	const minLabelId = `min-label-${id}`;
+
+	const min = Math.max(value.min, minRestraint);
+	const max = Math.min(value.max, maxRestraint);
+	const slider1Percent = (min - minRestraint) / (maxRestraint - minRestraint);
+	const slider2Percent = (max - minRestraint) / (maxRestraint - minRestraint);
+	const slider1Size = slider1Percent + (slider2Percent - slider1Percent) / 2;
+	const slider2Size = 1 - slider1Size;
+
+	const getInputProperties = (isSlider1: boolean) => ({
+		...formatAriaProperties(aria),
+		'aria-describedby': isSlider1 ? minLabelId : maxLabelId,
+		'aria-invalid': valid === false ? 'true' : null,
+		'aria-labelledby': `${widgetId}-label`,
+		'aria-readonly': readOnly === true ? 'true' : null,
+		classes: [themeCss.input, fixedCss.nativeInput],
+		disabled,
+		max: `${maxRestraint}`,
+		min: `${minRestraint}`,
+		name: isSlider1 ? minName : maxName,
+		onblur: () => {
+			onBlur && onBlur();
+		},
+		onfocus: () => {
+			onFocus && onFocus();
+		},
+		oninput: (event: Event) => {
+			onInput(event, isSlider1);
+		},
+		readonly: readOnly,
+		required,
+		step: `${step}`,
+		type: 'range'
+	});
+
+	const onInput = (event: Event, isMinEvent: boolean) => {
 		if (!onValue) {
 			return;
 		}
@@ -105,239 +168,139 @@ export class RangeSlider extends ThemedMixin(WidgetBase)<RangeSliderProperties> 
 			: { min, max: Math.max(min, parseFloat(value)) };
 
 		onValue(returnValues);
-	}
+	};
 
-	private _getInputProperties(isSlider1: boolean) {
-		const {
-			aria = {},
-			disabled,
-			valid,
-			max = 100,
-			min = 0,
-			name = '',
-			readOnly,
-			required,
-			step = 1,
-			widgetId = this._widgetId,
-			onFocus,
-			onBlur
-		} = this.properties;
-		const { minName = `${name}_min`, maxName = `${name}_max` } = this.properties;
-
-		return {
-			...formatAriaProperties(aria),
-			'aria-invalid': valid === false ? 'true' : null,
-			'aria-readonly': readOnly === true ? 'true' : null,
-			'aria-describedby': isSlider1 ? this._minLabelId : this._maxLabelId,
-			'aria-labelledby': `${widgetId}-label`,
-			type: 'range',
-			min: `${min}`,
-			max: `${max}`,
-			step: `${step}`,
-			readonly: readOnly,
-			required,
-			disabled,
-			name: isSlider1 ? minName : maxName,
-			onblur: () => {
-				onBlur && onBlur();
-			},
-			onfocus: () => {
-				onFocus && onFocus();
-			},
-			oninput: (event: Event) => {
-				this._onInput(event, isSlider1);
-			},
-			classes: [this.theme(css.input), fixedCss.nativeInput]
-		};
-	}
-
-	protected renderOutput(value: RangeValue, percentValue: number[]): DNode {
-		const { output, outputIsTooltip = false } = this.properties;
-
-		const outputNode = output ? output(value) : `${value.min}, ${value.max}`;
-
-		// output styles
-		let outputStyles: { left?: string; top?: string } = {};
-		if (outputIsTooltip) {
-			outputStyles = {
-				left: `${Math.round(
-					(percentValue[0] + (percentValue[1] - percentValue[0]) / 2) * 100
-				)}%`
-			};
-		}
-
-		return v(
-			'output',
-			{
-				classes: this.theme([css.output, outputIsTooltip ? css.outputTooltip : null]),
-				for: this._widgetId,
-				styles: outputStyles,
-				tabIndex: -1 /* needed so Edge doesn't select the element while tabbing through */
-			},
-			[outputNode]
-		);
-	}
-
-	render(): DNode {
-		const {
-			disabled,
-			widgetId = this._widgetId,
-			valid,
-			label,
-			labelAfter,
-			labelHidden,
-			max: maxRestraint = 100,
-			min: minRestraint = 0,
-			readOnly,
-			required,
-			theme,
-			classes,
-			showOutput = false,
-			minimumLabel = 'Minimum',
-			maximumLabel = 'Maximum',
-			onOver,
-			onOut
-		} = this.properties;
-		const focus = this.meta(Focus).get('root');
-		let { value: { min, max } = { min: minRestraint, max: maxRestraint } } = this.properties;
-
-		min = Math.max(min, minRestraint);
-		max = Math.min(max, maxRestraint);
-
-		const slider1Percent = (min - minRestraint) / (maxRestraint - minRestraint);
-		const slider2Percent = (max - minRestraint) / (maxRestraint - minRestraint);
-
-		const slider1Size = slider1Percent + (slider2Percent - slider1Percent) / 2;
-		const slider2Size = 1 - slider1Size;
-
-		const size = this.meta(Dimensions).get('root');
-
-		const slider1Focus = this.meta(Focus).get('slider1');
-		const slider2Focus = this.meta(Focus).get('slider2');
-
-		const slider1 = v('input', {
-			...this._getInputProperties(true),
-			key: 'slider1',
-			value: `${min}`,
-			styles: {
+	const slider1 = (
+		<input
+			{...getInputProperties(true)}
+			key="slider1"
+			value={`${min}`}
+			styles={{
 				clip: `rect(auto, ${Math.round(slider1Size * size.client.width)}px, auto, auto)`
-			}
-		});
-		const slider2 = v('input', {
-			...this._getInputProperties(false),
-			key: 'slider2',
-			value: `${max}`,
-			styles: {
+			}}
+		/>
+	);
+
+	const slider2 = (
+		<input
+			{...getInputProperties(false)}
+			key="slider2"
+			styles={{
 				clip: `rect(auto, auto, auto, ${Math.round(
 					(1 - slider2Size) * size.client.width
 				)}px)`
-			}
-		});
+			}}
+			value={`${max}`}
+		/>
+	);
 
-		const children = [
-			label
-				? w(
-						Label,
-						{
-							key: 'label',
-							theme,
-							classes,
-							disabled,
-							focused: focus.containsFocus,
-							valid,
-							readOnly,
-							required,
-							hidden: labelHidden,
-							widgetId: `${widgetId}-label`,
-							secondary: true
-						},
-						[label]
-				  )
-				: null,
-			v(
-				'div',
-				{
-					classes: [this.theme(css.inputWrapper), fixedCss.inputWrapperFixed],
-					onpointerenter: () => {
-						onOver && onOver();
-					},
-					onpointerleave: () => {
-						onOut && onOut();
+	console.log('label', label);
+
+	const children = [
+		label ? (
+			<Label
+				classes={classes}
+				disabled={disabled}
+				focused={focus.isFocused('root')}
+				hidden={labelHidden}
+				key="label"
+				readOnly={readOnly}
+				required={required}
+				secondary={true}
+				theme={theme}
+				valid={valid}
+				widgetId={`${widgetId}-label`}
+			>
+				{label}
+			</Label>
+		) : null,
+		<div
+			classes={[themeCss.inputWrapper, fixedCss.inputWrapperFixed]}
+			onpointerenter={() => {
+				onOver && onOver();
+			}}
+			onpointerleave={() => {
+				onOut && onOut();
+			}}
+		>
+			{slider1}
+			<div classes={baseCss.visuallyHidden} id={minLabelId} key="minimumLabel">
+				{minimumLabel}
+			</div>
+			{slider2}
+			<div classes={baseCss.visuallyHidden} id={maxLabelId} key="maximumLabel">
+				{maximumLabel}
+			</div>
+			<div
+				classes={[themeCss.filled, fixedCss.filledFixed]}
+				key="track"
+				styles={{
+					left: Math.round(slider1Percent * 100) + '%',
+					width: Math.round((slider2Percent - slider1Percent) * 100) + '%'
+				}}
+			/>
+			<div
+				key="leftThumb"
+				classes={[
+					themeCss.thumb,
+					themeCss.leftThumb,
+					focus.isFocused('slider1') ? themeCss.focused : undefined,
+					fixedCss.thumbFixed
+				]}
+				styles={{
+					left: Math.round(slider1Percent * 100) + '%'
+				}}
+			/>
+			<div
+				key="rightThumb"
+				classes={[
+					themeCss.thumb,
+					themeCss.rightThumb,
+					focus.isFocused('slider2') ? themeCss.focused : undefined,
+					fixedCss.thumbFixed
+				]}
+				styles={{
+					left: Math.round(slider2Percent * 100) + '%'
+				}}
+			/>
+			{showOutput ? (
+				<output
+					classes={[themeCss.output, outputIsTooltip ? themeCss.outputTooltip : null]}
+					for={widgetId}
+					styles={
+						outputIsTooltip
+							? {
+									left: `${Math.round(
+										(slider1Percent + (slider2Percent - slider1Percent) / 2) *
+											100
+									)}%`
+							  }
+							: undefined
 					}
-				},
-				[
-					slider1,
-					v(
-						'div',
-						{
-							key: 'minimumLabel',
-							classes: [baseCss.visuallyHidden],
-							id: this._minLabelId
-						},
-						[minimumLabel]
-					),
-					slider2,
-					v(
-						'div',
-						{
-							key: 'maximumLabel',
-							classes: [baseCss.visuallyHidden],
-							id: this._maxLabelId
-						},
-						[maximumLabel]
-					),
-					v('div', {
-						key: 'track',
-						classes: [this.theme(css.filled), fixedCss.filledFixed],
-						styles: {
-							left: Math.round(slider1Percent * 100) + '%',
-							width: Math.round((slider2Percent - slider1Percent) * 100) + '%'
-						}
-					}),
-					v('div', {
-						key: 'leftThumb',
-						classes: [
-							...this.theme([
-								css.thumb,
-								css.leftThumb,
-								slider1Focus.active ? css.focused : undefined
-							]),
-							fixedCss.thumbFixed
-						],
-						styles: {
-							left: Math.round(slider1Percent * 100) + '%'
-						}
-					}),
-					v('div', {
-						key: 'rightThumb',
-						classes: [
-							...this.theme([
-								css.thumb,
-								css.rightThumb,
-								slider2Focus.active ? css.focused : undefined
-							]),
-							fixedCss.thumbFixed
-						],
-						styles: {
-							left: Math.round(slider2Percent * 100) + '%'
-						}
-					}),
-					showOutput
-						? this.renderOutput({ min, max }, [slider1Percent, slider2Percent])
-						: null
-				]
-			)
-		];
+					tabIndex={-1}
+				>
+					{output ? output({ min, max }) : `${min}, ${max}`}
+				</output>
+			) : null}
+		</div>
+	];
 
-		return v(
-			'div',
-			{
-				key: 'root',
-				classes: this.theme(this.getRootClasses())
-			},
-			labelAfter ? children.reverse() : children
-		);
-	}
-}
+	return (
+		<div
+			key="root"
+			classes={[
+				themeCss.root,
+				disabled ? themeCss.disabled : null,
+				focus.isFocused('root') ? themeCss.focused : null,
+				valid === false ? themeCss.invalid : null,
+				valid === true ? themeCss.valid : null,
+				readOnly ? themeCss.readonly : null,
+				showOutput ? themeCss.hasOutput : null
+			]}
+		>
+			{labelAfter ? children.reverse() : children}
+		</div>
+	);
+});
 
 export default RangeSlider;

--- a/src/range-slider/index.tsx
+++ b/src/range-slider/index.tsx
@@ -201,8 +201,6 @@ export const RangeSlider = factory(function RangeSlider({
 		/>
 	);
 
-	const children = [];
-
 	return (
 		<div
 			key="root"

--- a/src/range-slider/index.tsx
+++ b/src/range-slider/index.tsx
@@ -109,6 +109,7 @@ export const RangeSlider = factory(function RangeSlider({
 		required,
 		showOutput = false,
 		step = 1,
+		theme: themeProp,
 		valid,
 		value = {
 			max: maxRestraint,
@@ -194,8 +195,6 @@ export const RangeSlider = factory(function RangeSlider({
 		/>
 	);
 
-	console.log('label', label);
-
 	const children = [
 		label ? (
 			<Label
@@ -207,7 +206,7 @@ export const RangeSlider = factory(function RangeSlider({
 				readOnly={readOnly}
 				required={required}
 				secondary={true}
-				theme={theme}
+				theme={themeProp}
 				valid={valid}
 				widgetId={`${widgetId}-label`}
 			>

--- a/src/range-slider/index.tsx
+++ b/src/range-slider/index.tsx
@@ -19,8 +19,6 @@ export interface RangeSliderProperties {
 	disabled?: boolean;
 	/** Adds a <label> element with the supplied text */
 	label?: string;
-	/** Adds the label element after (true) or before (false) */
-	labelAfter?: boolean;
 	/** Hides the label from view while still remaining accessible for screen readers */
 	labelHidden?: boolean;
 	/** The maximum value allowed */
@@ -91,7 +89,6 @@ export const RangeSlider = factory(function RangeSlider({
 		classes,
 		disabled,
 		label,
-		labelAfter,
 		labelHidden,
 		maxName = `${name}_max`,
 		maximumLabel = 'Maximum',
@@ -204,94 +201,7 @@ export const RangeSlider = factory(function RangeSlider({
 		/>
 	);
 
-	const children = [
-		label ? (
-			<Label
-				classes={classes}
-				disabled={disabled}
-				focused={focus.isFocused('root')}
-				hidden={labelHidden}
-				key="label"
-				readOnly={readOnly}
-				required={required}
-				secondary={true}
-				theme={themeProp}
-				valid={valid}
-				widgetId={`${widgetId}-label`}
-			>
-				{label}
-			</Label>
-		) : null,
-		<div
-			classes={[themeCss.inputWrapper, fixedCss.inputWrapperFixed]}
-			onpointerenter={() => {
-				onOver && onOver();
-			}}
-			onpointerleave={() => {
-				onOut && onOut();
-			}}
-		>
-			{slider1}
-			<div classes={baseCss.visuallyHidden} id={minLabelId} key="minimumLabel">
-				{minimumLabel}
-			</div>
-			{slider2}
-			<div classes={baseCss.visuallyHidden} id={maxLabelId} key="maximumLabel">
-				{maximumLabel}
-			</div>
-			<div
-				classes={[themeCss.filled, fixedCss.filledFixed]}
-				key="track"
-				styles={{
-					left: Math.round(slider1Percent * 100) + '%',
-					width: Math.round((slider2Percent - slider1Percent) * 100) + '%'
-				}}
-			/>
-			<div
-				key="leftThumb"
-				classes={[
-					themeCss.thumb,
-					themeCss.leftThumb,
-					focus.isFocused('slider1') ? themeCss.focused : undefined,
-					fixedCss.thumbFixed
-				]}
-				styles={{
-					left: Math.round(slider1Percent * 100) + '%'
-				}}
-			/>
-			<div
-				key="rightThumb"
-				classes={[
-					themeCss.thumb,
-					themeCss.rightThumb,
-					focus.isFocused('slider2') ? themeCss.focused : undefined,
-					fixedCss.thumbFixed
-				]}
-				styles={{
-					left: Math.round(slider2Percent * 100) + '%'
-				}}
-			/>
-			{showOutput ? (
-				<output
-					classes={[themeCss.output, outputIsTooltip ? themeCss.outputTooltip : null]}
-					for={widgetId}
-					styles={
-						outputIsTooltip
-							? {
-									left: `${Math.round(
-										(slider1Percent + (slider2Percent - slider1Percent) / 2) *
-											100
-									)}%`
-							  }
-							: undefined
-					}
-					tabIndex={-1}
-				>
-					{output ? output({ min, max }) : `${min}, ${max}`}
-				</output>
-			) : null}
-		</div>
-	];
+	const children = [];
 
 	return (
 		<div
@@ -306,7 +216,93 @@ export const RangeSlider = factory(function RangeSlider({
 				showOutput ? themeCss.hasOutput : null
 			]}
 		>
-			{labelAfter ? children.reverse() : children}
+			{label ? (
+				<Label
+					classes={classes}
+					disabled={disabled}
+					focused={focus.isFocused('root')}
+					hidden={labelHidden}
+					key="label"
+					readOnly={readOnly}
+					required={required}
+					secondary={true}
+					theme={themeProp}
+					valid={valid}
+					widgetId={`${widgetId}-label`}
+				>
+					{label}
+				</Label>
+			) : null}
+			<div
+				classes={[themeCss.inputWrapper, fixedCss.inputWrapperFixed]}
+				onpointerenter={() => {
+					onOver && onOver();
+				}}
+				onpointerleave={() => {
+					onOut && onOut();
+				}}
+			>
+				{slider1}
+				<div classes={baseCss.visuallyHidden} id={minLabelId} key="minimumLabel">
+					{minimumLabel}
+				</div>
+				{slider2}
+				<div classes={baseCss.visuallyHidden} id={maxLabelId} key="maximumLabel">
+					{maximumLabel}
+				</div>
+				<div
+					classes={[themeCss.filled, fixedCss.filledFixed]}
+					key="track"
+					styles={{
+						left: Math.round(slider1Percent * 100) + '%',
+						width: Math.round((slider2Percent - slider1Percent) * 100) + '%'
+					}}
+				/>
+				<div
+					key="leftThumb"
+					classes={[
+						themeCss.thumb,
+						themeCss.leftThumb,
+						focus.isFocused('slider1') ? themeCss.focused : undefined,
+						fixedCss.thumbFixed
+					]}
+					styles={{
+						left: Math.round(slider1Percent * 100) + '%'
+					}}
+				/>
+				<div
+					key="rightThumb"
+					classes={[
+						themeCss.thumb,
+						themeCss.rightThumb,
+						focus.isFocused('slider2') ? themeCss.focused : undefined,
+						fixedCss.thumbFixed
+					]}
+					styles={{
+						left: Math.round(slider2Percent * 100) + '%'
+					}}
+				/>
+				{showOutput ? (
+					<output
+						classes={[themeCss.output, outputIsTooltip ? themeCss.outputTooltip : null]}
+						for={widgetId}
+						styles={
+							outputIsTooltip
+								? {
+										left: `${Math.round(
+											(slider1Percent +
+												(slider2Percent - slider1Percent) / 2) *
+												100
+										)}%`
+								  }
+								: undefined
+						}
+						tabIndex={-1}
+					>
+						{output ? output({ min, max }) : `${min}, ${max}`}
+					</output>
+				) : null}
+			</div>
 		</div>
 	);
 });

--- a/src/range-slider/index.tsx
+++ b/src/range-slider/index.tsx
@@ -125,7 +125,6 @@ export const RangeSlider = factory(function RangeSlider({
 		icache.set('value', initialValue);
 		icache.set('initialValue', initialValue);
 		value = initialValue;
-		onValue && onValue(initialValue);
 	}
 
 	const themeCss = theme.classes(css);

--- a/src/range-slider/tests/unit/RangeSlider.spec.tsx
+++ b/src/range-slider/tests/unit/RangeSlider.spec.tsx
@@ -147,28 +147,6 @@ describe('RangeSlider', () => {
 		h.expect(testTemplate);
 	});
 
-	it('renders label after', () => {
-		const h = harness(() => <RangeSlider label="label" labelAfter />);
-		const testTemplate = template.append('@root', [
-			<Label
-				classes={undefined}
-				disabled={undefined}
-				focused={false}
-				hidden={undefined}
-				key="label"
-				readOnly={undefined}
-				required={undefined}
-				secondary={true}
-				theme={undefined}
-				valid={undefined}
-				widgetId="range-slider-test-label"
-			>
-				label
-			</Label>
-		]);
-		h.expect(testTemplate);
-	});
-
 	it('renders output', () => {
 		const h = harness(() => <RangeSlider showOutput />);
 		const testTemplate = template

--- a/src/range-slider/tests/unit/RangeSlider.spec.tsx
+++ b/src/range-slider/tests/unit/RangeSlider.spec.tsx
@@ -1,571 +1,223 @@
-const { registerSuite } = intern.getInterface('object');
-const { assert } = intern.getPlugin('chai');
-import * as sinon from 'sinon';
-import { v, w } from '@dojo/framework/core/vdom';
-
-import Label from '../../../label/index';
-import RangeSlider from '../../index';
-import * as css from '../../../theme/default/range-slider.m.css';
+const { describe, it } = intern.getInterface('bdd');
+import * as baseCss from '../../../common/styles/base.m.css';
 import * as fixedCss from '../../styles/range-slider.m.css';
-import Focus from '../../../meta/Focus';
-import {
-	compareId,
-	compareForId,
-	createHarness,
-	MockMetaMixin,
-	stubEvent,
-	compareAriaDescribedBy,
-	compareWidgetId,
-	compareAriaLabelledBy
-} from '../../../common/tests/support/test-helpers';
-import Dimensions from '@dojo/framework/core/meta/Dimensions';
+import * as themeCss from '../../../theme/default/range-slider.m.css';
+import Label from '../../../label';
+import RangeSlider from '../../index';
+import assertationTemplate from '@dojo/framework/testing/assertionTemplate';
+import harness from '@dojo/framework/testing/harness';
+import { tsx } from '@dojo/framework/core/vdom';
 
-const compareFor = {
-	selector: '*',
-	property: 'for',
-	comparator: (property: any) => typeof property === 'string'
-};
-const harness = createHarness([compareId, compareForId, compareFor]);
+const noop = () => {};
 
-const sliderProps = {
-	'aria-invalid': null,
-	'aria-readonly': null,
-	'aria-describedby': 'mock-uuid',
-	'aria-labelledby': '',
-	type: 'range',
-	min: '0',
-	max: '100',
-	step: '1',
-	readonly: undefined,
-	required: undefined,
-	disabled: undefined,
-	onblur: () => {},
-	onfocus: () => {},
-	oninput: () => {},
-	classes: [css.input, fixedCss.nativeInput]
-};
-
-registerSuite('RangeSlider', {
-	tests: {
-		'renders two sliders'() {
-			const h = harness(() => w(RangeSlider, {}), [
-				compareAriaDescribedBy,
-				compareAriaLabelledBy
-			]);
-			h.expectPartial('@slider1', () =>
-				v('input', {
-					...sliderProps,
-					key: 'slider1',
-					name: '_min',
-					value: '0',
-					styles: {
-						clip: 'rect(auto, 0px, auto, auto)'
-					}
-				})
-			);
-
-			h.expectPartial('@slider2', () =>
-				v('input', {
-					...sliderProps,
-					key: 'slider2',
-					name: '_max',
-					value: '100',
-					styles: {
-						clip: 'rect(auto, auto, auto, 0px)'
-					}
-				})
-			);
-		},
-
-		'renders two thumbs'() {
-			const h = harness(() => w(RangeSlider, {}));
-			h.expectPartial('@leftThumb', () =>
-				v('div', {
-					key: 'leftThumb',
-					classes: [css.thumb, css.leftThumb, undefined, fixedCss.thumbFixed],
-					styles: {
-						left: '0%'
-					}
-				})
-			);
-			h.expectPartial('@rightThumb', () =>
-				v('div', {
-					key: 'rightThumb',
-					classes: [css.thumb, css.rightThumb, undefined, fixedCss.thumbFixed],
-					styles: {
-						left: '100%'
-					}
-				})
-			);
-		},
-
-		'renders a track'() {
-			const h = harness(() => w(RangeSlider, {}));
-			h.expectPartial('@track', () =>
-				v('div', {
-					key: 'track',
-					classes: [css.filled, fixedCss.filledFixed],
-					styles: {
-						left: '0%',
-						width: '100%'
-					}
-				})
-			);
-		},
-
-		name: {
-			'uses a default name'() {
-				const h = harness(
-					() =>
-						w(RangeSlider, {
-							name: 'test'
-						}),
-					[compareAriaDescribedBy, compareAriaLabelledBy]
-				);
-				h.expectPartial('@slider1', () =>
-					v('input', {
-						...sliderProps,
-						key: 'slider1',
-						name: 'test_min',
-						value: '0',
-						styles: {
-							clip: 'rect(auto, 0px, auto, auto)'
-						}
-					})
-				);
-
-				h.expectPartial('@slider2', () =>
-					v('input', {
-						...sliderProps,
-						key: 'slider2',
-						name: 'test_max',
-						value: '100',
-						styles: {
-							clip: 'rect(auto, auto, auto, 0px)'
-						}
-					})
-				);
-			},
-			'uses custom names'() {
-				const h = harness(
-					() =>
-						w(RangeSlider, {
-							minName: 'minValue',
-							maxName: 'maxValue'
-						}),
-					[compareAriaDescribedBy, compareAriaLabelledBy]
-				);
-				h.expectPartial('@slider1', () =>
-					v('input', {
-						...sliderProps,
-						key: 'slider1',
-						name: 'minValue',
-						value: '0',
-						styles: {
-							clip: 'rect(auto, 0px, auto, auto)'
-						}
-					})
-				);
-
-				h.expectPartial('@slider2', () =>
-					v('input', {
-						...sliderProps,
-						key: 'slider2',
-						name: 'maxValue',
-						value: '100',
-						styles: {
-							clip: 'rect(auto, auto, auto, 0px)'
-						}
-					})
-				);
-			}
-		},
-		disabled() {
-			const h = harness(
-				() =>
-					w(RangeSlider, {
-						disabled: true
-					}),
-				[compareAriaDescribedBy, compareAriaLabelledBy]
-			);
-			h.expectPartial('@slider1', () =>
-				v('input', {
-					...sliderProps,
-					key: 'slider1',
-					disabled: true,
-					name: '_min',
-					value: '0',
-					styles: {
-						clip: 'rect(auto, 0px, auto, auto)'
-					}
-				})
-			);
-
-			h.expectPartial('@slider2', () =>
-				v('input', {
-					...sliderProps,
-					key: 'slider2',
-					disabled: true,
-					name: '_max',
-					value: '100',
-					styles: {
-						clip: 'rect(auto, auto, auto, 0px)'
-					}
-				})
-			);
-		},
-		readonly() {
-			const h = harness(
-				() =>
-					w(RangeSlider, {
-						readOnly: true
-					}),
-				[compareAriaDescribedBy, compareAriaLabelledBy]
-			);
-			h.expectPartial('@slider1', () =>
-				v('input', {
-					...sliderProps,
-					'aria-readonly': 'true',
-					key: 'slider1',
-					readonly: true,
-					name: '_min',
-					value: '0',
-					styles: {
-						clip: 'rect(auto, 0px, auto, auto)'
-					}
-				})
-			);
-
-			h.expectPartial('@slider2', () =>
-				v('input', {
-					...sliderProps,
-					'aria-readonly': 'true',
-					key: 'slider2',
-					readonly: true,
-					name: '_max',
-					value: '100',
-					styles: {
-						clip: 'rect(auto, auto, auto, 0px)'
-					}
-				})
-			);
-		},
-		required() {
-			const h = harness(
-				() =>
-					w(RangeSlider, {
-						required: true
-					}),
-				[compareAriaDescribedBy, compareAriaLabelledBy]
-			);
-			h.expectPartial('@slider1', () =>
-				v('input', {
-					...sliderProps,
-					key: 'slider1',
-					required: true,
-					name: '_min',
-					value: '0',
-					styles: {
-						clip: 'rect(auto, 0px, auto, auto)'
-					}
-				})
-			);
-
-			h.expectPartial('@slider2', () =>
-				v('input', {
-					...sliderProps,
-					key: 'slider2',
-					required: true,
-					name: '_max',
-					value: '100',
-					styles: {
-						clip: 'rect(auto, auto, auto, 0px)'
-					}
-				})
-			);
-		},
-		invalid() {
-			const h = harness(
-				() =>
-					w(RangeSlider, {
-						valid: false
-					}),
-				[compareAriaDescribedBy, compareAriaLabelledBy]
-			);
-			h.expectPartial('@slider1', () =>
-				v('input', {
-					...sliderProps,
-					'aria-invalid': 'true',
-					key: 'slider1',
-					name: '_min',
-					value: '0',
-					styles: {
-						clip: 'rect(auto, 0px, auto, auto)'
-					}
-				})
-			);
-
-			h.expectPartial('@slider2', () =>
-				v('input', {
-					...sliderProps,
-					'aria-invalid': 'true',
-					key: 'slider2',
-					name: '_max',
-					value: '100',
-					styles: {
-						clip: 'rect(auto, auto, auto, 0px)'
-					}
-				})
-			);
-		},
-		'slider values'() {
-			const h = harness(
-				() =>
-					w(RangeSlider, {
-						min: 25,
-						max: 50,
-						value: { min: 25, max: 50 },
-						step: 5
-					}),
-				[compareAriaDescribedBy, compareAriaLabelledBy]
-			);
-
-			h.expectPartial('@slider1', () =>
-				v('input', {
-					...sliderProps,
-					key: 'slider1',
-					name: '_min',
-					value: '25',
-					min: '25',
-					max: '50',
-					step: '5',
-					styles: {
-						clip: 'rect(auto, 0px, auto, auto)'
-					}
-				})
-			);
-
-			h.expectPartial('@slider2', () =>
-				v('input', {
-					...sliderProps,
-					key: 'slider2',
-					name: '_max',
-					value: '50',
-					min: '25',
-					max: '50',
-					step: '5',
-					styles: {
-						clip: 'rect(auto, auto, auto, 0px)'
-					}
-				})
-			);
-		},
-		events: {
-			onValue() {
-				const onValue = sinon.stub();
-
-				const h = harness(() =>
-					w(RangeSlider, {
-						onValue
-					})
-				);
-
-				h.trigger('@slider1', 'oninput', {
-					stopPropagation: sinon.stub(),
-					target: {
-						value: '25'
-					}
-				});
-
-				assert(onValue.calledWith({ min: 25, max: 100 }));
-
-				h.trigger('@slider2', 'oninput', {
-					stopPropagation: sinon.stub(),
-					target: {
-						value: '50'
-					}
-				});
-
-				assert(onValue.calledWith({ min: 0, max: 50 }));
-			},
-
-			onBlur() {
-				const onBlur = sinon.stub();
-
-				const h = harness(() =>
-					w(RangeSlider, {
-						onBlur
-					})
-				);
-
-				h.trigger('@slider1', 'onblur', {
-					stopPropagation: sinon.stub(),
-					target: {
-						value: '25'
-					}
-				});
-
-				assert(onBlur.called);
-			},
-			onFocus() {
-				const onFocus = sinon.stub();
-
-				const h = harness(() =>
-					w(RangeSlider, {
-						onFocus
-					})
-				);
-
-				h.trigger('@slider1', 'onfocus', {
-					stopPropagation: sinon.stub(),
-					target: {
-						value: '25'
-					}
-				});
-
-				assert(onFocus.called);
-			},
-
-			'does not error on missing events'() {
-				const h = harness(() => w(RangeSlider, {}));
-
-				['onblur', 'onfocus', 'oninput'].forEach((key) => {
-					h.trigger('@slider1', key, stubEvent);
-					h.trigger('@slider2', key, stubEvent);
-				});
-			}
-		},
-		label: {
-			'plain label'() {
-				const h = harness(
-					() =>
-						w(RangeSlider, {
-							label: 'Test'
-						}),
-					[compareWidgetId]
-				);
-
-				h.expectPartial('@label', () =>
-					w(
-						Label,
-						{
-							key: 'label',
-							theme: undefined,
-							classes: undefined,
-							disabled: undefined,
-							focused: false,
-							valid: undefined,
-							readOnly: undefined,
-							required: undefined,
-							hidden: undefined,
-							widgetId: '',
-							secondary: true
-						},
-						['Test']
-					)
-				);
-			},
-
-			'disabled/required/readonly label'() {
-				const h = harness(
-					() =>
-						w(RangeSlider, {
-							label: 'Test',
-							disabled: true,
-							required: true,
-							readOnly: true
-						}),
-					[compareWidgetId]
-				);
-
-				h.expectPartial('@label', () =>
-					w(
-						Label,
-						{
-							key: 'label',
-							theme: undefined,
-							classes: undefined,
-							disabled: true,
-							focused: false,
-							valid: undefined,
-							readOnly: true,
-							required: true,
-							hidden: undefined,
-							widgetId: '',
-							secondary: true
-						},
-						['Test']
-					)
-				);
-			}
-		},
-
-		focus: {
-			'detects focus'() {
-				const mockMeta = sinon.stub();
-				const mockFocusGet = sinon.stub().returns({
-					active: true,
-					containsFocus: true
-				});
-				const mockDimensionsGet = sinon.stub().returns({
-					client: {
-						width: 100
-					}
-				});
-				mockMeta.withArgs(Focus).returns({
-					get: mockFocusGet
-				});
-				mockMeta.withArgs(Dimensions).returns({
-					get: mockDimensionsGet
-				});
-
-				const h = harness(
-					() =>
-						w(MockMetaMixin(RangeSlider, mockMeta), {
-							label: 'Test'
-						}),
-					[compareWidgetId]
-				);
-				h.expectPartial('@label', () =>
-					w(
-						Label,
-						{
-							key: 'label',
-							theme: undefined,
-							classes: undefined,
-							disabled: undefined,
-							focused: true,
-							valid: undefined,
-							readOnly: undefined,
-							required: undefined,
-							hidden: undefined,
-							widgetId: '',
-							secondary: true
-						},
-						['Test']
-					)
-				);
-
-				h.expectPartial('@leftThumb', () =>
-					v('div', {
-						key: 'leftThumb',
-						classes: [css.thumb, css.leftThumb, css.focused, fixedCss.thumbFixed],
-						styles: {
+describe('RangeSlider', () => {
+	const template = assertationTemplate(() => {
+		return (
+			<div key="root" classes={[themeCss.root, null, null, null, null, null, null]}>
+				<div
+					classes={[themeCss.inputWrapper, fixedCss.inputWrapperFixed]}
+					onpointerenter={noop}
+					onpointerleave={noop}
+				>
+					<input
+						aria-describedby="min-label-test"
+						aria-invalid={null}
+						aria-labelledby="range-slider-test-label"
+						aria-readonly={null}
+						classes={[themeCss.input, fixedCss.nativeInput]}
+						disabled={undefined}
+						key="slider1"
+						max="100"
+						min="0"
+						name="_min"
+						onblur={noop}
+						onfocus={noop}
+						oninput={noop}
+						readonly={undefined}
+						required={undefined}
+						step="1"
+						styles={{
+							clip: `rect(auto, 0px, auto, auto)`
+						}}
+						type="range"
+						value="0"
+					/>
+					<div classes={baseCss.visuallyHidden} id="min-label-test" key="minimumLabel">
+						Minimum
+					</div>
+					<input
+						aria-labelledby="range-slider-test-label"
+						aria-describedby="max-label-test"
+						aria-invalid={null}
+						aria-readonly={null}
+						classes={[themeCss.input, fixedCss.nativeInput]}
+						disabled={undefined}
+						key="slider2"
+						max="100"
+						min="0"
+						name="_max"
+						onblur={noop}
+						onfocus={noop}
+						oninput={noop}
+						readonly={undefined}
+						required={undefined}
+						step="1"
+						styles={{
+							clip: `rect(auto, auto, auto, 0px)`
+						}}
+						type="range"
+						value="100"
+					/>
+					<div classes={baseCss.visuallyHidden} id="max-label-test" key="maximumLabel">
+						Maximum
+					</div>
+					<div
+						classes={[themeCss.filled, fixedCss.filledFixed]}
+						key="track"
+						styles={{
+							left: '0%',
+							width: '100%'
+						}}
+					/>
+					<div
+						key="leftThumb"
+						classes={[
+							themeCss.thumb,
+							themeCss.leftThumb,
+							undefined,
+							fixedCss.thumbFixed
+						]}
+						styles={{
 							left: '0%'
-						}
-					})
-				);
-
-				h.expectPartial('@rightThumb', () =>
-					v('div', {
-						key: 'rightThumb',
-						classes: [css.thumb, css.rightThumb, css.focused, fixedCss.thumbFixed],
-						styles: {
+						}}
+					/>
+					<div
+						key="rightThumb"
+						classes={[
+							themeCss.thumb,
+							themeCss.rightThumb,
+							undefined,
+							fixedCss.thumbFixed
+						]}
+						styles={{
 							left: '100%'
-						}
-					})
-				);
-			}
-		}
-	}
+						}}
+					/>
+				</div>
+			</div>
+		);
+	});
+
+	it('renders', () => {
+		const h = harness(() => <RangeSlider />);
+		h.expect(template);
+	});
+
+	it('renders a label', () => {
+		const h = harness(() => <RangeSlider label="label" />);
+		const testTemplate = template.prepend('@root', [
+			<Label
+				classes={undefined}
+				disabled={undefined}
+				focused={false}
+				hidden={undefined}
+				key="label"
+				readOnly={undefined}
+				required={undefined}
+				secondary={true}
+				theme={undefined}
+				valid={undefined}
+				widgetId="range-slider-test-label"
+			>
+				label
+			</Label>
+		]);
+		h.expect(testTemplate);
+	});
+
+	it('renders max and min constraints', () => {
+		const h = harness(() => <RangeSlider min={10} max={1337} />);
+		const testTemplate = template
+			.setProperty('@slider1', 'min', '10')
+			.setProperty('@slider1', 'max', '1337')
+			.setProperty('@slider1', 'value', '10')
+			.setProperty('@slider2', 'min', '10')
+			.setProperty('@slider2', 'max', '1337')
+			.setProperty('@slider2', 'value', '1337');
+		h.expect(testTemplate);
+	});
+
+	it('renders label after', () => {
+		const h = harness(() => <RangeSlider label="label" labelAfter />);
+		const testTemplate = template.append('@root', [
+			<Label
+				classes={undefined}
+				disabled={undefined}
+				focused={false}
+				hidden={undefined}
+				key="label"
+				readOnly={undefined}
+				required={undefined}
+				secondary={true}
+				theme={undefined}
+				valid={undefined}
+				widgetId="range-slider-test-label"
+			>
+				label
+			</Label>
+		]);
+		h.expect(testTemplate);
+	});
+
+	it('renders output', () => {
+		const h = harness(() => <RangeSlider showOutput />);
+		const testTemplate = template
+			.setProperty('@root', 'classes', [
+				themeCss.root,
+				null,
+				null,
+				null,
+				null,
+				null,
+				themeCss.hasOutput
+			])
+			.insertAfter('@rightThumb', [
+				<output
+					classes={[themeCss.output, null]}
+					for="range-slider-test"
+					styles={undefined}
+					tabIndex={-1}
+				>
+					0, 100
+				</output>
+			]);
+		h.expect(testTemplate);
+	});
+
+	it('renders output tooltip', () => {
+		const h = harness(() => <RangeSlider showOutput outputIsTooltip />);
+		const testTemplate = template
+			.setProperty('@root', 'classes', [
+				themeCss.root,
+				null,
+				null,
+				null,
+				null,
+				null,
+				themeCss.hasOutput
+			])
+			.insertAfter('@rightThumb', [
+				<output
+					classes={[themeCss.output, themeCss.outputTooltip]}
+					for="range-slider-test"
+					styles={{
+						left: '50%'
+					}}
+					tabIndex={-1}
+				>
+					0, 100
+				</output>
+			]);
+		h.expect(testTemplate);
+	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request updates `RangeSlider` to be a functional widget, updates its tests to use assertion templates, and updates its internal logic to use the new `initialValue` pattern.

Resolves #1028
Resolves #1147

**Preview:**

<img width="1210" alt="preview" src="https://user-images.githubusercontent.com/334586/77114068-477bdc80-6a02-11ea-9532-27cd2b8ad9f5.png">
