### PR TITLE
Add aria back to Progress widget

### DIFF
--- a/src/progress/index.tsx
+++ b/src/progress/index.tsx
@@ -3,8 +3,11 @@ import { create, tsx } from '@dojo/framework/core/vdom';
 
 import theme from '../middleware/theme';
 import * as css from '../theme/default/progress.m.css';
+import { formatAriaProperties } from '../common/util';
 
 export interface ProgressProperties {
+	/** Custom aria attributes */
+	aria?: { [key: string]: string | null };
 	/** Value used to calculate percent width */
 	max?: number;
 	/** Value used to calculate percent width */
@@ -33,6 +36,7 @@ export const Progress = factory(function Progress({
 }) {
 	const themeCss = theme.classes(css);
 	const {
+		aria = {},
 		value,
 		showOutput = true,
 		max = 100,
@@ -57,6 +61,7 @@ export const Progress = factory(function Progress({
 			<div
 				classes={themeCss.bar}
 				role="progressbar"
+				{...formatAriaProperties(aria)}
 				aria-valuemin={`${min}`}
 				aria-valuemax={`${max}`}
 				aria-valuenow={`${value}`}

--- a/src/progress/tests/unit/Progress.spec.tsx
+++ b/src/progress/tests/unit/Progress.spec.tsx
@@ -100,4 +100,11 @@ describe('Progress', () => {
 
 		h.expect(template.setProperty('~progressbar', 'id', 'my-id'));
 	});
+
+	it('accepts aria properties', () => {
+		const h = harness(() => (
+			<Progress value={50} aria={{ describedBy: 'foo', valueNow: 'overridden' }} />
+		));
+		h.expect(template.setProperty('~progressbar', 'aria-describedby', 'foo'));
+	});
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds the `aria` bundle back in to the `Progress` widget. This was previously removed, but is being added back to keep things standardized until further discussion/changes.

Resolves #1276 
