### PR TITLE
Checkbox v7 migration doc updates

### DIFF
--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -146,20 +146,67 @@ Latest example can be found on [widgets.dojo.io/#widget/calendar/overview](https
 ### checkbox
 
 #### Property changes
-##### Additional Mandatory Properties
-- foo: string
-	- this prop does x
 ##### Changed properties
-- bar: string
-	- this prop replaced x
-	- this prop does foo bar baz
-	- more info
+- onBlur: () => void;
+	- this prop now is passed zero arguments, whereas previously it was passed the current `value` and `checked` property values.
+- onFocus: () => void;
+	- this prop now is passed zero arguments, whereas previously it was passed the current `value` and `checked` property values.
 ##### Removed properties
-- baz: string
-	- replaced by foo
-	- any additional info
-#### Changes in behaviour
+- onChange: (value: string, checked: boolean) => void;
+	- replaced by `onValue(checked: boolean)`
+- onClick: (value: string, checked: boolean) => void;
+	- replaced by `onValue(checked: boolean)`
 #### Example of migration from v6 to v7
+
+```ts
+// v6
+import { create, tsx } from '@dojo/framework/core/vdom';
+import icache from '@dojo/framework/core/middleware/icache';
+import Checkbox from '@dojo/widgets/checkbox';
+
+const factory = create({ icache });
+
+export default factory(function CheckboxExample({ middleware: { icache } }) {
+	const checkboxStates = icache.getOrSet('checkboxStates', {});
+	return [
+		<Checkbox
+			checked={checked.checkbox0}
+			label="v6 Checkbox Example"
+			value="checkbox0"
+			onChange={(value, checked) => {
+				icache.set('checkboxStates', {
+					...checkboxStates,
+					[value]: checked
+				});
+			}}
+		/>,
+		// other checkboxes...
+	];
+});
+```
+
+```ts
+// v7
+import { create, tsx } from '@dojo/framework/core/vdom';
+import icache from '@dojo/framework/core/middleware/icache';
+import Checkbox from '@dojo/widgets/checkbox';
+
+const factory = create({ icache });
+
+export default factory(function CheckboxExample({ middleware: { icache } }) {
+	const checkboxStates = icache.getOrSet('checkboxStates', {});
+	return [
+		<Checkbox
+			checked={icache.get('isChecked0')}
+			label="v7 Checkbox Example"
+			onValue={(checked) => {
+				icache.set('isChecked0', checked);
+			}}
+		/>,
+		// other checkboxes...
+	];
+});
+```
 
 Latest example can be found on [widgets.dojo.io/#widget/checkbox/overview](https://widgets.dojo.io/#widget/checkbox/overview)
 

--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -152,6 +152,8 @@ Latest example can be found on [widgets.dojo.io/#widget/calendar/overview](https
 - onFocus: () => void;
 	- this prop now is passed zero arguments, whereas previously it was passed the current `value` and `checked` property values.
 ##### Removed properties
+- label: string;
+	- Removed in favor of using a child to render the label
 - onChange: (value: string, checked: boolean) => void;
 	- replaced by `onValue(checked: boolean)`
 - onClick: (value: string, checked: boolean) => void;
@@ -198,11 +200,12 @@ export default factory(function CheckboxExample({ middleware: { icache } }) {
 	return [
 		<Checkbox
 			checked={icache.get('isChecked0')}
-			label="v7 Checkbox Example"
 			onValue={(checked) => {
 				icache.set('isChecked0', checked);
 			}}
-		/>,
+		>
+			v7 Checkbox Example
+		</Checkbox>,
 		// other checkboxes...
 	];
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Addresses part of #1243.

Update the v7 migration document with property changes to the checkbox widget, along with an example demonstrating a migration from v6 to v7.
