### PR TITLE
Clean up the grid styling across default, dojo and material

### DIFF
--- a/src/grid/Body.tsx
+++ b/src/grid/Body.tsx
@@ -66,10 +66,6 @@ const offscreen = (dnode: DNode) => {
 	return dimensions;
 };
 
-const defaultPlaceholderRowRenderer = (index: number) => {
-	return w(PlaceholderRow, { key: index });
-};
-
 @theme(css)
 @diffProperty('pages', reference)
 export default class Body<S> extends I18nMixin(ThemedMixin(WidgetBase))<BodyProperties<S>> {
@@ -79,6 +75,11 @@ export default class Body<S> extends I18nMixin(ThemedMixin(WidgetBase))<BodyProp
 	private _start = 0;
 	private _end = 100;
 	private _resetScroll = false;
+
+	private _defaultPlaceholderRow(key: number) {
+		const { classes, theme } = this.properties;
+		return w(PlaceholderRow, { key, theme, classes });
+	}
 
 	private _updater(rowNumber: number, columnId: string, value: any) {
 		const page = Math.max(Math.ceil(rowNumber / this.properties.pageSize), 1);
@@ -118,7 +119,7 @@ export default class Body<S> extends I18nMixin(ThemedMixin(WidgetBase))<BodyProp
 			fetcher,
 			pages,
 			columnConfig,
-			placeholderRowRenderer = defaultPlaceholderRowRenderer,
+			placeholderRowRenderer = this._defaultPlaceholderRow,
 			pageChange,
 			totalRows,
 			theme,
@@ -186,7 +187,7 @@ export default class Body<S> extends I18nMixin(ThemedMixin(WidgetBase))<BodyProp
 
 	protected render(): DNode {
 		const {
-			placeholderRowRenderer = defaultPlaceholderRowRenderer,
+			placeholderRowRenderer = this._defaultPlaceholderRow,
 			totalRows = 0,
 			pageSize,
 			height,

--- a/src/grid/Header.tsx
+++ b/src/grid/Header.tsx
@@ -19,7 +19,7 @@ export interface SortRenderer {
 export interface FilterRenderer {
 	(
 		column: ColumnConfig,
-		filterValue: string | undefined,
+		filterValue: string,
 		doFilter: (value: string) => void,
 		title?: string | DNode
 	): DNode;
@@ -90,7 +90,7 @@ export default class Header extends I18nMixin(ThemedMixin(WidgetBase))<HeaderPro
 
 	private _filterRenderer = (
 		columnConfig: ColumnConfig,
-		filterValue: string | undefined,
+		filterValue: string,
 		doFilter: (value: string) => void,
 		title?: string | DNode
 	) => {
@@ -111,7 +111,7 @@ export default class Header extends I18nMixin(ThemedMixin(WidgetBase))<HeaderPro
 			label: format('filterBy', { name: title }),
 			labelHidden: true,
 			type: 'search',
-			initialValue: filterValue,
+			initialValue: filterValue || undefined,
 			onValue: doFilter
 		});
 	};
@@ -165,8 +165,7 @@ export default class Header extends I18nMixin(ThemedMixin(WidgetBase))<HeaderPro
 
 				const filterKeys = Object.keys(filter);
 				const direction = !isSorted ? undefined : isSortedAsc ? 'asc' : 'desc';
-				const filterValue =
-					filterKeys.indexOf(column.id) > -1 ? filter[column.id] : undefined;
+				const filterValue = filterKeys.indexOf(column.id) > -1 ? filter[column.id] : '';
 				const doFilter = (value: string) => {
 					filterer(column.id, value);
 				};

--- a/src/grid/Header.tsx
+++ b/src/grid/Header.tsx
@@ -19,7 +19,7 @@ export interface SortRenderer {
 export interface FilterRenderer {
 	(
 		column: ColumnConfig,
-		filterValue: string,
+		filterValue: string | undefined,
 		doFilter: (value: string) => void,
 		title?: string | DNode
 	): DNode;
@@ -90,13 +90,12 @@ export default class Header extends I18nMixin(ThemedMixin(WidgetBase))<HeaderPro
 
 	private _filterRenderer = (
 		columnConfig: ColumnConfig,
-		filterValue: string,
+		filterValue: string | undefined,
 		doFilter: (value: string) => void,
 		title?: string | DNode
 	) => {
-		const { theme, classes } = this.properties;
+		const { theme, classes = {} } = this.properties;
 		const { format } = this.localizeBundle(bundle);
-		const passedInputClasses = (classes && classes['@dojo/widgets/text-input']) || {};
 		return w(TextInput, {
 			key: 'filter',
 			theme,
@@ -106,7 +105,7 @@ export default class Header extends I18nMixin(ThemedMixin(WidgetBase))<HeaderPro
 					root: [this.theme(css.filter)],
 					input: [this.theme(css.filterInput)],
 					noLabel: [this.theme(css.filterNoLabel)],
-					...passedInputClasses
+					...classes['@dojo/widgets/text-input']
 				}
 			},
 			label: format('filterBy', { name: title }),
@@ -166,7 +165,8 @@ export default class Header extends I18nMixin(ThemedMixin(WidgetBase))<HeaderPro
 
 				const filterKeys = Object.keys(filter);
 				const direction = !isSorted ? undefined : isSortedAsc ? 'asc' : 'desc';
-				const filterValue = filterKeys.indexOf(column.id) > -1 ? filter[column.id] : '';
+				const filterValue =
+					filterKeys.indexOf(column.id) > -1 ? filter[column.id] : undefined;
 				const doFilter = (value: string) => {
 					filterer(column.id, value);
 				};

--- a/src/grid/PaginatedBody.tsx
+++ b/src/grid/PaginatedBody.tsx
@@ -42,15 +42,16 @@ export interface PaginatedBodyProperties<S> {
 	selectedRows?: number[];
 }
 
-const defaultPlaceholderRowRenderer = (index: number) => {
-	return w(PlaceholderRow, { key: index });
-};
-
 @theme(css)
 @diffProperty('pages', reference)
 export default class PaginatedBody<S> extends I18nMixin(ThemedMixin(WidgetBase))<
 	PaginatedBodyProperties<S>
 > {
+	private _defaultPlaceholderRow(key: number) {
+		const { classes, theme } = this.properties;
+		return w(PlaceholderRow, { key, theme, classes });
+	}
+
 	private _updater(rowNumber: number, columnId: string, value: any) {
 		const page = Math.max(Math.ceil(rowNumber / this.properties.pageSize), 1);
 		const pageItemNumber = rowNumber - (page - 1) * this.properties.pageSize;
@@ -69,7 +70,7 @@ export default class PaginatedBody<S> extends I18nMixin(ThemedMixin(WidgetBase))
 			fetcher,
 			pages,
 			columnConfig,
-			placeholderRowRenderer = defaultPlaceholderRowRenderer,
+			placeholderRowRenderer = this._defaultPlaceholderRow,
 			pageNumber,
 			theme,
 			classes,

--- a/src/grid/PaginatedFooter.tsx
+++ b/src/grid/PaginatedFooter.tsx
@@ -113,7 +113,7 @@ export default class PaginatedFooter extends I18nMixin(ThemedMixin(WidgetBase))<
 		const { onPageChange, page, total, pageSize } = this.properties;
 		const { format, messages } = this.localizeBundle(bundle);
 		if (total === undefined) {
-			return null;
+			return v('div', { classes: [this.theme(css.root), fixedCss.rootFixed] });
 		}
 		const totalPages = Math.ceil(total / pageSize);
 		const from = page === 1 ? '1' : `${(page - 1) * pageSize + 1}`;

--- a/src/grid/PlaceholderRow.tsx
+++ b/src/grid/PlaceholderRow.tsx
@@ -3,11 +3,12 @@ import { v } from '@dojo/framework/core/vdom';
 import ThemedMixin, { theme } from '@dojo/framework/core/mixins/Themed';
 import { DNode } from '@dojo/framework/core/interfaces';
 import * as css from '../theme/default/grid-placeholder-row.m.css';
+import * as fixedCss from './styles/placeholder-row.m.css';
 
 @theme(css)
 export default class PlaceholderRow extends ThemedMixin(WidgetBase) {
 	protected render(): DNode {
-		return v('div', { classes: this.theme(css.root) }, [
+		return v('div', { classes: [fixedCss.root, this.theme(css.root)] }, [
 			v('div', { classes: this.theme(css.loading) })
 		]);
 	}

--- a/src/grid/index.tsx
+++ b/src/grid/index.tsx
@@ -191,8 +191,6 @@ export default class Grid<S> extends I18nMixin(ThemedMixin(WidgetBase))<GridProp
 		this.invalidate();
 	}
 
-	private _renderBody() {}
-
 	protected render(): DNode {
 		const {
 			i18nBundle,

--- a/src/grid/index.tsx
+++ b/src/grid/index.tsx
@@ -97,13 +97,18 @@ export default class Grid<S> extends I18nMixin(ThemedMixin(WidgetBase))<GridProp
 
 	private _getBodyDimensions() {
 		const { height } = this.properties;
-		const headerHeight = this.meta(Dimensions).get('header');
 		const headerWrapper = this.meta(Dimensions).get('header-wrapper');
-		const footerHeight = this.meta(Dimensions).get('footer');
+		const {
+			size: { height: headerHeight, width: bodyWidth }
+		} = this.meta(Dimensions).get('header');
+		const {
+			size: { height: footerHeight }
+		} = this.meta(Dimensions).get('footer');
+
 		return {
 			headerWidth: headerWrapper.size.width,
-			bodyHeight: height - headerHeight.size.height - footerHeight.size.height,
-			bodyWidth: headerHeight.size.width
+			bodyHeight: footerHeight && footerHeight ? height - headerHeight - footerHeight : 0,
+			bodyWidth
 		};
 	}
 
@@ -185,6 +190,8 @@ export default class Grid<S> extends I18nMixin(ThemedMixin(WidgetBase))<GridProp
 		this._scrollLeft = value;
 		this.invalidate();
 	}
+
+	private _renderBody() {}
 
 	protected render(): DNode {
 		const {
@@ -269,44 +276,46 @@ export default class Grid<S> extends I18nMixin(ThemedMixin(WidgetBase))<GridProp
 						])
 					]
 				),
-				pagination
-					? w(PaginatedBody, {
-							key: 'paginated-body',
-							i18nBundle,
-							theme,
-							classes,
-							pages,
-							columnWidths: this._columnWidths,
-							pageNumber: meta.page,
-							pageSize: this._pageSize,
-							onScroll: this._onScroll,
-							columnConfig,
-							fetcher: this._fetcher,
-							updater: this._updater,
-							height: bodyHeight,
-							width: hasResizableColumns ? this._gridWidth : undefined,
-							onRowSelect: onRowSelect ? this._selection : undefined,
-							selectedRows: meta.selection
-					  })
-					: w(Body, {
-							key: 'body',
-							i18nBundle,
-							theme,
-							classes,
-							pages,
-							columnWidths: this._columnWidths,
-							totalRows: meta.total,
-							pageSize: this._pageSize,
-							columnConfig,
-							fetcher: this._fetcher,
-							pageChange: this._pageChange,
-							updater: this._updater,
-							onScroll: this._onScroll,
-							height: bodyHeight,
-							width: hasResizableColumns ? this._gridWidth : undefined,
-							onRowSelect: onRowSelect ? this._selection : undefined,
-							selectedRows: meta.selection
-					  }),
+				bodyHeight
+					? pagination
+						? w(PaginatedBody, {
+								key: 'paginated-body',
+								i18nBundle,
+								theme,
+								classes,
+								pages,
+								columnWidths: this._columnWidths,
+								pageNumber: meta.page,
+								pageSize: this._pageSize,
+								onScroll: this._onScroll,
+								columnConfig,
+								fetcher: this._fetcher,
+								updater: this._updater,
+								height: bodyHeight,
+								width: hasResizableColumns ? this._gridWidth : undefined,
+								onRowSelect: onRowSelect ? this._selection : undefined,
+								selectedRows: meta.selection
+						  })
+						: w(Body, {
+								key: 'body',
+								i18nBundle,
+								theme,
+								classes,
+								pages,
+								columnWidths: this._columnWidths,
+								totalRows: meta.total,
+								pageSize: this._pageSize,
+								columnConfig,
+								fetcher: this._fetcher,
+								pageChange: this._pageChange,
+								updater: this._updater,
+								onScroll: this._onScroll,
+								height: bodyHeight,
+								width: hasResizableColumns ? this._gridWidth : undefined,
+								onRowSelect: onRowSelect ? this._selection : undefined,
+								selectedRows: meta.selection
+						  })
+					: null,
 				v('div', { key: 'footer' }, [
 					pagination
 						? w(PaginatedFooter, {

--- a/src/grid/styles/grid.m.css
+++ b/src/grid/styles/grid.m.css
@@ -7,4 +7,5 @@
 	overflow-y: scroll;
 	overflow-x: hidden;
 	box-sizing: border-box;
+	height: 100%;
 }

--- a/src/grid/styles/header.m.css
+++ b/src/grid/styles/header.m.css
@@ -26,3 +26,7 @@
 .resize:active {
 	background: rgba(0, 0, 0, 0.25);
 }
+
+.filterInput {
+	width: 100%;
+}

--- a/src/grid/styles/header.m.css.d.ts
+++ b/src/grid/styles/header.m.css.d.ts
@@ -2,3 +2,4 @@ export const rootFixed: string;
 export const cellFixed: string;
 export const column: string;
 export const resize: string;
+export const filterInput: string;

--- a/src/grid/styles/placeholder-row.m.css
+++ b/src/grid/styles/placeholder-row.m.css
@@ -1,0 +1,5 @@
+.root {
+	justify-content: center;
+	display: flex;
+	align-items: center;
+}

--- a/src/grid/styles/placeholder-row.m.css.d.ts
+++ b/src/grid/styles/placeholder-row.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;

--- a/src/grid/styles/row.m.css
+++ b/src/grid/styles/row.m.css
@@ -1,5 +1,4 @@
 .rootFixed {
-	border-left-style: none;
 	box-sizing: border-box;
 	display: flex;
 }

--- a/src/grid/tests/unit/Body.spec.tsx
+++ b/src/grid/tests/unit/Body.spec.tsx
@@ -57,7 +57,7 @@ describe('Body', () => {
 
 		let rows: any[] = [];
 		for (let i = 0; i < 100; i++) {
-			rows.push(w(PlaceholderRow, { key: i }));
+			rows.push(w(PlaceholderRow, { key: i, theme: undefined, classes: undefined }));
 		}
 
 		h.expect(() =>
@@ -158,7 +158,7 @@ describe('Body', () => {
 
 		let rows: any[] = [];
 		for (let i = 0; i < 80; i++) {
-			rows.push(w(PlaceholderRow, { key: i }));
+			rows.push(w(PlaceholderRow, { key: i, theme: undefined, classes: undefined }));
 		}
 
 		h.expect(() =>
@@ -252,7 +252,7 @@ describe('Body', () => {
 
 		rows = [];
 		for (let i = 286; i < 334; i++) {
-			rows.push(w(PlaceholderRow, { key: i }));
+			rows.push(w(PlaceholderRow, { key: i, theme: undefined, classes: undefined }));
 		}
 
 		h.expect(() =>
@@ -402,7 +402,7 @@ describe('Body', () => {
 
 			const rows: any[] = [];
 			for (let i = 0; i < 100; i++) {
-				rows.push(w(PlaceholderRow, { key: i }));
+				rows.push(w(PlaceholderRow, { key: i, theme: undefined, classes: undefined }));
 			}
 
 			h.expect(() =>

--- a/src/grid/tests/unit/Header.spec.tsx
+++ b/src/grid/tests/unit/Header.spec.tsx
@@ -157,7 +157,7 @@ describe('Header', () => {
 							label: 'Filter by Custom Title',
 							labelHidden: true,
 							type: 'search',
-							initialValue: '',
+							initialValue: undefined,
 							onValue: noop,
 							theme: undefined
 						})
@@ -241,7 +241,7 @@ describe('Header', () => {
 							label: 'Filter by Custom Title',
 							labelHidden: true,
 							type: 'search',
-							initialValue: '',
+							initialValue: undefined,
 							onValue: noop,
 							theme: undefined
 						})
@@ -331,7 +331,7 @@ describe('Header', () => {
 							label: 'Filter by Custom Title',
 							labelHidden: true,
 							type: 'search',
-							initialValue: '',
+							initialValue: undefined,
 							onValue: noop,
 							theme: undefined
 						})
@@ -584,7 +584,7 @@ describe('Header', () => {
 								label: 'Filter by Custom Title',
 								labelHidden: true,
 								type: 'search',
-								initialValue: '',
+								initialValue: undefined,
 								onValue: noop,
 								theme: undefined
 							})
@@ -669,7 +669,7 @@ describe('Header', () => {
 								label: 'Filter by Custom Title',
 								labelHidden: true,
 								type: 'search',
-								initialValue: '',
+								initialValue: undefined,
 								onValue: noop,
 								theme: undefined
 							})

--- a/src/grid/tests/unit/PaginatedBody.spec.tsx
+++ b/src/grid/tests/unit/PaginatedBody.spec.tsx
@@ -27,7 +27,7 @@ describe('PaginatedBody', () => {
 
 		let rows: any[] = [];
 		for (let i = 0; i < 100; i++) {
-			rows.push(w(PlaceholderRow, { key: i }));
+			rows.push(w(PlaceholderRow, { key: i, theme: undefined, classes: undefined }));
 		}
 
 		h.expect(() =>

--- a/src/grid/tests/unit/PaginatedFooter.spec.tsx
+++ b/src/grid/tests/unit/PaginatedFooter.spec.tsx
@@ -163,7 +163,7 @@ describe('PaginatedFooter', () => {
 				onPageChange: noop
 			})
 		);
-		h.expect(() => null);
+		h.expect(() => v('div', { classes: [css.root, fixedCss.rootFixed] }));
 	});
 
 	it('should render the controls for the initial page', () => {

--- a/src/header-card/index.tsx
+++ b/src/header-card/index.tsx
@@ -24,7 +24,7 @@ export const HeaderCard = factory(function HeaderCard({
 }) {
 	const themeCss = theme.classes(css);
 	const { title, subtitle, avatar, ...cardProps } = properties();
-	const [ cardChildren ] = children();
+	const [cardChildren] = children();
 	return (
 		<Card key="root" {...cardProps}>
 			{{

--- a/src/theme/default/grid-cell.m.css
+++ b/src/theme/default/grid-cell.m.css
@@ -4,7 +4,7 @@
 .root {
 	border: 1px solid var(--component-color);
 	border-top-style: none;
-	border-right-style: none;
+	border-left-style: none;
 	padding: 2px 4px;
 	align-items: center;
 	min-width: 100px;

--- a/src/theme/default/grid-header.m.css
+++ b/src/theme/default/grid-header.m.css
@@ -2,6 +2,7 @@
 
 /* The root class of the grid Header */
 .root {
+	border-left: 1px solid var(--component-color);
 }
 
 /* Contains the header cell for a column */
@@ -58,6 +59,7 @@
 }
 
 .filterInput {
+	width: 100%;
 }
 
 .filterNoLabel {

--- a/src/theme/default/grid-paginated-footer.m.css
+++ b/src/theme/default/grid-paginated-footer.m.css
@@ -1,4 +1,5 @@
 .root {
+	height: 45px;
 }
 
 .pagination {

--- a/src/theme/default/grid-placeholder-row.m.css
+++ b/src/theme/default/grid-placeholder-row.m.css
@@ -2,20 +2,21 @@
 
 /* The root class for the PlaceholderRow */
 .root {
-	composes: root from './grid-row.m.css';
 	line-height: 30px;
-	border-left: 1px solid #ccc;
-	border-bottom: 1px solid #ccc;
+	border: 1px solid black;
+	border-top: none;
 	white-space: nowrap;
 	overflow: hidden;
 	text-overflow: ellipsis;
+	box-sizing: border-box;
+	height: 30px;
 }
 
 /* Added to the loading row */
 .loading {
-	margin: 6px;
-	width: 12px;
-	height: 12px;
+	margin: auto;
+	width: 16px;
+	height: 16px;
 	border: 3px solid var(--disabled-color);
 	border-radius: 50%;
 	border-top-color: var(--component-color);

--- a/src/theme/default/grid-row.m.css
+++ b/src/theme/default/grid-row.m.css
@@ -2,7 +2,7 @@
 .root {
 	box-sizing: border-box;
 	height: 30px;
-	border-left-style: none;
+	border-left: 1px solid black;
 }
 
 /* the class applied when a row is selected */

--- a/src/theme/dojo/grid-placeholder-row.m.css
+++ b/src/theme/dojo/grid-placeholder-row.m.css
@@ -2,18 +2,23 @@
 
 .root {
 	composes: root from './grid-row.m.css';
-	border-left: 1px solid #ccc;
-	border-bottom: 1px solid #ccc;
+	border: 1px solid #ccc;
+	border-bottom: none;
+	border-left: none;
 	height: calc(var(--grid-base) * 5);
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
 }
 
+.root:last-of-type {
+	border-bottom: 1px solid #ccc;
+}
+
 .loading {
-	margin: 6px;
-	width: 12px;
-	height: 12px;
+	margin: auto;
+	width: calc(var(--grid-base) * 2.5);
+	height: calc(var(--grid-base) * 2.5);
 	border: var(--border-width-emphasized) solid var(--color-text-faded);
 	border-radius: 50%;
 	border-top-color: transparent;

--- a/src/theme/material/grid-placeholder-row.m.css
+++ b/src/theme/material/grid-placeholder-row.m.css
@@ -1,2 +1,33 @@
+@import './variables.css';
+
 .root {
+	composes: root from './grid-row.m.css';
+	border: 1px solid #ccc;
+	border-bottom: none;
+	border-left: none;
+	height: calc(var(--mdc-grid-base) * 5);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
+}
+
+.root:last-of-type {
+	border-bottom: 1px solid #ccc;
+}
+
+.loading {
+	margin: auto;
+	width: calc(var(--mdc-grid-base) * 2.5);
+	height: calc(var(--mdc-grid-base) * 2.5);
+	border: 2px solid var(--mdc-theme-text-secondary-on-light);
+	border-radius: 50%;
+	border-top-color: transparent;
+	animation: spin 1s ease infinite;
+	will-change: auto;
+}
+
+@keyframes spin {
+	to {
+		transform: rotate(360deg);
+	}
 }

--- a/src/theme/material/grid-placeholder-row.m.css.d.ts
+++ b/src/theme/material/grid-placeholder-row.m.css.d.ts
@@ -1,1 +1,3 @@
 export const root: string;
+export const loading: string;
+export const spin: string;

--- a/src/theme/material/grid-row.m.css
+++ b/src/theme/material/grid-row.m.css
@@ -1,6 +1,9 @@
 @import './variables.css';
 
 .root {
+	box-sizing: border-box;
+	height: calc(var(--mdc-grid-base) * 5);
+	/* border-top: var(--mdc-border-width) solid var(--mdc-border-color); */
 }
 
 .selected {

--- a/src/theme/material/grid-row.m.css
+++ b/src/theme/material/grid-row.m.css
@@ -3,7 +3,6 @@
 .root {
 	box-sizing: border-box;
 	height: calc(var(--mdc-grid-base) * 5);
-	/* border-top: var(--mdc-border-width) solid var(--mdc-border-color); */
 }
 
 .selected {

--- a/src/theme/material/variables.css
+++ b/src/theme/material/variables.css
@@ -42,6 +42,7 @@
 	--zindex-dialog: 400;
 	--mdc-border-color: rgba(0, 0, 0, 0.38);
 	--mdc-border-radius: 4px;
+	--mdc-border-width: 1px;
 	--mdc-avatar-size-small: 24px;
 	--mdc-avatar-size-medium: 40px;
 	--mdc-avatar-size-large: 56px;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Tweaks to the overall look and feel of the grid in all three themes. Plus using the correct mdc vars for the grid material theme.

Resolves #1184 