### PR TITLE
Add basic GlobalEvent example

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -187,6 +187,7 @@ import BasicHeader from './widgets/header/Basic';
 import LeadingHeader from './widgets/header/Leading';
 import StickyHeader from './widgets/header/Sticky';
 import TrailingHeader from './widgets/header/Trailing';
+import BasicGlobalEvent from './widgets/global-event/Basic';
 
 `!has('docs')`;
 import testsContext from './tests';
@@ -625,6 +626,15 @@ export const config = {
 				example: {
 					filename: 'Basic',
 					module: BasicForm
+				}
+			}
+		},
+		'global-event': {
+			filename: 'index',
+			overview: {
+				example: {
+					module: BasicGlobalEvent,
+					filename: 'Basic'
 				}
 			}
 		},

--- a/src/examples/src/widgets/global-event/Basic.tsx
+++ b/src/examples/src/widgets/global-event/Basic.tsx
@@ -1,0 +1,25 @@
+import icache from '@dojo/framework/core/middleware/icache';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import GlobalEvent from '@dojo/widgets/global-event';
+
+const factory = create({ icache });
+
+export default factory(function Basic({ middleware: { icache } }) {
+	const keyup = (event: KeyboardEvent) => {
+		event.stopPropagation();
+		icache.set('keycode', event.which);
+	};
+
+	return (
+		<virtual key="root">
+			<GlobalEvent key="global" document={{ keyup }} />
+			<div>Press a key to get the JavaScript event keycode.</div>
+
+			{icache.get('keycode') && (
+				<div key="result" style="color: ">
+					Keycode of pressed key: {`${icache.get('keycode')}`}
+				</div>
+			)}
+		</virtual>
+	);
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds a basic example of using the `GlobalEvent` widget to add a keyup listener.

Resolves #822 

![Screen Shot 2020-03-27 at 1 36 29 PM](https://user-images.githubusercontent.com/1054198/77788871-00a86b00-7030-11ea-8cc4-2bf6cceb1a48.png)
