### PR TITLE
Convert `<TabController />` and `<TabButton />` to functional widgets

### DIFF
--- a/src/tab-controller/tests/unit/TabButton.spec.tsx
+++ b/src/tab-controller/tests/unit/TabButton.spec.tsx
@@ -3,14 +3,14 @@ const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
 
-import { v, w } from '@dojo/framework/core/vdom';
-import harness from '@dojo/framework/testing/harness';
-import { Keys } from '../../../common/util';
+import { tsx } from '@dojo/framework/core/vdom';
 import { assign } from '@dojo/framework/shim/object';
+import harness from '@dojo/framework/testing/harness';
 
-import TabButton, { TabButtonProperties } from '../../TabButton';
-import * as css from '../../../theme/default/tab-controller.m.css';
 import { noop, stubEvent } from '../../../common/tests/support/test-helpers';
+import { Keys } from '../../../common/util';
+import * as css from '../../../theme/default/tab-controller.m.css';
+import TabButton, { TabButtonProperties } from '../../TabButton';
 
 const props = function(props = {}) {
 	return assign(
@@ -23,7 +23,7 @@ const props = function(props = {}) {
 	);
 };
 
-const testChildren = [v('p', ['lorem ipsum']), v('a', { href: '#foo' }, ['foo'])];
+const testChildren = [<p>lorem ipsum</p>, <a href="#foo">foo</a>];
 
 const expected = function(
 	closeable = false,
@@ -32,67 +32,53 @@ const expected = function(
 	children: any[] = []
 ) {
 	children.push(
-		closeable
-			? v(
-					'button',
-					{
-						tabIndex: activeTab,
-						classes: css.close,
-						type: 'button',
-						onclick: noop
-					},
-					['close']
-			  )
-			: null,
-		v(
-			'span',
-			{ classes: [css.indicator, activeTab !== -1 ? css.indicatorActive : undefined] },
-			[v('span', { classes: css.indicatorContent })]
-		)
+		closeable ? (
+			<button tabIndex={activeTab} classes={css.close} type="button" onclick={noop}>
+				close
+			</button>
+		) : null,
+		<span classes={[css.indicator, activeTab !== -1 ? css.indicatorActive : undefined]}>
+			<span classes={css.indicatorContent} />
+		</span>
 	);
 
-	return v(
-		'div',
-		{
-			'aria-controls': 'foo',
-			'aria-disabled': disabled ? 'true' : 'false',
-			'aria-selected': activeTab !== -1 ? 'true' : 'false',
-			classes: [
+	return (
+		<div
+			aria-controls="foo"
+			aria-disabled={disabled ? 'true' : 'false'}
+			aria-selected={activeTab !== -1 ? 'true' : 'false'}
+			classes={[
 				css.tabButton,
 				activeTab !== -1 ? css.activeTabButton : null,
 				closeable ? css.closeable : null,
 				disabled ? css.disabledTabButton : null
-			],
-			id: 'foo',
-			focus: noop,
-			key: 'tab-button',
-			onclick: noop,
-			onkeydown: noop,
-			role: 'tab',
-			tabIndex: activeTab
-		},
-		[v('span', { classes: css.tabButtonContent }, children)]
+			]}
+			id="foo"
+			focus={noop}
+			key="tab-button"
+			onclick={noop}
+			onkeydown={noop}
+			role="tab"
+			tabIndex={activeTab}
+		>
+			<span classes={css.tabButtonContent}>{children}</span>
+		</div>
 	);
 };
 
 registerSuite('TabButton', {
 	tests: {
 		'default properties'() {
-			const h = harness(() => w(TabButton, props()));
+			const h = harness(() => <TabButton {...props()} />);
 			h.expect(expected);
 		},
 
 		'custom properties'() {
-			const h = harness(() =>
-				w(
-					TabButton,
-					props({
-						closeable: true,
-						disabled: true
-					}),
-					testChildren
-				)
-			);
+			const h = harness(() => (
+				<TabButton {...props({ closeable: true, disabled: true })}>
+					{testChildren}
+				</TabButton>
+			));
 			h.expect(() => expected(true, true, -1, testChildren));
 		},
 
@@ -100,7 +86,7 @@ registerSuite('TabButton', {
 			let extraProps: Partial<TabButtonProperties> = {
 				active: true
 			};
-			const h = harness(() => w(TabButton, props(extraProps)));
+			const h = harness(() => <TabButton {...props(extraProps)} />);
 			h.expect(() => expected(false, false, 0));
 
 			extraProps = {
@@ -113,15 +99,7 @@ registerSuite('TabButton', {
 		onCloseClick() {
 			const onCloseClick = sinon.stub();
 			const stopPropagation = sinon.stub();
-			const h = harness(() =>
-				w(
-					TabButton,
-					props({
-						closeable: true,
-						onCloseClick
-					})
-				)
-			);
+			const h = harness(() => <TabButton {...props({ closeable: true, onCloseClick })} />);
 
 			h.trigger('button', 'onclick', { stopPropagation });
 			assert.isTrue(
@@ -136,7 +114,7 @@ registerSuite('TabButton', {
 			let extraProps: Partial<TabButtonProperties> = {
 				onClick
 			};
-			const h = harness(() => w(TabButton, props(extraProps)));
+			const h = harness(() => <TabButton {...props(extraProps)} />);
 			h.trigger('@tab-button', 'onclick', { stopPropagation });
 			assert.isTrue(onClick.calledOnce, 'onClick handler called when tab is clicked');
 			assert.isTrue(onClick.calledWith(0), 'onClick called with index as argument');
@@ -165,7 +143,7 @@ registerSuite('TabButton', {
 				onRightArrowPress,
 				onUpArrowPress
 			};
-			const h = harness(() => w(TabButton, props(extraProps)));
+			const h = harness(() => <TabButton {...props(extraProps)} />);
 			h.trigger('@tab-button', 'onkeydown', {
 				which: Keys.Down,
 				stopPropagation,
@@ -241,7 +219,7 @@ registerSuite('TabButton', {
 			let extraProps: Partial<TabButtonProperties> = {
 				onCloseClick
 			};
-			const h = harness(() => w(TabButton, props(extraProps)));
+			const h = harness(() => <TabButton {...props(extraProps)} />);
 			h.trigger('@tab-button', 'onkeydown', {
 				which: Keys.Escape,
 				stopPropagation,

--- a/src/tab-controller/tests/unit/TabController.spec.tsx
+++ b/src/tab-controller/tests/unit/TabController.spec.tsx
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
 
-import { v, w } from '@dojo/framework/core/vdom';
+import { tsx } from '@dojo/framework/core/vdom';
 import { DNode } from '@dojo/framework/core/interfaces';
 
 import TabController, { Align } from '../../index';
@@ -25,36 +25,15 @@ const harness = createHarness([compareId, compareWidgetId, compareControls, comp
 
 const tabChildren = function(tabs = 2) {
 	const children = [
-		w(
-			Tab,
-			{
-				key: '0'
-			},
-			['tab content 1']
-		),
-		w(
-			Tab,
-			{
-				closeable: true,
-				disabled: true,
-				key: '1',
-				label: 'foo'
-			},
-			['tab content 2']
-		)
+		<Tab key="0">tab content 1</Tab>,
+		<Tab closeable={true} disabled={true} key="1" label="foo">
+			tab content 2
+		</Tab>
 	];
 
 	if (tabs > 2) {
 		for (let i = 2; i < tabs; i++) {
-			children.push(
-				w(
-					Tab,
-					{
-						key: `${i}`
-					},
-					[`tab content ${i}`]
-				)
-			);
+			children.push(<Tab key={`${i}`}>tab content {`${i}`}</Tab>);
 		}
 	}
 
@@ -63,72 +42,56 @@ const tabChildren = function(tabs = 2) {
 
 const expectedTabButtons = function(empty = false, activeIndex = 0): DNode {
 	if (empty) {
-		return v(
-			'div',
-			{
-				key: 'buttons',
-				classes: css.tabButtons
-			},
-			[]
-		);
+		return <div key="buttons" classes={css.tabButtons} />;
 	}
 
-	return v(
-		'div',
-		{
-			key: 'buttons',
-			classes: css.tabButtons
-		},
-		[
-			w(
-				TabButton,
-				{
-					active: activeIndex === 0,
-					closeable: undefined,
-					controls: '',
-					disabled: undefined,
-					id: '',
-					index: 0,
-					focus: noop,
-					key: '0-tabbutton',
-					onClick: noop,
-					onCloseClick: noop,
-					onDownArrowPress: noop,
-					onEndPress: noop,
-					onHomePress: noop,
-					onLeftArrowPress: noop,
-					onRightArrowPress: noop,
-					onUpArrowPress: noop,
-					theme: undefined,
-					classes: undefined
-				},
-				[null]
-			),
-			w(
-				TabButton,
-				{
-					active: activeIndex === 1,
-					closeable: true,
-					controls: '',
-					disabled: true,
-					id: '',
-					index: 1,
-					focus: noop,
-					key: '1-tabbutton',
-					onClick: noop,
-					onCloseClick: noop,
-					onDownArrowPress: noop,
-					onEndPress: noop,
-					onHomePress: noop,
-					onLeftArrowPress: noop,
-					onRightArrowPress: noop,
-					onUpArrowPress: noop,
-					theme: undefined,
-					classes: undefined
-				},
-				['foo']
-			)
-		]
+	return (
+		<div key="buttons" classes={css.tabButtons}>
+			<TabButton
+				active={activeIndex === 0}
+				closeable={undefined}
+				controls=""
+				disabled={undefined}
+				id=""
+				index={0}
+				focus={noop}
+				key="0-tabbutton"
+				onClick={noop}
+				onCloseClick={noop}
+				onDownArrowPress={noop}
+				onEndPress={noop}
+				onHomePress={noop}
+				onLeftArrowPress={noop}
+				onRightArrowPress={noop}
+				onUpArrowPress={noop}
+				theme={undefined}
+				classes={undefined}
+			>
+				{null}
+			</TabButton>
+			<TabButton
+				active={activeIndex === 1}
+				closeable={true}
+				controls=""
+				disabled={true}
+				id=""
+				index={1}
+				focus={noop}
+				key={'1-tabbutton'}
+				onClick={noop}
+				onCloseClick={noop}
+				onDownArrowPress={noop}
+				onEndPress={noop}
+				onHomePress={noop}
+				onLeftArrowPress={noop}
+				onRightArrowPress={noop}
+				onUpArrowPress={noop}
+				theme={undefined}
+				classes={undefined}
+			>
+				foo
+			</TabButton>
+		</div>
 	);
 };
 
@@ -137,38 +100,23 @@ const expectedTabContent = function(index = 0): DNode {
 		return null;
 	}
 
-	const tabs = [
-		w(
-			Tab,
-			{
-				key: '0',
-				widgetId: '',
-				labelledBy: '',
-				show: index === 0
-			},
-			['tab content 1']
-		),
-		w(
-			Tab,
-			{
-				closeable: true,
-				disabled: true,
-				key: '1',
-				label: 'foo',
-				widgetId: '',
-				show: index === 1,
-				labelledBy: ''
-			},
-			['tab content 2']
-		)
-	];
-	return v(
-		'div',
-		{
-			key: 'tabs',
-			classes: css.tabs
-		},
-		tabs
+	return (
+		<div key="tabs" classes={css.tabs}>
+			<Tab key="0" widgetId="" labelledBy="" show={index === 0}>
+				tab content 1
+			</Tab>
+			<Tab
+				closeable={true}
+				disabled={true}
+				key="1"
+				label="foo"
+				widgetId=""
+				show={index === 1}
+				labelledBy=""
+			>
+				tab content 2
+			</Tab>
+		</div>
 	);
 };
 
@@ -183,15 +131,15 @@ const expected = function(
 				'aria-describedby': describedby
 		  }
 		: null;
-	return v(
-		'div',
-		{
-			'aria-orientation': vertical ? 'vertical' : 'horizontal',
-			classes,
-			role: 'tablist',
-			...overrides
-		},
-		children
+	return (
+		<div
+			aria-orientation={vertical ? 'vertical' : 'horizontal'}
+			classes={classes}
+			role="tablist"
+			{...overrides}
+		>
+			{children}
+		</div>
 	);
 };
 
@@ -199,15 +147,7 @@ registerSuite('TabController', {
 	tests: {
 		'default properties'() {
 			let children: any[] = [];
-			const h = harness(() =>
-				w(
-					TabController,
-					{
-						activeIndex: 0
-					},
-					children
-				)
-			);
+			const h = harness(() => <TabController activeIndex={0}>{children}</TabController>);
 			let tabButtons = expectedTabButtons(true);
 			let tabContent: any = null;
 
@@ -219,15 +159,12 @@ registerSuite('TabController', {
 		},
 
 		'aria properties'() {
-			const h = harness(() =>
-				w(TabController, {
-					activeIndex: 0,
-					aria: {
-						describedBy: 'foo',
-						orientation: 'overridden'
-					}
-				})
-			);
+			const h = harness(() => (
+				<TabController
+					activeIndex={0}
+					aria={{ describedBy: 'foo', orientation: 'overridden' }}
+				/>
+			));
 
 			h.expect(() => expected([expectedTabButtons(true), null], 'foo'));
 		},
@@ -237,7 +174,7 @@ registerSuite('TabController', {
 				activeIndex: 0,
 				alignButtons: Align.bottom
 			};
-			const h = harness(() => w(TabController, properties, tabChildren()));
+			const h = harness(() => <TabController {...properties}>{tabChildren()}</TabController>);
 
 			let tabButtons = expectedTabButtons();
 			let tabContent = expectedTabContent();
@@ -263,16 +200,11 @@ registerSuite('TabController', {
 
 		'Clicking tab should change activeIndex'() {
 			const onRequestTabChange = sinon.stub();
-			const h = harness(() =>
-				w(
-					TabController,
-					{
-						activeIndex: 2,
-						onRequestTabChange
-					},
-					tabChildren(3)
-				)
-			);
+			const h = harness(() => (
+				<TabController activeIndex={2} onRequestTabChange={onRequestTabChange}>
+					{tabChildren(3)}
+				</TabController>
+			));
 			h.trigger('@0-tabbutton', 'onClick', 0);
 			assert.isTrue(
 				onRequestTabChange.calledOnce,
@@ -298,16 +230,11 @@ registerSuite('TabController', {
 
 		'Closing a tab should change tabs'() {
 			const onRequestTabClose = sinon.stub();
-			const h = harness(() =>
-				w(
-					TabController,
-					{
-						activeIndex: 2,
-						onRequestTabClose
-					},
-					tabChildren(3)
-				)
-			);
+			const h = harness(() => (
+				<TabController activeIndex={2} onRequestTabClose={onRequestTabClose}>
+					{tabChildren(3)}
+				</TabController>
+			));
 
 			h.trigger('@2-tabbutton', 'onCloseClick', 2);
 			assert.isTrue(
@@ -322,16 +249,11 @@ registerSuite('TabController', {
 
 		'Basic keyboard navigation'() {
 			const onRequestTabChange = sinon.stub();
-			const h = harness(() =>
-				w(
-					TabController,
-					{
-						activeIndex: 2,
-						onRequestTabChange
-					},
-					tabChildren(5)
-				)
-			);
+			const h = harness(() => (
+				<TabController activeIndex={2} onRequestTabChange={onRequestTabChange}>
+					{tabChildren(5)}
+				</TabController>
+			));
 
 			h.trigger('@2-tabbutton', 'onRightArrowPress', 2);
 			assert.strictEqual(
@@ -372,7 +294,9 @@ registerSuite('TabController', {
 				activeIndex: 0,
 				onRequestTabChange
 			};
-			const h = harness(() => w(TabController, properties, tabChildren(3)));
+			const h = harness(() => (
+				<TabController {...properties}>{tabChildren(3)}</TabController>
+			));
 
 			h.trigger('@0-tabbutton', 'onLeftArrowPress', 2);
 			assert.isTrue(
@@ -398,7 +322,9 @@ registerSuite('TabController', {
 				alignButtons: Align.right,
 				onRequestTabChange
 			};
-			const h = harness(() => w(TabController, properties, tabChildren(5)));
+			const h = harness(() => (
+				<TabController {...properties}>{tabChildren(5)}</TabController>
+			));
 
 			h.trigger('@0-tabbutton', 'onDownArrowPress', 0);
 			assert.strictEqual(
@@ -443,44 +369,29 @@ registerSuite('TabController', {
 
 		'Should default to last tab if invalid activeIndex passed'() {
 			const onRequestTabChange = sinon.stub();
-			harness(() =>
-				w(
-					TabController,
-					{
-						activeIndex: 5,
-						onRequestTabChange
-					},
-					tabChildren(5)
-				)
-			);
+			const h = harness(() => (
+				<TabController activeIndex={5} onRequestTabChange={onRequestTabChange}>
+					{tabChildren(5)}
+				</TabController>
+			));
+			h.expect(() => null);
 			assert.isTrue(onRequestTabChange.calledWith(4));
 		},
 
 		'Should skip tab if activeIndex is disabled'() {
 			const onRequestTabChange = sinon.stub();
-			harness(() =>
-				w(
-					TabController,
-					{
-						activeIndex: 1,
-						onRequestTabChange
-					},
-					tabChildren(5)
-				)
-			);
+			const h = harness(() => (
+				<TabController activeIndex={1} onRequestTabChange={onRequestTabChange}>
+					{tabChildren(5)}
+				</TabController>
+			));
+			h.expect(() => null);
 			assert.isTrue(onRequestTabChange.calledWith(2));
 		},
 
 		'Calls focus when arrowing through tabs'() {
 			const h = harness(
-				() =>
-					w(
-						TabController,
-						{
-							activeIndex: 0
-						},
-						tabChildren()
-					),
+				() => <TabController activeIndex={0}>{tabChildren()}</TabController>,
 				[
 					{
 						selector: '@0-tabbutton',
@@ -490,22 +401,15 @@ registerSuite('TabController', {
 				]
 			);
 			h.trigger('@0-tabbutton', 'onRightArrowPress');
-			let tabButtons = expectedTabButtons();
-			let tabContent = expectedTabContent();
+			const tabButtons = expectedTabButtons();
+			const tabContent = expectedTabContent();
 
 			h.expect(() => expected([tabButtons, tabContent]));
 		},
 
 		'Calls focus when closing a tab'() {
 			const h = harness(
-				() =>
-					w(
-						TabController,
-						{
-							activeIndex: 0
-						},
-						tabChildren()
-					),
+				() => <TabController activeIndex={0}>{tabChildren()}</TabController>,
 				[
 					{
 						selector: '@0-tabbutton',
@@ -515,8 +419,8 @@ registerSuite('TabController', {
 				]
 			);
 			h.trigger('@1-tabbutton', 'onCloseClick', 1);
-			let tabButtons = expectedTabButtons();
-			let tabContent = expectedTabContent();
+			const tabButtons = expectedTabButtons();
+			const tabContent = expectedTabContent();
 
 			h.expect(() => expected([tabButtons, tabContent]));
 		}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Addresses a portion of #1171

- Convert `<TabController>` and `<TabButton>` to functional widgets using tsx.
- Convert the associated test files to use tsx.