### PR TITLE
Don’t rewrite exact prefix matches

### DIFF
--- a/src/middleware/tests/theme.spec.tsx
+++ b/src/middleware/tests/theme.spec.tsx
@@ -414,4 +414,32 @@ describe('theme middleware', () => {
 			}
 		});
 	});
+
+	it('should not create empty keys', () => {
+		const baseClasses = {
+			' _key': '@dojo/widgets/Base',
+			root: 'base_root',
+			selected: 'base_selected',
+			active: 'base_active'
+		};
+
+		const variantClasses = {
+			' _key': '@dojo/widgets/Variant',
+			base: 'variant_base',
+			baseActive: 'variant_active'
+		};
+
+		const composedClasses = composesInstance.compose(
+			baseClasses,
+			variantClasses,
+			'base'
+		);
+		assert.deepEqual(composedClasses, {
+			'@dojo/widgets/Base': {
+				root: 'base_root',
+				selected: 'base_selected',
+				active: 'variant_active'
+			}
+		});
+	});
 });

--- a/src/middleware/theme.tsx
+++ b/src/middleware/theme.tsx
@@ -48,7 +48,7 @@ export const theme = factory(function({ middleware: { coreTheme }, properties })
 			if (prefix) {
 				const prefixedCss = Object.keys({ ...virtualTheme, ...variantTheme }).reduce(
 					(prefixCss, key) => {
-						if (key.indexOf(prefix) === 0) {
+						if (key.indexOf(prefix) === 0 && key.length > prefix.length) {
 							const classKey = lowercaseFirstChar(key.replace(prefix, ''));
 							if (
 								!variantTheme[key] &&

--- a/src/middleware/theme.tsx
+++ b/src/middleware/theme.tsx
@@ -48,7 +48,7 @@ export const theme = factory(function({ middleware: { coreTheme }, properties })
 			if (prefix) {
 				const prefixedCss = Object.keys({ ...virtualTheme, ...variantTheme }).reduce(
 					(prefixCss, key) => {
-						if (key.indexOf(prefix) === 0 && key.length > prefix.length) {
+						if (key.indexOf(prefix) === 0 && key !== prefix) {
 							const classKey = lowercaseFirstChar(key.replace(prefix, ''));
 							if (
 								!variantTheme[key] &&


### PR DESCRIPTION
**Type:** bug

Only considers strings to be prefixed if larger than the prefix string length.

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #1206
