### PR TITLE
Move PasswordInput to theme.compose

### DIFF
--- a/src/password-input/index.tsx
+++ b/src/password-input/index.tsx
@@ -4,6 +4,7 @@ import Button from '../button';
 import Icon from '../icon';
 import ConstrainedInput, { ConstrainedInputProperties } from '../constrained-input';
 import theme from '../middleware/theme';
+import * as buttonCss from '../theme/default/button.m.css';
 import * as css from '../theme/default/password-input.m.css';
 import * as textInputCss from '../theme/default/text-input.m.css';
 import TextInput from '../text-input';
@@ -37,7 +38,11 @@ export const PasswordInput = factory(function PasswordInput({
 			onClick={() => {
 				icache.set('showPassword', !showPassword);
 			}}
-			classes={{ '@dojo/widgets/button': { root: [css.togglePasswordButton] } }}
+			theme={theme.compose(
+				buttonCss,
+				css,
+				'toggleButton'
+			)}
 		>
 			<Icon type={showPassword ? 'eyeSlashIcon' : 'eyeIcon'} />
 		</Button>

--- a/src/password-input/tests/unit/password-input.spec.tsx
+++ b/src/password-input/tests/unit/password-input.spec.tsx
@@ -1,5 +1,4 @@
-import harness from '@dojo/framework/testing/harness';
-import { compareTheme } from '../../../common/tests/support/test-helpers';
+import { createHarness, compareTheme } from '../../../common/tests/support/test-helpers';
 import * as textInputCss from '../../../theme/default/text-input.m.css';
 import Button from '../../../button';
 import Icon from '../../../icon';
@@ -11,12 +10,12 @@ import { tsx } from '@dojo/framework/core/vdom';
 import TextInput from '../../../text-input';
 
 const { describe, it } = intern.getInterface('bdd');
-
+const harness = createHarness([compareTheme]);
 const rules = { length: { min: 1 } };
 
 describe('PasswordInput', () => {
 	it('renders with default properties', () => {
-		const h = harness(() => <PasswordInput rules={rules} />, [compareTheme]);
+		const h = harness(() => <PasswordInput rules={rules} />);
 		h.expect(() => (
 			<ConstrainedInput
 				rules={rules}
@@ -29,7 +28,7 @@ describe('PasswordInput', () => {
 	});
 
 	it('renders a textinput when no rules are passed', () => {
-		const h = harness(() => <PasswordInput />, [compareTheme]);
+		const h = harness(() => <PasswordInput />);
 		h.expect(() => (
 			<TextInput
 				key="root"
@@ -43,7 +42,7 @@ describe('PasswordInput', () => {
 	});
 
 	it('handles required validation when no rules are passed', () => {
-		const h = harness(() => <PasswordInput required />, [compareTheme]);
+		const h = harness(() => <PasswordInput required />);
 		h.trigger('@root', 'onValidate', false, 'this is required');
 		h.expect(() => (
 			<TextInput
@@ -59,7 +58,7 @@ describe('PasswordInput', () => {
 	});
 
 	it('renders as a text input after click', () => {
-		const h = harness(() => <PasswordInput rules={rules} />, [compareTheme]);
+		const h = harness(() => <PasswordInput rules={rules} />);
 		h.expect(() => (
 			<ConstrainedInput
 				rules={rules}
@@ -73,10 +72,7 @@ describe('PasswordInput', () => {
 		const eyeRender = h.trigger('@root', 'trailing');
 		h.expect(
 			() => (
-				<Button
-					onClick={() => {}}
-					classes={{ '@dojo/widgets/button': { root: [css.togglePasswordButton] } }}
-				>
+				<Button onClick={() => {}} theme={{}}>
 					<Icon type="eyeIcon" />
 				</Button>
 			),
@@ -98,10 +94,7 @@ describe('PasswordInput', () => {
 		const slashRender = h.trigger('@root', 'trailing');
 		h.expect(
 			() => (
-				<Button
-					onClick={() => {}}
-					classes={{ '@dojo/widgets/button': { root: [css.togglePasswordButton] } }}
-				>
+				<Button onClick={() => {}} theme={{}}>
 					<Icon type="eyeSlashIcon" />
 				</Button>
 			),

--- a/src/password-input/tests/unit/password-input.spec.tsx
+++ b/src/password-input/tests/unit/password-input.spec.tsx
@@ -3,7 +3,6 @@ import * as textInputCss from '../../../theme/default/text-input.m.css';
 import Button from '../../../button';
 import Icon from '../../../icon';
 import ConstrainedInput from '../../../constrained-input';
-import * as css from '../../../theme/default/password-input.m.css';
 import PasswordInput from '../..';
 
 import { tsx } from '@dojo/framework/core/vdom';

--- a/src/theme/default/index.ts
+++ b/src/theme/default/index.ts
@@ -1,6 +1,5 @@
 import * as accordionPane from './accordion-pane.m.css';
 import * as avatar from './avatar.m.css';
-import * as breadcrumb from './breadcrumb.m.css';
 import * as breadcrumbGroup from './breadcrumb-group.m.css';
 import * as button from './button.m.css';
 import * as calendar from './calendar.m.css';
@@ -50,7 +49,6 @@ import * as tooltip from './tooltip.m.css';
 export default {
 	'@dojo/widgets/accordion-pane': accordionPane,
 	'@dojo/widgets/avatar': avatar,
-	'@dojo/widgets/breadcrumb': breadcrumb,
 	'@dojo/widgets/breadcrumb-group': breadcrumbGroup,
 	'@dojo/widgets/button': button,
 	'@dojo/widgets/calendar': calendar,
@@ -95,6 +93,5 @@ export default {
 	'@dojo/widgets/text-input': textInput,
 	'@dojo/widgets/time-picker': timePicker,
 	'@dojo/widgets/title-pane': titlePane,
-
 	'@dojo/widgets/tooltip': tooltip
 };

--- a/src/theme/default/password-input.m.css
+++ b/src/theme/default/password-input.m.css
@@ -3,14 +3,15 @@
 }
 
 /* The button that toggles password visibility */
-.togglePasswordButton {
+.toggleButtonRoot {
+	composes: root from './button.m.css';
 	min-width: unset;
 	background: none;
 	border: none;
 }
 
-.togglePasswordButton:hover,
-.togglePasswordButton:focus {
+.toggleButtonRoot:hover,
+.toggleButtonRoot:focus {
 	box-shadow: none;
 }
 

--- a/src/theme/default/password-input.m.css
+++ b/src/theme/default/password-input.m.css
@@ -5,13 +5,16 @@
 /* The button that toggles password visibility */
 .toggleButtonRoot {
 	composes: root from './button.m.css';
+}
+
+.root .toggleButtonRoot {
 	min-width: unset;
 	background: none;
 	border: none;
 }
 
-.toggleButtonRoot:hover,
-.toggleButtonRoot:focus {
+.root .toggleButtonRoot:hover,
+.root .toggleButtonRoot:focus {
 	box-shadow: none;
 }
 

--- a/src/theme/default/password-input.m.css.d.ts
+++ b/src/theme/default/password-input.m.css.d.ts
@@ -1,3 +1,3 @@
 export const root: string;
-export const togglePasswordButton: string;
+export const toggleButtonRoot: string;
 export const trailing: string;

--- a/src/theme/dojo/breadcrumb-group.m.css.d.ts
+++ b/src/theme/dojo/breadcrumb-group.m.css.d.ts
@@ -1,5 +1,1 @@
-export const root: string;
-export const list: string;
 export const listItem: string;
-export const breadcrumb: string;
-export const current: string;

--- a/src/theme/dojo/password-input.m.css
+++ b/src/theme/dojo/password-input.m.css
@@ -4,13 +4,16 @@
 
 .toggleButtonRoot {
 	composes: root from './button.m.css';
+}
+
+.root .toggleButtonRoot {
 	min-width: unset;
 	background: none;
 	border: none;
 }
 
-.toggleButtonRoot:hover,
-.toggleButtonRoot:focus {
+.root .toggleButtonRoot:hover,
+.root .toggleButtonRoot:focus {
 	box-shadow: none;
 }
 

--- a/src/theme/dojo/password-input.m.css
+++ b/src/theme/dojo/password-input.m.css
@@ -2,14 +2,15 @@
 	composes: root from './text-input.m.css';
 }
 
-.togglePasswordButton {
+.toggleButtonRoot {
+	composes: root from './button.m.css';
 	min-width: unset;
 	background: none;
 	border: none;
 }
 
-.togglePasswordButton:hover,
-.togglePasswordButton:focus {
+.toggleButtonRoot:hover,
+.toggleButtonRoot:focus {
 	box-shadow: none;
 }
 

--- a/src/theme/dojo/password-input.m.css.d.ts
+++ b/src/theme/dojo/password-input.m.css.d.ts
@@ -1,3 +1,3 @@
 export const root: string;
-export const togglePasswordButtonRoot: string;
+export const toggleButtonRoot: string;
 export const trailing: string;

--- a/src/theme/dojo/password-input.m.css.d.ts
+++ b/src/theme/dojo/password-input.m.css.d.ts
@@ -1,3 +1,3 @@
 export const root: string;
-export const togglePasswordButton: string;
+export const togglePasswordButtonRoot: string;
 export const trailing: string;

--- a/src/theme/material/breadcrumb-group.m.css.d.ts
+++ b/src/theme/material/breadcrumb-group.m.css.d.ts
@@ -1,4 +1,3 @@
 export const root: string;
-export const list: string;
 export const listItem: string;
 export const current: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Moves the styles for the embedded `PasswordInput` to the prefix `toggleButton`.

References #1038 
