### PR TITLE
Convert Calendar to functional TSX widget

### DIFF
--- a/src/calendar/CalendarCell.tsx
+++ b/src/calendar/CalendarCell.tsx
@@ -1,8 +1,8 @@
-import { theme, ThemeProperties } from '../middleware/theme';
+import theme from '../middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import * as css from '../theme/default/calendar.m.css';
 
-export interface CalendarCellProperties extends ThemeProperties {
+export interface CalendarCellProperties {
 	/** Used to immediately call focus on the cell */
 	callFocus?: boolean;
 	/** The set date value */

--- a/src/calendar/DatePicker.tsx
+++ b/src/calendar/DatePicker.tsx
@@ -97,7 +97,9 @@ export const DatePicker = factory(function DatePicker({
 	}
 
 	function getPopupState() {
-		return monthPopupOpen || yearPopupOpen;
+		const monthPopupOpen = icache.get('monthPopupOpen');
+		const yearPopupOpen = icache.get('yearPopupOpen');
+		return !!monthPopupOpen || !!yearPopupOpen;
 	}
 
 	function getYearInputKey(year: number): string {

--- a/src/calendar/DatePicker.tsx
+++ b/src/calendar/DatePicker.tsx
@@ -1,7 +1,6 @@
-import theme, { ThemeProperties } from '../middleware/theme';
+import theme from '../middleware/theme';
 import focus from '@dojo/framework/core/middleware/focus';
 import icache from '@dojo/framework/core/middleware/icache';
-import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import calendarBundle from './nls/Calendar';
 import { Keys } from '../common/util';
@@ -27,7 +26,7 @@ export enum Controls {
 	year = 'year'
 }
 
-export interface DatePickerProperties extends ThemeProperties, FocusProperties {
+export interface DatePickerProperties {
 	/** Id to reference label containing current month and year */
 	labelId?: string;
 	/** Customize or internationalize accessible helper text */

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -1,8 +1,4 @@
-import { WidgetBase } from '@dojo/framework/core/WidgetBase';
-import { I18nMixin, I18nProperties } from '@dojo/framework/core/mixins/I18n';
-import { FocusMixin } from '@dojo/framework/core/mixins/Focus';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
-import { v, w } from '@dojo/framework/core/vdom';
+import { tsx, create } from '@dojo/framework/core/vdom';
 import { DNode } from '@dojo/framework/core/interfaces';
 import { uuid } from '@dojo/framework/core/util';
 import commonBundle from '../common/nls/common';
@@ -14,6 +10,12 @@ import Icon from '../icon/index';
 import calendarBundle from './nls/Calendar';
 import * as css from '../theme/default/calendar.m.css';
 import * as baseCss from '../common/styles/base.m.css';
+
+import theme, { ThemeProperties } from '../middleware/theme';
+import icache from '@dojo/framework/core/middleware/icache';
+import focus from '@dojo/framework/core/middleware/focus';
+import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
+import i18n, { I18nProperties } from '@dojo/framework/core/middleware/i18n';
 
 export type CalendarMessages = typeof calendarBundle.messages;
 
@@ -27,7 +29,7 @@ export enum FirstDayOfWeek {
 	saturday = 6
 }
 
-export interface CalendarProperties extends ThemedProperties, I18nProperties {
+export interface CalendarProperties extends ThemeProperties, I18nProperties, FocusProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Customize or internationalize accessible text for the Calendar widget */
@@ -90,29 +92,56 @@ const DEFAULT_WEEKDAYS: ShortLong<typeof commonBundle.messages>[] = [
 	{ short: 'satShort', long: 'saturday' }
 ];
 
-@theme(css)
-export class Calendar extends FocusMixin(I18nMixin(ThemedMixin(WidgetBase)))<CalendarProperties> {
-	private _callDateFocus = false;
-	private _defaultDate = new Date();
-	private _focusedDay = 1;
-	private _monthLabelId = uuid();
-	private _popupOpen = false;
-	private _shouldFocus = false;
+const factory = create({ icache, i18n, theme, focus }).properties<CalendarProperties>();
 
-	private _getMonthLength(month: number, year: number) {
+export const Calendar = factory(function Calendar({
+	middleware: { icache, i18n, theme, focus },
+	properties
+}) {
+	const themeCss = theme.classes(css);
+	const { messages: commonMessages } = i18n.localize(commonBundle);
+	const callDateFocus = icache.getOrSet('callDateFocus', false);
+	const defaultDate = icache.getOrSet('defaultDate', new Date());
+	const focusedDay = icache.getOrSet('focusedDay', 1);
+	const monthLabelId = icache.getOrSet('monthLabelId', uuid());
+	const popupOpen = icache.getOrSet('popupOpen', false);
+	const shouldFocus = icache.getOrSet('shouldFocus', focus.shouldFocus);
+
+	const {
+		labels = i18n.localize(calendarBundle).messages,
+		aria = {},
+		selectedDate,
+		minDate,
+		maxDate,
+		weekdayNames = getWeekdays(commonMessages),
+		firstDayOfWeek = 0
+	} = properties();
+	const { year, month } = getMonthYear();
+
+	let weekdayOrder: number[] = [];
+	for (let i = firstDayOfWeek; i < firstDayOfWeek + 7; i++) {
+		weekdayOrder.push(i > 6 ? i - 7 : i);
+	}
+
+	const weekdays = weekdayOrder.map((order) => (
+		<th role="columnheader" classes={themeCss.weekday}>
+			{renderWeekdayCell(weekdayNames[order])}
+		</th>
+	));
+
+	function getMonthLength(month: number, year: number) {
 		const lastDate = new Date(year, month + 1, 0);
 		return lastDate.getDate();
 	}
-
-	private _getMonths(commonMessages: typeof commonBundle.messages) {
+	function getMonths(commonMessages: typeof commonBundle.messages) {
 		return DEFAULT_MONTHS.map((month) => ({
 			short: commonMessages[month.short],
 			long: commonMessages[month.long]
 		}));
 	}
 
-	private _getMonthYear() {
-		const { month, selectedDate = this._defaultDate, year } = this.properties;
+	function getMonthYear() {
+		const { month, selectedDate = defaultDate, year } = properties();
 
 		return {
 			month: typeof month === 'number' ? month : selectedDate.getMonth(),
@@ -120,87 +149,86 @@ export class Calendar extends FocusMixin(I18nMixin(ThemedMixin(WidgetBase)))<Cal
 		};
 	}
 
-	private _getWeekdays(commonMessages: typeof commonBundle.messages) {
+	function getWeekdays(commonMessages: typeof commonBundle.messages) {
 		return DEFAULT_WEEKDAYS.map((weekday) => ({
 			short: commonMessages[weekday.short],
 			long: commonMessages[weekday.long]
 		}));
 	}
 
-	private _goToDate(day: number) {
-		const { month, year } = this._getMonthYear();
-		const currentMonthLength = this._getMonthLength(month, year);
-		const previousMonthLength = this._getMonthLength(month - 1, year);
+	function goToDate(day: number) {
+		const { month, year } = getMonthYear();
+		const currentMonthLength = getMonthLength(month, year);
+		const previousMonthLength = getMonthLength(month - 1, year);
 
-		this._ensureDayIsInMinMax(new Date(year, month, day), (updatedDay) => (day = updatedDay));
+		ensureDayIsInMinMax(new Date(year, month, day), (updatedDay) => (day = updatedDay));
 
 		if (day < 1) {
-			this._onMonthDecrement();
+			onMonthDecrement();
 			day += previousMonthLength;
 		} else if (day > currentMonthLength) {
-			this._onMonthIncrement();
+			onMonthIncrement();
 			day -= currentMonthLength;
 		}
 
-		this._focusedDay = day;
-		this._callDateFocus = true;
-		this.invalidate();
+		icache.set('focusedDay', day);
+		icache.set('cellDateFocus', true);
 	}
 
-	private _onDateClick(date: number, disabled: boolean) {
-		const { onDateSelect } = this.properties;
-		let { month, year } = this._getMonthYear();
+	function onDateClick(date: number, disabled: boolean) {
+		const { onDateSelect } = properties();
+		let { month, year } = getMonthYear();
 
 		if (disabled) {
-			({ month, year } = date < 15 ? this._onMonthIncrement() : this._onMonthDecrement());
-			this._callDateFocus = true;
+			({ month, year } = date < 15 ? onMonthIncrement() : onMonthDecrement());
+			icache.set('cellDateFocus', true);
 		}
-		this._focusedDay = date;
+		icache.set('focusedDay', date);
 		onDateSelect && onDateSelect(new Date(year, month, date));
 	}
 
-	private _onDateFocusCalled() {
-		this._callDateFocus = false;
+	function onDateFocusCalled() {
+		icache.set('callDateFocus', false);
 	}
 
-	private _onDateKeyDown(key: number, preventDefault: () => void) {
-		const { month, year } = this._getMonthYear();
+	function onDateKeyDown(key: number, preventDefault: () => void) {
+		const { month, year } = getMonthYear();
 		switch (key) {
 			case Keys.Up:
 				preventDefault();
-				this._goToDate(this._focusedDay - 7);
+				goToDate(focusedDay - 7);
 				break;
 			case Keys.Down:
 				preventDefault();
-				this._goToDate(this._focusedDay + 7);
+				goToDate(focusedDay + 7);
 				break;
 			case Keys.Left:
 				preventDefault();
-				this._goToDate(this._focusedDay - 1);
+				goToDate(focusedDay - 1);
 				break;
 			case Keys.Right:
 				preventDefault();
-				this._goToDate(this._focusedDay + 1);
+				goToDate(focusedDay + 1);
 				break;
 			case Keys.PageUp:
 				preventDefault();
-				this._goToDate(1);
+				goToDate(1);
 				break;
 			case Keys.PageDown:
 				preventDefault();
-				const monthLengh = this._getMonthLength(month, year);
-				this._goToDate(monthLengh);
+				const monthLengh = getMonthLength(month, year);
+				goToDate(monthLengh);
 				break;
 			case Keys.Enter:
 			case Keys.Space:
-				const { onDateSelect } = this.properties;
-				onDateSelect && onDateSelect(new Date(year, month, this._focusedDay));
+				const { onDateSelect } = properties();
+				onDateSelect && onDateSelect(new Date(year, month, focusedDay));
 		}
 	}
 
-	private _onMonthDecrement() {
-		const { month, year } = this._getMonthYear();
-		const { onMonthChange, onYearChange } = this.properties;
+	function onMonthDecrement() {
+		const { month, year } = getMonthYear();
+		const { onMonthChange, onYearChange } = properties();
 
 		if (month === 0) {
 			onMonthChange && onMonthChange(11);
@@ -212,9 +240,9 @@ export class Calendar extends FocusMixin(I18nMixin(ThemedMixin(WidgetBase)))<Cal
 		return { month: month - 1, year: year };
 	}
 
-	private _onMonthIncrement() {
-		const { month, year } = this._getMonthYear();
-		const { onMonthChange, onYearChange } = this.properties;
+	function onMonthIncrement() {
+		const { month, year } = getMonthYear();
+		const { onMonthChange, onYearChange } = properties();
 
 		if (month === 11) {
 			onMonthChange && onMonthChange(0);
@@ -226,18 +254,18 @@ export class Calendar extends FocusMixin(I18nMixin(ThemedMixin(WidgetBase)))<Cal
 		return { month: month + 1, year: year };
 	}
 
-	private _onMonthPageDown(event: MouseEvent) {
+	function onMonthPageDown(event: MouseEvent) {
 		event.stopPropagation();
-		this._onMonthDecrement();
+		onMonthDecrement();
 	}
 
-	private _onMonthPageUp(event: MouseEvent) {
+	function onMonthPageUp(event: MouseEvent) {
 		event.stopPropagation();
-		this._onMonthIncrement();
+		onMonthIncrement();
 	}
 
-	private _ensureDayIsInMinMax(newDate: Date, update: (day: number) => void) {
-		const { minDate, maxDate } = this.properties;
+	function ensureDayIsInMinMax(newDate: Date, update: (day: number) => void) {
+		const { minDate, maxDate } = properties();
 
 		if (minDate && newDate < minDate) {
 			update(minDate.getDate());
@@ -246,16 +274,15 @@ export class Calendar extends FocusMixin(I18nMixin(ThemedMixin(WidgetBase)))<Cal
 		}
 	}
 
-	private _renderDateGrid(selectedDate?: Date) {
-		const { month, year } = this._getMonthYear();
-		const { firstDayOfWeek = 0 } = this.properties;
+	function renderDateGrid(selectedDate?: Date) {
+		const { month, year } = getMonthYear();
+		const { firstDayOfWeek = 0 } = properties();
 
-		this._ensureDayIsInMinMax(
-			new Date(year, month, this._focusedDay),
-			(newDay) => (this._focusedDay = newDay)
+		ensureDayIsInMinMax(new Date(year, month, focusedDay), (newDay) =>
+			icache.set('focusedDay', newDay)
 		);
-		const currentMonthLength = this._getMonthLength(month, year);
-		const previousMonthLength = this._getMonthLength(month - 1, year);
+		const currentMonthLength = getMonthLength(month, year);
+		const previousMonthLength = getMonthLength(month - 1, year);
 		const currentMonthStartDay = new Date(year, month, 1).getDay();
 		const initialWeekday =
 			currentMonthStartDay - firstDayOfWeek < 0
@@ -301,53 +328,54 @@ export class Calendar extends FocusMixin(I18nMixin(ThemedMixin(WidgetBase)))<Cal
 				isToday = dateString === todayString;
 
 				days.push(
-					this.renderDateCell(dateObj, dayIndex++, isSelectedDay, isCurrentMonth, isToday)
+					renderDateCell(dateObj, dayIndex++, isSelectedDay, isCurrentMonth, isToday)
 				);
 			}
 
-			weeks.push(v('tr', days));
+			weeks.push(<tr>{days}</tr>);
 		}
 
 		return weeks;
 	}
 
-	protected renderDateCell(
+	function renderDateCell(
 		dateObj: Date,
 		index: number,
 		selected: boolean,
 		currentMonth: boolean,
 		today: boolean
 	): DNode {
-		const { minDate, maxDate } = this.properties;
+		const { minDate, maxDate, theme, classes } = properties();
 
 		const date = dateObj.getDate();
-		const { theme, classes } = this.properties;
 		const outOfRange = isOutOfDateRange(dateObj, minDate, maxDate);
-		const focusable = currentMonth && date === this._focusedDay;
+		const focusable = currentMonth && date === focusedDay;
 
-		return w(CalendarCell, {
-			classes,
-			key: `date-${index}`,
-			callFocus: (this._callDateFocus || this._shouldFocus) && focusable,
-			date,
-			outOfRange,
-			focusable,
-			disabled: !currentMonth,
-			selected,
-			theme,
-			today,
-			onClick: outOfRange ? undefined : this._onDateClick,
-			onFocusCalled: this._onDateFocusCalled,
-			onKeyDown: this._onDateKeyDown
-		});
+		return (
+			<CalendarCell
+				classes={classes}
+				key={`date-${index}`}
+				callFocus={(callDateFocus || shouldFocus) && focusable}
+				date={date}
+				outOfRange={outOfRange}
+				focusable={focusable}
+				disabled={!currentMonth}
+				selected={selected}
+				theme={theme}
+				today={today}
+				onClick={outOfRange ? undefined : onDateClick}
+				onFocusCalled={onDateFocusCalled}
+				onKeyDown={onDateKeyDown}
+			/>
+		);
 	}
 
-	protected renderDatePicker(
+	function renderDatePicker(
 		commonMessages: typeof commonBundle.messages,
 		labels: CalendarMessages
 	): DNode {
 		const {
-			monthNames = this._getMonths(commonMessages),
+			monthNames = getMonths(commonMessages),
 			renderMonthLabel,
 			theme,
 			classes,
@@ -355,154 +383,98 @@ export class Calendar extends FocusMixin(I18nMixin(ThemedMixin(WidgetBase)))<Cal
 			onYearChange,
 			minDate,
 			maxDate
-		} = this.properties;
-		const { month, year } = this._getMonthYear();
+		} = properties();
+		const { month, year } = getMonthYear();
 
-		return w(DatePicker, {
-			key: 'date-picker',
-			classes,
-			labelId: this._monthLabelId,
-			labels,
-			month,
-			monthNames,
-			renderMonthLabel,
-			theme,
-			year,
-			minDate,
-			maxDate,
-			onPopupChange: (open: boolean) => {
-				this._popupOpen = open;
-				this.invalidate();
-			},
-			onRequestMonthChange: (requestMonth: number) => {
-				onMonthChange && onMonthChange(requestMonth);
-			},
-			onRequestYearChange: (requestYear: number) => {
-				onYearChange && onYearChange(requestYear);
-			}
-		});
+		return (
+			<DatePicker
+				key="date-picker"
+				classes={classes}
+				labelId={monthLabelId}
+				labels={labels}
+				month={month}
+				monthNames={monthNames}
+				renderMonthLabel={renderMonthLabel}
+				theme={theme}
+				year={year}
+				minDate={minDate}
+				maxDate={maxDate}
+				onPopupChange={(open: boolean) => {
+					icache.set('popupOpen', open);
+				}}
+				onRequestMonthChange={(requestMonth: number) => {
+					onMonthChange && onMonthChange(requestMonth);
+				}}
+				onRequestYearChange={(requestYear: number) => {
+					onYearChange && onYearChange(requestYear);
+				}}
+			/>
+		);
 	}
 
-	protected renderPagingButtonContent(type: Paging, labels: CalendarMessages): DNode[] {
-		const { theme, classes } = this.properties;
+	function renderPagingButtonContent(type: Paging, labels: CalendarMessages): DNode[] {
+		const { theme, classes } = properties();
 		const iconType = type === Paging.next ? 'rightIcon' : 'leftIcon';
 		const labelText = type === Paging.next ? labels.nextMonth : labels.previousMonth;
 
 		return [
-			w(Icon, {
-				type: iconType,
-				theme,
-				classes: {
-					...classes,
-					'@dojo/widgets/icon': { icon: [this.theme(css.icon)] }
-				}
-			}),
-			v('span', { classes: [baseCss.visuallyHidden] }, [labelText])
+			<Icon
+				type={iconType}
+				theme={theme}
+				classes={{ ...classes, '@dojo/widgets/icon': { icon: [themeCss.icon] } }}
+			/>,
+			<span classes={[baseCss.visuallyHidden]}>{labelText}</span>
 		];
 	}
 
-	protected renderWeekdayCell(day: { short: string; long: string }): DNode {
-		const { renderWeekdayCell } = this.properties;
-		return renderWeekdayCell
-			? renderWeekdayCell(day)
-			: v('abbr', { classes: this.theme(css.abbr), title: day.long }, [day.short]);
-	}
-
-	protected render(): DNode {
-		const { messages: commonMessages } = this.localizeBundle(commonBundle);
-		const {
-			labels = this.localizeBundle(calendarBundle).messages,
-			aria = {},
-			selectedDate,
-			minDate,
-			maxDate,
-			weekdayNames = this._getWeekdays(commonMessages),
-			firstDayOfWeek = 0
-		} = this.properties;
-		const { year, month } = this._getMonthYear();
-		this._shouldFocus = this.shouldFocus();
-
-		let weekdayOrder: number[] = [];
-		for (let i = firstDayOfWeek; i < firstDayOfWeek + 7; i++) {
-			weekdayOrder.push(i > 6 ? i - 7 : i);
-		}
-
-		// Calendar Weekday array
-		const weekdays = weekdayOrder.map((order) =>
-			v(
-				'th',
-				{
-					role: 'columnheader',
-					classes: this.theme(css.weekday)
-				},
-				[this.renderWeekdayCell(weekdayNames[order])]
-			)
-		);
-
-		return v(
-			'div',
-			{
-				classes: this.theme(css.root),
-				...formatAriaProperties(aria)
-			},
-			[
-				// header
-				this.renderDatePicker(commonMessages, labels),
-				// date table
-				v(
-					'table',
-					{
-						cellspacing: '0',
-						cellpadding: '0',
-						role: 'grid',
-						'aria-labelledby': this._monthLabelId,
-						classes: [
-							this.theme(css.dateGrid),
-							this._popupOpen ? baseCss.visuallyHidden : null
-						]
-					},
-					[
-						v('thead', [v('tr', weekdays)]),
-						v('tbody', this._renderDateGrid(selectedDate))
-					]
-				),
-				// controls
-				v(
-					'div',
-					{
-						classes: [
-							this.theme(css.controls),
-							this._popupOpen ? baseCss.visuallyHidden : null
-						]
-					},
-					[
-						v(
-							'button',
-							{
-								classes: this.theme(css.previous),
-								tabIndex: this._popupOpen ? -1 : 0,
-								type: 'button',
-								disabled: !monthInMin(year, month - 1, minDate),
-								onclick: this._onMonthPageDown
-							},
-							this.renderPagingButtonContent(Paging.previous, labels)
-						),
-						v(
-							'button',
-							{
-								classes: this.theme(css.next),
-								tabIndex: this._popupOpen ? -1 : 0,
-								type: 'button',
-								disabled: !monthInMax(year, month + 1, maxDate),
-								onclick: this._onMonthPageUp
-							},
-							this.renderPagingButtonContent(Paging.next, labels)
-						)
-					]
-				)
-			]
+	function renderWeekdayCell(day: { short: string; long: string }): DNode {
+		const { renderWeekdayCell } = properties();
+		return renderWeekdayCell ? (
+			renderWeekdayCell(day)
+		) : (
+			<abbr classes={themeCss.abbr} title={day.long}>
+				{day.short}
+			</abbr>
 		);
 	}
-}
+
+	return (
+		<div classes={themeCss.root} {...formatAriaProperties(aria)}>
+			{renderDatePicker(commonMessages, labels)}
+			<table
+				cellspacing="0"
+				cellpadding="0"
+				role="grid"
+				aria-labelledby={monthLabelId}
+				classes={[themeCss.dateGrid, popupOpen ? baseCss.visuallyHidden : null]}
+			>
+				<thead>
+					<tr>{weekdays}</tr>
+				</thead>
+				<tbody>{renderDateGrid(selectedDate)}</tbody>
+			</table>
+			<div classes={[themeCss.controls, popupOpen ? baseCss.visuallyHidden : null]}>
+				<button
+					classes={themeCss.previous}
+					tabIndex={popupOpen ? -1 : 0}
+					type="button"
+					disabled={!monthInMin(year, month - 1, minDate)}
+					onclick={onMonthPageDown}
+				>
+					{renderPagingButtonContent(Paging.previous, labels)}
+				</button>
+				<button
+					classes={themeCss.next}
+					tabIndex={popupOpen ? -1 : 0}
+					type="button"
+					disabled={!monthInMax(year, month + 1, maxDate)}
+					onclick={onMonthPageUp}
+				>
+					{renderPagingButtonContent(Paging.next, labels)}
+				</button>
+			</div>
+		</div>
+	);
+});
 
 export default Calendar;

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -11,11 +11,10 @@ import calendarBundle from './nls/Calendar';
 import * as css from '../theme/default/calendar.m.css';
 import * as baseCss from '../common/styles/base.m.css';
 
-import theme, { ThemeProperties } from '../middleware/theme';
+import theme from '../middleware/theme';
 import icache from '@dojo/framework/core/middleware/icache';
 import focus from '@dojo/framework/core/middleware/focus';
-import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
-import i18n, { I18nProperties } from '@dojo/framework/core/middleware/i18n';
+import i18n from '@dojo/framework/core/middleware/i18n';
 
 export type CalendarMessages = typeof calendarBundle.messages;
 
@@ -29,7 +28,7 @@ export enum FirstDayOfWeek {
 	saturday = 6
 }
 
-export interface CalendarProperties extends ThemeProperties, I18nProperties, FocusProperties {
+export interface CalendarProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
 	/** Customize or internationalize accessible text for the Calendar widget */
@@ -105,7 +104,7 @@ export const Calendar = factory(function Calendar({
 	const focusedDay = icache.getOrSet('focusedDay', 1);
 	const monthLabelId = icache.getOrSet('monthLabelId', uuid());
 	const popupOpen = icache.getOrSet('popupOpen', false);
-	const shouldFocus = icache.getOrSet('shouldFocus', focus.shouldFocus);
+	const shouldFocus = focus.shouldFocus();
 
 	const {
 		labels = i18n.localize(calendarBundle).messages,
@@ -172,7 +171,7 @@ export const Calendar = factory(function Calendar({
 		}
 
 		icache.set('focusedDay', day);
-		icache.set('cellDateFocus', true);
+		icache.set('callDateFocus', true);
 	}
 
 	function onDateClick(date: number, disabled: boolean) {
@@ -181,7 +180,7 @@ export const Calendar = factory(function Calendar({
 
 		if (disabled) {
 			({ month, year } = date < 15 ? onMonthIncrement() : onMonthDecrement());
-			icache.set('cellDateFocus', true);
+			icache.set('callDateFocus', true);
 		}
 		icache.set('focusedDay', date);
 		onDateSelect && onDateSelect(new Date(year, month, date));
@@ -344,12 +343,12 @@ export const Calendar = factory(function Calendar({
 		selected: boolean,
 		currentMonth: boolean,
 		today: boolean
-	): DNode {
+	) {
 		const { minDate, maxDate, theme, classes } = properties();
 
 		const date = dateObj.getDate();
 		const outOfRange = isOutOfDateRange(dateObj, minDate, maxDate);
-		const focusable = currentMonth && date === focusedDay;
+		const focusable = currentMonth && date === icache.get('focusedDay');
 
 		return (
 			<CalendarCell
@@ -373,7 +372,7 @@ export const Calendar = factory(function Calendar({
 	function renderDatePicker(
 		commonMessages: typeof commonBundle.messages,
 		labels: CalendarMessages
-	): DNode {
+	) {
 		const {
 			monthNames = getMonths(commonMessages),
 			renderMonthLabel,
@@ -412,7 +411,7 @@ export const Calendar = factory(function Calendar({
 		);
 	}
 
-	function renderPagingButtonContent(type: Paging, labels: CalendarMessages): DNode[] {
+	function renderPagingButtonContent(type: Paging, labels: CalendarMessages) {
 		const { theme, classes } = properties();
 		const iconType = type === Paging.next ? 'rightIcon' : 'leftIcon';
 		const labelText = type === Paging.next ? labels.nextMonth : labels.previousMonth;
@@ -427,7 +426,7 @@ export const Calendar = factory(function Calendar({
 		];
 	}
 
-	function renderWeekdayCell(day: { short: string; long: string }): DNode {
+	function renderWeekdayCell(day: { short: string; long: string }) {
 		const { renderWeekdayCell } = properties();
 		return renderWeekdayCell ? (
 			renderWeekdayCell(day)

--- a/src/calendar/tests/unit/Calendar.spec.tsx
+++ b/src/calendar/tests/unit/Calendar.spec.tsx
@@ -222,7 +222,7 @@ const baseTemplate = assertionTemplate(() => {
 						{DEFAULT_WEEKDAYS.map((weekday: { short: string; long: string }) => (
 							<th role="columnheader" classes={css.weekday}>
 								<abbr title={weekday.long} classes={css.abbr}>
-									weekday.short
+									{weekday.short}
 								</abbr>
 							</th>
 						))}
@@ -316,7 +316,6 @@ const baseTemplate = assertionTemplate(() => {
 					/>
 					<span classes={[baseCss.visuallyHidden]}>Next Month</span>
 				</button>
-				)
 			</div>
 		</div>
 	);
@@ -346,8 +345,8 @@ registerSuite('Calendar', {
 				selectedDate: new Date('June 1 2017'),
 				weekdayNames: DEFAULT_WEEKDAYS,
 				year: testDate.getFullYear(),
-				renderMonthLabel: (month: number, year: number) => 'Foo',
-				renderWeekdayCell: (day: { short: string; long: string }) => 'Bar'
+				renderMonthLabel: () => 'Foo',
+				renderWeekdayCell: () => 'Bar'
 			};
 			const h = harness(() => <Calendar {...properties} />);
 

--- a/src/calendar/tests/unit/Calendar.spec.tsx
+++ b/src/calendar/tests/unit/Calendar.spec.tsx
@@ -1,7 +1,7 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
-import { v, w } from '@dojo/framework/core/vdom';
+import { tsx } from '@dojo/framework/core/vdom';
 import { Keys } from '../../../common/util';
 
 import { DEFAULT_LABELS, DEFAULT_MONTHS, DEFAULT_WEEKDAYS } from '../support/defaults';
@@ -32,21 +32,23 @@ const expectedDateCell = function(
 	outOfRange = false,
 	selectedIndex = -1
 ) {
-	return w(CalendarCell, {
-		key: `date-${dateIndex}`,
-		callFocus: false,
-		date,
-		outOfRange,
-		disabled: !currentMonth,
-		focusable: date === 1 && currentMonth,
-		selected: dateIndex === selectedIndex,
-		theme: undefined,
-		classes: undefined,
-		today: false,
-		onClick: outOfRange ? undefined : noop,
-		onFocusCalled: noop,
-		onKeyDown: noop
-	});
+	return (
+		<CalendarCell
+			key={`date-${dateIndex}`}
+			callFocus={false}
+			date={date}
+			outOfRange={outOfRange}
+			disabled={!currentMonth}
+			focusable={date === 1 && currentMonth}
+			selected={dateIndex === selectedIndex}
+			theme={undefined}
+			classes={undefined}
+			today={false}
+			onClick={outOfRange ? undefined : noop}
+			onFocusCalled={noop}
+			onKeyDown={noop}
+		/>
+	);
 };
 
 const expected = function(
@@ -58,346 +60,279 @@ const expected = function(
 ) {
 	const overrides = describedby ? { 'aria-describedby': describedby } : {};
 	let dateIndex = 0;
-	return v(
-		'div',
-		{
-			classes: css.root,
-			...overrides
-		},
-		[
-			w(DatePicker, {
-				key: 'date-picker',
-				labelId: '',
-				labels: DEFAULT_LABELS,
-				month: 5,
-				monthNames: DEFAULT_MONTHS,
-				renderMonthLabel: customMonthLabel ? noop : undefined,
-				theme: undefined,
-				classes: undefined,
-				year: 2017,
-				minDate: undefined,
-				maxDate: undefined,
-				onPopupChange: noop,
-				onRequestMonthChange: noop,
-				onRequestYearChange: noop
-			}),
-			v(
-				'table',
-				{
-					cellspacing: '0',
-					cellpadding: '0',
-					role: 'grid',
-					'aria-labelledby': '', // this._monthLabelId,
-					classes: [css.dateGrid, popupOpen ? baseCss.visuallyHidden : null]
-				},
-				[
-					v('thead', [
-						v(
-							'tr',
-							DEFAULT_WEEKDAYS.map((weekday: { short: string; long: string }) =>
-								v(
-									'th',
-									{
-										role: 'columnheader',
-										classes: css.weekday
-									},
-									[
-										weekdayLabel
-											? weekdayLabel
-											: v(
-													'abbr',
-													{ title: weekday.long, classes: css.abbr },
-													[weekday.short]
-											  )
-									]
-								)
-							)
-						)
-					]),
-					v('tbody', [
-						v('tr', [
-							expectedDateCell(dateIndex++, 28, false, false, selectedIndex),
-							expectedDateCell(dateIndex++, 29, false, false, selectedIndex),
-							expectedDateCell(dateIndex++, 30, false, false, selectedIndex),
-							expectedDateCell(dateIndex++, 31, false, false, selectedIndex),
-							expectedDateCell(dateIndex++, 1, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 2, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 3, true, false, selectedIndex)
-						]),
-						v('tr', [
-							expectedDateCell(dateIndex++, 4, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 5, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 6, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 7, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 8, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 9, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 10, true, false, selectedIndex)
-						]),
-						v('tr', [
-							expectedDateCell(dateIndex++, 11, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 12, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 13, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 14, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 15, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 16, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 17, true, false, selectedIndex)
-						]),
-						v('tr', [
-							expectedDateCell(dateIndex++, 18, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 19, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 20, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 21, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 22, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 23, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 24, true, false, selectedIndex)
-						]),
-						v('tr', [
-							expectedDateCell(dateIndex++, 25, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 26, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 27, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 28, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 29, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 30, true, false, selectedIndex),
-							expectedDateCell(dateIndex++, 1, false, false, selectedIndex)
-						]),
-						v('tr', [
-							expectedDateCell(dateIndex++, 2, false, false, selectedIndex),
-							expectedDateCell(dateIndex++, 3, false, false, selectedIndex),
-							expectedDateCell(dateIndex++, 4, false, false, selectedIndex),
-							expectedDateCell(dateIndex++, 5, false, false, selectedIndex),
-							expectedDateCell(dateIndex++, 6, false, false, selectedIndex),
-							expectedDateCell(dateIndex++, 7, false, false, selectedIndex),
-							expectedDateCell(dateIndex++, 8, false, false, selectedIndex)
-						])
-					])
-				]
-			),
-			v(
-				'div',
-				{
-					classes: [css.controls, popupOpen ? baseCss.visuallyHidden : null]
-				},
-				[
-					v(
-						'button',
-						{
-							classes: css.previous,
-							disabled: false,
-							tabIndex: popupOpen ? -1 : 0,
-							type: 'button',
-							onclick: noop
-						},
-						[
-							w(Icon, {
-								type: 'leftIcon',
-								theme: undefined,
-								classes: { '@dojo/widgets/icon': { icon: [css.icon] } }
-							}),
-							v('span', { classes: [baseCss.visuallyHidden] }, ['Previous Month'])
-						]
-					),
-					v(
-						'button',
-						{
-							classes: css.next,
-							disabled: false,
-							tabIndex: popupOpen ? -1 : 0,
-							type: 'button',
-							onclick: noop
-						},
-						[
-							w(Icon, {
-								type: 'rightIcon',
-								theme: undefined,
-								classes: { '@dojo/widgets/icon': { icon: [css.icon] } }
-							}),
-							v('span', { classes: [baseCss.visuallyHidden] }, ['Next Month'])
-						]
-					)
-				]
-			)
-		]
+	return (
+		<div classes={css.root} {...overrides}>
+			<DatePicker
+				key="date-picker"
+				labelId=""
+				labels={DEFAULT_LABELS}
+				month={5}
+				monthNames={DEFAULT_MONTHS}
+				renderMonthLabel={customMonthLabel ? noop : undefined}
+				theme={undefined}
+				classes={undefined}
+				year={2017}
+				minDate={undefined}
+				maxDate={undefined}
+				onPopupChange={noop}
+				onRequestMonthChange={noop}
+				onRequestYearChange={noop}
+			/>
+			<table
+				cellspacing="0"
+				cellpadding="0"
+				role="grid"
+				aria-labelledby=""
+				classes={[css.dateGrid, popupOpen ? baseCss.visuallyHidden : null]}
+			>
+				<thead>
+					<tr>
+						{DEFAULT_WEEKDAYS.map((weekday: { short: string; long: string }) => (
+							<th role="columnheader" classes={css.weekday}>
+								{weekdayLabel ? (
+									weekdayLabel
+								) : (
+									<abbr title={weekday.long} classes={css.abbr}>
+										{weekday.short}
+									</abbr>
+								)}
+							</th>
+						))}
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						{expectedDateCell(dateIndex++, 28, false, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 29, false, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 30, false, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 31, false, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 1, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 2, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 3, true, false, selectedIndex)}
+					</tr>
+					<tr>
+						{expectedDateCell(dateIndex++, 4, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 5, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 6, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 7, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 8, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 9, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 10, true, false, selectedIndex)}
+					</tr>
+					<tr>
+						{expectedDateCell(dateIndex++, 11, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 12, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 13, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 14, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 15, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 16, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 17, true, false, selectedIndex)}
+					</tr>
+					<tr>
+						{expectedDateCell(dateIndex++, 18, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 19, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 20, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 21, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 22, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 23, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 24, true, false, selectedIndex)}
+					</tr>
+					<tr>
+						{expectedDateCell(dateIndex++, 25, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 26, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 27, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 28, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 29, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 30, true, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 1, false, false, selectedIndex)}
+					</tr>
+					<tr>
+						{expectedDateCell(dateIndex++, 2, false, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 3, false, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 4, false, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 5, false, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 6, false, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 7, false, false, selectedIndex)}
+						{expectedDateCell(dateIndex++, 8, false, false, selectedIndex)}
+					</tr>
+				</tbody>
+			</table>
+			<div classes={[css.controls, popupOpen ? baseCss.visuallyHidden : null]}>
+				<button
+					classes={css.previous}
+					disabled={false}
+					tabIndex={popupOpen ? -1 : 0}
+					type="button"
+					onclick={noop}
+				>
+					<Icon
+						type="leftIcon"
+						theme={undefined}
+						classes={{ '@dojo/widgets/icon': { icon: [css.icon] } }}
+					/>
+					<span classes={[baseCss.visuallyHidden]}>Previous Month</span>
+				</button>
+				<button
+					classes={css.next}
+					disabled={false}
+					tabIndex={popupOpen ? -1 : 0}
+					type="button"
+					onclick={noop}
+				>
+					<Icon
+						type="rightIcon"
+						theme={undefined}
+						classes={{ '@dojo/widgets/icon': { icon: [css.icon] } }}
+					/>
+					<span classes={[baseCss.visuallyHidden]}>Next Month</span>
+				</button>
+			</div>
+		</div>
 	);
 };
 const baseTemplate = assertionTemplate(() => {
 	let dateIndex = 0;
-	return v(
-		'div',
-		{
-			classes: css.root
-		},
-		[
-			w(DatePicker, {
-				key: 'date-picker',
-				labelId: '',
-				labels: DEFAULT_LABELS,
-				month: 5,
-				monthNames: DEFAULT_MONTHS,
-				renderMonthLabel: undefined,
-				theme: undefined,
-				classes: undefined,
-				year: 2017,
-				minDate: undefined,
-				maxDate: undefined,
-				onPopupChange: noop,
-				onRequestMonthChange: noop,
-				onRequestYearChange: noop
-			}),
-			v(
-				'table',
-				{
-					cellspacing: '0',
-					cellpadding: '0',
-					role: 'grid',
-					'aria-labelledby': '', // this._monthLabelId,
-					classes: [css.dateGrid, null]
-				},
-				[
-					v('thead', [
-						v(
-							'tr',
-							DEFAULT_WEEKDAYS.map((weekday: { short: string; long: string }) =>
-								v(
-									'th',
-									{
-										role: 'columnheader',
-										classes: css.weekday
-									},
-									[
-										v('abbr', { title: weekday.long, classes: css.abbr }, [
-											weekday.short
-										])
-									]
-								)
-							)
-						)
-					]),
-					v('tbody', [
-						v('tr', [
-							expectedDateCell(dateIndex++, 28, false),
-							expectedDateCell(dateIndex++, 29, false),
-							expectedDateCell(dateIndex++, 30, false),
-							expectedDateCell(dateIndex++, 31, false),
-							expectedDateCell(dateIndex++, 1, true),
-							expectedDateCell(dateIndex++, 2, true),
-							expectedDateCell(dateIndex++, 3, true)
-						]),
-						v('tr', [
-							expectedDateCell(dateIndex++, 4, true),
-							expectedDateCell(dateIndex++, 5, true),
-							expectedDateCell(dateIndex++, 6, true),
-							expectedDateCell(dateIndex++, 7, true),
-							expectedDateCell(dateIndex++, 8, true),
-							expectedDateCell(dateIndex++, 9, true),
-							expectedDateCell(dateIndex++, 10, true)
-						]),
-						v('tr', [
-							expectedDateCell(dateIndex++, 11, true),
-							expectedDateCell(dateIndex++, 12, true),
-							expectedDateCell(dateIndex++, 13, true),
-							expectedDateCell(dateIndex++, 14, true),
-							expectedDateCell(dateIndex++, 15, true),
-							expectedDateCell(dateIndex++, 16, true),
-							expectedDateCell(dateIndex++, 17, true)
-						]),
-						v('tr', [
-							expectedDateCell(dateIndex++, 18, true),
-							expectedDateCell(dateIndex++, 19, true),
-							expectedDateCell(dateIndex++, 20, true),
-							expectedDateCell(dateIndex++, 21, true),
-							expectedDateCell(dateIndex++, 22, true),
-							expectedDateCell(dateIndex++, 23, true),
-							expectedDateCell(dateIndex++, 24, true)
-						]),
-						v('tr', [
-							expectedDateCell(dateIndex++, 25, true),
-							expectedDateCell(dateIndex++, 26, true),
-							expectedDateCell(dateIndex++, 27, true),
-							expectedDateCell(dateIndex++, 28, true),
-							expectedDateCell(dateIndex++, 29, true),
-							expectedDateCell(dateIndex++, 30, true),
-							expectedDateCell(dateIndex++, 1, false)
-						]),
-						v('tr', [
-							expectedDateCell(dateIndex++, 2, false),
-							expectedDateCell(dateIndex++, 3, false),
-							expectedDateCell(dateIndex++, 4, false),
-							expectedDateCell(dateIndex++, 5, false),
-							expectedDateCell(dateIndex++, 6, false),
-							expectedDateCell(dateIndex++, 7, false),
-							expectedDateCell(dateIndex++, 8, false)
-						])
-					])
-				]
-			),
-			v(
-				'div',
-				{
-					classes: [css.controls, null]
-				},
-				[
-					v(
-						'button',
-						{
-							'assertion-key': 'previousMonth',
-							classes: css.previous,
-							disabled: false,
-							tabIndex: 0,
-							type: 'button',
-							onclick: noop
-						},
-						[
-							w(Icon, {
-								type: 'leftIcon',
-								theme: undefined,
-								classes: { '@dojo/widgets/icon': { icon: [css.icon] } }
-							}),
-							v('span', { classes: [baseCss.visuallyHidden] }, ['Previous Month'])
-						]
-					),
-					v(
-						'button',
-						{
-							'assertion-key': 'nextMonth',
-							classes: css.next,
-							disabled: false,
-							tabIndex: 0,
-							type: 'button',
-							onclick: noop
-						},
-						[
-							w(Icon, {
-								type: 'rightIcon',
-								theme: undefined,
-								classes: { '@dojo/widgets/icon': { icon: [css.icon] } }
-							}),
-							v('span', { classes: [baseCss.visuallyHidden] }, ['Next Month'])
-						]
-					)
-				]
-			)
-		]
+	return (
+		<div classes={css.root}>
+			<DatePicker
+				key="date-picker"
+				labelId=""
+				labels={DEFAULT_LABELS}
+				month={5}
+				monthNames={DEFAULT_MONTHS}
+				renderMonthLabel={undefined}
+				theme={undefined}
+				classes={undefined}
+				year={2017}
+				minDate={undefined}
+				maxDate={undefined}
+				onPopupChange={noop}
+				onRequestMonthChange={noop}
+				onRequestYearChange={noop}
+			/>
+			<table
+				cellspacing="0"
+				cellpadding="0"
+				role="grid"
+				aria-labelledby=""
+				classes={[css.dateGrid, null]}
+			>
+				<thead>
+					<tr>
+						{DEFAULT_WEEKDAYS.map((weekday: { short: string; long: string }) => (
+							<th role="columnheader" classes={css.weekday}>
+								<abbr title={weekday.long} classes={css.abbr}>
+									weekday.short
+								</abbr>
+							</th>
+						))}
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						{expectedDateCell(dateIndex++, 28, false)}
+						{expectedDateCell(dateIndex++, 29, false)}
+						{expectedDateCell(dateIndex++, 30, false)}
+						{expectedDateCell(dateIndex++, 31, false)}
+						{expectedDateCell(dateIndex++, 1, true)}
+						{expectedDateCell(dateIndex++, 2, true)}
+						{expectedDateCell(dateIndex++, 3, true)}
+					</tr>
+					<tr>
+						{expectedDateCell(dateIndex++, 4, true)}
+						{expectedDateCell(dateIndex++, 5, true)}
+						{expectedDateCell(dateIndex++, 6, true)}
+						{expectedDateCell(dateIndex++, 7, true)}
+						{expectedDateCell(dateIndex++, 8, true)}
+						{expectedDateCell(dateIndex++, 9, true)}
+						{expectedDateCell(dateIndex++, 10, true)}
+					</tr>
+					<tr>
+						{expectedDateCell(dateIndex++, 11, true)}
+						{expectedDateCell(dateIndex++, 12, true)}
+						{expectedDateCell(dateIndex++, 13, true)}
+						{expectedDateCell(dateIndex++, 14, true)}
+						{expectedDateCell(dateIndex++, 15, true)}
+						{expectedDateCell(dateIndex++, 16, true)}
+						{expectedDateCell(dateIndex++, 17, true)}
+					</tr>
+					<tr>
+						{expectedDateCell(dateIndex++, 18, true)}
+						{expectedDateCell(dateIndex++, 19, true)}
+						{expectedDateCell(dateIndex++, 20, true)}
+						{expectedDateCell(dateIndex++, 21, true)}
+						{expectedDateCell(dateIndex++, 22, true)}
+						{expectedDateCell(dateIndex++, 23, true)}
+						{expectedDateCell(dateIndex++, 24, true)}
+					</tr>
+					<tr>
+						{expectedDateCell(dateIndex++, 25, true)}
+						{expectedDateCell(dateIndex++, 26, true)}
+						{expectedDateCell(dateIndex++, 27, true)}
+						{expectedDateCell(dateIndex++, 28, true)}
+						{expectedDateCell(dateIndex++, 29, true)}
+						{expectedDateCell(dateIndex++, 30, true)}
+						{expectedDateCell(dateIndex++, 1, false)}
+					</tr>
+					<tr>
+						{expectedDateCell(dateIndex++, 2, false)}
+						{expectedDateCell(dateIndex++, 3, false)}
+						{expectedDateCell(dateIndex++, 4, false)}
+						{expectedDateCell(dateIndex++, 5, false)}
+						{expectedDateCell(dateIndex++, 6, false)}
+						{expectedDateCell(dateIndex++, 7, false)}
+						{expectedDateCell(dateIndex++, 8, false)}
+					</tr>
+				</tbody>
+			</table>
+			<div classes={[css.controls, null]}>
+				<button
+					assertion-key="previousMonth"
+					classes={css.previous}
+					disabled={false}
+					tabIndex={0}
+					type="button"
+					onclick={noop}
+				>
+					<Icon
+						type="leftIcon"
+						theme={undefined}
+						classes={{ '@dojo/widgets/icon': { icon: [css.icon] } }}
+					/>
+					<span classes={[baseCss.visuallyHidden]}>Previous Month</span>
+				</button>
+				<button
+					assertion-key="nextMonth"
+					classes={css.next}
+					disabled={false}
+					tabIndex={0}
+					type="button"
+					onclick={noop}
+				>
+					<Icon
+						type="rightIcon"
+						theme={undefined}
+						classes={{ '@dojo/widgets/icon': { icon: [css.icon] } }}
+					/>
+					<span classes={[baseCss.visuallyHidden]}>Next Month</span>
+				</button>
+				)
+			</div>
+		</div>
 	);
 });
 
 registerSuite('Calendar', {
 	tests: {
 		'Render specific month with default props'() {
-			const h = harness(() =>
-				w(Calendar, {
-					month: testDate.getMonth(),
-					year: testDate.getFullYear()
-				})
-			);
+			const h = harness(() => (
+				<Calendar month={testDate.getMonth()} year={testDate.getFullYear()} />
+			));
 			h.expect(expected);
 		},
 
 		'Render specific month and year with selectedDate'() {
-			const h = harness(() =>
-				w(Calendar, {
-					selectedDate: testDate
-				})
-			);
+			const h = harness(() => <Calendar selectedDate={testDate} />);
 
 			h.expect(() => expected(false, 8));
 		},
@@ -414,7 +349,7 @@ registerSuite('Calendar', {
 				renderMonthLabel: (month: number, year: number) => 'Foo',
 				renderWeekdayCell: (day: { short: string; long: string }) => 'Bar'
 			};
-			const h = harness(() => w(Calendar, properties));
+			const h = harness(() => <Calendar {...properties} />);
 
 			h.expect(() => expected(false, 4, 'Bar', true, 'foo'));
 			properties = {
@@ -426,15 +361,15 @@ registerSuite('Calendar', {
 
 		'Click to select date'() {
 			let selectedDate = testDate;
-			const h = harness(() =>
-				w(Calendar, {
-					month: testDate.getMonth(),
-					year: testDate.getFullYear(),
-					onDateSelect: (date: Date) => {
+			const h = harness(() => (
+				<Calendar
+					month={testDate.getMonth()}
+					year={testDate.getFullYear()}
+					onDateSelect={(date: Date) => {
 						selectedDate = date;
-					}
-				})
-			);
+					}}
+				/>
+			));
 			h.trigger('@date-4', 'onClick', 1, false);
 
 			assert.strictEqual(selectedDate.getDate(), 1, 'Clicking cell selects correct date');
@@ -463,7 +398,7 @@ registerSuite('Calendar', {
 					selectedDate = date;
 				}
 			};
-			const h = harness(() => w(Calendar, properties));
+			const h = harness(() => <Calendar {...properties} />);
 
 			h.trigger('@date-34', 'onClick', 1, true);
 			assert.strictEqual(currentMonth, 6, 'Month changes to July');
@@ -478,15 +413,15 @@ registerSuite('Calendar', {
 
 		'Keyboard date select'() {
 			let selectedDate = testDate;
-			const h = harness(() =>
-				w(Calendar, {
-					month: testDate.getMonth(),
-					year: testDate.getFullYear(),
-					onDateSelect: (date: Date) => {
+			const h = harness(() => (
+				<Calendar
+					month={testDate.getMonth()}
+					year={testDate.getFullYear()}
+					onDateSelect={(date: Date) => {
 						selectedDate = date;
-					}
-				})
-			);
+					}}
+				/>
+			));
 
 			// right arrow, then select
 			h.trigger('@date-4', 'onKeyDown', Keys.Right, () => {});
@@ -539,15 +474,15 @@ registerSuite('Calendar', {
 
 		'Arrow keys can change month'() {
 			let currentMonth = testDate.getMonth();
-			const h = harness(() =>
-				w(Calendar, {
-					month: currentMonth,
-					year: testDate.getFullYear(),
-					onMonthChange: (month: number) => {
+			const h = harness(() => (
+				<Calendar
+					month={currentMonth}
+					year={testDate.getFullYear()}
+					onMonthChange={(month: number) => {
 						currentMonth = month;
-					}
-				})
-			);
+					}}
+				/>
+			));
 
 			h.trigger('@date-4', 'onKeyDown', Keys.Left, () => {});
 			assert.strictEqual(
@@ -578,7 +513,7 @@ registerSuite('Calendar', {
 					currentYear = year;
 				}
 			};
-			const h = harness(() => w(Calendar, properties));
+			const h = harness(() => <Calendar {...properties} />);
 
 			h.trigger('@date-0', 'onKeyDown', Keys.Up, () => {});
 
@@ -605,18 +540,18 @@ registerSuite('Calendar', {
 		'Month popup events change month and year'() {
 			let currentMonth = testDate.getMonth();
 			let currentYear = testDate.getFullYear();
-			const h = harness(() =>
-				w(Calendar, {
-					month: currentMonth,
-					year: currentYear,
-					onMonthChange: (month: number) => {
+			const h = harness(() => (
+				<Calendar
+					month={currentMonth}
+					year={currentYear}
+					onMonthChange={(month: number) => {
 						currentMonth = month;
-					},
-					onYearChange: (year: number) => {
+					}}
+					onYearChange={(year: number) => {
 						currentYear = year;
-					}
-				})
-			);
+					}}
+				/>
+			));
 
 			h.trigger('@date-picker', 'onRequestMonthChange', 2);
 			assert.strictEqual(
@@ -635,14 +570,14 @@ registerSuite('Calendar', {
 
 		'Previous button should decrement month'() {
 			let currentMonth = testDate.getMonth();
-			const h = harness(() =>
-				w(Calendar, {
-					month: currentMonth,
-					onMonthChange: (month: number) => {
+			const h = harness(() => (
+				<Calendar
+					month={currentMonth}
+					onMonthChange={(month: number) => {
 						currentMonth = month;
-					}
-				})
-			);
+					}}
+				/>
+			));
 
 			h.trigger(`.${css.previous}`, 'onclick', stubEvent);
 			assert.strictEqual(
@@ -654,14 +589,14 @@ registerSuite('Calendar', {
 
 		'Next button should increment month'() {
 			let currentMonth = testDate.getMonth();
-			const h = harness(() =>
-				w(Calendar, {
-					month: currentMonth,
-					onMonthChange: (month: number) => {
+			const h = harness(() => (
+				<Calendar
+					month={currentMonth}
+					onMonthChange={(month: number) => {
 						currentMonth = month;
-					}
-				})
-			);
+					}}
+				/>
+			));
 
 			h.trigger(`.${css.next}`, 'onclick', stubEvent);
 			assert.strictEqual(
@@ -673,7 +608,7 @@ registerSuite('Calendar', {
 
 		'onPopupChange should control visibility'() {
 			let properties: any = {};
-			const h = harness(() => w(Calendar, properties));
+			const h = harness(() => <Calendar {...properties} />);
 			h.trigger('@date-picker', 'onPopupChange', true);
 			properties = {
 				month: testDate.getMonth(),
@@ -731,98 +666,85 @@ const baseMinMaxTemplate = baseTemplate
 registerSuite('Custom first day of week', {
 	tests: {
 		'render the correct first day of week'() {
-			const h = harness(() =>
-				w(Calendar, {
-					month: testDate.getMonth(),
-					year: testDate.getFullYear(),
-					firstDayOfWeek: 2
-				})
-			);
+			const h = harness(() => (
+				<Calendar
+					month={testDate.getMonth()}
+					year={testDate.getFullYear()}
+					firstDayOfWeek={2}
+				/>
+			));
 			const firstDayOfWeekTemplate = baseTemplate
 				.replaceChildren('thead', () => {
 					let dayOrder = [2, 3, 4, 5, 6, 0, 1];
 					return [
-						v(
-							'tr',
-							dayOrder.map((order) =>
-								v(
-									'th',
-									{
-										role: 'columnheader',
-										classes: css.weekday
-									},
-									[
-										v(
-											'abbr',
-											{
-												title: DEFAULT_WEEKDAYS[order].long,
-												classes: css.abbr
-											},
-											[DEFAULT_WEEKDAYS[order].short]
-										)
-									]
-								)
-							)
-						)
+						<tr>
+							{dayOrder.map((order) => (
+								<th role="columnheader" classes={css.weekday}>
+									<abbr title={DEFAULT_WEEKDAYS[order].long} classes={css.abbr}>
+										{DEFAULT_WEEKDAYS[order].short}
+									</abbr>
+								</th>
+							))}
+						</tr>
 					];
 				})
 				.replaceChildren('tbody', () => {
 					let dateIndex = 0;
 					return [
-						v('tr', [
-							expectedDateCell(dateIndex++, 30, false),
-							expectedDateCell(dateIndex++, 31, false),
-							expectedDateCell(dateIndex++, 1, true),
-							expectedDateCell(dateIndex++, 2, true),
-							expectedDateCell(dateIndex++, 3, true),
-							expectedDateCell(dateIndex++, 4, true),
-							expectedDateCell(dateIndex++, 5, true)
-						]),
-						v('tr', [
-							expectedDateCell(dateIndex++, 6, true),
-							expectedDateCell(dateIndex++, 7, true),
-							expectedDateCell(dateIndex++, 8, true),
-							expectedDateCell(dateIndex++, 9, true),
-							expectedDateCell(dateIndex++, 10, true),
-							expectedDateCell(dateIndex++, 11, true),
-							expectedDateCell(dateIndex++, 12, true)
-						]),
-						v('tr', [
-							expectedDateCell(dateIndex++, 13, true),
-							expectedDateCell(dateIndex++, 14, true),
-							expectedDateCell(dateIndex++, 15, true),
-							expectedDateCell(dateIndex++, 16, true),
-							expectedDateCell(dateIndex++, 17, true),
-							expectedDateCell(dateIndex++, 18, true),
-							expectedDateCell(dateIndex++, 19, true)
-						]),
-						v('tr', [
-							expectedDateCell(dateIndex++, 20, true),
-							expectedDateCell(dateIndex++, 21, true),
-							expectedDateCell(dateIndex++, 22, true),
-							expectedDateCell(dateIndex++, 23, true),
-							expectedDateCell(dateIndex++, 24, true),
-							expectedDateCell(dateIndex++, 25, true),
-							expectedDateCell(dateIndex++, 26, true)
-						]),
-						v('tr', [
-							expectedDateCell(dateIndex++, 27, true),
-							expectedDateCell(dateIndex++, 28, true),
-							expectedDateCell(dateIndex++, 29, true),
-							expectedDateCell(dateIndex++, 30, true),
-							expectedDateCell(dateIndex++, 1, false),
-							expectedDateCell(dateIndex++, 2, false),
-							expectedDateCell(dateIndex++, 3, false)
-						]),
-						v('tr', [
-							expectedDateCell(dateIndex++, 4, false),
-							expectedDateCell(dateIndex++, 5, false),
-							expectedDateCell(dateIndex++, 6, false),
-							expectedDateCell(dateIndex++, 7, false),
-							expectedDateCell(dateIndex++, 8, false),
-							expectedDateCell(dateIndex++, 9, false),
-							expectedDateCell(dateIndex++, 10, false)
-						])
+						<tr>
+							{expectedDateCell(dateIndex++, 30, false)}
+							{expectedDateCell(dateIndex++, 31, false)}
+							{expectedDateCell(dateIndex++, 1, true)}
+							{expectedDateCell(dateIndex++, 2, true)}
+							{expectedDateCell(dateIndex++, 3, true)}
+							{expectedDateCell(dateIndex++, 4, true)}
+							{expectedDateCell(dateIndex++, 5, true)}
+						</tr>,
+						<tr>
+							{expectedDateCell(dateIndex++, 6, true)}
+							{expectedDateCell(dateIndex++, 7, true)}
+							{expectedDateCell(dateIndex++, 8, true)}
+							{expectedDateCell(dateIndex++, 9, true)}
+							{expectedDateCell(dateIndex++, 10, true)}
+							{expectedDateCell(dateIndex++, 11, true)}
+							{expectedDateCell(dateIndex++, 12, true)}
+						</tr>,
+						<tr>
+							{expectedDateCell(dateIndex++, 13, true)}
+							{expectedDateCell(dateIndex++, 14, true)}
+							{expectedDateCell(dateIndex++, 15, true)}
+							{expectedDateCell(dateIndex++, 16, true)}
+							{expectedDateCell(dateIndex++, 17, true)}
+							{expectedDateCell(dateIndex++, 18, true)}
+							{expectedDateCell(dateIndex++, 19, true)}
+						</tr>,
+						<tr>
+							{expectedDateCell(dateIndex++, 20, true)}
+							{expectedDateCell(dateIndex++, 21, true)}
+							{expectedDateCell(dateIndex++, 22, true)}
+							{expectedDateCell(dateIndex++, 23, true)}
+							{expectedDateCell(dateIndex++, 24, true)}
+							{expectedDateCell(dateIndex++, 25, true)}
+							{expectedDateCell(dateIndex++, 26, true)}
+						</tr>,
+						<tr>
+							{expectedDateCell(dateIndex++, 27, true)}
+							{expectedDateCell(dateIndex++, 28, true)}
+							{expectedDateCell(dateIndex++, 29, true)}
+							{expectedDateCell(dateIndex++, 30, true)}
+							{expectedDateCell(dateIndex++, 1, false)}
+							{expectedDateCell(dateIndex++, 2, false)}
+							{expectedDateCell(dateIndex++, 3, false)}
+						</tr>,
+						<tr>
+							{expectedDateCell(dateIndex++, 4, false)}
+							{expectedDateCell(dateIndex++, 5, false)}
+							{expectedDateCell(dateIndex++, 6, false)}
+							{expectedDateCell(dateIndex++, 7, false)}
+							{expectedDateCell(dateIndex++, 8, false)}
+							{expectedDateCell(dateIndex++, 9, false)}
+							{expectedDateCell(dateIndex++, 10, false)}
+						</tr>
 					];
 				});
 			h.expect(firstDayOfWeekTemplate);
@@ -844,14 +766,14 @@ registerSuite('Calendar with min-max', {
 			const minDate = new Date('May 15, 2017');
 			const maxDate = new Date('July 15, 2017');
 
-			const h = harness(() =>
-				w(Calendar, {
-					month: testDate.getMonth(),
-					year: testDate.getFullYear(),
-					minDate,
-					maxDate
-				})
-			);
+			const h = harness(() => (
+				<Calendar
+					month={testDate.getMonth()}
+					year={testDate.getFullYear()}
+					minDate={minDate}
+					maxDate={maxDate}
+				/>
+			));
 			h.expect(
 				baseTemplate
 					.setProperty('@date-picker', 'minDate', minDate)
@@ -860,13 +782,13 @@ registerSuite('Calendar with min-max', {
 		},
 
 		'Render the month and year with min and max date limitations'() {
-			const h = harness(() =>
-				w(Calendar, {
-					selectedDate: testDate,
-					minDate: minDateInMonth,
-					maxDate: maxDateInMonth
-				})
-			);
+			const h = harness(() => (
+				<Calendar
+					selectedDate={testDate}
+					minDate={minDateInMonth}
+					maxDate={maxDateInMonth}
+				/>
+			));
 
 			h.expect(baseMinMaxTemplate.setProperty('@date-8', 'selected', true));
 		},
@@ -877,13 +799,9 @@ registerSuite('Calendar with min-max', {
 			const minDate = new Date('June 3, 2017 23:59:59.999');
 			const maxDate = new Date('June 29, 2017 00:00:00.000');
 
-			const h = harness(() =>
-				w(Calendar, {
-					selectedDate: testDate,
-					minDate,
-					maxDate
-				})
-			);
+			const h = harness(() => (
+				<Calendar selectedDate={testDate} minDate={minDate} maxDate={maxDate} />
+			));
 			h.expect(
 				baseMinMaxTemplate
 					.setProperty('@date-8', 'selected', true)
@@ -900,30 +818,30 @@ registerSuite('Calendar with min-max', {
 				maxDate
 			};
 
-			const h = harness(() => w(Calendar, calendarProperties));
+			const h = harness(() => <Calendar {...calendarProperties} />);
 
 			h.trigger('@date-1', 'onKeyDown', Keys.Down, () => {});
 			h.trigger('@date-8', 'onKeyDown', Keys.Down, () => {});
 			h.trigger('@date-15', 'onKeyDown', Keys.Down, () => {});
 			h.trigger('@date-22', 'onKeyDown', Keys.Down, () => {});
 
-			h.expectPartial('@date-29', () =>
-				w(CalendarCell, {
-					key: `date-29`,
-					callFocus: true,
-					date: 29,
-					outOfRange: false,
-					disabled: false,
-					focusable: true, // 29nd is focused
-					selected: false,
-					theme: undefined,
-					classes: undefined,
-					today: false,
-					onClick: noop,
-					onFocusCalled: noop,
-					onKeyDown: noop
-				})
-			);
+			h.expectPartial('@date-29', () => (
+				<CalendarCell
+					key="date-29"
+					callFocus={true}
+					date={29}
+					outOfRange={false}
+					disabled={false}
+					focusable={true}
+					selected={false}
+					theme={undefined}
+					classes={undefined}
+					today={false}
+					onClick={noop}
+					onFocusCalled={noop}
+					onKeyDown={noop}
+				/>
+			));
 
 			// Change to next month so 29th cell is invalid
 			calendarProperties.month = testDate.getMonth();
@@ -963,13 +881,13 @@ registerSuite('Calendar with min-max', {
 		},
 
 		'Allows the selected date even if outside the min/max'() {
-			const h = harness(() =>
-				w(Calendar, {
-					selectedDate: new Date('June 1, 2017'),
-					minDate: minDateInMonth,
-					maxDate: maxDateInMonth
-				})
-			);
+			const h = harness(() => (
+				<Calendar
+					selectedDate={new Date('June 1, 2017')}
+					minDate={minDateInMonth}
+					maxDate={maxDateInMonth}
+				/>
+			));
 
 			h.expect(baseMinMaxTemplate.setProperty('@date-4', 'selected', true));
 		},
@@ -977,17 +895,17 @@ registerSuite('Calendar with min-max', {
 		'Click to select date does not click outOfRange dates'() {
 			const defaultDate = testDate.toDateString();
 			let selectedDate = testDate.toDateString();
-			const h = harness(() =>
-				w(Calendar, {
-					month: testDate.getMonth(),
-					year: testDate.getFullYear(),
-					minDate: minDateInMonth,
-					maxDate: maxDateInMonth,
-					onDateSelect: (date: Date) => {
+			const h = harness(() => (
+				<Calendar
+					month={testDate.getMonth()}
+					year={testDate.getFullYear()}
+					minDate={minDateInMonth}
+					maxDate={maxDateInMonth}
+					onDateSelect={(date: Date) => {
 						selectedDate = date.toDateString();
-					}
-				})
-			);
+					}}
+				/>
+			));
 
 			h.trigger('@date-2', 'onClick', 30, true);
 			assert.strictEqual(
@@ -1028,17 +946,17 @@ registerSuite('Calendar with min-max', {
 		'Arrow keys keep month in min/max'() {
 			let originalMonth = testDate.getMonth();
 			let currentMonth = originalMonth;
-			const h = harness(() =>
-				w(Calendar, {
-					month: currentMonth,
-					year: testDate.getFullYear(),
-					minDate: minDateInMonth,
-					maxDate: maxDateInMonth,
-					onMonthChange: (month: number) => {
+			const h = harness(() => (
+				<Calendar
+					month={currentMonth}
+					year={testDate.getFullYear()}
+					minDate={minDateInMonth}
+					maxDate={maxDateInMonth}
+					onMonthChange={(month: number) => {
 						currentMonth = month;
-					}
-				})
-			);
+					}}
+				/>
+			));
 
 			h.trigger('@date-4', 'onKeyDown', Keys.Left, () => {});
 			assert.strictEqual(

--- a/src/calendar/tests/unit/CalendarCell.spec.tsx
+++ b/src/calendar/tests/unit/CalendarCell.spec.tsx
@@ -2,7 +2,7 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/core/vdom';
+import { tsx } from '@dojo/framework/core/vdom';
 
 import CalendarCell from '../../CalendarCell';
 import * as css from '../../../theme/default/calendar.m.css';
@@ -11,115 +11,93 @@ import { noop, stubEvent } from '../../../common/tests/support/test-helpers';
 registerSuite('CalendarCell', {
 	tests: {
 		'Calendar cell with default properties'() {
-			const h = harness(() =>
-				w(CalendarCell, {
-					date: 1
-				})
-			);
+			const h = harness(() => <CalendarCell date={1} />);
 
-			h.expect(() =>
-				v(
-					'td',
-					{
-						key: 'root',
-						focus: undefined,
-						role: 'gridcell',
-						'aria-selected': 'false',
-						tabIndex: -1,
-						classes: [css.date, null, null, null, null],
-						onclick: noop,
-						onkeydown: noop
-					},
-					[v('span', {}, ['1'])]
-				)
-			);
+			h.expect(() => (
+				<td
+					key="root"
+					focus={undefined}
+					role="gridcell"
+					aria-selected="false"
+					tabIndex={-1}
+					classes={[css.date, null, null, null, null]}
+					onclick={noop}
+					onkeydown={noop}
+				>
+					<span>1</span>
+				</td>
+			));
 		},
 
 		'Calendar cell with custom properties'() {
-			const h = harness(() =>
-				w(CalendarCell, {
-					date: 2,
-					outOfRange: true,
-					focusable: true,
-					selected: true,
-					today: true
-				})
-			);
+			const h = harness(() => (
+				<CalendarCell
+					date={2}
+					outOfRange={true}
+					focusable={true}
+					selected={true}
+					today={true}
+				/>
+			));
 
-			h.expect(() =>
-				v(
-					'td',
-					{
-						key: 'root',
-						focus: undefined,
-						role: 'gridcell',
-						'aria-selected': 'true',
-						tabIndex: 0,
-						classes: [
-							css.date,
-							css.inactiveDate,
-							css.outOfRange,
-							css.selectedDate,
-							css.todayDate
-						],
-						onclick: noop,
-						onkeydown: noop
-					},
-					[v('span', {}, ['2'])]
-				)
-			);
+			h.expect(() => (
+				<td
+					key="root"
+					focus={undefined}
+					role="gridcell"
+					aria-selected="true"
+					tabIndex={0}
+					classes={[
+						css.date,
+						css.inactiveDate,
+						css.outOfRange,
+						css.selectedDate,
+						css.todayDate
+					]}
+					onclick={noop}
+					onkeydown={noop}
+				>
+					<span>2</span>
+				</td>
+			));
 		},
 
 		'Calendar cells for other months display as inactive'() {
-			const h = harness(() =>
-				w(CalendarCell, {
-					date: 30,
-					disabled: true
-				})
-			);
+			const h = harness(() => <CalendarCell date={30} disabled={true} />);
 
-			h.expect(() =>
-				v(
-					'td',
-					{
-						key: 'root',
-						focus: undefined,
-						role: 'gridcell',
-						'aria-selected': 'false',
-						tabIndex: -1,
-						classes: [css.date, css.inactiveDate, null, null, null],
-						onclick: noop,
-						onkeydown: noop
-					},
-					[v('span', {}, ['30'])]
-				)
-			);
+			h.expect(() => (
+				<td
+					key="root"
+					focus={undefined}
+					role="gridcell"
+					aria-selected="false"
+					tabIndex={-1}
+					classes={[css.date, css.inactiveDate, null, null, null]}
+					onclick={noop}
+					onkeydown={noop}
+				>
+					<span>30</span>
+				</td>
+			));
 		},
 
 		'Calendar cells for out of range dates display as inactive'() {
-			const h = harness(() =>
-				w(CalendarCell, {
-					date: 30,
-					outOfRange: true
-				})
-			);
+			const h = harness(() => <CalendarCell date={30} outOfRange={true} />);
 
-			h.expect(() =>
-				v(
-					'td',
-					{
-						key: 'root',
-						focus: undefined,
-						role: 'gridcell',
-						'aria-selected': 'false',
-						tabIndex: -1,
-						classes: [css.date, css.inactiveDate, css.outOfRange, null, null],
-						onclick: noop,
-						onkeydown: noop
-					},
-					[v('span', {}, ['30'])]
-				)
-			);
+			h.expect(() => (
+				<td
+					key="root"
+					focus={undefined}
+					role="gridcell"
+					aria-selected="false"
+					tabIndex={-1}
+					classes={[css.date, css.inactiveDate, css.outOfRange, null, null]}
+					onclick={noop}
+					onkeydown={noop}
+				>
+					<span>30</span>
+				</td>
+			));
 		},
 
 		'Click handler called with correct arguments'() {
@@ -127,16 +105,16 @@ registerSuite('CalendarCell', {
 			let clickedCurrentMonth = false;
 			let date = 1;
 			let disabled = true;
-			const h = harness(() =>
-				w(CalendarCell, {
-					date,
-					disabled,
-					onClick: (callbackDate: number, callbackCurrentMonth: boolean) => {
+			const h = harness(() => (
+				<CalendarCell
+					date={date}
+					disabled={disabled}
+					onClick={(callbackDate: number, callbackCurrentMonth: boolean) => {
 						clickedDate = callbackDate;
 						clickedCurrentMonth = callbackCurrentMonth;
-					}
-				})
-			);
+					}}
+				/>
+			));
 
 			h.trigger('td', 'onclick', stubEvent);
 			assert.strictEqual(clickedDate, 1);
@@ -151,68 +129,64 @@ registerSuite('CalendarCell', {
 
 		'Keydown handler called'() {
 			let called = false;
-			const h = harness(() =>
-				w(CalendarCell, {
-					date: 1,
-					onKeyDown: () => {
+			const h = harness(() => (
+				<CalendarCell
+					date={1}
+					onKeyDown={() => {
 						called = true;
-					}
-				})
-			);
+					}}
+				/>
+			));
 			h.trigger('td', 'onkeydown', stubEvent);
 			assert.isTrue(called);
 		},
 
 		'Focus is set with callback'() {
-			let callFocus = true;
+			let callFocus = false;
 			let date = 1;
-			const h = harness(() =>
-				w(CalendarCell, {
-					callFocus,
-					date,
-					onFocusCalled: () => {
+			const h = harness(() => (
+				<CalendarCell
+					callFocus={callFocus}
+					date={date}
+					onFocusCalled={() => {
 						callFocus = false;
-					}
-				})
-			);
+					}}
+				/>
+			));
 
-			h.expect(() =>
-				v(
-					'td',
-					{
-						key: 'root',
-						focus: false,
-						role: 'gridcell',
-						'aria-selected': 'false',
-						tabIndex: -1,
-						classes: [css.date, null, null, null, null],
-						onclick: noop,
-						onkeydown: noop
-					},
-					[v('span', {}, ['1'])]
-				)
-			);
+			h.expect(() => (
+				<td
+					key="root"
+					focus={false}
+					role="gridcell"
+					aria-selected="false"
+					tabIndex={-1}
+					classes={[css.date, null, null, null, null]}
+					onclick={noop}
+					onkeydown={noop}
+				>
+					<span>1</span>
+				</td>
+			));
 
 			assert.isFalse(callFocus, 'Focus callback should set callFocus to false');
 
 			callFocus = true;
 			date = 2;
-			h.expect(() =>
-				v(
-					'td',
-					{
-						key: 'root',
-						focus: true,
-						role: 'gridcell',
-						'aria-selected': 'false',
-						tabIndex: -1,
-						classes: [css.date, null, null, null, null],
-						onclick: noop,
-						onkeydown: noop
-					},
-					[v('span', {}, ['2'])]
-				)
-			);
+			h.expect(() => (
+				<td
+					key="root"
+					focus={true}
+					role="gridcell"
+					aria-selected="false"
+					tabIndex={-1}
+					classes={[css.date, null, null, null, null]}
+					onclick={noop}
+					onkeydown={noop}
+				>
+					<span>2</span>
+				</td>
+			));
 
 			assert.isFalse(callFocus, 'Focus callback should set callFocus to false');
 		}

--- a/src/calendar/tests/unit/DatePicker.spec.tsx
+++ b/src/calendar/tests/unit/DatePicker.spec.tsx
@@ -2,7 +2,7 @@ const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/core/vdom';
+import { tsx } from '@dojo/framework/core/vdom';
 import { Keys } from '../../../common/util';
 
 import { DEFAULT_LABELS, DEFAULT_MONTHS } from '../support/defaults';
@@ -44,40 +44,31 @@ const compareName = {
 };
 
 const monthRadios = function(open?: boolean) {
-	return DEFAULT_MONTHS.map((monthName, i) =>
-		v(
-			'label',
-			{
-				key: '',
-				classes: [css.monthRadio, i === 5 ? css.monthRadioChecked : null],
-				for: '',
-				onmouseup: noop
-			},
-			[
-				v('input', {
-					checked: i === 5,
-					classes: css.monthRadioInput,
-					id: '',
-					key: '',
-					name: '',
-					tabIndex: open ? 0 : -1,
-					focus: open && i === 5 ? noop : undefined,
-					type: 'radio',
-					disabled: false,
-					value: `${i}`,
-					onchange: noop
-				}),
-				v(
-					'abbr',
-					{
-						classes: css.monthRadioLabel,
-						title: monthName.long
-					},
-					[monthName.short]
-				)
-			]
-		)
-	);
+	return DEFAULT_MONTHS.map((monthName, i) => (
+		<label
+			key=""
+			classes={[css.monthRadio, i === 5 ? css.monthRadioChecked : null]}
+			for=""
+			onmouseup={noop}
+		>
+			<input
+				checked={i === 5}
+				classes={css.monthRadioInput}
+				id=""
+				key=""
+				name=""
+				tabIndex={open ? 0 : -1}
+				focus={open && i === 5 ? noop : undefined}
+				type="radio"
+				disabled={false}
+				value={`${i}`}
+				onchange={noop}
+			/>
+			<abbr classes={css.monthRadioLabel} title={monthName.long}>
+				{monthName.short}
+			</abbr>
+		</label>
+	));
 };
 
 const yearRadios = function(
@@ -91,72 +82,47 @@ const yearRadios = function(
 	const radios = [];
 	for (let i = yearStart; i < yearEnd; i++) {
 		radios.push(
-			v(
-				'label',
-				{
-					key: '',
-					classes: [css.yearRadio, i === checkedYear ? css.yearRadioChecked : null],
-					for: '',
-					onmouseup: noop
-				},
-				[
-					v('input', {
-						checked: i === checkedYear,
-						classes: css.yearRadioInput,
-						id: '',
-						tabIndex: open ? 0 : -1,
-						focus: open && i === checkedYear ? noop : undefined,
-						type: 'radio',
-						key: '',
-						name: '',
-						disabled: i < minYear || i > maxYear,
-						value: `${i}`,
-						onchange: noop
-					}),
-					v(
-						'abbr',
-						{
-							classes: css.yearRadioLabel
-						},
-						[`${i}`]
-					)
-				]
-			)
+			<label
+				key=""
+				classes={[css.yearRadio, i === checkedYear ? css.yearRadioChecked : null]}
+				for=""
+				onmouseup={noop}
+			>
+				<input
+					checked={i === checkedYear}
+					classes={css.yearRadioInput}
+					id=""
+					tabIndex={open ? 0 : -1}
+					focus={open && i === checkedYear ? noop : undefined}
+					type="radio"
+					key=""
+					name=""
+					disabled={i < minYear || i > maxYear}
+					value={`${i}`}
+					onchange={noop}
+				/>
+				<abbr classes={css.yearRadioLabel}>{`${i}`}</abbr>
+			</label>
 		);
 	}
 	return radios;
 };
 
 const expectedMonthPopup = function(open: boolean) {
-	return v(
-		'div',
-		{
-			id: '',
-			key: 'month-grid',
-			'aria-hidden': `${!open}`,
-			'aria-labelledby': '',
-			classes: [css.monthGrid, !open ? baseCss.visuallyHidden : null],
-			role: 'dialog'
-		},
-		[
-			v(
-				'fieldset',
-				{
-					classes: css.monthFields,
-					onkeydown: noop
-				},
-				[
-					v(
-						'legend',
-						{
-							classes: baseCss.visuallyHidden
-						},
-						[DEFAULT_LABELS.chooseMonth]
-					),
-					...monthRadios(open)
-				]
-			)
-		]
+	return (
+		<div
+			id=""
+			key="month-grid"
+			aria-hidden={`${!open}`}
+			aria-labelledby=""
+			classes={[css.monthGrid, !open ? baseCss.visuallyHidden : null]}
+			role="dialog"
+		>
+			<fieldset classes={css.monthFields} onkeydown={noop}>
+				<legend classes={baseCss.visuallyHidden}>{DEFAULT_LABELS.chooseMonth}</legend>
+				{...monthRadios(open)}
+			</fieldset>
+		</div>
 	);
 };
 
@@ -167,69 +133,42 @@ const expectedYearPopup = function(
 	minYear?: number,
 	maxYear?: number
 ) {
-	return v(
-		'div',
-		{
-			key: 'year-grid',
-			'aria-hidden': `${!open}`,
-			'aria-labelledby': '',
-			classes: [css.yearGrid, !open ? baseCss.visuallyHidden : null],
-			id: '',
-			role: 'dialog'
-		},
-		[
-			v(
-				'fieldset',
-				{
-					classes: css.yearFields,
-					onkeydown: noop
-				},
-				[
-					v('legend', { classes: [baseCss.visuallyHidden] }, [DEFAULT_LABELS.chooseYear]),
-					...yearRadios(open, yearStart, yearEnd, undefined, minYear, maxYear)
-				]
-			),
-			v(
-				'div',
-				{
-					classes: css.controls
-				},
-				[
-					v(
-						'button',
-						{
-							classes: css.previous,
-							tabIndex: open ? 0 : -1,
-							type: 'button',
-							disabled: false,
-							onclick: noop
-						},
-						[
-							w(Icon, { type: 'leftIcon', theme: undefined, classes: undefined }),
-							v('span', { classes: baseCss.visuallyHidden }, [
-								DEFAULT_LABELS.previousYears
-							])
-						]
-					),
-					v(
-						'button',
-						{
-							classes: css.next,
-							tabIndex: open ? 0 : -1,
-							type: 'button',
-							disabled: false,
-							onclick: noop
-						},
-						[
-							w(Icon, { type: 'rightIcon', theme: undefined, classes: undefined }),
-							v('span', { classes: baseCss.visuallyHidden }, [
-								DEFAULT_LABELS.nextYears
-							])
-						]
-					)
-				]
-			)
-		]
+	return (
+		<div
+			key="year-grid"
+			aria-hidden={`${!open}`}
+			aria-labelledby=""
+			classes={[css.yearGrid, !open ? baseCss.visuallyHidden : null]}
+			id=""
+			role="dialog"
+		>
+			<fieldset classes={css.yearFields} onkeydown={noop}>
+				<legend classes={[baseCss.visuallyHidden]}>{DEFAULT_LABELS.chooseYear}</legend>
+				{...yearRadios(open, yearStart, yearEnd, undefined, minYear, maxYear)}
+			</fieldset>
+			<div classes={css.controls}>
+				<button
+					classes={css.previous}
+					tabIndex={open ? 0 : -1}
+					type="button"
+					disabled={false}
+					onclick={noop}
+				>
+					<Icon type="leftIcon" theme={undefined} classes={undefined} />
+					<span classes={baseCss.visuallyHidden}>{DEFAULT_LABELS.previousYears}</span>
+				</button>
+				<button
+					classes={css.next}
+					tabIndex={open ? 0 : -1}
+					type="button"
+					disabled={false}
+					onclick={noop}
+				>
+					<Icon type="rightIcon" theme={undefined} classes={undefined} />
+					<span classes={baseCss.visuallyHidden}>{DEFAULT_LABELS.nextYears}</span>
+				</button>
+			</div>
+		</div>
 	);
 };
 interface ExpectedOptions {
@@ -252,102 +191,73 @@ const expected = function(monthOpen = false, yearOpen = false, options: Expected
 		monthTriggerFocus,
 		yearTriggerFocus
 	} = options;
-	// new
-	return v(
-		'div',
-		{
-			classes: css.datePicker
-		},
-		[
-			v(
-				'div',
-				{
-					classes: css.topMatter,
-					role: 'menubar'
-				},
-				[
-					// hidden label
-					v(
-						'label',
-						{
-							id: customProps.labelId ? customProps.labelId : '',
-							classes: [baseCss.visuallyHidden],
-							'aria-live': 'polite',
-							'aria-atomic': 'false'
-						},
-						[monthLabel]
-					),
+	return (
+		<div classes={css.datePicker}>
+			<div classes={css.topMatter} role="menubar">
+				<label
+					id={customProps.labelId ? customProps.labelId : ''}
+					classes={[baseCss.visuallyHidden]}
+					aria-live="polite"
+					aria-atomic="false"
+				>
+					{monthLabel}
+				</label>
 
-					// month trigger
-					v(
-						'button',
-						{
-							key: 'month-button',
-							'aria-controls': '',
-							'aria-expanded': `${monthOpen}`,
-							'aria-haspopup': 'true',
-							focus: monthTriggerFocus,
-							id: '',
-							classes: [css.monthTrigger, monthOpen ? css.monthTriggerActive : null],
-							role: 'menuitem',
-							type: 'button',
-							onclick: noop
-						},
-						['June']
-					),
+				<button
+					key="month-button"
+					aria-controls=""
+					aria-expanded={`${monthOpen}`}
+					aria-haspopup="true"
+					focus={monthTriggerFocus}
+					id=""
+					classes={[css.monthTrigger, monthOpen ? css.monthTriggerActive : null]}
+					role="menuitem"
+					type="button"
+					onclick={noop}
+				>
+					June
+				</button>
 
-					// year trigger
-					v(
-						'button',
-						{
-							key: 'year-button',
-							'aria-controls': '',
-							'aria-expanded': `${yearOpen}`,
-							'aria-haspopup': 'true',
-							focus: yearTriggerFocus,
-							id: '',
-							classes: [css.yearTrigger, yearOpen ? css.yearTriggerActive : null],
-							role: 'menuitem',
-							type: 'button',
-							onclick: noop
-						},
-						['2017']
-					)
-				]
-			),
+				<button
+					key="year-button"
+					aria-controls=""
+					aria-expanded={`${yearOpen}`}
+					aria-haspopup="true"
+					focus={yearTriggerFocus}
+					id=""
+					classes={[css.yearTrigger, yearOpen ? css.yearTriggerActive : null]}
+					role="menuitem"
+					type="button"
+					onclick={noop}
+				>
+					2017
+				</button>
+			</div>
 
-			// month picker
-			expectedMonthPopup(monthOpen),
+			{expectedMonthPopup(monthOpen)}
 
-			// year picker
-			expectedYearPopup(
+			{expectedYearPopup(
 				yearOpen,
 				yearStart,
 				yearEnd,
 				minDate && minDate.getFullYear(),
 				maxDate && maxDate.getFullYear()
-			)
-		]
+			)}
+		</div>
 	);
 };
 
 registerSuite('Calendar DatePicker', {
 	tests: {
 		'Popup should render with default properties'() {
-			const h = harness(
-				() =>
-					w(DatePicker, {
-						...requiredProps
-					}),
-				[
-					compareId,
-					compareAriaLabelledBy,
-					compareAriaControls,
-					compareKey,
-					compareFor,
-					compareName
-				]
-			);
+			const h = harness(() => <DatePicker {...requiredProps} />, [
+				compareId,
+				compareAriaLabelledBy,
+				compareAriaControls,
+				compareKey,
+				compareFor,
+				compareName
+			]);
 
 			h.expect(() => expected());
 		},
@@ -361,14 +271,15 @@ registerSuite('Calendar DatePicker', {
 			};
 
 			const h = harness(
-				() =>
-					w(DatePicker, {
-						renderMonthLabel: () => {
+				() => (
+					<DatePicker
+						renderMonthLabel={() => {
 							return 'bar';
-						},
-						...customProps,
-						...requiredProps
-					}),
+						}}
+						{...customProps}
+						{...requiredProps}
+					/>
+				),
 				[
 					compareId,
 					compareAriaLabelledBy,
@@ -394,7 +305,7 @@ registerSuite('Calendar DatePicker', {
 			let properties = {
 				...requiredProps
 			};
-			const h = harness(() => w(DatePicker, properties), [
+			const h = harness(() => <DatePicker {...properties} />, [
 				compareKey,
 				compareFor,
 				compareName,
@@ -409,224 +320,145 @@ registerSuite('Calendar DatePicker', {
 				year: 1997
 			};
 
-			h.expect(() =>
-				v(
-					'div',
-					{
-						classes: css.datePicker
-					},
-					[
-						v(
-							'div',
-							{
-								classes: css.topMatter,
-								role: 'menubar'
-							},
-							[
-								// hidden label
-								v(
-									'label',
-									{
-										id: '',
-										classes: [baseCss.visuallyHidden],
-										'aria-live': 'polite',
-										'aria-atomic': 'false'
-									},
-									['June 1997']
-								),
+			h.expect(() => (
+				<div classes={css.datePicker}>
+					<div classes={css.topMatter} role="menubar">
+						<label
+							id=""
+							classes={[baseCss.visuallyHidden]}
+							aria-live="polite"
+							aria-atomic="false"
+						>
+							June 1997
+						</label>
 
-								// month trigger
-								v(
-									'button',
-									{
-										key: 'month-button',
-										'aria-controls': '',
-										'aria-expanded': 'false',
-										'aria-haspopup': 'true',
-										focus: undefined,
-										id: '',
-										classes: [css.monthTrigger, null],
-										role: 'menuitem',
-										type: 'button',
-										onclick: noop
-									},
-									['June']
-								),
+						<button
+							key="month-button"
+							aria-controls=""
+							aria-expanded="false"
+							aria-haspopup="true"
+							focus={undefined}
+							id=""
+							classes={[css.monthTrigger, null]}
+							role="menuitem"
+							type="button"
+							onclick={noop}
+						>
+							June
+						</button>
 
-								// year trigger
-								v(
-									'button',
-									{
-										key: 'year-button',
-										'aria-controls': '',
-										'aria-expanded': 'false',
-										'aria-haspopup': 'true',
-										focus: undefined,
-										id: '',
-										classes: [css.yearTrigger, null],
-										role: 'menuitem',
-										type: 'button',
-										onclick: noop
-									},
-									['1997']
-								)
-							]
-						),
-						v(
-							'div',
-							{
-								id: '',
-								key: 'month-grid',
-								'aria-hidden': 'true',
-								'aria-labelledby': '',
-								classes: [css.monthGrid, baseCss.visuallyHidden],
-								role: 'dialog'
-							},
-							[
-								v(
-									'fieldset',
-									{
-										classes: css.monthFields,
-										onkeydown: noop
-									},
-									[
-										v(
-											'legend',
-											{
-												classes: baseCss.visuallyHidden
-											},
-											[DEFAULT_LABELS.chooseMonth]
-										),
-										...DEFAULT_MONTHS.map((monthName, i) =>
-											v(
-												'label',
-												{
-													for: '',
-													key: '',
-													classes: [
-														css.monthRadio,
-														i === 5 ? css.monthRadioChecked : null
-													],
-													onmouseup: noop
-												},
-												[
-													v('input', {
-														checked: i === 5,
-														classes: css.monthRadioInput,
-														disabled: false,
-														focus: undefined,
-														id: '',
-														key: '',
-														name: '',
-														tabIndex: -1,
-														type: 'radio',
-														value: `${i}`,
-														onchange: noop
-													}),
-													v(
-														'abbr',
-														{
-															classes: css.monthRadioLabel,
-															title: monthName.long
-														},
-														[monthName.short]
-													)
-												]
-											)
-										)
-									]
-								)
-							]
-						),
-						v(
-							'div',
-							{
-								key: 'year-grid',
-								'aria-hidden': 'true',
-								'aria-labelledby': '',
-								classes: [css.yearGrid, baseCss.visuallyHidden],
-								id: '',
-								role: 'dialog'
-							},
-							[
-								v(
-									'fieldset',
-									{
-										classes: css.yearFields,
-										onkeydown: noop
-									},
-									[
-										v('legend', { classes: [baseCss.visuallyHidden] }, [
-											DEFAULT_LABELS.chooseYear
-										]),
-										...yearRadios(false, 1980, 2000, 1997)
-									]
-								),
-								v(
-									'div',
-									{
-										classes: css.controls
-									},
-									[
-										v(
-											'button',
-											{
-												classes: css.previous,
-												disabled: false,
-												tabIndex: -1,
-												type: 'button',
-												onclick: noop
-											},
-											[
-												w(Icon, {
-													type: 'leftIcon',
-													theme: undefined,
-													classes: undefined
-												}),
-												v('span', { classes: baseCss.visuallyHidden }, [
-													DEFAULT_LABELS.previousYears
-												])
-											]
-										),
-										v(
-											'button',
-											{
-												classes: css.next,
-												disabled: false,
-												tabIndex: -1,
-												type: 'button',
-												onclick: noop
-											},
-											[
-												w(Icon, {
-													type: 'rightIcon',
-													theme: undefined,
-													classes: undefined
-												}),
-												v('span', { classes: baseCss.visuallyHidden }, [
-													DEFAULT_LABELS.nextYears
-												])
-											]
-										)
-									]
-								)
-							]
-						)
-					]
-				)
-			);
+						<button
+							key="year-button"
+							aria-controls=""
+							aria-expanded="false"
+							aria-haspopup="true"
+							focus={undefined}
+							id=""
+							classes={[css.yearTrigger, null]}
+							role="menuitem"
+							type="button"
+							onclick={noop}
+						>
+							1997
+						</button>
+					</div>
+					<div
+						id=""
+						key="month-grid"
+						aria-hidden="true"
+						aria-labelledby=""
+						classes={[css.monthGrid, baseCss.visuallyHidden]}
+						role="dialog"
+					>
+						<fieldset classes={css.monthFields} onkeydown={noop}>
+							<legend classes={baseCss.visuallyHidden}>
+								{DEFAULT_LABELS.chooseMonth}
+							</legend>
+							{...DEFAULT_MONTHS.map((monthName, i) => (
+								<label
+									for=""
+									key=""
+									classes={[
+										css.monthRadio,
+										i === 5 ? css.monthRadioChecked : null
+									]}
+									onmouseup={noop}
+								>
+									<input
+										checked={i === 5}
+										classes={css.monthRadioInput}
+										disabled={false}
+										focus={undefined}
+										id=""
+										key=""
+										name=""
+										tabIndex={-1}
+										type="radio"
+										value={`${i}`}
+										onchange={noop}
+									/>
+									<abbr classes={css.monthRadioLabel} title={monthName.long}>
+										{monthName.short}
+									</abbr>
+								</label>
+							))}
+						</fieldset>
+					</div>
+					<div
+						key="year-grid"
+						aria-hidden="true"
+						aria-labelledby=""
+						classes={[css.yearGrid, baseCss.visuallyHidden]}
+						id=""
+						role="dialog"
+					>
+						<fieldset classes={css.yearFields} onkeydown={noop}>
+							<legend classes={[baseCss.visuallyHidden]}>
+								{DEFAULT_LABELS.chooseYear}
+							</legend>
+							{...yearRadios(false, 1980, 2000, 1997)}
+						</fieldset>
+						<div classes={css.controls}>
+							<button
+								classes={css.previous}
+								disabled={false}
+								tabIndex={-1}
+								type="button"
+								onclick={noop}
+							>
+								<Icon type="leftIcon" theme={undefined} classes={undefined} />
+								<span classes={baseCss.visuallyHidden}>
+									{DEFAULT_LABELS.previousYears}
+								</span>
+							</button>
+							<button
+								classes={css.next}
+								disabled={false}
+								tabIndex={-1}
+								type="button"
+								onclick={noop}
+							>
+								<Icon type="rightIcon" theme={undefined} classes={undefined} />
+								<span classes={baseCss.visuallyHidden}>
+									{DEFAULT_LABELS.nextYears}
+								</span>
+							</button>
+						</div>
+					</div>
+				</div>
+			));
 		},
 
 		'Month popup opens and closes on button click'() {
 			let isOpen;
-			const h = harness(() =>
-				w(DatePicker, {
-					onPopupChange: (open: boolean) => {
+			const h = harness(() => (
+				<DatePicker
+					onPopupChange={(open: boolean) => {
 						isOpen = open;
-					},
-					...requiredProps
-				})
-			);
+					}}
+					{...requiredProps}
+				/>
+			));
 
 			h.trigger('@month-button', 'onclick', stubEvent);
 			assert.isTrue(isOpen, 'First click should open popup');
@@ -636,14 +468,14 @@ registerSuite('Calendar DatePicker', {
 
 		'Year popup opens and closes on button click'() {
 			let isOpen;
-			const h = harness(() =>
-				w(DatePicker, {
-					onPopupChange: (open: boolean) => {
+			const h = harness(() => (
+				<DatePicker
+					onPopupChange={(open: boolean) => {
 						isOpen = open;
-					},
-					...requiredProps
-				})
-			);
+					}}
+					{...requiredProps}
+				/>
+			));
 
 			h.trigger('@year-button', 'onclick', stubEvent);
 			assert.isTrue(isOpen, 'First click should open popup');
@@ -655,13 +487,14 @@ registerSuite('Calendar DatePicker', {
 		'Popup switches between month and year'() {
 			let isOpen;
 			const h = harness(
-				() =>
-					w(DatePicker, {
-						onPopupChange: (open: boolean) => {
+				() => (
+					<DatePicker
+						onPopupChange={(open: boolean) => {
 							isOpen = open;
-						},
-						...requiredProps
-					}),
+						}}
+						{...requiredProps}
+					/>
+				),
 				[
 					compareId,
 					compareAriaLabelledBy,
@@ -685,13 +518,14 @@ registerSuite('Calendar DatePicker', {
 		'Month popup closes with correct keys'() {
 			let isOpen = true;
 			const h = harness(
-				() =>
-					w(DatePicker, {
-						onPopupChange: (open: boolean) => {
+				() => (
+					<DatePicker
+						onPopupChange={(open: boolean) => {
 							isOpen = open;
-						},
-						...requiredProps
-					}),
+						}}
+						{...requiredProps}
+					/>
+				),
 				[
 					compareId,
 					compareAriaLabelledBy,
@@ -748,13 +582,14 @@ registerSuite('Calendar DatePicker', {
 		'year popup closes with correct keys'() {
 			let isOpen = true;
 			const h = harness(
-				() =>
-					w(DatePicker, {
-						onPopupChange: (open: boolean) => {
+				() => (
+					<DatePicker
+						onPopupChange={(open: boolean) => {
 							isOpen = open;
-						},
-						...requiredProps
-					}),
+						}}
+						{...requiredProps}
+					/>
+				),
 				[
 					compareId,
 					compareAriaLabelledBy,
@@ -809,20 +644,14 @@ registerSuite('Calendar DatePicker', {
 		},
 
 		'Clicking buttons changes year page'() {
-			const h = harness(
-				() =>
-					w(DatePicker, {
-						...requiredProps
-					}),
-				[
-					compareId,
-					compareAriaLabelledBy,
-					compareAriaControls,
-					compareKey,
-					compareFor,
-					compareName
-				]
-			);
+			const h = harness(() => <DatePicker {...requiredProps} />, [
+				compareId,
+				compareAriaLabelledBy,
+				compareAriaControls,
+				compareKey,
+				compareFor,
+				compareName
+			]);
 			h.trigger('@year-button', 'onclick', stubEvent);
 			h.expect(() => expected(false, true));
 
@@ -837,16 +666,17 @@ registerSuite('Calendar DatePicker', {
 			let currentMonth = testDate.getMonth();
 			let isOpen = false;
 			const h = harness(
-				() =>
-					w(DatePicker, {
-						...requiredProps,
-						onPopupChange: (open: boolean) => {
+				() => (
+					<DatePicker
+						{...requiredProps}
+						onPopupChange={(open: boolean) => {
 							isOpen = open;
-						},
-						onRequestMonthChange: (month: number) => {
+						}}
+						onRequestMonthChange={(month: number) => {
 							currentMonth = month;
-						}
-					}),
+						}}
+					/>
+				),
 				[
 					compareId,
 					compareAriaLabelledBy,
@@ -874,16 +704,17 @@ registerSuite('Calendar DatePicker', {
 			let currentYear = testDate.getMonth();
 			let isOpen = false;
 			const h = harness(
-				() =>
-					w(DatePicker, {
-						...requiredProps,
-						onPopupChange: (open: boolean) => {
+				() => (
+					<DatePicker
+						{...requiredProps}
+						onPopupChange={(open: boolean) => {
 							isOpen = open;
-						},
-						onRequestYearChange: (year: number) => {
+						}}
+						onRequestYearChange={(year: number) => {
 							currentYear = year;
-						}
-					}),
+						}}
+					/>
+				),
 				[
 					compareId,
 					compareAriaLabelledBy,
@@ -916,21 +747,22 @@ registerSuite('Calendar DatePicker', {
 			let currentYear = testDate.getFullYear();
 			let isOpen = false;
 			const h = harness(
-				() =>
-					w(DatePicker, {
-						minDate: new Date('Nov 20, 2016'),
-						maxDate: new Date('Feb 2, 2018'),
-						...requiredProps,
-						onPopupChange: (open: boolean) => {
+				() => (
+					<DatePicker
+						minDate={new Date('Nov 20, 2016')}
+						maxDate={new Date('Feb 2, 2018')}
+						{...requiredProps}
+						onPopupChange={(open: boolean) => {
 							isOpen = open;
-						},
-						onRequestMonthChange: (month: number) => {
+						}}
+						onRequestMonthChange={(month: number) => {
 							currentMonth = month;
-						},
-						onRequestYearChange: (year: number) => {
+						}}
+						onRequestYearChange={(year: number) => {
 							currentYear = year;
-						}
-					}),
+						}}
+					/>
+				),
 				[
 					compareId,
 					compareAriaLabelledBy,

--- a/src/calendar/tests/unit/DatePicker.spec.tsx
+++ b/src/calendar/tests/unit/DatePicker.spec.tsx
@@ -841,7 +841,6 @@ registerSuite('Calendar DatePicker', {
 					w(DatePicker, {
 						...requiredProps,
 						onPopupChange: (open: boolean) => {
-							console.log('XXX onPopupChange', open);
 							isOpen = open;
 						},
 						onRequestMonthChange: (month: number) => {

--- a/src/calendar/tests/unit/DatePicker.spec.tsx
+++ b/src/calendar/tests/unit/DatePicker.spec.tsx
@@ -61,6 +61,7 @@ const monthRadios = function(open?: boolean) {
 					key: '',
 					name: '',
 					tabIndex: open ? 0 : -1,
+					focus: open && i === 5 ? noop : undefined,
 					type: 'radio',
 					disabled: false,
 					value: `${i}`,
@@ -104,6 +105,7 @@ const yearRadios = function(
 						classes: css.yearRadioInput,
 						id: '',
 						tabIndex: open ? 0 : -1,
+						focus: open && i === checkedYear ? noop : undefined,
 						type: 'radio',
 						key: '',
 						name: '',
@@ -236,10 +238,20 @@ interface ExpectedOptions {
 	monthLabel?: string;
 	minDate?: Date;
 	maxDate?: Date;
+	monthTriggerFocus?: () => any;
+	yearTriggerFocus?: () => any;
 }
 
 const expected = function(monthOpen = false, yearOpen = false, options: ExpectedOptions = {}) {
-	const { yearStart, yearEnd, monthLabel = 'June 2017', minDate, maxDate } = options;
+	const {
+		yearStart,
+		yearEnd,
+		monthLabel = 'June 2017',
+		minDate,
+		maxDate,
+		monthTriggerFocus,
+		yearTriggerFocus
+	} = options;
 	// new
 	return v(
 		'div',
@@ -274,6 +286,7 @@ const expected = function(monthOpen = false, yearOpen = false, options: Expected
 							'aria-controls': '',
 							'aria-expanded': `${monthOpen}`,
 							'aria-haspopup': 'true',
+							focus: monthTriggerFocus,
 							id: '',
 							classes: [css.monthTrigger, monthOpen ? css.monthTriggerActive : null],
 							role: 'menuitem',
@@ -291,6 +304,7 @@ const expected = function(monthOpen = false, yearOpen = false, options: Expected
 							'aria-controls': '',
 							'aria-expanded': `${yearOpen}`,
 							'aria-haspopup': 'true',
+							focus: yearTriggerFocus,
 							id: '',
 							classes: [css.yearTrigger, yearOpen ? css.yearTriggerActive : null],
 							role: 'menuitem',
@@ -429,6 +443,7 @@ registerSuite('Calendar DatePicker', {
 										'aria-controls': '',
 										'aria-expanded': 'false',
 										'aria-haspopup': 'true',
+										focus: undefined,
 										id: '',
 										classes: [css.monthTrigger, null],
 										role: 'menuitem',
@@ -446,6 +461,7 @@ registerSuite('Calendar DatePicker', {
 										'aria-controls': '',
 										'aria-expanded': 'false',
 										'aria-haspopup': 'true',
+										focus: undefined,
 										id: '',
 										classes: [css.yearTrigger, null],
 										role: 'menuitem',
@@ -498,6 +514,7 @@ registerSuite('Calendar DatePicker', {
 														checked: i === 5,
 														classes: css.monthRadioInput,
 														disabled: false,
+														focus: undefined,
 														id: '',
 														key: '',
 														name: '',
@@ -694,7 +711,7 @@ registerSuite('Calendar DatePicker', {
 				which: Keys.Escape,
 				...stubEvent
 			});
-			h.expect(() => expected(false, false));
+			h.expect(() => expected(false, false, { monthTriggerFocus: noop }));
 			assert.isFalse(isOpen, 'Should close on escape key press');
 
 			// enter key
@@ -704,7 +721,7 @@ registerSuite('Calendar DatePicker', {
 				which: Keys.Enter,
 				...stubEvent
 			});
-			h.expect(() => expected(false, false));
+			h.expect(() => expected(false, false, { monthTriggerFocus: noop }));
 			assert.isFalse(isOpen, 'Should close on enter key press');
 
 			// space key
@@ -714,7 +731,7 @@ registerSuite('Calendar DatePicker', {
 				which: Keys.Space,
 				...stubEvent
 			});
-			h.expect(() => expected(false, false));
+			h.expect(() => expected(false, false, { monthTriggerFocus: noop }));
 			assert.isFalse(isOpen, 'Should close on space key press');
 
 			// random key
@@ -757,7 +774,7 @@ registerSuite('Calendar DatePicker', {
 				which: Keys.Escape,
 				...stubEvent
 			});
-			h.expect(() => expected(false, false));
+			h.expect(() => expected(false, false, { yearTriggerFocus: noop }));
 			assert.isFalse(isOpen, 'Should close on escape key press');
 
 			// enter key
@@ -767,7 +784,7 @@ registerSuite('Calendar DatePicker', {
 				which: Keys.Enter,
 				...stubEvent
 			});
-			h.expect(() => expected(false, false));
+			h.expect(() => expected(false, false, { yearTriggerFocus: noop }));
 			assert.isFalse(isOpen, 'Should close on enter key press');
 
 			// space key
@@ -777,7 +794,7 @@ registerSuite('Calendar DatePicker', {
 				which: Keys.Space,
 				...stubEvent
 			});
-			h.expect(() => expected(false, false));
+			h.expect(() => expected(false, false, { yearTriggerFocus: noop }));
 			assert.isFalse(isOpen, 'Should close on space key press');
 
 			// random key
@@ -816,7 +833,7 @@ registerSuite('Calendar DatePicker', {
 			h.expect(() => expected(false, true, { yearStart: 2000, yearEnd: 2020 }));
 		},
 
-		'Change month radios'() {
+		'XXChange month radios'() {
 			let currentMonth = testDate.getMonth();
 			let isOpen = false;
 			const h = harness(
@@ -824,6 +841,7 @@ registerSuite('Calendar DatePicker', {
 					w(DatePicker, {
 						...requiredProps,
 						onPopupChange: (open: boolean) => {
+							console.log('XXX onPopupChange', open);
 							isOpen = open;
 						},
 						onRequestMonthChange: (month: number) => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This is a straight up conversion of the Calendar widget and its child widgets to be functional and use TSX over HyperScript. There is still more work to be done as described in #1112.

The following is covered in this PR from the original ticket:

- [x] Convert to functional widget using the appropriate middleware
- [x] Convert hyperscript to TSX
- [x] Ensure the properties align with the latest standards as seen in other converted widgets.
- [x] Update tests

<img width="671" alt="image" src="https://user-images.githubusercontent.com/293805/77365341-f4689900-6d23-11ea-9db9-96f6cd2bea2e.png">

