### PR TITLE
Fix year navigation styles in date picker

### DIFF
--- a/src/calendar/DatePicker.tsx
+++ b/src/calendar/DatePicker.tsx
@@ -362,26 +362,26 @@ export const DatePicker = factory(function DatePicker({
 					<legend classes={[baseCss.visuallyHidden]}>{labels.chooseYear}</legend>
 					{...renderYearRadios()}
 				</fieldset>
-				<div classes={themeCss.controls}>
-					<button
-						classes={themeCss.previous}
-						tabIndex={yearPopupOpen ? 0 : -1}
-						type="button"
-						onclick={onYearPageDown}
-						disabled={!yearInMinMax(year - 1)}
-					>
-						{...renderPagingButtonContent(Paging.previous)}
-					</button>
-					<button
-						classes={themeCss.next}
-						tabIndex={yearPopupOpen ? 0 : -1}
-						type="button"
-						onclick={onYearPageUp}
-						disabled={!yearInMinMax(year + 1)}
-					>
-						{renderPagingButtonContent(Paging.next)}
-					</button>
-				</div>
+			</div>
+			<div classes={themeCss.controls}>
+				<button
+					classes={themeCss.previous}
+					tabindex={yearPopupOpen ? 0 : -1}
+					type="button"
+					onclick={onYearPageDown}
+					disabled={!yearInMinMax(year - 1)}
+				>
+					{...renderPagingButtonContent(Paging.previous)}
+				</button>
+				<button
+					classes={themeCss.next}
+					tabindex={yearPopupOpen ? 0 : -1}
+					type="button"
+					onclick={onYearPageUp}
+					disabled={!yearInMinMax(year + 1)}
+				>
+					{renderPagingButtonContent(Paging.next)}
+				</button>
 			</div>
 		</div>
 	);

--- a/src/calendar/tests/unit/DatePicker.spec.tsx
+++ b/src/calendar/tests/unit/DatePicker.spec.tsx
@@ -146,28 +146,33 @@ const expectedYearPopup = function(
 				<legend classes={[baseCss.visuallyHidden]}>{DEFAULT_LABELS.chooseYear}</legend>
 				{...yearRadios(open, yearStart, yearEnd, undefined, minYear, maxYear)}
 			</fieldset>
-			<div classes={css.controls}>
-				<button
-					classes={css.previous}
-					tabIndex={open ? 0 : -1}
-					type="button"
-					disabled={false}
-					onclick={noop}
-				>
-					<Icon type="leftIcon" theme={undefined} classes={undefined} />
-					<span classes={baseCss.visuallyHidden}>{DEFAULT_LABELS.previousYears}</span>
-				</button>
-				<button
-					classes={css.next}
-					tabIndex={open ? 0 : -1}
-					type="button"
-					disabled={false}
-					onclick={noop}
-				>
-					<Icon type="rightIcon" theme={undefined} classes={undefined} />
-					<span classes={baseCss.visuallyHidden}>{DEFAULT_LABELS.nextYears}</span>
-				</button>
-			</div>
+		</div>
+	);
+};
+
+const expectedControls = function(open: boolean) {
+	return (
+		<div classes={css.controls}>
+			<button
+				classes={css.previous}
+				tabindex={open ? 0 : -1}
+				type="button"
+				disabled={false}
+				onclick={noop}
+			>
+				<Icon type="leftIcon" theme={undefined} classes={undefined} />
+				<span classes={baseCss.visuallyHidden}>{DEFAULT_LABELS.previousYears}</span>
+			</button>
+			<button
+				classes={css.next}
+				tabindex={open ? 0 : -1}
+				type="button"
+				disabled={false}
+				onclick={noop}
+			>
+				<Icon type="rightIcon" theme={undefined} classes={undefined} />
+				<span classes={baseCss.visuallyHidden}>{DEFAULT_LABELS.nextYears}</span>
+			</button>
 		</div>
 	);
 };
@@ -243,6 +248,7 @@ const expected = function(monthOpen = false, yearOpen = false, options: Expected
 				minDate && minDate.getFullYear(),
 				maxDate && maxDate.getFullYear()
 			)}
+			{expectedControls(yearOpen)}
 		</div>
 	);
 };
@@ -418,32 +424,30 @@ registerSuite('Calendar DatePicker', {
 							</legend>
 							{...yearRadios(false, 1980, 2000, 1997)}
 						</fieldset>
-						<div classes={css.controls}>
-							<button
-								classes={css.previous}
-								disabled={false}
-								tabIndex={-1}
-								type="button"
-								onclick={noop}
-							>
-								<Icon type="leftIcon" theme={undefined} classes={undefined} />
-								<span classes={baseCss.visuallyHidden}>
-									{DEFAULT_LABELS.previousYears}
-								</span>
-							</button>
-							<button
-								classes={css.next}
-								disabled={false}
-								tabIndex={-1}
-								type="button"
-								onclick={noop}
-							>
-								<Icon type="rightIcon" theme={undefined} classes={undefined} />
-								<span classes={baseCss.visuallyHidden}>
-									{DEFAULT_LABELS.nextYears}
-								</span>
-							</button>
-						</div>
+					</div>
+					<div classes={css.controls}>
+						<button
+							classes={css.previous}
+							disabled={false}
+							tabindex={-1}
+							type="button"
+							onclick={noop}
+						>
+							<Icon type="leftIcon" theme={undefined} classes={undefined} />
+							<span classes={baseCss.visuallyHidden}>
+								{DEFAULT_LABELS.previousYears}
+							</span>
+						</button>
+						<button
+							classes={css.next}
+							disabled={false}
+							tabindex={-1}
+							type="button"
+							onclick={noop}
+						>
+							<Icon type="rightIcon" theme={undefined} classes={undefined} />
+							<span classes={baseCss.visuallyHidden}>{DEFAULT_LABELS.nextYears}</span>
+						</button>
 					</div>
 				</div>
 			));


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Moves the controls div in the date picker so the new styles placing the navigation in the header work
properly.
Resolves #1230 
