### PR TITLE
Adding typeahead widget (#795)

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -52,7 +52,8 @@
 			"src/time-picker",
 			"src/title-pane",
 			"src/tooltip",
-			"src/trigger-popup"
+			"src/trigger-popup",
+			"src/typeahead"
 		]
 	}
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1895,9 +1895,9 @@
       }
     },
     "@dojo/framework": {
-      "version": "7.0.0-alpha.13",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.13.tgz",
-      "integrity": "sha512-TjtL/icmRlksy//A5v4DPFjalNuOb5G8o9yWlkqJTjXYD7sef9VR44DH3fHCewNuFY0/ddXSTd1lH03WxQMo3w==",
+      "version": "7.0.0-alpha.14",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-alpha.14.tgz",
+      "integrity": "sha512-oDsk3GA+h+iCWyR4tTkkl5057LsCYfvWe5ODXA+deL6EJyr5hPIBemZ4tvCAiih0MNLsFY6uF6X5v/DLylCjTw==",
       "dev": true,
       "requires": {
         "@types/cldrjs": "0.4.20",
@@ -4831,9 +4831,9 @@
       "dev": true
     },
     "@types/uglify-js": {
-      "version": "3.0.4",
-      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.4.tgz",
-      "integrity": "sha512-SudIN9TRJ+v8g5pTG8RRCqfqTMNqgWCKKd3vtynhGzkIIjxaicNAMuY5TRadJ6tzDu3Dotf3ngaMILtmOdmWEQ==",
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/uglify-js/-/uglify-js-3.0.5.tgz",
+      "integrity": "sha512-L7EbSkhSaWBpkl+PZAEAqZTqtTeIsq7s/oX/q0LNnxxJoRVKQE0T81XDVyaxjiiKQwiV2vhVeYRqxdRNqGOGJw==",
       "dev": true,
       "requires": {
         "source-map": "^0.6.1"
@@ -4866,9 +4866,9 @@
       }
     },
     "@types/webpack": {
-      "version": "4.41.9",
-      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.9.tgz",
-      "integrity": "sha512-R68AotLGtaVL6HGfZRvEyYKsWcMv0CBFfSr4gxoYzhMn3LnjLV/ksP4dNi9de8dVG+Dn/GuDr1NwB/sDApB3pA==",
+      "version": "4.41.10",
+      "resolved": "https://registry.npmjs.org/@types/webpack/-/webpack-4.41.10.tgz",
+      "integrity": "sha512-vIy0qaq8AjOjZLuFPqpo7nAJzcoVXMdw3mvpNN07Uvdy0p1IpJeLNBe3obdRP7FX2jIusDE7z1pZa0A6qYUgnA==",
       "dev": true,
       "requires": {
         "@types/anymatch": "*",
@@ -6192,15 +6192,15 @@
       }
     },
     "browserslist": {
-      "version": "4.11.0",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.0.tgz",
-      "integrity": "sha512-WqEC7Yr5wUH5sg6ruR++v2SGOQYpyUdYYd4tZoAq1F7y+QXoLoYGXVbxhtaIqWmAJjtNTRjVD3HuJc1OXTel2A==",
+      "version": "4.11.1",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.11.1.tgz",
+      "integrity": "sha512-DCTr3kDrKEYNw6Jb9HFxVLQNaue8z+0ZfRBRjmCunKDEXEBajKDj2Y+Uelg+Pi29OnvaSGwjOsnRyNEkXzHg5g==",
       "dev": true,
       "requires": {
-        "caniuse-lite": "^1.0.30001035",
-        "electron-to-chromium": "^1.3.380",
-        "node-releases": "^1.1.52",
-        "pkg-up": "^3.1.0"
+        "caniuse-lite": "^1.0.30001038",
+        "electron-to-chromium": "^1.3.390",
+        "node-releases": "^1.1.53",
+        "pkg-up": "^2.0.0"
       },
       "dependencies": {
         "caniuse-lite": {
@@ -8960,17 +8960,17 @@
       },
       "dependencies": {
         "@types/node": {
-          "version": "12.12.32",
-          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.32.tgz",
-          "integrity": "sha512-44/reuCrwiQEsXud3I5X3sqI5jIXAmHB5xoiyKUw965olNHF3IWKjBLKK3F9LOSUZmK+oDt8jmyO637iX+hMgA==",
+          "version": "12.12.34",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-12.12.34.tgz",
+          "integrity": "sha512-BneGN0J9ke24lBRn44hVHNeDlrXRYF+VRp0HbSUNnEZahXGAysHZIqnf/hER6aabdBgzM4YOV4jrR8gj4Zfi0g==",
           "dev": true
         }
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.390",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.390.tgz",
-      "integrity": "sha512-4RvbM5x+002gKI8sltkqWEk5pptn0UnzekUx8RTThAMPDSb8jjpm6SwGiSnEve7f85biyZl8DMXaipaCxDjXag==",
+      "version": "1.3.392",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.392.tgz",
+      "integrity": "sha512-/hsgeVdReDsyTBE0aU9FRdh1wnNPrX3xlz3t61F+CJPOT+Umfi9DXHsCX85TEgWZQqlow0Rw44/4/jbU2Sqgkg==",
       "dev": true
     },
     "elegant-spinner": {
@@ -10392,29 +10392,25 @@
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
-          "resolved": false,
-          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "aproba": {
           "version": "1.2.0",
-          "resolved": false,
-          "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "are-we-there-yet": {
           "version": "1.1.5",
-          "resolved": false,
-          "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10424,15 +10420,13 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
-          "resolved": false,
-          "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10442,43 +10436,37 @@
         },
         "chownr": {
           "version": "1.1.4",
-          "resolved": false,
-          "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "code-point-at": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "resolved": false,
-          "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "resolved": false,
-          "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "debug": {
           "version": "3.2.6",
-          "resolved": false,
-          "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10487,29 +10475,25 @@
         },
         "deep-extend": {
           "version": "0.6.0",
-          "resolved": false,
-          "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "delegates": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "detect-libc": {
           "version": "1.0.3",
-          "resolved": false,
-          "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "fs-minipass": {
           "version": "1.2.7",
-          "resolved": false,
-          "integrity": "sha512-GWSSJGFy4e9GUeCcbIkED+bgAoFyj7XF1mV8rma3QW4NIqX9Kyx79N/PF61H5udOV3aY1IaMLs6pGbH71nlCTA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10518,15 +10502,13 @@
         },
         "fs.realpath": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "gauge": {
           "version": "2.7.4",
-          "resolved": false,
-          "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10542,8 +10524,7 @@
         },
         "glob": {
           "version": "7.1.6",
-          "resolved": false,
-          "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10557,15 +10538,13 @@
         },
         "has-unicode": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "iconv-lite": {
           "version": "0.4.24",
-          "resolved": false,
-          "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10574,8 +10553,7 @@
         },
         "ignore-walk": {
           "version": "3.0.3",
-          "resolved": false,
-          "integrity": "sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10584,8 +10562,7 @@
         },
         "inflight": {
           "version": "1.0.6",
-          "resolved": false,
-          "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10595,22 +10572,19 @@
         },
         "inherits": {
           "version": "2.0.4",
-          "resolved": false,
-          "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "ini": {
           "version": "1.3.5",
-          "resolved": false,
-          "integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10619,15 +10593,13 @@
         },
         "isarray": {
           "version": "1.0.0",
-          "resolved": false,
-          "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "minimatch": {
           "version": "3.0.4",
-          "resolved": false,
-          "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10636,15 +10608,13 @@
         },
         "minimist": {
           "version": "1.2.5",
-          "resolved": false,
-          "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "minipass": {
           "version": "2.9.0",
-          "resolved": false,
-          "integrity": "sha512-wxfUjg9WebH+CUDX/CdbRlh5SmfZiy/hpkxaRI16Y9W56Pa75sWgd/rvFilSgrauD9NyFymP/+JFV3KwzIsJeg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10654,8 +10624,7 @@
         },
         "minizlib": {
           "version": "1.3.3",
-          "resolved": false,
-          "integrity": "sha512-6ZYMOEnmVsdCeTJVE0W9ZD+pVnE8h9Hma/iOwwRDsdQoePpoX56/8B6z3P9VNwppJuBKNRuFDRNRqRWexT9G9Q==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10664,8 +10633,7 @@
         },
         "mkdirp": {
           "version": "0.5.3",
-          "resolved": false,
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10674,15 +10642,13 @@
         },
         "ms": {
           "version": "2.1.2",
-          "resolved": false,
-          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "needle": {
           "version": "2.3.3",
-          "resolved": false,
-          "integrity": "sha512-EkY0GeSq87rWp1hoq/sH/wnTWgFVhYlnIkbJ0YJFfRgEFlz2RraCjBpFQ+vrEgEdp0ThfyHADmkChEhcb7PKyw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10693,8 +10659,7 @@
         },
         "node-pre-gyp": {
           "version": "0.14.0",
-          "resolved": false,
-          "integrity": "sha512-+CvDC7ZttU/sSt9rFjix/P05iS43qHCOOGzcr3Ry99bXG7VX953+vFyEuph/tfqoYu8dttBkE86JSKBO2OzcxA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10712,8 +10677,7 @@
         },
         "nopt": {
           "version": "4.0.3",
-          "resolved": false,
-          "integrity": "sha512-CvaGwVMztSMJLOeXPrez7fyfObdZqNUK1cPAEzLHrTybIua9pMdmmPR5YwtfNftIOMv3DPUhFaxsZMNTQO20Kg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10723,8 +10687,7 @@
         },
         "npm-bundled": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10733,15 +10696,13 @@
         },
         "npm-normalize-package-bin": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "npm-packlist": {
           "version": "1.4.8",
-          "resolved": false,
-          "integrity": "sha512-5+AZgwru5IevF5ZdnFglB5wNlHG1AOOuw28WhUq8/8emhBmLv6jX5by4WJCh7lW0uSYZYS6DXqIsyZVIXRZU9A==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10752,8 +10713,7 @@
         },
         "npmlog": {
           "version": "4.1.2",
-          "resolved": false,
-          "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10765,22 +10725,19 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
-          "resolved": false,
-          "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "once": {
           "version": "1.4.0",
-          "resolved": false,
-          "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10789,22 +10746,19 @@
         },
         "os-homedir": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "os-tmpdir": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "osenv": {
           "version": "0.1.5",
-          "resolved": false,
-          "integrity": "sha512-0CWcCECdMVc2Rw3U5w9ZjqX6ga6ubk1xDVKxtBQPK7wis/0F2r9T6k4ydGYhecl7YUBxBVxhL5oisPsNxAPe2g==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10814,22 +10768,19 @@
         },
         "path-is-absolute": {
           "version": "1.0.1",
-          "resolved": false,
-          "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "process-nextick-args": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "rc": {
           "version": "1.2.8",
-          "resolved": false,
-          "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10841,8 +10792,7 @@
         },
         "readable-stream": {
           "version": "2.3.7",
-          "resolved": false,
-          "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10857,8 +10807,7 @@
         },
         "rimraf": {
           "version": "2.7.1",
-          "resolved": false,
-          "integrity": "sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10867,50 +10816,43 @@
         },
         "safe-buffer": {
           "version": "5.1.2",
-          "resolved": false,
-          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
-          "resolved": false,
-          "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "sax": {
           "version": "1.2.4",
-          "resolved": false,
-          "integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "semver": {
           "version": "5.7.1",
-          "resolved": false,
-          "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "set-blocking": {
           "version": "2.0.0",
-          "resolved": false,
-          "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "signal-exit": {
           "version": "3.0.2",
-          "resolved": false,
-          "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "string-width": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10921,8 +10863,7 @@
         },
         "string_decoder": {
           "version": "1.1.1",
-          "resolved": false,
-          "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10931,8 +10872,7 @@
         },
         "strip-ansi": {
           "version": "3.0.1",
-          "resolved": false,
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10941,15 +10881,13 @@
         },
         "strip-json-comments": {
           "version": "2.0.1",
-          "resolved": false,
-          "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "tar": {
           "version": "4.4.13",
-          "resolved": false,
-          "integrity": "sha512-w2VwSrBoHa5BsSyH+KxEqeQBAllHhccyMFVHtGtdMpF4W7IRWfZjFiQceJPChOeTsSDVUpER2T8FA93pr0L+QA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10964,15 +10902,13 @@
         },
         "util-deprecate": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "wide-align": {
           "version": "1.1.3",
-          "resolved": false,
-          "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+          "bundled": true,
           "dev": true,
           "optional": true,
           "requires": {
@@ -10981,15 +10917,13 @@
         },
         "wrappy": {
           "version": "1.0.2",
-          "resolved": false,
-          "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+          "bundled": true,
           "dev": true,
           "optional": true
         },
         "yallist": {
           "version": "3.1.1",
-          "resolved": false,
-          "integrity": "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==",
+          "bundled": true,
           "dev": true,
           "optional": true
         }
@@ -11417,20 +11351,12 @@
       "dev": true
     },
     "gonzales-pe": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.2.4.tgz",
-      "integrity": "sha512-v0Ts/8IsSbh9n1OJRnSfa7Nlxi4AkXIsWB6vPept8FDbL4bXn3FNuxjYtO/nmBGu7GDkL9MFeGebeSu6l55EPQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/gonzales-pe/-/gonzales-pe-4.3.0.tgz",
+      "integrity": "sha512-otgSPpUmdWJ43VXyiNgEYE4luzHCL2pz4wQ0OnDluC6Eg4Ko3Vexy/SrSynglw/eR+OhkzmqFCZa/OFa/RgAOQ==",
       "dev": true,
       "requires": {
-        "minimist": "1.1.x"
-      },
-      "dependencies": {
-        "minimist": {
-          "version": "1.1.3",
-          "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.1.3.tgz",
-          "integrity": "sha1-O+39kaktOQFvz6ocaB6Pqhoe/ag=",
-          "dev": true
-        }
+        "minimist": "^1.2.5"
       }
     },
     "good-listener": {
@@ -15983,57 +15909,12 @@
       }
     },
     "pkg-up": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-3.1.0.tgz",
-      "integrity": "sha512-nDywThFk1i4BQK4twPQ6TA4RT8bDY96yeuCVBWL3ePARCiEKDRSrNGbFIgUJpLp+XeIR65v8ra7WuJOFUBtkMA==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
+      "integrity": "sha1-yBmscoBZpGHKscOImivjxJoATX8=",
       "dev": true,
       "requires": {
-        "find-up": "^3.0.0"
-      },
-      "dependencies": {
-        "find-up": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
-          "integrity": "sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==",
-          "dev": true,
-          "requires": {
-            "locate-path": "^3.0.0"
-          }
-        },
-        "locate-path": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-3.0.0.tgz",
-          "integrity": "sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==",
-          "dev": true,
-          "requires": {
-            "p-locate": "^3.0.0",
-            "path-exists": "^3.0.0"
-          }
-        },
-        "p-limit": {
-          "version": "2.2.2",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.2.tgz",
-          "integrity": "sha512-WGR+xHecKTr7EbUEhyLSh5Dube9JtdiG78ufaeLxTgpudf/20KqyMioIUZJAezlTIi6evxuoUs9YXc11cU+yzQ==",
-          "dev": true,
-          "requires": {
-            "p-try": "^2.0.0"
-          }
-        },
-        "p-locate": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-3.0.0.tgz",
-          "integrity": "sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==",
-          "dev": true,
-          "requires": {
-            "p-limit": "^2.0.0"
-          }
-        },
-        "p-try": {
-          "version": "2.2.0",
-          "resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
-          "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
-          "dev": true
-        }
+        "find-up": "^2.1.0"
       }
     },
     "platform": {
@@ -21972,9 +21853,9 @@
       }
     },
     "unbzip2-stream": {
-      "version": "1.3.3",
-      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.3.3.tgz",
-      "integrity": "sha512-fUlAF7U9Ah1Q6EieQ4x4zLNejrRvDWUYmxXUpN3uziFYCHapjWFaCAnreY9bGgxzaMCFAPPpYNng57CypwJVhg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/unbzip2-stream/-/unbzip2-stream-1.4.0.tgz",
+      "integrity": "sha512-kVx7CDAsdBSWVf404Mw7oI9i09w5/mTT/Ruk+RWa64PLYKvsAucLLFHvQtnvjeADM4ZizxrvG5SHnF4Te4T2Cg==",
       "dev": true,
       "requires": {
         "buffer": "^5.2.1",

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -191,6 +191,10 @@ import LeadingHeader from './widgets/header/Leading';
 import StickyHeader from './widgets/header/Sticky';
 import TrailingHeader from './widgets/header/Trailing';
 import BasicGlobalEvent from './widgets/global-event/Basic';
+import BasicTypeahead from './widgets/typeahead/Basic';
+import RemoteTypeahead from './widgets/typeahead/RemoteSource';
+import CustomFilterTypeahead from './widgets/typeahead/CustomFilter';
+import ValidatedTypeahead from './widgets/typeahead/Validation';
 
 `!has('docs')`;
 import testsContext from './tests';
@@ -1437,6 +1441,31 @@ export const config = {
 				example: {
 					filename: 'Basic',
 					module: BasicTooltip
+				}
+			}
+		},
+		typeahead: {
+			examples: [
+				{
+					filename: 'CustomFilter',
+					module: CustomFilterTypeahead,
+					title: 'Custom Filter'
+				},
+				{
+					filename: 'Remote',
+					module: RemoteTypeahead,
+					title: 'Remote Source'
+				},
+				{
+					filename: 'Validation',
+					module: ValidatedTypeahead,
+					title: 'Validation'
+				}
+			],
+			overview: {
+				example: {
+					filename: 'Typeahead',
+					module: BasicTypeahead
 				}
 			}
 		}

--- a/src/examples/src/widgets/list/memoryTemplate.tsx
+++ b/src/examples/src/widgets/list/memoryTemplate.tsx
@@ -1,4 +1,4 @@
-import { DataTemplate, createResource } from '@dojo/framework/core/resource';
+import { DataTemplate, createResource, ResourceQuery } from '@dojo/framework/core/resource';
 
 export function createMemoryResourceWithData<S = any>(data: S[]) {
 	const memoryTemplate = createMemoryTemplate<S>();
@@ -9,12 +9,44 @@ export function createMemoryResourceWithData<S = any>(data: S[]) {
 	};
 }
 
-export function createMemoryTemplate<S = void>(): DataTemplate<S> {
+export function defaultFilter(query: ResourceQuery[], v: any) {
+	let filterValue = '';
+
+	query.forEach((q) => {
+		if (q.keys.indexOf('value') >= -1) {
+			filterValue = q.value || '';
+		}
+	});
+
+	if (!filterValue) {
+		return true;
+	}
+
+	let filterText = v.label || v.value;
+	return filterText.toLocaleLowerCase().indexOf(filterValue.toLocaleLowerCase()) >= 0;
+}
+
+export function createMemoryResourceWithDataAndFilter<S = any>(
+	data: S[],
+	filter?: (query: ResourceQuery[], v: S) => boolean
+) {
+	const memoryTemplate = createMemoryTemplate<S>({ filter: filter || defaultFilter });
+
+	return {
+		resource: () => createResource(memoryTemplate),
+		data
+	};
+}
+
+export function createMemoryTemplate<S = void>({
+	filter
+}: { filter?: (query: ResourceQuery[], v: S) => boolean } = {}): DataTemplate<S> {
 	return {
 		read: ({ query }, put, get) => {
 			let data: any[] = get();
-			put(0, data);
-			return { data, total: data.length };
+			const filteredData = filter && query ? data.filter((i) => filter(query, i)) : data;
+			put(0, filteredData);
+			return { data: filteredData, total: filteredData.length };
 		}
 	};
 }

--- a/src/examples/src/widgets/typeahead/Basic.tsx
+++ b/src/examples/src/widgets/typeahead/Basic.tsx
@@ -1,0 +1,30 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import { defaultTransform } from '@dojo/widgets/select';
+import icache from '@dojo/framework/core/middleware/icache';
+import { createMemoryResourceWithDataAndFilter } from '../list/memoryTemplate';
+import Typeahead from '@dojo/widgets/typeahead';
+
+const factory = create({ icache });
+const options = [
+	{ value: 'cat', label: 'Cat' },
+	{ value: 'dog', label: 'Dog' },
+	{ value: 'fish', label: 'Fish' }
+];
+
+const resource = createMemoryResourceWithDataAndFilter(options);
+
+export default factory(function Basic({ middleware: { icache } }) {
+	return (
+		<virtual>
+			<Typeahead
+				label="Basic Typeahead"
+				resource={resource}
+				transform={defaultTransform}
+				onValue={(value) => {
+					icache.set('value', value);
+				}}
+			/>
+			<pre>{icache.getOrSet('value', '')}</pre>
+		</virtual>
+	);
+});

--- a/src/examples/src/widgets/typeahead/CustomFilter.tsx
+++ b/src/examples/src/widgets/typeahead/CustomFilter.tsx
@@ -1,0 +1,44 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import { defaultTransform } from '@dojo/widgets/select';
+import icache from '@dojo/framework/core/middleware/icache';
+import { createMemoryResourceWithDataAndFilter } from '../list/memoryTemplate';
+import Typeahead from '@dojo/widgets/typeahead';
+import states from './states';
+
+const factory = create({ icache });
+
+const resource = createMemoryResourceWithDataAndFilter(states, (query, option) => {
+	let filterText = '';
+
+	query.forEach(({ keys, value }) => {
+		if (keys.indexOf('value') >= 0) {
+			filterText = value || '';
+		}
+	});
+
+	if (!filterText) {
+		return true;
+	}
+
+	if (filterText.length <= 2) {
+		return option.value.toLocaleLowerCase().indexOf(filterText.toLocaleLowerCase()) === 0;
+	} else {
+		return option.label.toLocaleLowerCase().indexOf(filterText.toLocaleLowerCase()) >= 0;
+	}
+});
+
+export default factory(function CustomFilter({ middleware: { icache } }) {
+	return (
+		<virtual>
+			<Typeahead
+				label="Basic Typeahead"
+				resource={resource}
+				transform={defaultTransform}
+				onValue={(value) => {
+					icache.set('value', value);
+				}}
+			/>
+			<pre>{icache.getOrSet('value', '')}</pre>
+		</virtual>
+	);
+});

--- a/src/examples/src/widgets/typeahead/RemoteSource.tsx
+++ b/src/examples/src/widgets/typeahead/RemoteSource.tsx
@@ -1,0 +1,62 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import icache from '@dojo/framework/core/middleware/icache';
+import Typeahead from '@dojo/widgets/typeahead';
+import { createResource, createTransformer, DataTemplate } from '@dojo/framework/core/resource';
+
+const fetcher = async (options: any) => {
+	const { offset, size, query } = options;
+	let url = `https://mixolydian-appendix.glitch.me/user?`;
+
+	const pageNumber = offset / size + 1;
+	url = `${url}page=${pageNumber}&size=${size}`;
+
+	if (query) {
+		query.forEach(({ keys, value }: { keys: string[]; value: string }) => {
+			keys.forEach((key) => {
+				url = `${url}&${key}=${value}`;
+			});
+		});
+	}
+
+	const response = await fetch(url, {
+		headers: {
+			'Content-Type': 'application/json'
+		}
+	});
+	const data = await response.json();
+
+	return {
+		data: data.data,
+		total: data.total
+	};
+};
+
+const template: DataTemplate<{ firstName: string; lastName: string }> = {
+	read: fetcher
+};
+
+const transformer = createTransformer(template, {
+	value: ['lastName'],
+	label: ['firstName', 'lastName']
+});
+
+const resource = createResource(template);
+
+const factory = create({ icache });
+
+export default factory(function Remote({ middleware: { icache } }) {
+	return (
+		<virtual>
+			<Typeahead
+				label="Remote Source Typeahead"
+				helperText="Type to filter by last name"
+				resource={resource}
+				transform={transformer}
+				onValue={(value) => {
+					icache.set('value', value);
+				}}
+			/>
+			<pre>{icache.getOrSet('value', '')}</pre>
+		</virtual>
+	);
+});

--- a/src/examples/src/widgets/typeahead/Validation.tsx
+++ b/src/examples/src/widgets/typeahead/Validation.tsx
@@ -1,0 +1,31 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import { defaultTransform } from '@dojo/widgets/select';
+import icache from '@dojo/framework/core/middleware/icache';
+import { createMemoryResourceWithDataAndFilter } from '../list/memoryTemplate';
+import Typeahead from '@dojo/widgets/typeahead';
+
+const factory = create({ icache });
+const options = [
+	{ value: 'cat', label: 'Cat' },
+	{ value: 'dog', label: 'Dog' },
+	{ value: 'fish', label: 'Fish' }
+];
+
+const resource = createMemoryResourceWithDataAndFilter(options);
+
+export default factory(function Validation({ middleware: { icache } }) {
+	return (
+		<virtual>
+			<Typeahead
+				label="Validation"
+				resource={resource}
+				transform={defaultTransform}
+				onValue={(value) => {
+					icache.set('value', value);
+				}}
+				required
+			/>
+			<pre>{icache.getOrSet('value', '')}</pre>
+		</virtual>
+	);
+});

--- a/src/examples/src/widgets/typeahead/states.ts
+++ b/src/examples/src/widgets/typeahead/states.ts
@@ -1,0 +1,238 @@
+export default [
+	{
+		label: 'Alabama',
+		value: 'AL'
+	},
+	{
+		label: 'Alaska',
+		value: 'AK'
+	},
+	{
+		label: 'American Samoa',
+		value: 'AS'
+	},
+	{
+		label: 'Arizona',
+		value: 'AZ'
+	},
+	{
+		label: 'Arkansas',
+		value: 'AR'
+	},
+	{
+		label: 'California',
+		value: 'CA'
+	},
+	{
+		label: 'Colorado',
+		value: 'CO'
+	},
+	{
+		label: 'Connecticut',
+		value: 'CT'
+	},
+	{
+		label: 'Delaware',
+		value: 'DE'
+	},
+	{
+		label: 'District Of Columbia',
+		value: 'DC'
+	},
+	{
+		label: 'Federated States Of Micronesia',
+		value: 'FM'
+	},
+	{
+		label: 'Florida',
+		value: 'FL'
+	},
+	{
+		label: 'Georgia',
+		value: 'GA'
+	},
+	{
+		label: 'Guam',
+		value: 'GU'
+	},
+	{
+		label: 'Hawaii',
+		value: 'HI'
+	},
+	{
+		label: 'Idaho',
+		value: 'ID'
+	},
+	{
+		label: 'Illinois',
+		value: 'IL'
+	},
+	{
+		label: 'Indiana',
+		value: 'IN'
+	},
+	{
+		label: 'Iowa',
+		value: 'IA'
+	},
+	{
+		label: 'Kansas',
+		value: 'KS'
+	},
+	{
+		label: 'Kentucky',
+		value: 'KY'
+	},
+	{
+		label: 'Louisiana',
+		value: 'LA'
+	},
+	{
+		label: 'Maine',
+		value: 'ME'
+	},
+	{
+		label: 'Marshall Islands',
+		value: 'MH'
+	},
+	{
+		label: 'Maryland',
+		value: 'MD'
+	},
+	{
+		label: 'Massachusetts',
+		value: 'MA'
+	},
+	{
+		label: 'Michigan',
+		value: 'MI'
+	},
+	{
+		label: 'Minnesota',
+		value: 'MN'
+	},
+	{
+		label: 'Mississippi',
+		value: 'MS'
+	},
+	{
+		label: 'Missouri',
+		value: 'MO'
+	},
+	{
+		label: 'Montana',
+		value: 'MT'
+	},
+	{
+		label: 'Nebraska',
+		value: 'NE'
+	},
+	{
+		label: 'Nevada',
+		value: 'NV'
+	},
+	{
+		label: 'New Hampshire',
+		value: 'NH'
+	},
+	{
+		label: 'New Jersey',
+		value: 'NJ'
+	},
+	{
+		label: 'New Mexico',
+		value: 'NM'
+	},
+	{
+		label: 'New York',
+		value: 'NY'
+	},
+	{
+		label: 'North Carolina',
+		value: 'NC'
+	},
+	{
+		label: 'North Dakota',
+		value: 'ND'
+	},
+	{
+		label: 'Northern Mariana Islands',
+		value: 'MP'
+	},
+	{
+		label: 'Ohio',
+		value: 'OH'
+	},
+	{
+		label: 'Oklahoma',
+		value: 'OK'
+	},
+	{
+		label: 'Oregon',
+		value: 'OR'
+	},
+	{
+		label: 'Palau',
+		value: 'PW'
+	},
+	{
+		label: 'Pennsylvania',
+		value: 'PA'
+	},
+	{
+		label: 'Puerto Rico',
+		value: 'PR'
+	},
+	{
+		label: 'Rhode Island',
+		value: 'RI'
+	},
+	{
+		label: 'South Carolina',
+		value: 'SC'
+	},
+	{
+		label: 'South Dakota',
+		value: 'SD'
+	},
+	{
+		label: 'Tennessee',
+		value: 'TN'
+	},
+	{
+		label: 'Texas',
+		value: 'TX'
+	},
+	{
+		label: 'Utah',
+		value: 'UT'
+	},
+	{
+		label: 'Vermont',
+		value: 'VT'
+	},
+	{
+		label: 'Virgin Islands',
+		value: 'VI'
+	},
+	{
+		label: 'Virginia',
+		value: 'VA'
+	},
+	{
+		label: 'Washington',
+		value: 'WA'
+	},
+	{
+		label: 'West Virginia',
+		value: 'WV'
+	},
+	{
+		label: 'Wisconsin',
+		value: 'WI'
+	},
+	{
+		label: 'Wyoming',
+		value: 'WY'
+	}
+];

--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -222,12 +222,12 @@ export const List = factory(function List({
 				const index = i + startNode;
 				const page = Math.floor(index / count) + 1;
 				if (!pages[page]) {
-					setOptions({
+					const pageOptions = {
 						...getOptions(),
 						pageNumber: page
-					});
-					pages[page] = getOrRead(getOptions()) || [];
-					loading[page] = isLoading(getOptions());
+					};
+					pages[page] = getOrRead(pageOptions) || [];
+					loading[page] = isLoading(pageOptions);
 				}
 				const indexWithinPage = index - (page - 1) * count;
 				const menuOption = pages[page][indexWithinPage];

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -112,7 +112,7 @@ export const Select = factory(function Select({
 	let valid = icache.get('valid');
 	const dirty = icache.get('dirty');
 	const { messages } = i18n.localize(bundle);
-	const { get, getOptions, isLoading } = data();
+	const { get, getOptions, isLoading, getTotal } = data();
 
 	if (required && dirty) {
 		const isValid = value !== undefined;
@@ -230,7 +230,7 @@ export const Select = factory(function Select({
 							close();
 						}
 
-						return isLoading(getOptions()) ? (
+						return getTotal(getOptions()) === undefined && isLoading(getOptions()) ? (
 							<LoadingIndicator key="loading" />
 						) : (
 							<div key="menu-wrapper" classes={themedCss.menuWrapper}>

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -24,6 +24,7 @@ import * as iconCss from '../theme/default/icon.m.css';
 import * as css from '../theme/default/select.m.css';
 import bundle from './select.nls';
 import { find } from '@dojo/framework/shim/array';
+import LoadingIndicator from '../loading-indicator';
 
 export interface SelectProperties {
 	/** Callback called when user selects a value */
@@ -111,7 +112,7 @@ export const Select = factory(function Select({
 	let valid = icache.get('valid');
 	const dirty = icache.get('dirty');
 	const { messages } = i18n.localize(bundle);
-	const { get, getOptions } = data();
+	const { get, getOptions, isLoading } = data();
 
 	if (required && dirty) {
 		const isValid = value !== undefined;
@@ -174,7 +175,7 @@ export const Select = factory(function Select({
 						}
 
 						let valueOption: ListOption | undefined;
-						const currentOptions = get(getOptions());
+						const currentOptions = get({ query: getOptions().query });
 						if (currentOptions && currentOptions.length) {
 							valueOption = find(currentOptions, (option) => option.value === value);
 						}
@@ -229,7 +230,9 @@ export const Select = factory(function Select({
 							close();
 						}
 
-						return (
+						return isLoading(getOptions()) ? (
+							<LoadingIndicator key="loading" />
+						) : (
 							<div key="menu-wrapper" classes={themedCss.menuWrapper}>
 								<List
 									key="menu"

--- a/src/theme/default/index.ts
+++ b/src/theme/default/index.ts
@@ -44,6 +44,7 @@ import * as textInput from './text-input.m.css';
 import * as timePicker from './time-picker.m.css';
 import * as titlePane from './title-pane.m.css';
 import * as tooltip from './tooltip.m.css';
+import * as typeahead from './typeahead.m.css';
 import * as defaultVariant from './variants/default.m.css';
 
 export default {
@@ -93,7 +94,8 @@ export default {
 		'@dojo/widgets/text-input': textInput,
 		'@dojo/widgets/time-picker': timePicker,
 		'@dojo/widgets/title-pane': titlePane,
-		'@dojo/widgets/tooltip': tooltip
+		'@dojo/widgets/tooltip': tooltip,
+		'@dojo/widgets/typeahead': typeahead
 	},
 	variants: {
 		default: defaultVariant

--- a/src/theme/default/typeahead.m.css
+++ b/src/theme/default/typeahead.m.css
@@ -1,0 +1,14 @@
+.root {
+	display: flex;
+	flex-direction: column;
+}
+.disabled {
+}
+.invalid {
+}
+.valid {
+}
+.trigger {
+}
+.menuWrapper {
+}

--- a/src/theme/default/typeahead.m.css.d.ts
+++ b/src/theme/default/typeahead.m.css.d.ts
@@ -1,0 +1,6 @@
+export const root: string;
+export const disabled: string;
+export const invalid: string;
+export const valid: string;
+export const trigger: string;
+export const menuWrapper: string;

--- a/src/theme/dojo/index.ts
+++ b/src/theme/dojo/index.ts
@@ -45,6 +45,7 @@ import * as textInput from './text-input.m.css';
 import * as timePicker from './time-picker.m.css';
 import * as titlePane from './title-pane.m.css';
 import * as tooltip from './tooltip.m.css';
+import * as typeahead from './typeahead.m.css';
 import * as defaultVariant from './variants/default.m.css';
 
 export default {
@@ -95,7 +96,8 @@ export default {
 		'@dojo/widgets/text-input': textInput,
 		'@dojo/widgets/time-picker': timePicker,
 		'@dojo/widgets/title-pane': titlePane,
-		'@dojo/widgets/tooltip': tooltip
+		'@dojo/widgets/tooltip': tooltip,
+		'@dojo/widgets/typeahead': typeahead
 	},
 	variants: {
 		default: defaultVariant

--- a/src/theme/dojo/typeahead.m.css
+++ b/src/theme/dojo/typeahead.m.css
@@ -1,0 +1,4 @@
+.root {
+	display: flex;
+	flex-direction: column;
+}

--- a/src/theme/dojo/typeahead.m.css.d.ts
+++ b/src/theme/dojo/typeahead.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;

--- a/src/theme/material/index.ts
+++ b/src/theme/material/index.ts
@@ -44,6 +44,7 @@ import * as textInput from './text-input.m.css';
 import * as timePicker from './time-picker.m.css';
 import * as titlePane from './title-pane.m.css';
 import * as tooltip from './tooltip.m.css';
+import * as typeahead from './typeahead.m.css';
 import * as defaultVariant from './variants/default.m.css';
 
 export default {
@@ -93,7 +94,8 @@ export default {
 		'@dojo/widgets/text-input': textInput,
 		'@dojo/widgets/time-picker': timePicker,
 		'@dojo/widgets/title-pane': titlePane,
-		'@dojo/widgets/tooltip': tooltip
+		'@dojo/widgets/tooltip': tooltip,
+		'@dojo/widgets/typeahead': typeahead
 	},
 	variants: {
 		default: defaultVariant

--- a/src/theme/material/typeahead.m.css
+++ b/src/theme/material/typeahead.m.css
@@ -1,0 +1,4 @@
+.root {
+	display: flex;
+	flex-direction: column;
+}

--- a/src/theme/material/typeahead.m.css.d.ts
+++ b/src/theme/material/typeahead.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;

--- a/src/typeahead/README.md
+++ b/src/typeahead/README.md
@@ -1,0 +1,32 @@
+# @dojo/widgets/typeahead
+
+Dojo's `Typeahead` provides a form input with a filterable list of options. As the user types, the options are filtered and presented to the user.
+
+## Features
+
+- Compatible with any underlying data provider, data format, or store
+- Allows customization of option state and vdom
+- Keyboard accessible
+
+### Keyboard Usage
+
+The `Typeahead` supports keyboard navigation for opening and closing the options menu and moving through options.
+
+#### Trigger Button Events
+
+- Down Key: opens the options menu
+- Up Key: opens the options menu
+- Any change to the input value opens the options menu
+
+#### Options Menu Events
+
+- Enter Key: selects the current option and closes the menu
+- Up Arrow: highlights the previous option
+- Down Arrow: highlights the next option
+- Home/Page Up: highlights the first option
+- End/Page Down: highlights the last option
+- Escape Key: closes the options menu without selecting an option
+
+### Accessibility Features
+
+All instances of this widget should make use of the `label` property or a separate `label` node associated with the select's `widgetId` property.

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -141,7 +141,7 @@ export const Typeahead = factory(function Typeahead({
 			case Keys.Enter:
 				preventDefault();
 
-				const allItems = get({ query: getOptions().query }) as ListOption[];
+				const allItems = get({ query: getOptions().query });
 				if (allItems && allItems.length >= activeIndex) {
 					const activeItem = allItems[activeIndex];
 					if (!activeItem.disabled) {
@@ -272,7 +272,7 @@ export const Typeahead = factory(function Typeahead({
 							toggleClosed();
 						}
 
-						return isLoading(getOptions()) ? (
+						return getTotal(getOptions()) === undefined && isLoading(getOptions()) ? (
 							<LoadingIndicator key="loading" />
 						) : (
 							<div key="menu-wrapper" classes={themedCss.menuWrapper}>

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -1,0 +1,319 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import { PopupPosition } from '@dojo/widgets/popup';
+import { RenderResult } from '@dojo/framework/core/interfaces';
+import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
+import { createDataMiddleware } from '@dojo/framework/core/middleware/data';
+import List, { ItemRendererProperties, ListOption } from '../list';
+import theme from '../middleware/theme';
+import focus from '@dojo/framework/core/middleware/focus';
+import * as css from '../theme/default/typeahead.m.css';
+import Label from '../label';
+import * as labelCss from '../theme/default/label.m.css';
+import TriggerPopup from '../trigger-popup';
+import { find } from '@dojo/framework/shim/array';
+import TextInput from '../text-input';
+import bundle from '../select/select.nls';
+import i18n from '@dojo/framework/core/middleware/i18n';
+import HelperText from '../helper-text';
+import * as listCss from '../theme/default/list.m.css';
+import { Keys } from '../common/util';
+import LoadingIndicator from '../loading-indicator';
+import * as inputCss from '../theme/default/text-input.m.css';
+
+export interface TypeaheadProperties {
+	/** Callback called when user selects a value */
+	onValue(value: string): void;
+	/** The initial selected value */
+	initialValue?: string;
+	/** Property to determine how many items to render. Defaults to 6 */
+	itemsInView?: number;
+	/** Placement of the select menu; 'above' or 'below' */
+	position?: PopupPosition;
+	/** Property to determine if the input is disabled */
+	disabled?: boolean;
+	/** Sets the helper text of the input */
+	helperText?: string;
+	/** The label to show */
+	label?: RenderResult;
+	/** Boolean to indicate if field is required */
+	required?: boolean;
+	/** Callback when valid state has changed */
+	onValidate?(valid?: boolean): void;
+	/** The name property of the input */
+	name?: string;
+}
+
+export interface TypeaheadICache {
+	value: string;
+	activeIndex: number;
+	dirty: boolean;
+	expanded: boolean;
+	focusNode: string;
+	initial: string;
+	valid: boolean;
+}
+
+export interface SelectChildren {
+	/** Custom renderer for item contents */
+	(properties: ItemRendererProperties): RenderResult;
+}
+
+const factory = create({
+	icache: createICacheMiddleware<TypeaheadICache>(),
+	data: createDataMiddleware<ListOption>(),
+	theme,
+	focus,
+	i18n
+})
+	.properties<TypeaheadProperties>()
+	.children<SelectChildren | undefined>();
+
+export const Typeahead = factory(function Typeahead({
+	id,
+	properties,
+	children,
+	middleware: { icache, data, theme, focus, i18n }
+}) {
+	const {
+		initialValue,
+		disabled,
+		label,
+		required,
+		position,
+		name,
+		helperText,
+		itemsInView,
+		transform,
+		onValidate
+	} = properties();
+	const themedCss = theme.classes(css);
+	const { messages } = i18n.localize(bundle);
+	const { get, getOptions, setOptions, shared, getTotal, isLoading } = data();
+	const sharedResource = shared();
+
+	const [itemRenderer] = children();
+
+	if (initialValue !== undefined && initialValue !== icache.get('initial')) {
+		icache.set('initial', initialValue);
+		icache.set('value', initialValue);
+	}
+
+	let valid = icache.get('valid');
+	const value = icache.get('value');
+	const listId = `typeahead-list-${id}`;
+	const triggerId = `typeahead-trigger-${id}`;
+	const dirty = icache.get('dirty');
+
+	if (required && dirty) {
+		const isValid = Boolean(value);
+		if (isValid !== valid) {
+			icache.set('valid', isValid);
+			valid = isValid;
+			onValidate && onValidate(isValid);
+		}
+	}
+
+	function onKeyDown(
+		event: number,
+		preventDefault: () => void,
+		onOpen: () => boolean,
+		onClose: () => void
+	) {
+		const activeIndex = icache.getOrSet('activeIndex', 0);
+		const total = getTotal(getOptions()) || 0;
+
+		switch (event) {
+			case Keys.Escape:
+				onClose();
+				break;
+			case Keys.Down:
+				preventDefault();
+				if (!onOpen()) {
+					icache.set('activeIndex', (activeIndex + 1) % total);
+				}
+				break;
+			case Keys.Up:
+				preventDefault();
+				if (!onOpen()) {
+					icache.set('activeIndex', (activeIndex - 1 + total) % total);
+				}
+				break;
+			case Keys.Enter:
+				preventDefault();
+
+				const allItems = get({ query: getOptions().query }) as ListOption[];
+				if (allItems && allItems.length >= activeIndex) {
+					const activeItem = allItems[activeIndex];
+					if (!activeItem.disabled) {
+						const { onValue } = properties();
+
+						icache.set('value', activeItem.value);
+						onClose();
+						onValue(activeItem.value);
+					}
+				}
+				break;
+		}
+	}
+
+	return (
+		<div
+			key="root"
+			classes={[
+				theme.variant(),
+				themedCss.root,
+				disabled && themedCss.disabled,
+				valid === true && themedCss.valid,
+				valid === false && themedCss.invalid
+			]}
+		>
+			{label && (
+				<Label
+					key="label"
+					theme={theme.compose(
+						labelCss,
+						css,
+						'label'
+					)}
+					disabled={disabled}
+					valid={valid}
+					required={required}
+					active={!!(value || icache.get('expanded'))}
+				>
+					{label}
+				</Label>
+			)}
+			<TriggerPopup
+				key="popup"
+				onOpen={() => icache.set('expanded', true)}
+				onClose={() => {
+					icache.set('expanded', false);
+					if (!icache.get('dirty')) {
+						icache.set('dirty', true);
+					}
+				}}
+				position={position}
+			>
+				{{
+					trigger: (toggleOpen) => {
+						function openMenu() {
+							const { disabled } = properties();
+
+							if (!disabled && !icache.get('expanded')) {
+								toggleOpen();
+								icache.set('expanded', true);
+								icache.set('activeIndex', 0);
+								return true;
+							}
+
+							return false;
+						}
+
+						function closeMenu() {
+							if (icache.get('expanded')) {
+								toggleOpen();
+								icache.set('expanded', false);
+							}
+						}
+
+						let valueOption: ListOption | undefined;
+						const currentOptions = get(getOptions());
+						if (currentOptions && currentOptions.length) {
+							valueOption = find(currentOptions, (option) => option.value === value);
+						}
+
+						return (
+							<TextInput
+								onValue={(value) => {
+									if (value !== icache.get('value')) {
+										openMenu();
+
+										setOptions({ query: { value: value } });
+										icache.set('value', value || '');
+									}
+								}}
+								theme={theme.compose(
+									inputCss,
+									css,
+									'input'
+								)}
+								onBlur={() => {
+									closeMenu();
+								}}
+								name={name}
+								initialValue={valueOption ? valueOption.label : value}
+								focus={() =>
+									icache.get('focusNode') === 'trigger' && focus.shouldFocus()
+								}
+								aria={{
+									controls: listId,
+									haspopup: 'listbox',
+									expanded: `${icache.getOrSet('expanded', false)}`
+								}}
+								key="trigger"
+								widgetId={triggerId}
+								disabled={disabled}
+								classes={{
+									'@dojo/widgets/text-input': {
+										root: [themedCss.trigger]
+									}
+								}}
+								onClick={openMenu}
+								onKeyDown={(event, preventDefault) => {
+									onKeyDown(event, preventDefault, openMenu, closeMenu);
+								}}
+								valid={valid}
+							/>
+						);
+					},
+					content: (toggleClosed) => {
+						function closeMenu() {
+							icache.set('focusNode', 'trigger');
+							toggleClosed();
+						}
+
+						return isLoading(getOptions()) ? (
+							<LoadingIndicator key="loading" />
+						) : (
+							<div key="menu-wrapper" classes={themedCss.menuWrapper}>
+								<List
+									key="menu"
+									focusable={false}
+									activeIndex={icache.get('activeIndex')}
+									resource={sharedResource}
+									transform={transform}
+									onValue={(value) => {
+										const { onValue } = properties();
+										focus.focus();
+										closeMenu();
+										value !== icache.get('value') && icache.set('value', value);
+										onValue(value);
+									}}
+									onRequestClose={closeMenu}
+									onBlur={closeMenu}
+									initialValue={value}
+									itemsInView={itemsInView}
+									theme={theme.compose(
+										listCss,
+										css,
+										'menu'
+									)}
+									widgetId={listId}
+								>
+									{itemRenderer}
+								</List>
+							</div>
+						);
+					}
+				}}
+			</TriggerPopup>
+			<HelperText
+				key="helperText"
+				text={valid === false ? messages.requiredMessage : helperText}
+				valid={valid}
+			/>
+		</div>
+	);
+});
+
+export default Typeahead;

--- a/src/typeahead/tests/unit/Typeahead.spec.tsx
+++ b/src/typeahead/tests/unit/Typeahead.spec.tsx
@@ -1,0 +1,428 @@
+import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
+import Label from '../../../label';
+import * as labelCss from '../../../theme/default/label.m.css';
+import * as themedCss from '../../../theme/default/typeahead.m.css';
+import TriggerPopup from '../../../trigger-popup';
+import HelperText from '../../../helper-text';
+import { tsx } from '@dojo/framework/core/vdom';
+import { compareTheme, createHarness } from '../../../common/tests/support/test-helpers';
+import Typeahead from '../../../typeahead';
+import List, { defaultTransform, ListOption } from '../../../list';
+import { createMemoryTemplate } from '../../../examples/src/widgets/list/memoryTemplate';
+import { createResource } from '@dojo/framework/core/resource';
+import { stub } from 'sinon';
+import TextInput from '../../../text-input';
+import * as listCss from '../../../theme/default/list.m.css';
+import * as inputCss from '../../../theme/default/text-input.m.css';
+import { Keys } from '../../../common/util';
+
+const { assert } = intern.getPlugin('chai');
+
+const harness = createHarness([compareTheme]);
+
+const { registerSuite } = intern.getInterface('object');
+const noop = stub();
+
+const animalOptions: ListOption[] = [
+	{ value: 'dog' },
+	{ value: 'cat', label: 'Cat' },
+	{ value: 'fish', disabled: true }
+];
+
+const memoryTemplate = createMemoryTemplate();
+
+const resource = {
+	resource: () => createResource(memoryTemplate),
+	data: animalOptions
+};
+
+const baseAssertion = assertionTemplate(() => (
+	<div key="root" classes={[undefined, themedCss.root, undefined, false, false]}>
+		<Label
+			key="label"
+			theme={{ '@dojo/widgets/label': labelCss }}
+			disabled={undefined}
+			valid={undefined}
+			required={undefined}
+			active={false}
+		>
+			Test
+		</Label>
+		<TriggerPopup key="popup" onOpen={noop} onClose={noop} position={undefined}>
+			{{
+				trigger: noop,
+				content: noop
+			}}
+		</TriggerPopup>
+		<HelperText key="helperText" text={undefined} valid={undefined} />
+	</div>
+));
+
+const inputTemplate = assertionTemplate(() => (
+	<TextInput
+		onValue={noop}
+		onBlur={noop}
+		name={undefined}
+		initialValue={undefined}
+		focus={noop}
+		aria={{
+			controls: 'typeahead-list-test',
+			haspopup: 'listbox',
+			expanded: 'false'
+		}}
+		key="trigger"
+		widgetId="typeahead-trigger-test"
+		disabled={undefined}
+		classes={{
+			'@dojo/widgets/text-input': {
+				root: [themedCss.trigger]
+			}
+		}}
+		onClick={noop}
+		onKeyDown={noop}
+		valid={undefined}
+		theme={{ '@dojo/widgets/text-input': inputCss }}
+	/>
+));
+
+const listTemplate = assertionTemplate(() => (
+	<div key="menu-wrapper" classes={themedCss.menuWrapper}>
+		<List
+			key="menu"
+			focusable={false}
+			activeIndex={undefined}
+			resource={{ resource: resource.resource(), createOptionsWrapper: noop }}
+			transform={defaultTransform}
+			onValue={noop}
+			onRequestClose={noop}
+			onBlur={noop}
+			initialValue={undefined}
+			itemsInView={undefined}
+			theme={{ '@dojo/widgets/list': listCss }}
+			widgetId={'typeahead-list-test'}
+		>
+			{}
+		</List>
+	</div>
+));
+
+registerSuite('Typeahead', {
+	tests: {
+		'renders a typeahead'() {
+			const h = harness(() => (
+				<Typeahead
+					label="Test"
+					resource={resource}
+					transform={defaultTransform}
+					onValue={noop}
+				/>
+			));
+
+			h.expect(baseAssertion);
+		},
+
+		'renders the typeahead trigger'() {
+			const h = harness(() => (
+				<Typeahead
+					label="Test"
+					resource={resource}
+					transform={defaultTransform}
+					onValue={noop}
+				/>
+			));
+
+			const toggleOpenStub = stub();
+
+			const triggerRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].trigger,
+				toggleOpenStub
+			);
+
+			h.expect(inputTemplate, () => triggerRenderResult);
+		},
+
+		'renders the typeahead content'() {
+			const h = harness(() => (
+				<Typeahead
+					label="Test"
+					resource={resource}
+					transform={defaultTransform}
+					onValue={noop}
+				/>
+			));
+
+			const toggleCloseStub = stub();
+
+			const contentRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].content,
+				toggleCloseStub
+			);
+
+			h.expect(listTemplate, () => contentRenderResult);
+		},
+
+		'opens the typeahead on input value'() {
+			const h = harness(() => (
+				<Typeahead
+					label="Test"
+					resource={resource}
+					transform={defaultTransform}
+					onValue={noop}
+				/>
+			));
+
+			const toggleOpenStub = stub();
+
+			const triggerRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].trigger,
+				toggleOpenStub
+			);
+
+			triggerRenderResult.properties.onValue('value');
+
+			assert.isTrue(toggleOpenStub.calledOnce);
+		},
+
+		'opens the typeahead on input click'() {
+			const h = harness(() => (
+				<Typeahead
+					label="Test"
+					resource={resource}
+					transform={defaultTransform}
+					onValue={noop}
+				/>
+			));
+
+			const toggleOpenStub = stub();
+
+			const triggerRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].trigger,
+				toggleOpenStub
+			);
+
+			triggerRenderResult.properties.onClick();
+
+			assert.isTrue(toggleOpenStub.calledOnce);
+		},
+
+		'opens the typeahead on down press'() {
+			const h = harness(() => (
+				<Typeahead
+					label="Test"
+					resource={resource}
+					transform={defaultTransform}
+					onValue={noop}
+				/>
+			));
+
+			const toggleOpenStub = stub();
+
+			const triggerRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].trigger,
+				toggleOpenStub
+			);
+
+			const preventDefaultStub = stub();
+
+			triggerRenderResult.properties.onKeyDown(Keys.Down, preventDefaultStub);
+
+			assert.isTrue(preventDefaultStub.calledOnce);
+			assert.isTrue(toggleOpenStub.calledOnce);
+		},
+		'opens the typeahead on up press'() {
+			const h = harness(() => (
+				<Typeahead
+					label="Test"
+					resource={resource}
+					transform={defaultTransform}
+					onValue={noop}
+				/>
+			));
+
+			const toggleOpenStub = stub();
+
+			const triggerRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].trigger,
+				toggleOpenStub
+			);
+
+			const preventDefaultStub = stub();
+
+			triggerRenderResult.properties.onKeyDown(Keys.Up, preventDefaultStub);
+
+			assert.isTrue(preventDefaultStub.calledOnce);
+			assert.isTrue(toggleOpenStub.calledOnce);
+		},
+		'controls the list with keyboard events'() {
+			const h = harness(() => (
+				<Typeahead
+					label="Test"
+					resource={resource}
+					transform={defaultTransform}
+					onValue={noop}
+				/>
+			));
+
+			const toggleOpenStub = stub();
+			const toggleCloseStub = stub();
+			const preventDefaultStub = stub();
+
+			const triggerRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].trigger,
+				toggleOpenStub
+			);
+
+			// first to open the popup
+			triggerRenderResult.properties.onKeyDown(Keys.Down, preventDefaultStub);
+			// next to move the active index
+			triggerRenderResult.properties.onKeyDown(Keys.Down, preventDefaultStub);
+
+			const contentRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].content,
+				toggleCloseStub
+			);
+
+			h.expect(
+				listTemplate.setProperty('@menu', 'activeIndex', 1),
+				() => contentRenderResult
+			);
+		},
+		'wraps list items when gets to the top'() {
+			const h = harness(() => (
+				<Typeahead
+					label="Test"
+					resource={resource}
+					transform={defaultTransform}
+					onValue={noop}
+				/>
+			));
+
+			const toggleOpenStub = stub();
+			const toggleCloseStub = stub();
+			const preventDefaultStub = stub();
+
+			const triggerRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].trigger,
+				toggleOpenStub
+			);
+
+			// first to open the popup
+			triggerRenderResult.properties.onKeyDown(Keys.Up, preventDefaultStub);
+			// second to wrap from the top ot the bottom
+			triggerRenderResult.properties.onKeyDown(Keys.Up, preventDefaultStub);
+
+			const contentRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].content,
+				toggleCloseStub
+			);
+
+			h.expect(
+				listTemplate.setProperty('@menu', 'activeIndex', 2),
+				() => contentRenderResult
+			);
+		},
+		'wraps list items when gets to the bottom'() {
+			const h = harness(() => (
+				<Typeahead
+					label="Test"
+					resource={resource}
+					transform={defaultTransform}
+					onValue={noop}
+				/>
+			));
+
+			const toggleOpenStub = stub();
+			const toggleCloseStub = stub();
+			const preventDefaultStub = stub();
+
+			const triggerRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].trigger,
+				toggleOpenStub
+			);
+
+			// first to open the popup
+			triggerRenderResult.properties.onKeyDown(Keys.Down, preventDefaultStub);
+
+			// loop through all options to wrap back to the top
+			animalOptions.forEach(() => {
+				triggerRenderResult.properties.onKeyDown(Keys.Down, preventDefaultStub);
+			});
+
+			const contentRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].content,
+				toggleCloseStub
+			);
+
+			h.expect(
+				listTemplate.setProperty('@menu', 'activeIndex', 0),
+				() => contentRenderResult
+			);
+		},
+		'selects a value on enter'() {
+			const onValue = stub();
+
+			const h = harness(() => (
+				<Typeahead
+					label="Test"
+					resource={resource}
+					transform={defaultTransform}
+					onValue={onValue}
+				/>
+			));
+
+			const toggleOpenStub = stub();
+			const preventDefaultStub = stub();
+
+			const triggerRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].trigger,
+				toggleOpenStub
+			);
+
+			// first to open the popup
+			triggerRenderResult.properties.onKeyDown(Keys.Down, preventDefaultStub);
+			triggerRenderResult.properties.onKeyDown(Keys.Enter, preventDefaultStub);
+
+			assert.isTrue(onValue.calledWith(animalOptions[0].value));
+		},
+		'does not select a value on escape'() {
+			const onValue = stub();
+
+			const h = harness(() => (
+				<Typeahead
+					label="Test"
+					resource={resource}
+					transform={defaultTransform}
+					onValue={onValue}
+				/>
+			));
+
+			const toggleOpenStub = stub();
+			const preventDefaultStub = stub();
+
+			const triggerRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].trigger,
+				toggleOpenStub
+			);
+
+			// first to open the popup
+			triggerRenderResult.properties.onKeyDown(Keys.Down, preventDefaultStub);
+			triggerRenderResult.properties.onKeyDown(Keys.Escape, preventDefaultStub);
+
+			assert.isFalse(onValue.called);
+		}
+	}
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding Typeahead widget!

![2020-04-01 09 59 06](https://user-images.githubusercontent.com/2008858/78146214-dbd14080-73ff-11ea-937f-9af6082e60f4.gif)
![2020-04-01 09 59 28](https://user-images.githubusercontent.com/2008858/78146218-dc69d700-73ff-11ea-95ee-6721d7b94ed4.gif)
![2020-04-01 09 59 56](https://user-images.githubusercontent.com/2008858/78146219-dd026d80-73ff-11ea-9877-f91c10717217.gif)
![2020-04-01 10 00 31](https://user-images.githubusercontent.com/2008858/78146220-dd9b0400-73ff-11ea-8338-5fe0f84de057.gif)
![2020-04-01 10 00 50](https://user-images.githubusercontent.com/2008858/78146222-de339a80-73ff-11ea-87e9-4696b9225752.gif)


Resolves #795 
