### PR TITLE
Convert Label wiget to be function based

### DIFF
--- a/src/label/index.tsx
+++ b/src/label/index.tsx
@@ -7,7 +7,6 @@ import { formatAriaProperties } from '../common/util';
 
 export interface LabelProperties {
 	/** Custom aria attributes */
-
 	aria?: { [key: string]: string | null };
 	/** If the label should be disabled */
 	disabled?: boolean;

--- a/src/label/index.tsx
+++ b/src/label/index.tsx
@@ -3,8 +3,12 @@ import { create, tsx } from '@dojo/framework/core/vdom';
 import * as baseCss from '../common/styles/base.m.css';
 import theme from '../middleware/theme';
 import * as css from '../theme/default/label.m.css';
+import { formatAriaProperties } from '../common/util';
 
 export interface LabelProperties {
+	/** Custom aria attributes */
+
+	aria?: { [key: string]: string | null };
 	/** If the label should be disabled */
 	disabled?: boolean;
 	/** If the label is focused */
@@ -31,6 +35,7 @@ const factory = create({ theme }).properties<LabelProperties>();
 
 export const Label = factory(function Label({ properties, id, children, middleware: { theme } }) {
 	const {
+		aria = {},
 		active,
 		disabled,
 		focused,
@@ -47,6 +52,7 @@ export const Label = factory(function Label({ properties, id, children, middlewa
 
 	return (
 		<label
+			{...formatAriaProperties(aria)}
 			id={widgetId}
 			classes={[
 				themeCss.root,

--- a/src/label/index.tsx
+++ b/src/label/index.tsx
@@ -1,14 +1,10 @@
-import { WidgetBase } from '@dojo/framework/core/WidgetBase';
-import { DNode } from '@dojo/framework/core/interfaces';
-import { ThemedMixin, ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
-import { v } from '@dojo/framework/core/vdom';
-import { formatAriaProperties } from '../common/util';
-import * as css from '../theme/default/label.m.css';
-import * as baseCss from '../common/styles/base.m.css';
+import { create, tsx } from '@dojo/framework/core/vdom';
 
-export interface LabelProperties extends ThemedProperties {
-	/** Custom aria attributes */
-	aria?: { [key: string]: string | null };
+import * as baseCss from '../common/styles/base.m.css';
+import theme from '../middleware/theme';
+import * as css from '../theme/default/label.m.css';
+
+export interface LabelProperties {
 	/** If the label should be disabled */
 	disabled?: boolean;
 	/** If the label is focused */
@@ -31,40 +27,44 @@ export interface LabelProperties extends ThemedProperties {
 	active?: boolean;
 }
 
-@theme(css)
-export class Label extends ThemedMixin(WidgetBase)<LabelProperties> {
-	protected getRootClasses(): (string | null)[] {
-		const { disabled, focused, valid, readOnly, required, secondary, active } = this.properties;
-		return [
-			css.root,
-			disabled ? css.disabled : null,
-			focused ? css.focused : null,
-			valid === true ? css.valid : null,
-			valid === false ? css.invalid : null,
-			readOnly ? css.readonly : null,
-			required ? css.required : null,
-			secondary ? css.secondary : null,
-			active ? css.active : null
-		];
-	}
+const factory = create({ theme }).properties<LabelProperties>();
 
-	render(): DNode {
-		const { aria = {}, forId, hidden, widgetId } = this.properties;
+export const Label = factory(function Label({ properties, id, children, middleware: { theme } }) {
+	const {
+		active,
+		disabled,
+		focused,
+		forId,
+		hidden,
+		readOnly,
+		required,
+		secondary,
+		valid,
+		widgetId = `label-${id}`
+	} = properties();
 
-		return v(
-			'label',
-			{
-				...formatAriaProperties(aria),
-				id: widgetId,
-				classes: [
-					...this.theme(this.getRootClasses()),
-					hidden ? baseCss.visuallyHidden : null
-				],
-				for: forId
-			},
-			this.children
-		);
-	}
-}
+	const themeCss = theme.classes(css);
+
+	return (
+		<label
+			id={widgetId}
+			classes={[
+				themeCss.root,
+				disabled ? themeCss.disabled : null,
+				focused ? themeCss.focused : null,
+				valid === true ? themeCss.valid : null,
+				valid === false ? themeCss.invalid : null,
+				readOnly ? themeCss.readonly : null,
+				required ? themeCss.required : null,
+				secondary ? themeCss.secondary : null,
+				active ? themeCss.active : null,
+				hidden ? baseCss.visuallyHidden : null
+			]}
+			for={forId}
+		>
+			{children()}
+		</label>
+	);
+});
 
 export default Label;

--- a/src/label/tests/unit/Label.spec.tsx
+++ b/src/label/tests/unit/Label.spec.tsx
@@ -25,6 +25,7 @@ registerSuite('Label', {
 		custom() {
 			const h = harness(() => (
 				<Label
+					aria={{ describedBy: 'bar' }}
 					forId="foo"
 					disabled={true}
 					focused={true}
@@ -39,6 +40,7 @@ registerSuite('Label', {
 
 			h.expect(() => (
 				<label
+					aria-describedby="bar"
 					classes={[
 						css.root,
 						css.disabled,

--- a/src/label/tests/unit/Label.spec.tsx
+++ b/src/label/tests/unit/Label.spec.tsx
@@ -25,14 +25,17 @@ registerSuite('Label', {
 		custom() {
 			const h = harness(() => (
 				<Label
+					active={true}
 					aria={{ describedBy: 'bar' }}
 					forId="foo"
 					disabled={true}
 					focused={true}
+					hidden={false}
 					readOnly={true}
 					required={true}
 					valid={false}
 					secondary={true}
+					widgetId="foo-id"
 				>
 					baz
 				</Label>
@@ -50,11 +53,11 @@ registerSuite('Label', {
 						css.readonly,
 						css.required,
 						css.secondary,
-						null,
+						css.active,
 						null
 					]}
 					for="foo"
-					id="label-test"
+					id="foo-id"
 				>
 					baz
 				</label>

--- a/src/label/tests/unit/Label.spec.tsx
+++ b/src/label/tests/unit/Label.spec.tsx
@@ -1,107 +1,87 @@
 const { registerSuite } = intern.getInterface('object');
 
+import { tsx } from '@dojo/framework/core/vdom';
 import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/core/vdom';
 
-import Label from '../../index';
-import * as css from '../../../theme/default/label.m.css';
 import * as baseCss from '../../../common/styles/base.m.css';
+import * as css from '../../../theme/default/label.m.css';
+import Label from '../../index';
 
 registerSuite('Label', {
 	tests: {
 		simple() {
-			const h = harness(() => w(Label, {}, ['baz']));
-			h.expect(() =>
-				v(
-					'label',
-					{
-						classes: [css.root, null, null, null, null, null, null, null, null, null],
-						for: undefined,
-						id: undefined
-					},
-					['baz']
-				)
-			);
+			const h = harness(() => <Label>baz</Label>);
+			h.expect(() => (
+				<label
+					classes={[css.root, null, null, null, null, null, null, null, null, null]}
+					for="undefined"
+					id="label-test"
+				>
+					baz
+				</label>
+			));
 		},
 
 		custom() {
-			const h = harness(() =>
-				w(
-					Label,
-					{
-						forId: 'foo',
-						aria: {
-							describedBy: 'bar'
-						},
-						disabled: true,
-						focused: true,
-						readOnly: true,
-						required: true,
-						valid: false,
-						secondary: true
-					},
-					['baz']
-				)
-			);
+			const h = harness(() => (
+				<Label
+					forId="foo"
+					disabled={true}
+					focused={true}
+					readOnly={true}
+					required={true}
+					valid={false}
+					secondary={true}
+				>
+					baz
+				</Label>
+			));
 
-			h.expect(() =>
-				v(
-					'label',
-					{
-						classes: [
-							css.root,
-							css.disabled,
-							css.focused,
-							null,
-							css.invalid,
-							css.readonly,
-							css.required,
-							css.secondary,
-							null,
-							null
-						],
-						for: 'foo',
-						id: undefined,
-						'aria-describedby': 'bar'
-					},
-					['baz']
-				)
-			);
+			h.expect(() => (
+				<label
+					classes={[
+						css.root,
+						css.disabled,
+						css.focused,
+						null,
+						css.invalid,
+						css.readonly,
+						css.required,
+						css.secondary,
+						null,
+						null
+					]}
+					for="foo"
+					id="label-test"
+				>
+					baz
+				</label>
+			));
 		},
 
 		hidden() {
-			const h = harness(() =>
-				w(
-					Label,
-					{
-						hidden: true
-					},
-					['baz']
-				)
-			);
+			const h = harness(() => <Label hidden={true}>baz</Label>);
 
-			h.expect(() =>
-				v(
-					'label',
-					{
-						classes: [
-							css.root,
-							null,
-							null,
-							null,
-							null,
-							null,
-							null,
-							null,
-							null,
-							baseCss.visuallyHidden
-						],
-						for: undefined,
-						id: undefined
-					},
-					['baz']
-				)
-			);
+			h.expect(() => (
+				<label
+					classes={[
+						css.root,
+						null,
+						null,
+						null,
+						null,
+						null,
+						null,
+						null,
+						null,
+						baseCss.visuallyHidden
+					]}
+					for="undefined"
+					id="label-test"
+				>
+					baz
+				</label>
+			));
 		}
 	}
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Updates the `Label` widget to be function based. Removes extraneous aria properties.

Resolves #1172 

![Screen Shot 2020-03-24 at 6 36 38 PM](https://user-images.githubusercontent.com/1054198/77486708-6b726000-6dfe-11ea-823b-21f8b68bd170.png)
