### PR TITLE
Use child renderer for Radio label

### DIFF
--- a/src/examples/src/widgets/radio-group/CustomRenderer.tsx
+++ b/src/examples/src/widgets/radio-group/CustomRenderer.tsx
@@ -27,11 +27,12 @@ const App = factory(function({ middleware: { icache } }) {
 									<span>I'm custom!</span>
 									<Radio
 										checked={checked()}
-										label={label || value}
 										name={name}
 										onValue={checked}
 										value={value}
-									/>
+									>
+										{label || value}
+									</Radio>
 									<hr
 										styles={{
 											borderColor: '#d6dde2',
@@ -46,6 +47,7 @@ const App = factory(function({ middleware: { icache } }) {
 							);
 						});
 					}
+
 				}}
 			</RadioGroup>
 			<pre>{`${get('custom')}`}</pre>

--- a/src/examples/src/widgets/radio/Events.tsx
+++ b/src/examples/src/widgets/radio/Events.tsx
@@ -1,7 +1,6 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Radio from '@dojo/widgets/radio';
 import icache from '@dojo/framework/core/middleware/icache';
-import Label from '@dojo/widgets/label';
 
 const factory = create({ icache });
 
@@ -17,10 +16,7 @@ export default factory(function EventsRadioButton({ middleware: { icache } }) {
 				onOver={() => icache.set('event', 'onOver')}
 			>
 				{{
-					label: () => (
-						<Label>{`Last event: ${icache.get('event') ||
-							'Awaiting first event'}`}</Label>
-					)
+					label: () => `Last event: ${icache.get('event') || 'Awaiting first event'}`
 				}}
 			</Radio>
 		</virtual>

--- a/src/examples/src/widgets/radio/Events.tsx
+++ b/src/examples/src/widgets/radio/Events.tsx
@@ -1,6 +1,7 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Radio from '@dojo/widgets/radio';
 import icache from '@dojo/framework/core/middleware/icache';
+import Label from '@dojo/widgets/label';
 
 const factory = create({ icache });
 
@@ -9,13 +10,19 @@ export default factory(function EventsRadioButton({ middleware: { icache } }) {
 		<virtual>
 			<Radio
 				checked={false}
-				label={`Last event: ${icache.get('event') || 'Awaiting first event'}`}
 				onValue={() => icache.set('event', 'onValue')}
 				onBlur={() => icache.set('event', 'onBlur')}
 				onFocus={() => icache.set('event', 'onFocus')}
 				onOut={() => icache.set('event', 'onOut')}
 				onOver={() => icache.set('event', 'onOver')}
-			/>
+			>
+				{{
+					label: () => (
+						<Label>{`Last event: ${icache.get('event') ||
+							'Awaiting first event'}`}</Label>
+					)
+				}}
+			</Radio>
 		</virtual>
 	);
 });

--- a/src/examples/src/widgets/radio/Events.tsx
+++ b/src/examples/src/widgets/radio/Events.tsx
@@ -15,9 +15,7 @@ export default factory(function EventsRadioButton({ middleware: { icache } }) {
 				onOut={() => icache.set('event', 'onOut')}
 				onOver={() => icache.set('event', 'onOver')}
 			>
-				{{
-					label: () => `Last event: ${icache.get('event') || 'Awaiting first event'}`
-				}}
+				{`Last event: ${icache.get('event') || 'Awaiting first event'}`}
 			</Radio>
 		</virtual>
 	);

--- a/src/examples/src/widgets/radio/Labelled.tsx
+++ b/src/examples/src/widgets/radio/Labelled.tsx
@@ -4,11 +4,5 @@ import Radio from '@dojo/widgets/radio';
 const factory = create();
 
 export default factory(function LabelledRadioButton() {
-	return (
-		<Radio>
-			{{
-				label: () => 'Radio Button 1'
-			}}
-		</Radio>
-	);
+	return <Radio>Radio Button 1</Radio>;
 });

--- a/src/examples/src/widgets/radio/Labelled.tsx
+++ b/src/examples/src/widgets/radio/Labelled.tsx
@@ -1,8 +1,15 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Radio from '@dojo/widgets/radio';
+import Label from '@dojo/widgets/label';
 
 const factory = create();
 
 export default factory(function LabelledRadioButton() {
-	return <Radio label={'Radio Button 1'} />;
+	return (
+		<Radio widgetId="radioId">
+			{{
+				label: () => <Label forId="radioId">Radio Button 1</Label>
+			}}
+		</Radio>
+	);
 });

--- a/src/examples/src/widgets/radio/Labelled.tsx
+++ b/src/examples/src/widgets/radio/Labelled.tsx
@@ -1,14 +1,13 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Radio from '@dojo/widgets/radio';
-import Label from '@dojo/widgets/label';
 
 const factory = create();
 
 export default factory(function LabelledRadioButton() {
 	return (
-		<Radio widgetId="radioId">
+		<Radio>
 			{{
-				label: () => <Label forId="radioId">Radio Button 1</Label>
+				label: () => 'Radio Button 1'
 			}}
 		</Radio>
 	);

--- a/src/radio-group/index.tsx
+++ b/src/radio-group/index.tsx
@@ -49,13 +49,9 @@ export const RadioGroup = factory(function({
 		return options.map(({ value, label }) => {
 			const { checked } = radio(value);
 			return (
-				<Radio
-					checked={checked()}
-					label={label || value}
-					name={name}
-					onValue={checked}
-					value={value}
-				/>
+				<Radio checked={checked()} name={name} onValue={checked} value={value}>
+					{label || value}
+				</Radio>
 			);
 		});
 	}

--- a/src/radio-group/tests/RadioGroup.spec.tsx
+++ b/src/radio-group/tests/RadioGroup.spec.tsx
@@ -22,9 +22,15 @@ describe('RadioGroup', () => {
 			/>
 		));
 		const optionTemplate = template.setChildren('@root', () => [
-			<Radio name="test" value="cat" label="cat" checked={undefined} onValue={noop} />,
-			<Radio name="test" value="fish" label="fish" checked={undefined} onValue={noop} />,
-			<Radio name="test" value="dog" label="dog" checked={undefined} onValue={noop} />
+			<Radio name="test" value="cat" checked={undefined} onValue={noop}>
+				cat
+			</Radio>,
+			<Radio name="test" value="fish" checked={undefined} onValue={noop}>
+				fish
+			</Radio>,
+			<Radio name="test" value="dog" checked={undefined} onValue={noop}>
+				dog
+			</Radio>
 		]);
 		h.expect(optionTemplate);
 	});
@@ -39,7 +45,9 @@ describe('RadioGroup', () => {
 		));
 		const labelTemplate = template.setChildren('@root', () => [
 			<legend classes={css.legend}>test label</legend>,
-			<Radio name="test" value="cat" label="cat" checked={undefined} onValue={noop} />
+			<Radio name="test" value="cat" checked={undefined} onValue={noop}>
+				cat
+			</Radio>
 		]);
 		h.expect(labelTemplate);
 	});
@@ -54,9 +62,15 @@ describe('RadioGroup', () => {
 			/>
 		));
 		const optionTemplate = template.setChildren('@root', () => [
-			<Radio name="test" value="cat" label="cat" checked={undefined} onValue={noop} />,
-			<Radio name="test" value="fish" label="fish" checked={true} onValue={noop} />,
-			<Radio name="test" value="dog" label="dog" checked={undefined} onValue={noop} />
+			<Radio name="test" value="cat" checked={undefined} onValue={noop}>
+				cat
+			</Radio>,
+			<Radio name="test" value="fish" checked={true} onValue={noop}>
+				fish
+			</Radio>,
+			<Radio name="test" value="dog" checked={undefined} onValue={noop}>
+				dog
+			</Radio>
 		]);
 		h.expect(optionTemplate);
 	});
@@ -72,10 +86,11 @@ describe('RadioGroup', () => {
 							<Radio
 								name="test"
 								value="cat"
-								label="cat"
 								checked={false}
 								onValue={noop}
-							/>,
+							>
+								cat
+							</Radio>,
 							<hr />
 						];
 					}
@@ -85,7 +100,9 @@ describe('RadioGroup', () => {
 		const customTemplate = template.setChildren('@root', () => [
 			<legend classes={css.legend}>custom render label</legend>,
 			<span>custom label</span>,
-			<Radio name="test" value="cat" label="cat" checked={false} onValue={noop} />,
+			<Radio name="test" value="cat" checked={false} onValue={noop}>
+				cat
+			</Radio>,
 			<hr />
 		]);
 		h.expect(customTemplate);

--- a/src/radio/README.md
+++ b/src/radio/README.md
@@ -10,4 +10,4 @@ Dojo's `Radio` widget provides a styleable radio widget with an optional label.
 
 `Radio` ensures that the proper attributes (ARIA or otherwise) are set along with classes when properties such as `disabled`, `readOnly`, `invalid`, etc. are used.
 
-`Label` is handled via a child renderer. We recommend pointing it at the input's `widgetId` property.
+`Label` is handled via a child renderer. Child content will be rendered within a Label.

--- a/src/radio/README.md
+++ b/src/radio/README.md
@@ -5,10 +5,9 @@ Dojo's `Radio` widget provides a styleable radio widget with an optional label.
 ## Features
 
 - Correctly handles a11y attributes
-- Wraps the input in an accessible `<label>` when the `label` property is added
 
 ### Accessibility Features
 
 `Radio` ensures that the proper attributes (ARIA or otherwise) are set along with classes when properties such as `disabled`, `readOnly`, `invalid`, etc. are used.
 
-If the `label` property is not used, we recommend creating a separate `label` and pointing it at the input's `widgetId` property.
+`Label` is handled via a child renderer. We recommend pointing it at the input's `widgetId` property.

--- a/src/radio/index.tsx
+++ b/src/radio/index.tsx
@@ -6,6 +6,7 @@ import { formatAriaProperties } from '../common/util';
 import theme, { ThemeProperties } from '../middleware/theme';
 import * as css from '../theme/default/radio.m.css';
 import { RenderResult } from '@dojo/framework/core/interfaces';
+import Label from '../label';
 
 export interface RadioProperties extends ThemeProperties, FocusProperties {
 	/** Custom aria attributes */
@@ -14,6 +15,8 @@ export interface RadioProperties extends ThemeProperties, FocusProperties {
 	checked?: boolean;
 	/** Set the disabled property of the control */
 	disabled?: boolean;
+	/** Hides the label from view while still remaining accessible for screen readers */
+	labelHidden?: boolean;
 	/** The name of the radio button */
 	name?: string;
 	/** Handler for when the element is blurred */
@@ -55,7 +58,9 @@ export const Radio = factory(function Radio({
 	const {
 		aria = {},
 		checked = false,
+		classes,
 		disabled,
+		labelHidden,
 		name,
 		onBlur,
 		onFocus,
@@ -64,6 +69,7 @@ export const Radio = factory(function Radio({
 		onValue,
 		readOnly,
 		required,
+		theme: themeProp,
 		valid,
 		value,
 		widgetId
@@ -118,7 +124,23 @@ export const Radio = factory(function Radio({
 					<div classes={themeCss.radioInner} />
 				</div>
 			</div>
-			{label && label()}
+			{label && (
+				<Label
+					key="label"
+					classes={classes}
+					theme={themeProp}
+					disabled={disabled}
+					focused={focus.isFocused('root')}
+					forId={idBase}
+					valid={valid}
+					readOnly={readOnly}
+					hidden={labelHidden}
+					required={required}
+					secondary={true}
+				>
+					{label()}
+				</Label>
+			)}
 		</div>
 	);
 });

--- a/src/radio/index.tsx
+++ b/src/radio/index.tsx
@@ -5,8 +5,8 @@ import { create, tsx } from '@dojo/framework/core/vdom';
 import { formatAriaProperties } from '../common/util';
 import theme, { ThemeProperties } from '../middleware/theme';
 import * as css from '../theme/default/radio.m.css';
-import { RenderResult } from '@dojo/framework/core/interfaces';
 import Label from '../label';
+import { RenderResult } from '@dojo/framework/core/interfaces';
 
 export interface RadioProperties extends ThemeProperties, FocusProperties {
 	/** Custom aria attributes */
@@ -41,13 +41,9 @@ export interface RadioProperties extends ThemeProperties, FocusProperties {
 	widgetId?: string;
 }
 
-export interface RadioChild {
-	label?: () => RenderResult;
-}
-
 const factory = create({ focus, theme })
 	.properties<RadioProperties>()
-	.children<RadioChild | undefined>();
+	.children<RenderResult | undefined>();
 
 export const Radio = factory(function Radio({
 	properties,
@@ -77,7 +73,6 @@ export const Radio = factory(function Radio({
 
 	const themeCss = theme.classes(css);
 	const idBase = widgetId || `radio-${id}`;
-	const { label } = children()[0] || {};
 
 	return (
 		<div
@@ -124,7 +119,7 @@ export const Radio = factory(function Radio({
 					<div classes={themeCss.radioInner} />
 				</div>
 			</div>
-			{label && (
+			{children().length > 0 && (
 				<Label
 					key="label"
 					classes={classes}
@@ -138,7 +133,7 @@ export const Radio = factory(function Radio({
 					required={required}
 					secondary={true}
 				>
-					{label()}
+					{children()}
 				</Label>
 			)}
 		</div>

--- a/src/radio/index.tsx
+++ b/src/radio/index.tsx
@@ -3,9 +3,9 @@ import { FocusProperties } from '@dojo/framework/core/mixins/Focus';
 import { create, tsx } from '@dojo/framework/core/vdom';
 
 import { formatAriaProperties } from '../common/util';
-import Label from '../label';
 import theme, { ThemeProperties } from '../middleware/theme';
 import * as css from '../theme/default/radio.m.css';
+import { RenderResult } from '@dojo/framework/core/interfaces';
 
 export interface RadioProperties extends ThemeProperties, FocusProperties {
 	/** Custom aria attributes */
@@ -14,10 +14,6 @@ export interface RadioProperties extends ThemeProperties, FocusProperties {
 	checked?: boolean;
 	/** Set the disabled property of the control */
 	disabled?: boolean;
-	/** Adds a <label> element with the supplied text */
-	label?: string;
-	/** Hides the label from view while still remaining accessible for screen readers */
-	labelHidden?: boolean;
 	/** The name of the radio button */
 	name?: string;
 	/** Handler for when the element is blurred */
@@ -42,16 +38,24 @@ export interface RadioProperties extends ThemeProperties, FocusProperties {
 	widgetId?: string;
 }
 
-const factory = create({ focus, theme }).properties<RadioProperties>();
+export interface RadioChild {
+	label?: () => RenderResult;
+}
 
-export const Radio = factory(function Radio({ properties, id, middleware: { focus, theme } }) {
+const factory = create({ focus, theme })
+	.properties<RadioProperties>()
+	.children<RadioChild | undefined>();
+
+export const Radio = factory(function Radio({
+	properties,
+	id,
+	children,
+	middleware: { focus, theme }
+}) {
 	const {
 		aria = {},
 		checked = false,
-		classes,
 		disabled,
-		label,
-		labelHidden,
 		name,
 		onBlur,
 		onFocus,
@@ -60,7 +64,6 @@ export const Radio = factory(function Radio({ properties, id, middleware: { focu
 		onValue,
 		readOnly,
 		required,
-		theme: themeProp,
 		valid,
 		value,
 		widgetId
@@ -68,6 +71,7 @@ export const Radio = factory(function Radio({ properties, id, middleware: { focu
 
 	const themeCss = theme.classes(css);
 	const idBase = widgetId || `radio-${id}`;
+	const { label } = children()[0] || {};
 
 	return (
 		<div
@@ -114,23 +118,7 @@ export const Radio = factory(function Radio({ properties, id, middleware: { focu
 					<div classes={themeCss.radioInner} />
 				</div>
 			</div>
-			{label && (
-				<Label
-					key="labelAfter"
-					classes={classes}
-					theme={themeProp}
-					disabled={disabled}
-					focused={focus.isFocused('root')}
-					forId={idBase}
-					valid={valid}
-					readOnly={readOnly}
-					hidden={labelHidden}
-					required={required}
-					secondary={true}
-				>
-					{label}
-				</Label>
-			)}
+			{label && label()}
 		</div>
 	);
 });

--- a/src/radio/tests/unit/Radio.spec.tsx
+++ b/src/radio/tests/unit/Radio.spec.tsx
@@ -120,10 +120,7 @@ registerSuite('Radio', {
 		},
 
 		label() {
-			const h = harness(() => <Radio>{{ label: () => 'foo' }}</Radio>, [
-				compareId,
-				compareForId
-			]);
+			const h = harness(() => <Radio>foo</Radio>, [compareId, compareForId]);
 
 			h.expect(expected({ label: true }));
 		},
@@ -159,9 +156,7 @@ registerSuite('Radio', {
 			const h = harness(
 				() => (
 					<Radio valid={false} disabled={true} readOnly={true} required={true}>
-						{{
-							label: () => 'foo'
-						}}
+						foo
 					</Radio>
 				),
 				[compareId, compareForId]

--- a/src/radio/tests/unit/Radio.spec.tsx
+++ b/src/radio/tests/unit/Radio.spec.tsx
@@ -29,7 +29,6 @@ function createMockFocusMiddleware({
 
 const expected = ({
 	label = false,
-	labelAfter = true,
 	checked = false,
 	disabled = undefined,
 	focused = false,
@@ -52,23 +51,6 @@ const expected = ({
 				required ? css.required : null
 			]}
 		>
-			{!labelAfter && label ? (
-				<Label
-					key="label"
-					classes={undefined}
-					theme={undefined}
-					disabled={disabled}
-					focused={false}
-					forId=""
-					valid={valid}
-					readOnly={readOnly}
-					hidden={undefined}
-					required={required}
-					secondary={true}
-				>
-					foo
-				</Label>
-			) : null}
 			<div classes={css.inputWrapper}>
 				<input
 					assertion-key="input"
@@ -95,23 +77,7 @@ const expected = ({
 					<div classes={css.radioInner} />
 				</div>
 			</div>
-			{labelAfter && label ? (
-				<Label
-					key="labelAfter"
-					classes={undefined}
-					theme={undefined}
-					disabled={disabled}
-					focused={false}
-					forId=""
-					valid={valid}
-					readOnly={readOnly}
-					hidden={undefined}
-					required={required}
-					secondary={true}
-				>
-					foo
-				</Label>
-			) : null}
+			{label ? <Label>foo</Label> : null}
 		</div>
 	));
 
@@ -138,7 +104,10 @@ registerSuite('Radio', {
 		},
 
 		label() {
-			const h = harness(() => <Radio label="foo" />, [compareId, compareForId]);
+			const h = harness(() => <Radio>{{ label: () => <Label>foo</Label> }}</Radio>, [
+				compareId,
+				compareForId
+			]);
 
 			h.expect(expected({ label: true }));
 		},
@@ -168,31 +137,6 @@ registerSuite('Radio', {
 			required = false;
 
 			h.expect(expected({ valid, disabled, readOnly, required }));
-		},
-
-		'state properties on label'() {
-			const h = harness(
-				() => (
-					<Radio
-						label="foo"
-						valid={false}
-						disabled={true}
-						readOnly={true}
-						required={true}
-					/>
-				),
-				[compareId, compareForId]
-			);
-
-			h.expect(
-				expected({
-					label: true,
-					disabled: true,
-					readOnly: true,
-					required: true,
-					valid: false
-				})
-			);
 		},
 
 		'focused class'() {

--- a/src/radio/tests/unit/Radio.spec.tsx
+++ b/src/radio/tests/unit/Radio.spec.tsx
@@ -77,7 +77,23 @@ const expected = ({
 					<div classes={css.radioInner} />
 				</div>
 			</div>
-			{label ? <Label>foo</Label> : null}
+			{label ? (
+				<Label
+					key="label"
+					classes={undefined}
+					theme={undefined}
+					disabled={disabled}
+					focused={false}
+					forId=""
+					valid={valid}
+					readOnly={readOnly}
+					hidden={undefined}
+					required={required}
+					secondary={true}
+				>
+					foo
+				</Label>
+			) : null}
 		</div>
 	));
 
@@ -104,7 +120,7 @@ registerSuite('Radio', {
 		},
 
 		label() {
-			const h = harness(() => <Radio>{{ label: () => <Label>foo</Label> }}</Radio>, [
+			const h = harness(() => <Radio>{{ label: () => 'foo' }}</Radio>, [
 				compareId,
 				compareForId
 			]);
@@ -137,6 +153,29 @@ registerSuite('Radio', {
 			required = false;
 
 			h.expect(expected({ valid, disabled, readOnly, required }));
+		},
+
+		'state properties on label'() {
+			const h = harness(
+				() => (
+					<Radio valid={false} disabled={true} readOnly={true} required={true}>
+						{{
+							label: () => 'foo'
+						}}
+					</Radio>
+				),
+				[compareId, compareForId]
+			);
+
+			h.expect(
+				expected({
+					label: true,
+					disabled: true,
+					readOnly: true,
+					required: true,
+					valid: false
+				})
+			);
 		},
 
 		'focused class'() {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Moves label property of Radio widget to an optional child of type RenderResult.

Resolves #1262 

![Screen Shot 2020-04-02 at 10 28 34 AM](https://user-images.githubusercontent.com/1054198/78267581-be1ddd00-74cc-11ea-9fd2-0f0a9276ee82.png)
