### PR TITLE
Add progress info to migration guide

### DIFF
--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -335,9 +335,11 @@ Latest example can be found on [widgets.dojo.io/#widget/native-select/overview](
 ### progress
 
 #### Property changes
-##### Removed properties
-- output?(value: number, percent: number): string;
+##### Changed properties
+- output?: () => RenderResult
 	- `output` was moved to a child renderer and should be handled in a child function.
+#### Changes in behaviour
+Output is now handled via an optional child renderer of type RenderResult.
 #### Example of migration from v6 to v7
 ```
 <Progress

--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -335,20 +335,24 @@ Latest example can be found on [widgets.dojo.io/#widget/native-select/overview](
 ### progress
 
 #### Property changes
-##### Additional Mandatory Properties
-- foo: string
-	- this prop does x
-##### Changed properties
-- bar: string
-	- this prop replaced x
-	- this prop does foo bar baz
-	- more info
 ##### Removed properties
-- baz: string
-	- replaced by foo
-	- any additional info
-#### Changes in behaviour
+- output?(value: number, percent: number): string;
+	- `output` was moved to a child renderer and should be handled in a child function.
 #### Example of migration from v6 to v7
+```
+<Progress
+	value={value}
+	max={max}
+	output={(value, percent) => `${value} of ${max} is ${percent}%`}
+/>
+```
+```
+<Progress value={value} max={max}>
+	{{
+		output: (value, percent) => `${value} of ${max} is ${percent}%`
+	}}
+</Progress>
+```
 
 Latest example can be found on [widgets.dojo.io/#widget/progress/overview](https://widgets.dojo.io/#widget/progress/overview)
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds info about the Progress widget to the migration guide.

Part of #1242 