### PR TITLE
Move TimePicker to theme.compose

### DIFF
--- a/src/theme/default/time-picker.m.css
+++ b/src/theme/default/time-picker.m.css
@@ -9,6 +9,3 @@
 
 .toggleMenuButton {
 }
-
-.inputTrailing {
-}

--- a/src/theme/default/time-picker.m.css.d.ts
+++ b/src/theme/default/time-picker.m.css.d.ts
@@ -2,4 +2,3 @@ export const root: string;
 export const menuWrapper: string;
 export const input: string;
 export const toggleMenuButton: string;
-export const inputTrailing: string;

--- a/src/theme/dojo/time-picker.m.css
+++ b/src/theme/dojo/time-picker.m.css
@@ -25,8 +25,8 @@
 	background: var(--color-background);
 }
 
-/* include .root prefix to ensure this overrides the default styling */
-.root .inputTrailing {
+.inputTrailing {
+	composes: trailing from './text-input.m.css';
 	background: none;
 	padding-bottom: 0;
 	padding-top: 0;

--- a/src/theme/dojo/time-picker.m.css
+++ b/src/theme/dojo/time-picker.m.css
@@ -27,6 +27,9 @@
 
 .inputTrailing {
 	composes: trailing from './text-input.m.css';
+}
+
+.root .inputTrailing {
 	background: none;
 	padding-bottom: 0;
 	padding-top: 0;

--- a/src/time-picker/index.tsx
+++ b/src/time-picker/index.tsx
@@ -4,6 +4,7 @@ import { padStart } from '@dojo/framework/shim/string';
 import { Menu, MenuOption } from '../menu';
 import focus from '@dojo/framework/core/middleware/focus';
 import * as css from '../theme/default/time-picker.m.css';
+import * as inputCss from '../theme/default/text-input.m.css';
 import TriggerPopup from '../trigger-popup';
 import TextInput from '../text-input';
 import Icon from '../icon';
@@ -345,11 +346,11 @@ export const TimePicker = factory(function TimePicker({
 									disabled={disabled}
 									required={required}
 									focus={() => shouldFocus && focusNode === 'input'}
-									classes={{
-										'@dojo/widgets/text-input': {
-											trailing: [classes.inputTrailing]
-										}
-									}}
+									theme={theme.compose(
+										inputCss,
+										css,
+										'input'
+									)}
 									trailing={() => (
 										<button
 											disabled={disabled}

--- a/src/time-picker/tests/unit/TimePicker.spec.tsx
+++ b/src/time-picker/tests/unit/TimePicker.spec.tsx
@@ -3,7 +3,6 @@ import * as sinon from 'sinon';
 
 import { create, tsx } from '@dojo/framework/core/vdom';
 import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
-import { harness } from '@dojo/framework/testing/harness';
 import TriggerPopup from '../../../trigger-popup';
 import TextInput from '../../../text-input';
 
@@ -12,12 +11,13 @@ import bundle from '../../nls/TimePicker';
 import * as css from '../../../theme/default/time-picker.m.css';
 import { padStart } from '@dojo/framework/shim/string';
 import select from '@dojo/framework/testing/support/selector';
-import { stubEvent } from '../../../common/tests/support/test-helpers';
+import { createHarness, compareTheme, stubEvent } from '../../../common/tests/support/test-helpers';
 import { Keys } from '../../../common/util';
 import focus from '@dojo/framework/core/middleware/focus';
 
 const { describe, it, afterEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
+const harness = createHarness([compareTheme]);
 
 const { messages } = bundle;
 const noop = () => {};
@@ -66,11 +66,7 @@ const buttonTemplate = assertionTemplate(() => {
 				key="input"
 				label={undefined}
 				focus={() => false}
-				classes={{
-					'@dojo/widgets/text-input': {
-						trailing: [css.inputTrailing]
-					}
-				}}
+				theme={{}}
 				onBlur={noop}
 				onValue={noop}
 				trailing={() => undefined}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Moves the styles for the embedded `TimePicker` to the prefix `input`.

References #1038 
