### PR TITLE
Move DateInput to theme.compose

### DIFF
--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -11,6 +11,7 @@ import Calendar from '../calendar';
 import TextInput from '../text-input';
 import Icon from '../icon';
 import TriggerPopup from '../trigger-popup';
+import * as textInputCss from '../theme/default/text-input.m.css';
 import * as css from '../theme/default/date-input.m.css';
 
 import bundle from './nls/DateInput';
@@ -126,11 +127,11 @@ export default factory(function({ properties, middleware: { theme, icache, i18n,
 								<TextInput
 									key="input"
 									focus={() => shouldFocus && focusNode === 'input'}
-									classes={{
-										'@dojo/widgets/text-input': {
-											trailing: [classes.inputTrailing]
-										}
-									}}
+									theme={theme.compose(
+										textInputCss,
+										css,
+										'input'
+									)}
 									trailing={() => (
 										<button
 											key="dateIcon"

--- a/src/date-input/tests/unit/DateInput.spec.tsx
+++ b/src/date-input/tests/unit/DateInput.spec.tsx
@@ -5,11 +5,10 @@ import * as sinon from 'sinon';
 
 import { tsx, create } from '@dojo/framework/core/vdom';
 import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
-import { harness } from '@dojo/framework/testing/harness';
 import select from '@dojo/framework/testing/support/selector';
 import focus from '@dojo/framework/core/middleware/focus';
 
-import { stubEvent } from '../../../common/tests/support/test-helpers';
+import { compareTheme, createHarness, stubEvent } from '../../../common/tests/support/test-helpers';
 import { Keys } from '../../../common/util';
 import Calendar from '../../../calendar';
 import TriggerPopup from '../../../trigger-popup';
@@ -24,6 +23,7 @@ const { messages } = bundle;
 const now = new Date();
 const today = new Date(now.getFullYear(), now.getMonth(), now.getDate());
 const noop = () => {};
+const harness = createHarness([compareTheme]);
 
 function createFocusMock({
 	shouldFocus = false,
@@ -67,11 +67,7 @@ const buttonTemplate = assertionTemplate(() => {
 			<TextInput
 				key="input"
 				focus={() => false}
-				classes={{
-					'@dojo/widgets/text-input': {
-						trailing: [css.inputTrailing]
-					}
-				}}
+				theme={{}}
 				type="text"
 				onBlur={noop}
 				onValue={noop}

--- a/src/theme/default/date-input.m.css
+++ b/src/theme/default/date-input.m.css
@@ -4,9 +4,6 @@
 .input {
 }
 
-.inputTrailing {
-}
-
 .toggleCalendarButton {
 }
 

--- a/src/theme/default/date-input.m.css.d.ts
+++ b/src/theme/default/date-input.m.css.d.ts
@@ -1,5 +1,4 @@
 export const root: string;
 export const input: string;
-export const inputTrailing: string;
 export const toggleCalendarButton: string;
 export const popup: string;

--- a/src/theme/dojo/date-input.m.css
+++ b/src/theme/dojo/date-input.m.css
@@ -27,6 +27,10 @@
 
 .inputTrailing {
 	composes: trailing from './text-input.m.css';
+}
+
+/* include .root prefix to ensure this overrides the default styling */
+.root .inputTrailing {
 	background: none;
 	padding-bottom: 0;
 	padding-top: 0;

--- a/src/theme/dojo/date-input.m.css
+++ b/src/theme/dojo/date-input.m.css
@@ -25,8 +25,8 @@
 	background: var(--color-background);
 }
 
-/* include .root prefix to ensure this overrides the default styling */
-.root .inputTrailing {
+.inputTrailing {
+	composes: trailing from './text-input.m.css';
 	background: none;
 	padding-bottom: 0;
 	padding-top: 0;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Moves the styles for the embedded `TextInput` to the prefix `input`.

References #1038 
