### PR TITLE
Use compose in calendar

### DIFF
--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -7,6 +7,7 @@ import Icon from '../icon/index';
 import calendarBundle from './nls/Calendar';
 import * as css from '../theme/default/calendar.m.css';
 import * as baseCss from '../common/styles/base.m.css';
+import * as iconCss from '../theme/default/icon.m.css';
 
 import theme from '../middleware/theme';
 import icache, { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
@@ -450,12 +451,20 @@ export const DatePicker = create({ theme, focus, icache }).properties<DatePicker
 		}
 
 		function renderPagingButtonContent(type: Paging) {
-			const { labels, theme, classes } = properties();
+			const { labels, classes } = properties();
 			const iconType = type === Paging.next ? 'rightIcon' : 'leftIcon';
 			const labelText = type === Paging.next ? labels.nextYears : labels.previousYears;
 
 			return [
-				<Icon type={iconType} theme={theme} classes={classes} />,
+				<Icon
+					type={iconType}
+					theme={theme.compose(
+						iconCss,
+						css,
+						'datePickerPaging'
+					)}
+					classes={classes}
+				/>,
 				<span classes={baseCss.visuallyHidden}>{labelText}</span>
 			];
 		}
@@ -949,15 +958,19 @@ export const Calendar = factory(function Calendar({
 	}
 
 	function renderPagingButtonContent(type: Paging, labels: CalendarMessages) {
-		const { theme, classes } = properties();
+		const { classes } = properties();
 		const iconType = type === Paging.next ? 'rightIcon' : 'leftIcon';
 		const labelText = type === Paging.next ? labels.nextMonth : labels.previousMonth;
 
 		return [
 			<Icon
 				type={iconType}
-				theme={theme}
-				classes={{ ...classes, '@dojo/widgets/icon': { icon: [themeCss.icon] } }}
+				theme={theme.compose(
+					iconCss,
+					css,
+					'calendarPaging'
+				)}
+				classes={classes}
 			/>,
 			<span classes={[baseCss.visuallyHidden]}>{labelText}</span>
 		];

--- a/src/calendar/tests/unit/Calendar.spec.tsx
+++ b/src/calendar/tests/unit/Calendar.spec.tsx
@@ -9,6 +9,7 @@ import Calendar, { CalendarProperties, CalendarCell, DatePicker } from '../../in
 import Icon from '../../../icon/index';
 import * as css from '../../../theme/default/calendar.m.css';
 import * as baseCss from '../../../common/styles/base.m.css';
+import { compareTheme } from '../../../common/tests/support/test-helpers';
 import {
 	compareId,
 	createHarness,
@@ -20,7 +21,7 @@ import {
 import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
 
 const testDate = new Date('June 5 2017');
-const harness = createHarness([compareId, compareLabelId, compareAriaLabelledBy]);
+const harness = createHarness([compareId, compareLabelId, compareAriaLabelledBy, compareTheme]);
 
 /** Index of current expected date cell. Used by date cell factory function */
 const expectedDateCell = function(
@@ -286,11 +287,7 @@ const expected = function(
 					type="button"
 					onclick={noop}
 				>
-					<Icon
-						type="leftIcon"
-						theme={undefined}
-						classes={{ '@dojo/widgets/icon': { icon: [css.icon] } }}
-					/>
+					<Icon type="leftIcon" theme={{}} classes={undefined} />
 					<span classes={[baseCss.visuallyHidden]}>Previous Month</span>
 				</button>
 				<button
@@ -300,11 +297,7 @@ const expected = function(
 					type="button"
 					onclick={noop}
 				>
-					<Icon
-						type="rightIcon"
-						theme={undefined}
-						classes={{ '@dojo/widgets/icon': { icon: [css.icon] } }}
-					/>
+					<Icon type="rightIcon" theme={{}} classes={undefined} />
 					<span classes={[baseCss.visuallyHidden]}>Next Month</span>
 				</button>
 			</div>
@@ -415,11 +408,7 @@ const baseTemplate = assertionTemplate(() => {
 					type="button"
 					onclick={noop}
 				>
-					<Icon
-						type="leftIcon"
-						theme={undefined}
-						classes={{ '@dojo/widgets/icon': { icon: [css.icon] } }}
-					/>
+					<Icon type="leftIcon" theme={{}} classes={undefined} />
 					<span classes={[baseCss.visuallyHidden]}>Previous Month</span>
 				</button>
 				<button
@@ -430,11 +419,7 @@ const baseTemplate = assertionTemplate(() => {
 					type="button"
 					onclick={noop}
 				>
-					<Icon
-						type="rightIcon"
-						theme={undefined}
-						classes={{ '@dojo/widgets/icon': { icon: [css.icon] } }}
-					/>
+					<Icon type="rightIcon" theme={{}} classes={undefined} />
 					<span classes={[baseCss.visuallyHidden]}>Next Month</span>
 				</button>
 			</div>

--- a/src/calendar/tests/unit/CalendarCell.spec.tsx
+++ b/src/calendar/tests/unit/CalendarCell.spec.tsx
@@ -129,16 +129,28 @@ registerSuite('CalendarCell', {
 
 		'Keydown handler called'() {
 			let called = false;
+			let preventDefaultCalled = false;
+			let callback: () => any = () => {};
+			const localStubEvent = {
+				...stubEvent,
+				preventDefault() {
+					preventDefaultCalled = true;
+				}
+			};
 			const h = harness(() => (
 				<CalendarCell
 					date={1}
-					onKeyDown={() => {
+					onKeyDown={(_, localCallback) => {
 						called = true;
+						callback = localCallback;
 					}}
 				/>
 			));
-			h.trigger('td', 'onkeydown', stubEvent);
+			h.trigger('td', 'onkeydown', localStubEvent);
 			assert.isTrue(called);
+			assert.isFalse(preventDefaultCalled);
+			typeof callback && callback();
+			assert.isTrue(preventDefaultCalled);
 		},
 
 		'Focus is set with callback'() {

--- a/src/calendar/tests/unit/DatePicker.spec.tsx
+++ b/src/calendar/tests/unit/DatePicker.spec.tsx
@@ -1,7 +1,6 @@
 const { registerSuite } = intern.getInterface('object');
 const { assert } = intern.getPlugin('chai');
 
-import harness from '@dojo/framework/testing/harness';
 import { tsx } from '@dojo/framework/core/vdom';
 import { Keys } from '../../../common/util';
 
@@ -15,9 +14,12 @@ import {
 	compareAriaControls,
 	compareId,
 	stubEvent,
-	noop
+	noop,
+	createHarness,
+	compareTheme
 } from '../../../common/tests/support/test-helpers';
 
+const harness = createHarness([compareTheme]);
 const testDate = new Date('June 3 2017');
 const requiredProps = {
 	labels: DEFAULT_LABELS,
@@ -160,7 +162,7 @@ const expectedControls = function(open: boolean) {
 				disabled={false}
 				onclick={noop}
 			>
-				<Icon type="leftIcon" theme={undefined} classes={undefined} />
+				<Icon type="leftIcon" theme={{}} classes={undefined} />
 				<span classes={baseCss.visuallyHidden}>{DEFAULT_LABELS.previousYears}</span>
 			</button>
 			<button
@@ -170,7 +172,7 @@ const expectedControls = function(open: boolean) {
 				disabled={false}
 				onclick={noop}
 			>
-				<Icon type="rightIcon" theme={undefined} classes={undefined} />
+				<Icon type="rightIcon" theme={{}} classes={undefined} />
 				<span classes={baseCss.visuallyHidden}>{DEFAULT_LABELS.nextYears}</span>
 			</button>
 		</div>
@@ -433,7 +435,7 @@ registerSuite('Calendar DatePicker', {
 							type="button"
 							onclick={noop}
 						>
-							<Icon type="leftIcon" theme={undefined} classes={undefined} />
+							<Icon type="leftIcon" theme={{}} classes={undefined} />
 							<span classes={baseCss.visuallyHidden}>
 								{DEFAULT_LABELS.previousYears}
 							</span>
@@ -445,7 +447,7 @@ registerSuite('Calendar DatePicker', {
 							type="button"
 							onclick={noop}
 						>
-							<Icon type="rightIcon" theme={undefined} classes={undefined} />
+							<Icon type="rightIcon" theme={{}} classes={undefined} />
 							<span classes={baseCss.visuallyHidden}>{DEFAULT_LABELS.nextYears}</span>
 						</button>
 					</div>

--- a/src/theme/default/calendar.m.css
+++ b/src/theme/default/calendar.m.css
@@ -44,7 +44,7 @@
 }
 
 /* Icons */
-.icon {
+.calendarPagingIcon {
 }
 
 /* Added the days of the week header (e.g. Sun, Mon, Tue) */

--- a/src/theme/default/calendar.m.css
+++ b/src/theme/default/calendar.m.css
@@ -45,6 +45,7 @@
 
 /* Icons */
 .calendarPagingIcon {
+	composes: icon from './icon.m.css';
 }
 
 /* Added the days of the week header (e.g. Sun, Mon, Tue) */

--- a/src/theme/default/calendar.m.css.d.ts
+++ b/src/theme/default/calendar.m.css.d.ts
@@ -6,7 +6,7 @@ export const todayDate: string;
 export const date: string;
 export const dateGrid: string;
 export const abbr: string;
-export const icon: string;
+export const calendarPagingIcon: string;
 export const weekday: string;
 export const datePicker: string;
 export const topMatter: string;

--- a/src/theme/dojo/calendar.m.css
+++ b/src/theme/dojo/calendar.m.css
@@ -137,6 +137,7 @@
 }
 
 .calendarPagingIcon {
+	composes: icon from './icon.m.css';
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/src/theme/dojo/calendar.m.css
+++ b/src/theme/dojo/calendar.m.css
@@ -136,7 +136,7 @@
 	top: var(--grid-base);
 }
 
-.icon {
+.calendarPagingIcon {
 	display: flex;
 	justify-content: center;
 	align-items: center;

--- a/src/theme/dojo/calendar.m.css.d.ts
+++ b/src/theme/dojo/calendar.m.css.d.ts
@@ -13,7 +13,7 @@ export const previous: string;
 export const next: string;
 export const monthTriggerActive: string;
 export const yearTriggerActive: string;
-export const icon: string;
+export const calendarPagingIcon: string;
 export const monthGrid: string;
 export const yearGrid: string;
 export const monthFields: string;

--- a/src/theme/material/calendar.m.css
+++ b/src/theme/material/calendar.m.css
@@ -124,6 +124,10 @@
 	background-color: var(--mdc-theme-primary);
 }
 
+.calendarPagingIcon {
+	composes: icon from './icon.m.css';
+}
+
 .yearRadioChecked .yearRadioLabel,
 .monthRadioChecked .monthRadioLabel {
 	color: var(--mdc-theme-on-primary);

--- a/src/theme/material/calendar.m.css.d.ts
+++ b/src/theme/material/calendar.m.css.d.ts
@@ -16,6 +16,7 @@ export const yearRadio: string;
 export const monthRadio: string;
 export const yearRadioChecked: string;
 export const monthRadioChecked: string;
+export const calendarPagingIcon: string;
 export const yearRadioLabel: string;
 export const monthRadioLabel: string;
 export const yearRadioInput: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Uses `theme.compose` for child icon widgets. Depends on #1233 
Resolves #1219 
