### PR TITLE
feat: functional TitlePane and AccordionPane

### DIFF
--- a/src/accordion-pane/tests/unit/AccordionPane.spec.tsx
+++ b/src/accordion-pane/tests/unit/AccordionPane.spec.tsx
@@ -31,15 +31,15 @@ describe('AccordionPane', () => {
 	it('renders closed panes', () => {
 		const h = harness(() => (
 			<AccordionPane>
-				{() => {
+				{(onOpen, onClose) => {
 					return [
-						<TitlePane key="foo">
+						<TitlePane key="foo" onOpen={onOpen('foo')} onClose={onClose('foo')}>
 							{{
 								title: () => 'foo title',
 								content: () => 'foo content'
 							}}
 						</TitlePane>,
-						<TitlePane key="bar">
+						<TitlePane key="bar" onOpen={onOpen('bar')} onClose={onClose('bar')}>
 							{{
 								title: () => 'bar title',
 								content: () => 'bar content'
@@ -49,7 +49,19 @@ describe('AccordionPane', () => {
 				}}
 			</AccordionPane>
 		));
-		h.expect(baseTemplate);
+
+		h.trigger('@foo', 'onOpen');
+		h.trigger('@bar', 'onOpen');
+		h.trigger('@foo', 'onClose');
+		h.trigger('@bar', 'onClose');
+
+		const testTemplate = baseTemplate
+			.setProperty('@foo', 'onOpen', noop)
+			.setProperty('@foo', 'onClose', noop)
+			.setProperty('@bar', 'onOpen', noop)
+			.setProperty('@bar', 'onClose', noop);
+
+		h.expect(testTemplate);
 	});
 
 	it('renders open panes', () => {

--- a/src/examples/src/widgets/accordion-pane/Basic.tsx
+++ b/src/examples/src/widgets/accordion-pane/Basic.tsx
@@ -1,55 +1,70 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
-import icache from '@dojo/framework/core/middleware/icache';
-
 import AccordionPane from '@dojo/widgets/accordion-pane';
 import TitlePane from '@dojo/widgets/title-pane';
+import { create, tsx } from '@dojo/framework/core/vdom';
 
-const factory = create({ icache });
+const factory = create();
 
-export default factory(function Basic({ middleware: { icache } }) {
-	let openKeys = icache.getOrSet<string[]>('open', []);
+export default factory(function Basic() {
 	return (
-		<AccordionPane
-			onRequestClose={(key) => {
-				const idx = openKeys.findIndex((k) => k === key);
-				if (idx !== -1) {
-					openKeys.splice(idx, 1);
-				}
-				icache.set('open', [...openKeys]);
+		<AccordionPane>
+			{(onOpen, onClose, initialOpen, theme) => {
+				return [
+					<TitlePane
+						key="foo"
+						onOpen={onOpen('foo')}
+						onClose={onClose('foo')}
+						initialOpen={initialOpen('foo')}
+						theme={theme}
+					>
+						{{
+							title: () => 'Pane 1',
+							content: () => (
+								<div>
+									Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
+									id purus ipsum. Aenean ac purus purus. Nam sollicitudin varius
+									augue, sed lacinia felis tempor in.
+								</div>
+							)
+						}}
+					</TitlePane>,
+					<TitlePane
+						key="bar"
+						onOpen={onOpen('bar')}
+						onClose={onClose('bar')}
+						initialOpen={initialOpen('bar')}
+						theme={theme}
+					>
+						{{
+							title: () => 'Pane 2',
+							content: () => (
+								<div>
+									Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
+									id purus ipsum. Aenean ac purus purus. Nam sollicitudin varius
+									augue, sed lacinia felis tempor in.
+								</div>
+							)
+						}}
+					</TitlePane>,
+					<TitlePane
+						key="baz"
+						onOpen={onOpen('baz')}
+						onClose={onClose('baz')}
+						initialOpen={initialOpen('baz')}
+						theme={theme}
+					>
+						{{
+							title: () => 'Pane 3',
+							content: () => (
+								<div>
+									Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
+									id purus ipsum. Aenean ac purus purus. Nam sollicitudin varius
+									augue, sed lacinia felis tempor in.
+								</div>
+							)
+						}}
+					</TitlePane>
+				];
 			}}
-			onRequestOpen={(key) => {
-				const idx = openKeys.findIndex((k) => k === key);
-				if (idx === -1) {
-					openKeys = [...openKeys, key];
-				}
-				icache.set('open', openKeys);
-			}}
-			openKeys={openKeys}
-		>
-			<TitlePane key="foo" title="Pane 1">
-				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sodales ante sed
-				massa finibus, at euismod ex molestie. Donec sagittis ligula at lorem blandit
-				imperdiet. Aenean sapien justo, blandit at aliquet a, tincidunt ac nulla. Donec quis
-				dapibus est. Donec id massa eu nisl cursus ornare quis sit amet velit.
-			</TitlePane>
-			<TitlePane key="la" title="Pane 2">
-				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sodales ante sed
-				massa finibus, at euismod ex molestie. Donec sagittis ligula at lorem blandit
-				imperdiet. Aenean sapien justo, blandit at aliquet a, tincidunt ac nulla. Donec quis
-				dapibus est. Donec id massa eu nisl cursus ornare quis sit amet velit.
-			</TitlePane>
-			<TitlePane key="dee" title="Pane 3">
-				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sodales ante sed
-				massa finibus, at euismod ex molestie. Donec sagittis ligula at lorem blandit
-				imperdiet. Aenean sapien justo, blandit at aliquet a, tincidunt ac nulla. Donec quis
-				dapibus est. Donec id massa eu nisl cursus ornare quis sit amet velit.
-			</TitlePane>
-			<TitlePane key="bar" title="Pane 4">
-				Ut non lectus vitae eros hendrerit pellentesque. In rhoncus ut lectus id tempus.
-				Cras eget mauris scelerisque, condimentum ante sed, vehicula tellus. Donec congue
-				ligula felis, a porta felis aliquet nec. Nulla mi lorem, efficitur nec lectus
-				vehicula, vehicula varius eros.
-			</TitlePane>
 		</AccordionPane>
 	);
 });

--- a/src/examples/src/widgets/accordion-pane/Exclusive.tsx
+++ b/src/examples/src/widgets/accordion-pane/Exclusive.tsx
@@ -1,47 +1,65 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
-import icache from '@dojo/framework/core/middleware/icache';
-
 import AccordionPane from '@dojo/widgets/accordion-pane';
 import TitlePane from '@dojo/widgets/title-pane';
+import { create, tsx } from '@dojo/framework/core/vdom';
 
-const factory = create({ icache });
+const factory = create();
 
-export default factory(function Exclusive({ middleware: { icache } }) {
-	let exclusiveKey = icache.getOrSet('exclusiveKey', undefined);
+export default factory(function Basic() {
 	return (
-		<AccordionPane
-			onRequestClose={(key) => {
-				icache.set('exclusiveKey', undefined);
-			}}
-			onRequestOpen={(key) => {
-				icache.set('exclusiveKey', key);
-			}}
-			openKeys={exclusiveKey ? [exclusiveKey] : []}
-		>
-			<TitlePane key="baz" title="Pane 1">
-				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque sodales ante sed
-				massa finibus, at euismod ex molestie. Donec sagittis ligula at lorem blandit
-				imperdiet. Aenean sapien justo, blandit at aliquet a, tincidunt ac nulla. Donec quis
-				dapibus est. Donec id massa eu nisl cursus ornare quis sit amet velit.
-			</TitlePane>
-			<TitlePane key="bax" title="Pane 2">
-				Ut non lectus vitae eros hendrerit pellentesque. In rhoncus ut lectus id tempus.
-				Cras eget mauris scelerisque, condimentum ante sed, vehicula tellus. Donec congue
-				ligula felis, a porta felis aliquet nec. Nulla mi lorem, efficitur nec lectus
-				vehicula, vehicula varius eros.
-			</TitlePane>
-			<TitlePane key="la" title="Pane 3">
-				Ut non lectus vitae eros hendrerit pellentesque. In rhoncus ut lectus id tempus.
-				Cras eget mauris scelerisque, condimentum ante sed, vehicula tellus. Donec congue
-				ligula felis, a porta felis aliquet nec. Nulla mi lorem, efficitur nec lectus
-				vehicula, vehicula varius eros.
-			</TitlePane>
-			<TitlePane key="dee" title="Pane 4">
-				Ut non lectus vitae eros hendrerit pellentesque. In rhoncus ut lectus id tempus.
-				Cras eget mauris scelerisque, condimentum ante sed, vehicula tellus. Donec congue
-				ligula felis, a porta felis aliquet nec. Nulla mi lorem, efficitur nec lectus
-				vehicula, vehicula varius eros.
-			</TitlePane>
+		<AccordionPane>
+			{(onOpen, onClose, initialOpen) => [
+				<TitlePane
+					key="foo"
+					onOpen={onOpen('foo')}
+					onClose={onClose('foo')}
+					initialOpen={initialOpen('foo')}
+				>
+					{{
+						title: () => 'Pane 1',
+						content: () => (
+							<div>
+								Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id
+								purus ipsum. Aenean ac purus purus. Nam sollicitudin varius augue,
+								sed lacinia felis tempor in.
+							</div>
+						)
+					}}
+				</TitlePane>,
+				<TitlePane
+					key="bar"
+					onOpen={onOpen('bar')}
+					onClose={onClose('bar')}
+					initialOpen={initialOpen('bar')}
+				>
+					{{
+						title: () => 'Pane 2',
+						content: () => (
+							<div>
+								Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id
+								purus ipsum. Aenean ac purus purus. Nam sollicitudin varius augue,
+								sed lacinia felis tempor in.
+							</div>
+						)
+					}}
+				</TitlePane>,
+				<TitlePane
+					key="baz"
+					onOpen={onOpen('baz')}
+					onClose={onClose('baz')}
+					initialOpen={initialOpen('baz')}
+				>
+					{{
+						title: () => 'Pane 3',
+						content: () => (
+							<div>
+								Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id
+								purus ipsum. Aenean ac purus purus. Nam sollicitudin varius augue,
+								sed lacinia felis tempor in.
+							</div>
+						)
+					}}
+				</TitlePane>
+			]}
 		</AccordionPane>
 	);
 });

--- a/src/examples/src/widgets/title-pane/Basic.tsx
+++ b/src/examples/src/widgets/title-pane/Basic.tsx
@@ -1,27 +1,21 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import TitlePane from '@dojo/widgets/title-pane';
-import icache from '@dojo/framework/core/middleware/icache';
+import { create, tsx } from '@dojo/framework/core/vdom';
 
-const factory = create({ icache });
+const factory = create();
 
-export default factory(function Basic({ middleware: { icache } }) {
-	const open = icache.getOrSet('open', true);
-
+export default factory(function Basic() {
 	return (
-		<TitlePane
-			title="Basic Title Pane"
-			open={open}
-			onRequestOpen={() => {
-				icache.set('open', true);
+		<TitlePane>
+			{{
+				title: () => 'Basic Title Pane',
+				content: () => (
+					<div>
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id purus
+						ipsum. Aenean ac purus purus. Nam sollicitudin varius augue, sed lacinia
+						felis tempor in.
+					</div>
+				)
 			}}
-			onRequestClose={() => {
-				icache.set('open', false);
-			}}
-		>
-			<div>
-				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id purus ipsum.
-				Aenean ac purus purus. Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			</div>
 		</TitlePane>
 	);
 });

--- a/src/examples/src/widgets/title-pane/HeadingLevel.tsx
+++ b/src/examples/src/widgets/title-pane/HeadingLevel.tsx
@@ -1,28 +1,21 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import TitlePane from '@dojo/widgets/title-pane';
-import icache from '@dojo/framework/core/middleware/icache';
+import { create, tsx } from '@dojo/framework/core/vdom';
 
-const factory = create({ icache });
+const factory = create();
 
-export default factory(function HeadingLevel({ middleware: { icache } }) {
-	const open = icache.getOrSet('open', true);
-
+export default factory(function Basic() {
 	return (
-		<TitlePane
-			title="Aria Heading level 2"
-			headingLevel={2}
-			open={open}
-			onRequestOpen={() => {
-				icache.set('open', true);
+		<TitlePane headingLevel={2}>
+			{{
+				title: () => 'Aria Heading Level 2',
+				content: () => (
+					<div>
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id purus
+						ipsum. Aenean ac purus purus. Nam sollicitudin varius augue, sed lacinia
+						felis tempor in.
+					</div>
+				)
 			}}
-			onRequestClose={() => {
-				icache.set('open', false);
-			}}
-		>
-			<div>
-				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id purus ipsum.
-				Aenean ac purus purus. Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			</div>
 		</TitlePane>
 	);
 });

--- a/src/examples/src/widgets/title-pane/NonCloseable.tsx
+++ b/src/examples/src/widgets/title-pane/NonCloseable.tsx
@@ -1,15 +1,21 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import TitlePane from '@dojo/widgets/title-pane';
+import { create, tsx } from '@dojo/framework/core/vdom';
 
 const factory = create();
 
-export default factory(function NonClosable() {
+export default factory(function Basic() {
 	return (
-		<TitlePane title="I can't be closed" closeable={false}>
-			<div>
-				Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id purus ipsum.
-				Aenean ac purus purus. Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			</div>
+		<TitlePane closeable={false}>
+			{{
+				title: () => "I can't be closed",
+				content: () => (
+					<div>
+						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id purus
+						ipsum. Aenean ac purus purus. Nam sollicitudin varius augue, sed lacinia
+						felis tempor in.
+					</div>
+				)
+			}}
 		</TitlePane>
 	);
 });

--- a/src/header/index.tsx
+++ b/src/header/index.tsx
@@ -1,10 +1,9 @@
 import * as css from '../theme/default/header.m.css';
 import theme from '../middleware/theme';
 import { RenderResult } from '@dojo/framework/core/interfaces';
-import { ThemedProperties } from '@dojo/framework/core/mixins/Themed';
 import { create, tsx } from '@dojo/framework/core/vdom';
 
-export interface HeaderProperties extends ThemedProperties {
+export interface HeaderProperties {
 	/** Determines if this header is fixed */
 	sticky?: boolean;
 }

--- a/src/theme/default/accordion-pane.m.css
+++ b/src/theme/default/accordion-pane.m.css
@@ -2,18 +2,10 @@
 .root {
 }
 
-/* Class added to the first titlepane */
-.firstTitlePane {
+/* Class added to each child titlepane */
+.paneRoot {
 }
 
-/* Class added to the last titlepane */
-.lastTitlePane {
-}
-
-/* Class added to the open titlepane */
-.openTitlePane {
-}
-
-/* Class added to all titlepanes */
-.rootTitlePane {
+/* Class added open child titlepanes */
+.paneOpen {
 }

--- a/src/theme/default/accordion-pane.m.css.d.ts
+++ b/src/theme/default/accordion-pane.m.css.d.ts
@@ -1,5 +1,3 @@
 export const root: string;
-export const firstTitlePane: string;
-export const lastTitlePane: string;
-export const openTitlePane: string;
-export const rootTitlePane: string;
+export const paneRoot: string;
+export const paneOpen: string;

--- a/src/theme/material/accordion-pane.m.css
+++ b/src/theme/material/accordion-pane.m.css
@@ -4,33 +4,32 @@
 	font-family: var(--mdc-theme-font-family);
 }
 
-.firstTitlePane {
-	border-top-left-radius: 4px;
-	border-top-right-radius: 4px;
-}
-
-.lastTitlePane {
-	border-bottom-left-radius: 4px;
-	border-bottom-right-radius: 4px;
-}
-
-.openTitlePane.rootTitlePane {
-	margin: 16px 0;
-}
-
-.firstTitlePane.openTitlePane.rootTitlePane {
-	margin-top: 0;
-}
-
-.lastTitlePane.openTitlePane.rootTitlePane {
-	margin-bottom: 0;
-}
-
-.rootTitlePane {
+.paneRoot {
+	composes: root from './title-pane.m.css';
 	margin-bottom: 1px;
 	transition: margin ease-in-out 0.25s;
 }
 
-.lastTitlePane.rootTitlePane {
+.paneRoot:first-child {
+	border-top-left-radius: 4px;
+	border-top-right-radius: 4px;
+}
+
+.paneRoot:last-child {
+	border-bottom-left-radius: 4px;
+	border-bottom-right-radius: 4px;
+	margin-bottom: 0;
+}
+
+.paneOpen {
+	composes: open from './title-pane.m.css';
+	margin: 16px 0;
+}
+
+.paneOpen:first-child {
+	margin-top: 0;
+}
+
+.paneOpen:last-child {
 	margin-bottom: 0;
 }

--- a/src/title-pane/index.tsx
+++ b/src/title-pane/index.tsx
@@ -1,162 +1,131 @@
-import { uuid } from '@dojo/framework/core/util';
-import { DNode, WidgetProperties } from '@dojo/framework/core/interfaces';
-import { theme, ThemedMixin, ThemedProperties } from '@dojo/framework/core/mixins/Themed';
-import { FocusMixin, FocusProperties } from '@dojo/framework/core/mixins/Focus';
-import { v, w } from '@dojo/framework/core/vdom';
-import { WidgetBase } from '@dojo/framework/core/WidgetBase';
-
-import Icon from '../icon/index';
-import * as fixedCss from './styles/title-pane.m.css';
 import * as css from '../theme/default/title-pane.m.css';
-import { Dimensions } from '@dojo/framework/core/meta/Dimensions';
-import GlobalEvent from '../global-event/index';
+import * as fixedCss from './styles/title-pane.m.css';
+import Icon from '../icon';
+import dimensions from '@dojo/framework/core/middleware/dimensions';
+import focus from '@dojo/framework/core/middleware/focus';
+import theme from '../middleware/theme';
+import { RenderResult } from '@dojo/framework/core/interfaces';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 
-export interface TitlePaneProperties extends WidgetProperties, ThemedProperties, FocusProperties {
+export interface TitlePaneProperties {
 	/** If false the pane will not collapse in response to clicking the title */
 	closeable?: boolean;
 	/** 'aria-level' for the title's DOM node */
 	headingLevel?: number;
-	/** Called when the title of an open pane is clicked */
-	onRequestClose?(key: string | number | undefined): void;
+	/** If true the pane is opened and content is visible initially */
+	initialOpen?: boolean;
 	/** Called when the title of a closed pane is clicked */
-	onRequestOpen?(key: string | number | undefined): void;
-	/** If true the pane is opened and content is visible */
+	onClose?(): void;
+	/** Called when the title of an open pane is clicked */
+	onOpen?(): void;
+}
+
+export interface TitlePaneICache {
+	initialOpen?: boolean;
 	open?: boolean;
-	/** Title to display above the content */
-	title: DNode;
 }
 
-@theme(css)
-export class TitlePane extends ThemedMixin(FocusMixin(WidgetBase))<TitlePaneProperties> {
-	private _id = uuid();
-	private _open: boolean | undefined;
+export type TitlePaneChildren = {
+	/** Renderer for the pane content */
+	content?(): RenderResult;
+	/** Renderer for the pane title */
+	title(): RenderResult;
+};
 
-	private _onWindowResize = () => {
-		this.invalidate();
-	};
+const factory = create({
+	dimensions,
+	focus,
+	icache: createICacheMiddleware<TitlePaneICache>(),
+	theme
+})
+	.properties<TitlePaneProperties>()
+	.children<TitlePaneChildren>();
 
-	private _onTitleClick(event: MouseEvent) {
-		event.stopPropagation();
-		this._toggle();
+export const TitlePane = factory(function TitlePane({
+	id,
+	children,
+	properties,
+	middleware: { dimensions, focus, icache, theme }
+}) {
+	const themeCss = theme.classes(css);
+	const {
+		closeable = true,
+		headingLevel,
+		initialOpen,
+		onClose,
+		onOpen,
+		theme: themeProp
+	} = properties();
+	const { content, title } = children()[0];
+
+	let open = icache.get('open');
+	let performTransition = false;
+	const existingInitialOpen = icache.get('initialOpen');
+	if (existingInitialOpen !== initialOpen) {
+		icache.set('open', initialOpen);
+		icache.set('initialOpen', initialOpen);
+		open = initialOpen;
+		onOpen && onOpen();
+		performTransition = true;
 	}
 
-	private _toggle() {
-		const {
-			closeable = true,
-			key,
-			onRequestClose,
-			onRequestOpen,
-			open = true
-		} = this.properties;
+	console.log(open ? '0px' : `-${dimensions.get('content').offset.height}px`);
 
-		if (!closeable) {
-			return;
-		}
-
-		if (open) {
-			onRequestClose && onRequestClose(key);
-		} else {
-			onRequestOpen && onRequestOpen(key);
-		}
-	}
-
-	protected getButtonContent(): DNode {
-		return this.properties.title;
-	}
-
-	protected getFixedModifierClasses(): (string | null)[] {
-		const { closeable = true } = this.properties;
-		return [closeable ? fixedCss.closeableFixed : null];
-	}
-
-	protected getModifierClasses(): (string | null)[] {
-		const { closeable = true } = this.properties;
-		return [closeable ? css.closeable : null];
-	}
-
-	protected getPaneContent(): DNode[] {
-		return this.children;
-	}
-
-	protected renderExpandIcon(): DNode {
-		const { open = true, theme, classes } = this.properties;
-		return v('span', { classes: this.theme(css.arrow) }, [
-			w(Icon, { type: open ? 'downIcon' : 'rightIcon', theme, classes })
-		]);
-	}
-
-	protected getPaneStyles(): any {
-		const { open = true } = this.properties;
-		const contentDimensions = this.meta(Dimensions).get('content');
-		return { marginTop: open ? '0px' : `-${contentDimensions.offset.height}px` };
-	}
-
-	protected render(): DNode {
-		const { closeable = true, headingLevel, open = true } = this.properties;
-
-		let transition = false;
-
-		if (open !== this._open) {
-			transition = true;
-			this._open = open;
-		}
-
-		return v(
-			'div',
-			{
-				classes: [...this.theme([css.root, open ? css.open : null]), fixedCss.rootFixed]
-			},
-			[
-				w(GlobalEvent, { key: 'global', window: { resize: this._onWindowResize } }),
-				v(
-					'div',
-					{
-						'aria-level': headingLevel ? `${headingLevel}` : null,
-						classes: [
-							...this.theme([css.title, ...this.getModifierClasses()]),
-							fixedCss.titleFixed,
-							...this.getFixedModifierClasses()
-						],
-						role: 'heading'
-					},
-					[
-						v(
-							'button',
-							{
-								'aria-controls': `${this._id}-content`,
-								'aria-expanded': `${open}`,
-								disabled: !closeable,
-								classes: [
-									fixedCss.titleButtonFixed,
-									...this.theme([css.titleButton])
-								],
-								focus: this.shouldFocus,
-								id: `${this._id}-title`,
-								type: 'button',
-								onclick: this._onTitleClick
-							},
-							[this.renderExpandIcon(), this.getButtonContent()]
-						)
-					]
-				),
-				v(
-					'div',
-					{
-						'aria-hidden': open ? null : 'true',
-						'aria-labelledby': `${this._id}-title`,
-						classes: [
-							...this.theme([css.content, transition ? css.contentTransition : null]),
-							fixedCss.contentFixed
-						],
-						id: `${this._id}-content`,
-						key: 'content',
-						styles: this.getPaneStyles()
-					},
-					this.getPaneContent()
-				)
-			]
-		);
-	}
-}
+	return (
+		<div classes={[themeCss.root, open ? themeCss.open : null, fixedCss.rootFixed]}>
+			<div
+				aria-level={headingLevel ? `${headingLevel}` : null}
+				classes={[
+					themeCss.title,
+					closeable ? themeCss.closeable : null,
+					fixedCss.titleFixed,
+					closeable ? fixedCss.closeableFixed : null
+				]}
+				role="heading"
+			>
+				<button
+					aria-controls={`${id}-content`}
+					aria-expanded={`${open}`}
+					disabled={!closeable}
+					classes={[fixedCss.titleButtonFixed, themeCss.titleButton]}
+					focus={focus.isFocused('title-button')}
+					key="title-button"
+					onclick={(event: MouseEvent) => {
+						event.stopPropagation();
+						icache.set('open', !open);
+						if (open) {
+							onClose && onClose();
+						} else {
+							onOpen && onOpen();
+						}
+					}}
+					type="button"
+				>
+					<span classes={themeCss.arrow}>
+						<Icon type={open ? 'downIcon' : 'rightIcon'} theme={themeProp} />
+					</span>
+					{title()}
+				</button>
+			</div>
+			<div
+				aria-hidden={open ? null : 'true'}
+				aria-labelledby={`${id}-title`}
+				classes={[
+					themeCss.content,
+					performTransition ? themeCss.contentTransition : null,
+					fixedCss.contentFixed
+				]}
+				id={`${id}-content`}
+				key="content"
+				styles={{
+					marginTop: open ? '0px' : `-${dimensions.get('content').offset.height}px`
+				}}
+			>
+				{content && content()}
+			</div>
+		</div>
+	);
+});
 
 export default TitlePane;

--- a/src/title-pane/index.tsx
+++ b/src/title-pane/index.tsx
@@ -66,11 +66,8 @@ export const TitlePane = factory(function TitlePane({
 		icache.set('open', initialOpen);
 		icache.set('initialOpen', initialOpen);
 		open = initialOpen;
-		onOpen && onOpen();
 		performTransition = true;
 	}
-
-	console.log(open ? '0px' : `-${dimensions.get('content').offset.height}px`);
 
 	return (
 		<div classes={[themeCss.root, open ? themeCss.open : null, fixedCss.rootFixed]}>

--- a/src/title-pane/tests/unit/TitlePane.spec.tsx
+++ b/src/title-pane/tests/unit/TitlePane.spec.tsx
@@ -1,4 +1,6 @@
 const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
+
 import * as fixedCss from '../../styles/title-pane.m.css';
 import * as themeCss from '../../../theme/default/title-pane.m.css';
 import Icon from '../../../icon';
@@ -6,6 +8,7 @@ import TitlePane, { TitlePaneProperties } from '../../index';
 import assertationTemplate from '@dojo/framework/testing/assertionTemplate';
 import harness from '@dojo/framework/testing/harness';
 import { tsx } from '@dojo/framework/core/vdom';
+import { stub } from 'sinon';
 
 const noop = () => {};
 
@@ -159,5 +162,37 @@ describe('TitlePane', () => {
 		h.trigger('@title-button', 'onclick', { stopPropagation: noop });
 
 		h.expect(getTemplate().setProperty('@title-button', 'aria-expanded', 'false'));
+	});
+
+	it('calls onOpen', () => {
+		const onOpen = stub();
+
+		const h = harness(() => (
+			<TitlePane onOpen={onOpen}>
+				{{
+					title: () => 'title',
+					content: () => 'content'
+				}}
+			</TitlePane>
+		));
+
+		h.trigger('@title-button', 'onclick', { stopPropagation: noop });
+		assert.isTrue(onOpen.called);
+	});
+
+	it('calls onClose', () => {
+		const onClose = stub();
+
+		const h = harness(() => (
+			<TitlePane initialOpen onClose={onClose}>
+				{{
+					title: () => 'title',
+					content: () => 'content'
+				}}
+			</TitlePane>
+		));
+
+		h.trigger('@title-button', 'onclick', { stopPropagation: noop });
+		assert.isTrue(onClose.called);
 	});
 });

--- a/src/title-pane/tests/unit/TitlePane.spec.tsx
+++ b/src/title-pane/tests/unit/TitlePane.spec.tsx
@@ -124,4 +124,40 @@ describe('TitlePane', () => {
 			})
 		);
 	});
+
+	it('opens a closed pane', () => {
+		const h = harness(() => (
+			<TitlePane>
+				{{
+					title: () => 'title',
+					content: () => 'content'
+				}}
+			</TitlePane>
+		));
+
+		h.trigger('@title-button', 'onclick', { stopPropagation: noop });
+
+		h.expect(
+			getTemplate({ initialOpen: true }).setProperty('@content', 'classes', [
+				themeCss.content,
+				null,
+				fixedCss.contentFixed
+			])
+		);
+	});
+
+	it('closes an open pane', () => {
+		const h = harness(() => (
+			<TitlePane initialOpen>
+				{{
+					title: () => 'title',
+					content: () => 'content'
+				}}
+			</TitlePane>
+		));
+
+		h.trigger('@title-button', 'onclick', { stopPropagation: noop });
+
+		h.expect(getTemplate().setProperty('@title-button', 'aria-expanded', 'false'));
+	});
 });

--- a/src/title-pane/tests/unit/TitlePane.spec.tsx
+++ b/src/title-pane/tests/unit/TitlePane.spec.tsx
@@ -13,7 +13,7 @@ describe('TitlePane', () => {
 	function getTemplate({
 		closeable = true,
 		headingLevel,
-		initiallyOpen: open
+		initialOpen: open
 	}: TitlePaneProperties = {}) {
 		return assertationTemplate(() => {
 			return (
@@ -79,7 +79,7 @@ describe('TitlePane', () => {
 
 	it('renders open', () => {
 		const h = harness(() => (
-			<TitlePane initiallyOpen>
+			<TitlePane initialOpen>
 				{{
 					title: () => 'title',
 					content: () => 'content'
@@ -88,7 +88,7 @@ describe('TitlePane', () => {
 		));
 		h.expect(
 			getTemplate({
-				initiallyOpen: true
+				initialOpen: true
 			})
 		);
 	});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request updates `TitlePane` to be a functional widget, updates its tests to use assertion templates, and updates its internal logic to use the new `initialValue` pattern.

Resolves #1167


**Preview:**

<img width="1162" alt="preview" src="https://user-images.githubusercontent.com/334586/77171663-2fa06900-6a93-11ea-9178-14ed2013c74e.png">
