### PR TITLE
Radio migration guide

### DIFF
--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -311,20 +311,21 @@ Latest example can be found on [widgets.dojo.io/#widget/progress/overview](https
 ### radio
 
 #### Property changes
-##### Additional Mandatory Properties
-- foo: string
-	- this prop does x
-##### Changed properties
-- bar: string
-	- this prop replaced x
-	- this prop does foo bar baz
-	- more info
 ##### Removed properties
-- baz: string
-	- replaced by foo
-	- any additional info
+- label?: () => RenderResult
+	- Label is now handled in a child renderer. Child content of the Radio widget is displayed in a Label.
+- labelAfter?: boolean;
+	- Removed in favor of a single label handled via a child renderer.
+	
 #### Changes in behaviour
+Label is now handled via an optional child renderer of type RenderResult.
 #### Example of migration from v6 to v7
+```
+<Radio label={'Radio Button 1'} />
+```
+```
+<Radio>Radio Button 1</Radio>
+```
 
 Latest example can be found on [widgets.dojo.io/#widget/radio/overview](https://widgets.dojo.io/#widget/radio/overview)
 

--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -311,12 +311,12 @@ Latest example can be found on [widgets.dojo.io/#widget/progress/overview](https
 ### radio
 
 #### Property changes
-##### Removed properties
-- label?: () => RenderResult
+##### Changed properties
+- label?: RenderResult
 	- Label is now handled in a child renderer. Child content of the Radio widget is displayed in a Label.
+##### Removed properties
 - labelAfter?: boolean;
 	- Removed in favor of a single label handled via a child renderer.
-	
 #### Changes in behaviour
 Label is now handled via an optional child renderer of type RenderResult.
 #### Example of migration from v6 to v7


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds info about the `Radio` and `RadioGroup` widgets to the migration guide. 

Part of #1242 
