### PR TITLE
Use npm install instead of npm ci

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - run: npm ci
+    - run: npm install
     - run: npm run build:lib
 
   build-lib-legecy:
@@ -32,7 +32,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - run: npm ci
+    - run: npm install
     - run: npm run build:lib:legacy
 
   build-ce:
@@ -46,7 +46,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - run: npm ci
+    - run: npm install
     - run: npm run build:ce
 
   build-themes:
@@ -60,7 +60,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - run: npm ci
+    - run: npm install
     - run: npm run build:themes
 
   tests:
@@ -74,7 +74,7 @@ jobs:
     - uses: actions/setup-node@v1
       with:
         node-version: 12.x
-    - run: npm ci
+    - run: npm install
     - run: npm run build:test
     - run: npm run test:headless
     - name: Upload coverage


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Attempt to fix CI