### PR TITLE
1271 TextInput Child Renderers

### DIFF
--- a/src/constrained-input/index.tsx
+++ b/src/constrained-input/index.tsx
@@ -1,4 +1,4 @@
-import TextInput, { BaseInputProperties, TextInputType } from '../text-input';
+import TextInput, { BaseInputProperties, TextInputType, TextInputChildren } from '../text-input';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import validation, { ValidationRules } from '../middleware/validation';
@@ -23,10 +23,14 @@ const factory = create({
 	icache: createICacheMiddleware<ConstrainedInputState>(),
 	validation,
 	theme
-}).properties<ConstrainedInputProperties>();
+})
+	.properties<ConstrainedInputProperties>()
+	.children<TextInputChildren | undefined>();
+
 export const ConstrainedInput = factory(function ConstrainedInput({
 	middleware: { icache, validation, theme },
-	properties
+	properties,
+	children
 }) {
 	const { rules, onValidate, helperText, ...props } = properties();
 	const valid = icache.get('valid');
@@ -53,7 +57,9 @@ export const ConstrainedInput = factory(function ConstrainedInput({
 			valid={valid}
 			onValidate={handleValidation}
 			helperText={helperText ? helperText : generatedDescribeHelperText}
-		/>
+		>
+			{children()[0]}
+		</TextInput>
 	);
 });
 

--- a/src/constrained-input/tests/unit/ConstrainedInput.spec.tsx
+++ b/src/constrained-input/tests/unit/ConstrainedInput.spec.tsx
@@ -45,10 +45,13 @@ describe('ConstrainedInput', () => {
 	});
 
 	it('passes properties to the input widget', () => {
-		const h = harness(() => <ConstrainedInput rules={rules} label="Test Label" />, {
-			middleware: [[validation, createMockValidationMiddleware(() => true)]],
-			customComparator: [compareTheme]
-		});
+		const h = harness(
+			() => <ConstrainedInput rules={rules}>{{ label: 'Test Label' }}</ConstrainedInput>,
+			{
+				middleware: [[validation, createMockValidationMiddleware(() => true)]],
+				customComparator: [compareTheme]
+			}
+		);
 		h.expect(() => (
 			<TextInput
 				key="root"
@@ -57,15 +60,18 @@ describe('ConstrainedInput', () => {
 				valid={undefined}
 				onValidate={() => {}}
 				helperText="description"
-				label="Test Label"
-			/>
+			>
+				{{ label: 'Test Label' }}
+			</TextInput>
 		));
 	});
 
 	it('will display user helperText if passed instead of generated description', () => {
 		const h = harness(
 			() => (
-				<ConstrainedInput rules={rules} label="Test Label" helperText="test helper text" />
+				<ConstrainedInput rules={rules} helperText="test helper text">
+					{{ label: 'Test Label' }}
+				</ConstrainedInput>
 			),
 			{
 				middleware: [[validation, createMockValidationMiddleware(() => true)]],
@@ -80,8 +86,9 @@ describe('ConstrainedInput', () => {
 				valid={undefined}
 				onValidate={() => {}}
 				helperText="test helper text"
-				label="Test Label"
-			/>
+			>
+				{{ label: 'Test Label' }}
+			</TextInput>
 		));
 	});
 

--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -126,19 +126,6 @@ export default factory(function({ properties, middleware: { theme, icache, i18n,
 										css,
 										'input'
 									)}
-									trailing={() => (
-										<button
-											key="dateIcon"
-											onclick={(e) => {
-												e.stopPropagation();
-												openCalendar();
-											}}
-											classes={classes.toggleCalendarButton}
-											type="button"
-										>
-											<Icon type="dateIcon" />
-										</button>
-									)}
 									type="text"
 									initialValue={icache.get('inputValue')}
 									onBlur={() => icache.set('shouldValidate', true)}
@@ -153,7 +140,23 @@ export default factory(function({ properties, middleware: { theme, icache, i18n,
 											openCalendar();
 										}
 									}}
-								/>
+								>
+									{{
+										trailing: (
+											<button
+												key="dateIcon"
+												onclick={(e) => {
+													e.stopPropagation();
+													openCalendar();
+												}}
+												classes={classes.toggleCalendarButton}
+												type="button"
+											>
+												<Icon type="dateIcon" />
+											</button>
+										)
+									}}
+								</TextInput>
 							</div>
 						);
 					},

--- a/src/date-input/tests/unit/DateInput.spec.tsx
+++ b/src/date-input/tests/unit/DateInput.spec.tsx
@@ -71,11 +71,12 @@ const buttonTemplate = assertionTemplate(() => {
 				type="text"
 				onBlur={noop}
 				onValue={noop}
-				trailing={() => undefined}
 				initialValue={formatDate(today)}
 				helperText=""
 				onKeyDown={noop}
-			/>
+			>
+				{{ trailing: undefined }}
+			</TextInput>
 		</div>
 	);
 });

--- a/src/date-input/tests/unit/DateInput.spec.tsx
+++ b/src/date-input/tests/unit/DateInput.spec.tsx
@@ -136,7 +136,7 @@ describe('DateInput', () => {
 		// Find the date icon & `click` it
 		const [dateIcon] = select(
 			'@dateIcon',
-			select('@input', triggerResult)[0].properties.trailing()
+			(select('@input', triggerResult)[0].children![0] as any).trailing
 		);
 		dateIcon.properties.onclick(stubEvent);
 		h.expect(baseTemplate());

--- a/src/dialog/index.tsx
+++ b/src/dialog/index.tsx
@@ -142,8 +142,6 @@ export const Dialog = factory(function Dialog({
 									role === 'alertdialog' ||
 									(properties() as DialogPropertiesDialogRole).modal;
 
-								console.log('click!');
-
 								event.stopPropagation();
 								!modal && close();
 							}}

--- a/src/email-input/index.tsx
+++ b/src/email-input/index.tsx
@@ -1,4 +1,4 @@
-import { TextInput, BaseInputProperties } from '../text-input/index';
+import { TextInput, BaseInputProperties, TextInputChildren } from '../text-input/index';
 import { tsx, create } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import theme from '../middleware/theme';
@@ -13,9 +13,15 @@ interface EmailInputICache {
 }
 
 const icache = createICacheMiddleware<EmailInputICache>();
-const factory = create({ icache, theme }).properties<EmailInputProperties>();
+const factory = create({ icache, theme })
+	.properties<EmailInputProperties>()
+	.children<TextInputChildren | undefined>();
 
-export const EmailInput = factory(function({ properties, middleware: { icache, theme } }) {
+export const EmailInput = factory(function({
+	properties,
+	children,
+	middleware: { icache, theme }
+}) {
 	const { get, set } = icache;
 	const props = properties();
 	return (
@@ -32,7 +38,9 @@ export const EmailInput = factory(function({ properties, middleware: { icache, t
 				textInputCss,
 				emailInputCss
 			)}
-		/>
+		>
+			{children()[0]}
+		</TextInput>
 	);
 });
 

--- a/src/examples/src/widgets/constrained-input/Basic.tsx
+++ b/src/examples/src/widgets/constrained-input/Basic.tsx
@@ -12,7 +12,8 @@ export default factory(function Basic() {
 					max: 10
 				}
 			}}
-			label="Minimum and Maximum Length Constraints"
-		/>
+		>
+			{{ label: 'Minimum and Maximum Length Constraints' }}
+		</ConstrainedInput>
 	);
 });

--- a/src/examples/src/widgets/constrained-input/Username.tsx
+++ b/src/examples/src/widgets/constrained-input/Username.tsx
@@ -17,7 +17,8 @@ export default factory(function Basic() {
 					specialCharacters: 1
 				}
 			}}
-			label="Enter Username"
-		/>
+		>
+			{{ label: 'Enter Username' }}
+		</ConstrainedInput>
 	);
 });

--- a/src/examples/src/widgets/dialog/FocusTrappedDialog.tsx
+++ b/src/examples/src/widgets/dialog/FocusTrappedDialog.tsx
@@ -18,8 +18,8 @@ export default factory(function FocusTrappedDialog({ middleware: { icache } }) {
 					title: () => 'Focus Trapped Dialog',
 					content: () => (
 						<virtual>
-							<TextInput label="First Name" key="first" />
-							<TextInput label="Last Name" key="last" />
+							<TextInput key="first">{{ label: 'First Name' }}</TextInput>
+							<TextInput key="last">{{ label: 'Last Name' }}</TextInput>
 						</virtual>
 					)
 				}}

--- a/src/examples/src/widgets/form/ActionForm.tsx
+++ b/src/examples/src/widgets/form/ActionForm.tsx
@@ -38,33 +38,37 @@ const App = factory(function({ middleware: { icache } }) {
 						<virtual>
 							<TextInput
 								key="firstName"
-								label="First Name"
 								placeholder="Enter first name"
 								initialValue={firstName.value()}
 								onValue={firstName.value}
-							/>
+							>
+								{{ label: 'First Name' }}
+							</TextInput>
 							<TextInput
 								key="middleName"
-								label="Middle Name"
 								placeholder="Enter a middle name"
 								initialValue={middleName.value()}
 								onValue={middleName.value}
-							/>
+							>
+								{{ label: 'Middle Name' }}
+							</TextInput>
 							<TextInput
 								key="lastName"
-								label="Last Name"
 								placeholder="Enter a last name"
 								initialValue={lastName.value()}
 								onValue={lastName.value}
-							/>
+							>
+								{{ label: 'Last Name' }}
+							</TextInput>
 							<TextInput
 								key="email"
-								label="Email"
 								placeholder="Enter an email address"
 								initialValue={email.value()}
 								onValue={email.value}
 								type="email"
-							/>
+							>
+								{{ label: 'Email' }}
+							</TextInput>
 						</virtual>
 					);
 				}}

--- a/src/examples/src/widgets/form/Basic.tsx
+++ b/src/examples/src/widgets/form/Basic.tsx
@@ -37,33 +37,37 @@ const App = factory(function({ middleware: { icache } }) {
 						<virtual>
 							<TextInput
 								key="firstName"
-								label="First Name"
 								placeholder="Enter first name"
 								initialValue={firstName.value()}
 								onValue={firstName.value}
-							/>
+							>
+								{{ label: 'First Name' }}
+							</TextInput>
 							<TextInput
 								key="middleName"
-								label="Middle Name"
 								placeholder="Enter a middle name"
 								initialValue={middleName.value()}
 								onValue={middleName.value}
-							/>
+							>
+								{{ label: 'Middle Name' }}
+							</TextInput>
 							<TextInput
 								key="lastName"
-								label="Last Name"
 								placeholder="Enter a last name"
 								initialValue={lastName.value()}
 								onValue={lastName.value}
-							/>
+							>
+								{{ label: 'Last Name' }}
+							</TextInput>
 							<TextInput
 								key="email"
-								label="Email"
 								placeholder="Enter an email address"
 								initialValue={email.value()}
 								onValue={email.value}
 								type="email"
-							/>
+							>
+								{{ label: 'Email' }}
+							</TextInput>
 						</virtual>
 					);
 				}}

--- a/src/examples/src/widgets/form/DisabledFieldsForm.tsx
+++ b/src/examples/src/widgets/form/DisabledFieldsForm.tsx
@@ -35,35 +35,39 @@ const App = factory(function({ middleware: { icache } }) {
 						<virtual>
 							<TextInput
 								key="firstName"
-								label="First Name"
 								placeholder="Enter first name	"
 								initialValue={firstName.value()}
 								onValue={firstName.value}
-							/>
+							>
+								{{ label: 'First Name' }}
+							</TextInput>
 							<TextInput
 								key="middleName"
-								label="Middle Name"
 								placeholder="Enter a middle name"
 								initialValue={middleName.value()}
 								onValue={middleName.value}
 								disabled={true}
-							/>
+							>
+								{{ label: 'Middle Name' }}
+							</TextInput>
 							<TextInput
 								key="lastName"
-								label="Last Name"
 								placeholder="Enter a last name"
 								initialValue={lastName.value()}
 								onValue={lastName.value}
-							/>
+							>
+								{{ label: 'Last Name' }}
+							</TextInput>
 							<TextInput
 								key="email"
-								label="Email"
 								placeholder="Enter an email address"
 								initialValue={email.value()}
 								onValue={email.value}
 								type="email"
 								disabled={email.disabled()}
-							/>
+							>
+								{{ label: 'Email' }}
+							</TextInput>
 							<Button
 								key="disableEmail"
 								type="button"

--- a/src/examples/src/widgets/form/DisabledForm.tsx
+++ b/src/examples/src/widgets/form/DisabledForm.tsx
@@ -35,37 +35,41 @@ const App = factory(function({ middleware: { icache } }) {
 						<virtual>
 							<TextInput
 								key="firstName"
-								label="First Name"
 								placeholder="Enter first name"
 								initialValue={firstName.value()}
 								onValue={firstName.value}
 								disabled={firstName.disabled()}
-							/>
+							>
+								{{ label: 'First Name' }}
+							</TextInput>
 							<TextInput
 								key="middleName"
-								label="Middle Name"
 								placeholder="Enter a middle name"
 								initialValue={middleName.value()}
 								onValue={middleName.value}
 								disabled={middleName.disabled()}
-							/>
+							>
+								{{ label: 'Middle Name' }}
+							</TextInput>
 							<TextInput
 								key="lastName"
-								label="Last Name"
 								placeholder="Enter a last name"
 								initialValue={lastName.value()}
 								onValue={lastName.value}
 								disabled={lastName.disabled()}
-							/>
+							>
+								{{ label: 'Last Name' }}
+							</TextInput>
 							<TextInput
 								key="email"
-								label="Email"
 								placeholder="Enter an email address"
 								initialValue={email.value()}
 								onValue={email.value}
 								type="email"
 								disabled={email.disabled()}
-							/>
+							>
+								{{ label: 'Email' }}
+							</TextInput>
 							<Button
 								key="disableForm"
 								type="button"

--- a/src/examples/src/widgets/form/FillingForm.tsx
+++ b/src/examples/src/widgets/form/FillingForm.tsx
@@ -35,33 +35,37 @@ const App = factory(function({ middleware: { icache } }) {
 						<virtual>
 							<TextInput
 								key="firstName"
-								label="First Name"
 								placeholder="Enter first name"
 								initialValue={firstName.value()}
 								onValue={firstName.value}
-							/>
+							>
+								{{ label: 'First Name' }}
+							</TextInput>
 							<TextInput
 								key="middleName"
-								label="Middle Name"
 								placeholder="Enter a middle name"
 								initialValue={middleName.value()}
 								onValue={middleName.value}
-							/>
+							>
+								{{ label: 'Middle Name' }}
+							</TextInput>
 							<TextInput
 								key="lastName"
-								label="Last Name"
 								placeholder="Enter a last name"
 								initialValue={lastName.value()}
 								onValue={lastName.value}
-							/>
+							>
+								{{ label: 'Last Name' }}
+							</TextInput>
 							<TextInput
 								key="email"
-								label="Email"
 								placeholder="Enter an email address"
 								initialValue={email.value()}
 								onValue={email.value}
 								type="email"
-							/>
+							>
+								{{ label: 'Email' }}
+							</TextInput>
 							<Button
 								key="fill"
 								type="button"

--- a/src/examples/src/widgets/form/InitialValueForm.tsx
+++ b/src/examples/src/widgets/form/InitialValueForm.tsx
@@ -40,33 +40,37 @@ const App = factory(function({ middleware: { icache } }) {
 						<virtual>
 							<TextInput
 								key="firstName"
-								label="First Name"
 								placeholder="Enter first name"
 								initialValue={firstName.value()}
 								onValue={firstName.value}
-							/>
+							>
+								{{ label: 'First Name' }}
+							</TextInput>
 							<TextInput
 								key="middleName"
-								label="Middle Name"
 								placeholder="Enter a middle name"
 								initialValue={middleName.value()}
 								onValue={middleName.value}
-							/>
+							>
+								{{ label: 'Middle Name' }}
+							</TextInput>
 							<TextInput
 								key="lastName"
-								label="Last Name"
 								placeholder="Enter a last name"
 								initialValue={lastName.value()}
 								onValue={lastName.value}
-							/>
+							>
+								{{ label: 'Last Name' }}
+							</TextInput>
 							<TextInput
 								key="email"
-								label="Email"
 								placeholder="Enter an email address"
 								initialValue={email.value()}
 								onValue={email.value}
 								type="email"
-							/>
+							>
+								{{ label: 'Email' }}
+							</TextInput>
 						</virtual>
 					);
 				}}

--- a/src/examples/src/widgets/form/KitchenSinkForm.tsx
+++ b/src/examples/src/widgets/form/KitchenSinkForm.tsx
@@ -45,7 +45,6 @@ const App = factory(function({ middleware: { icache } }) {
 						<virtual>
 							<TextInput
 								key="firstName"
-								label="First Name"
 								placeholder="Enter first name (must be Billy)"
 								pattern="Billy"
 								required={true}
@@ -54,10 +53,11 @@ const App = factory(function({ middleware: { icache } }) {
 								onValue={firstName.value}
 								onValidate={firstName.valid}
 								disabled={firstName.disabled()}
-							/>
+							>
+								{{ label: 'First Name' }}
+							</TextInput>
 							<TextInput
 								key="middleName"
-								label="Middle Name"
 								placeholder="Enter a middle name"
 								required={middleName.required()}
 								initialValue={middleName.value()}
@@ -66,10 +66,11 @@ const App = factory(function({ middleware: { icache } }) {
 								onValidate={middleName.valid}
 								maxLength={5}
 								disabled={middleName.disabled()}
-							/>
+							>
+								{{ label: 'Middle Name' }}
+							</TextInput>
 							<TextInput
 								key="lastName"
-								label="Last Name"
 								placeholder="Enter a last name"
 								required={true}
 								initialValue={lastName.value()}
@@ -78,10 +79,11 @@ const App = factory(function({ middleware: { icache } }) {
 								onValidate={lastName.valid}
 								minLength={2}
 								disabled={lastName.disabled()}
-							/>
+							>
+								{{ label: 'Last Name' }}
+							</TextInput>
 							<TextInput
 								key="email"
-								label="Email"
 								placeholder="Enter an email address"
 								required={false}
 								initialValue={email.value()}
@@ -91,7 +93,9 @@ const App = factory(function({ middleware: { icache } }) {
 								type="email"
 								pattern="^[^\s@]+@[^\s@]+\.[^\s@]{2,}$"
 								disabled={email.disabled()}
-							/>
+							>
+								{{ label: 'Email' }}
+							</TextInput>
 							<Button
 								key="fill"
 								type="button"

--- a/src/examples/src/widgets/form/RequiredFieldsForm.tsx
+++ b/src/examples/src/widgets/form/RequiredFieldsForm.tsx
@@ -35,42 +35,46 @@ const App = factory(function({ middleware: { icache } }) {
 						<virtual>
 							<TextInput
 								key="firstName"
-								label="First Name"
 								placeholder="Enter first name (must be Billy)"
 								required={true}
 								initialValue={firstName.value()}
 								valid={firstName.valid()}
 								onValue={firstName.value}
 								onValidate={firstName.valid}
-							/>
+							>
+								{{ label: 'First Name' }}
+							</TextInput>
 							<TextInput
 								key="middleName"
-								label="Middle Name"
 								placeholder="Enter a middle name"
 								required={middleName.required()}
 								initialValue={middleName.value()}
 								valid={middleName.valid()}
 								onValue={middleName.value}
 								onValidate={middleName.valid}
-							/>
+							>
+								{{ label: 'Middle Name' }}
+							</TextInput>
 							<TextInput
 								key="lastName"
-								label="Last Name"
 								placeholder="Enter a last name"
 								required={true}
 								initialValue={lastName.value()}
 								valid={lastName.valid()}
 								onValue={lastName.value}
 								onValidate={lastName.valid}
-							/>
+							>
+								{{ label: 'Last Name' }}
+							</TextInput>
 							<TextInput
 								key="email"
-								label="Email"
 								placeholder="Enter an email address"
 								initialValue={email.value()}
 								onValue={email.value}
 								type="email"
-							/>
+							>
+								{{ label: 'Email' }}
+							</TextInput>
 							<Button
 								key="requireMiddleName"
 								type="button"

--- a/src/examples/src/widgets/form/ResettingForm.tsx
+++ b/src/examples/src/widgets/form/ResettingForm.tsx
@@ -35,33 +35,37 @@ const App = factory(function({ middleware: { icache } }) {
 						<virtual>
 							<TextInput
 								key="firstName"
-								label="First Name"
 								placeholder="Enter first name"
 								initialValue={firstName.value()}
 								onValue={firstName.value}
-							/>
+							>
+								{{ label: 'First Name' }}
+							</TextInput>
 							<TextInput
 								key="middleName"
-								label="Middle Name"
 								placeholder="Enter a middle name"
 								initialValue={middleName.value()}
 								onValue={middleName.value}
-							/>
+							>
+								{{ label: 'Middle Name' }}
+							</TextInput>
 							<TextInput
 								key="lastName"
-								label="Last Name"
 								placeholder="Enter a last name"
 								initialValue={lastName.value()}
 								onValue={lastName.value}
-							/>
+							>
+								{{ label: 'Last Name' }}
+							</TextInput>
 							<TextInput
 								key="email"
-								label="Email"
 								placeholder="Enter an email address"
 								initialValue={email.value()}
 								onValue={email.value}
 								type="email"
-							/>
+							>
+								{{ label: 'Email' }}
+							</TextInput>
 							<Button key="reset" type="button" onClick={() => reset()}>
 								Reset
 							</Button>

--- a/src/examples/src/widgets/form/SubmitForm.tsx
+++ b/src/examples/src/widgets/form/SubmitForm.tsx
@@ -35,39 +35,43 @@ const App = factory(function({ middleware: { icache } }) {
 						<virtual>
 							<TextInput
 								key="firstName"
-								label="First Name"
 								placeholder="Enter first name (must be Billy)"
 								required={true}
 								initialValue={firstName.value()}
 								valid={firstName.valid()}
 								onValue={firstName.value}
 								onValidate={firstName.valid}
-							/>
+							>
+								{{ label: 'First Name' }}
+							</TextInput>
 							<TextInput
 								key="middleName"
-								label="Middle Name"
 								placeholder="Enter a middle name"
 								initialValue={middleName.value()}
 								onValue={middleName.value}
-							/>
+							>
+								{{ label: 'Middle Name' }}
+							</TextInput>
 							<TextInput
 								key="lastName"
-								label="Last Name"
 								placeholder="Enter a last name"
 								required={true}
 								initialValue={lastName.value()}
 								valid={lastName.valid()}
 								onValue={lastName.value}
 								onValidate={lastName.valid}
-							/>
+							>
+								{{ label: 'Last Name' }}
+							</TextInput>
 							<TextInput
 								key="email"
-								label="Email"
 								placeholder="Enter an email address"
 								initialValue={email.value()}
 								onValue={email.value}
 								type="email"
-							/>
+							>
+								{{ label: 'Email' }}
+							</TextInput>
 							<Button key="submit" type="submit" disabled={!valid()}>
 								Submit
 							</Button>

--- a/src/examples/src/widgets/form/Validation.tsx
+++ b/src/examples/src/widgets/form/Validation.tsx
@@ -34,37 +34,39 @@ const App = factory(function({ middleware: { icache } }) {
 						<virtual>
 							<TextInput
 								key="firstName"
-								label="First Name"
 								placeholder="Enter first name (must be Billy)"
 								pattern="Billy"
 								initialValue={firstName.value()}
 								valid={firstName.valid()}
 								onValue={firstName.value}
 								onValidate={firstName.valid}
-							/>
+							>
+								{{ label: 'First Name' }}
+							</TextInput>
 							<TextInput
 								key="middleName"
-								label="Middle Name"
 								placeholder="Enter a middle name"
 								initialValue={middleName.value()}
 								valid={middleName.valid()}
 								onValue={middleName.value}
 								onValidate={middleName.valid}
 								maxLength={5}
-							/>
+							>
+								{{ label: 'Middle Name' }}
+							</TextInput>
 							<TextInput
 								key="lastName"
-								label="Last Name"
 								placeholder="Enter a last name"
 								initialValue={lastName.value()}
 								valid={lastName.valid()}
 								onValue={lastName.value}
 								onValidate={lastName.valid}
 								minLength={2}
-							/>
+							>
+								{{ label: 'Last Name' }}
+							</TextInput>
 							<TextInput
 								key="email"
-								label="Email"
 								placeholder="Enter an email address"
 								initialValue={email.value()}
 								valid={email.valid()}
@@ -72,7 +74,9 @@ const App = factory(function({ middleware: { icache } }) {
 								onValidate={email.valid}
 								type="email"
 								pattern="^[^\s@]+@[^\s@]+\.[^\s@]{2,}$"
-							/>
+							>
+								{{ label: 'Email' }}
+							</TextInput>
 						</virtual>
 					);
 				}}

--- a/src/examples/src/widgets/grid/Advanced.tsx
+++ b/src/examples/src/widgets/grid/Advanced.tsx
@@ -117,26 +117,18 @@ export default factory(function Advanced({ middleware: { icache } }) {
 				{selectedItems.map((items) => {
 					return (
 						<div styles={{ margin: '5px', padding: '10px', border: '1px solid grey' }}>
-							<TextInput
-								label="First Name"
-								readOnly={true}
-								initialValue={items.firstName}
-							/>
-							<TextInput
-								label="Last Name"
-								readOnly={true}
-								initialValue={items.lastName}
-							/>
-							<TextInput
-								label="Phone"
-								readOnly={true}
-								initialValue={items.phoneNumber}
-							/>
-							<TextInput
-								label="Country"
-								readOnly={true}
-								initialValue={items.country}
-							/>
+							<TextInput readOnly={true} initialValue={items.firstName}>
+								{{ label: 'First Name' }}
+							</TextInput>
+							<TextInput readOnly={true} initialValue={items.lastName}>
+								{{ label: 'Last Name' }}
+							</TextInput>
+							<TextInput readOnly={true} initialValue={items.phoneNumber}>
+								{{ label: 'Phone' }}
+							</TextInput>
+							<TextInput readOnly={true} initialValue={items.country}>
+								{{ label: 'Country' }}
+							</TextInput>
 						</div>
 					);
 				})}

--- a/src/examples/src/widgets/grid/CustomFilterRenderer.tsx
+++ b/src/examples/src/widgets/grid/CustomFilterRenderer.tsx
@@ -99,12 +99,13 @@ export default factory(function CustomFilterRenderer() {
 					return (
 						<TextInput
 							key="filter"
-							label={`Filter by ${title}`}
 							labelHidden={true}
 							type="search"
 							initialValue={filterValue}
 							onValue={doFilter}
-						/>
+						>
+							{{ label: `Filter by ${title}` }}
+						</TextInput>
 					);
 				}
 			}}

--- a/src/examples/src/widgets/number-input/Validation.tsx
+++ b/src/examples/src/widgets/number-input/Validation.tsx
@@ -9,7 +9,6 @@ const Example = factory(function Example({ middleware: { icache } }) {
 
 	return (
 		<NumberInput
-			label="Value between 40 and 50"
 			initialValue={42}
 			min={40}
 			max={50}
@@ -17,7 +16,9 @@ const Example = factory(function Example({ middleware: { icache } }) {
 			onValidate={(valid, message) => {
 				icache.set('valid', { valid, message });
 			}}
-		/>
+		>
+			{{ label: 'Value between 40 and 50' }}
+		</NumberInput>
 	);
 });
 

--- a/src/examples/src/widgets/password-input/Basic.tsx
+++ b/src/examples/src/widgets/password-input/Basic.tsx
@@ -17,7 +17,8 @@ export default factory(function Basic() {
 					numbers: 1
 				}
 			}}
-			label="Enter Password"
-		/>
+		>
+			{{ label: 'Enter Password' }}
+		</PasswordInput>
 	);
 });

--- a/src/examples/src/widgets/password-input/NoRules.tsx
+++ b/src/examples/src/widgets/password-input/NoRules.tsx
@@ -4,5 +4,5 @@ import PasswordInput from '@dojo/widgets/password-input';
 const factory = create();
 
 export default factory(function NoRules() {
-	return <PasswordInput required label="Enter Password" />;
+	return <PasswordInput required>{{ label: 'Enter Password' }}</PasswordInput>;
 });

--- a/src/examples/src/widgets/text-input/Disabled.tsx
+++ b/src/examples/src/widgets/text-input/Disabled.tsx
@@ -5,6 +5,8 @@ const factory = create();
 
 export default factory(function Basic() {
 	return (
-		<TextInput initialValue="disabled input text" label="Can't type here" disabled readOnly />
+		<TextInput initialValue="disabled input text" disabled readOnly>
+			{{ label: "Can't type here" }}
+		</TextInput>
 	);
 });

--- a/src/examples/src/widgets/text-input/HelperText.tsx
+++ b/src/examples/src/widgets/text-input/HelperText.tsx
@@ -4,5 +4,5 @@ import TextInput from '@dojo/widgets/text-input';
 const factory = create();
 
 export default factory(function Basic() {
-	return <TextInput label="Input with helper text" helperText="Helper text" />;
+	return <TextInput helperText="Helper text">{{ label: 'Input with helper text' }}</TextInput>;
 });

--- a/src/examples/src/widgets/text-input/HiddenLabel.tsx
+++ b/src/examples/src/widgets/text-input/HiddenLabel.tsx
@@ -4,5 +4,5 @@ import TextInput from '@dojo/widgets/text-input';
 const factory = create();
 
 export default factory(function Basic() {
-	return <TextInput label="Hidden label" labelHidden />;
+	return <TextInput labelHidden>{{ label: 'Hidden label' }}</TextInput>;
 });

--- a/src/examples/src/widgets/text-input/LeadingTrailing.tsx
+++ b/src/examples/src/widgets/text-input/LeadingTrailing.tsx
@@ -5,10 +5,12 @@ const factory = create();
 
 export default factory(function Basic() {
 	return (
-		<TextInput
-			label="Input label"
-			leading={() => <span>A</span>}
-			trailing={() => <span>Z</span>}
-		/>
+		<TextInput>
+			{{
+				label: 'Input label',
+				leading: <span>A</span>,
+				trailing: <span>Z</span>
+			}}
+		</TextInput>
 	);
 });

--- a/src/examples/src/widgets/text-input/Validated.tsx
+++ b/src/examples/src/widgets/text-input/Validated.tsx
@@ -8,13 +8,14 @@ export default factory(function Basic({ middleware: { icache } }) {
 	const valid = icache.get<{ valid?: boolean; message?: string }>('valid');
 	return (
 		<TextInput
-			label="Type 'foo' or 'bar'"
 			valid={valid}
 			required
 			onValidate={(valid, message) => {
 				icache.set('valid', { valid, message });
 			}}
 			pattern="foo|bar"
-		/>
+		>
+			{{ label: "Type 'foo' or 'bar'" }}
+		</TextInput>
 	);
 });

--- a/src/examples/src/widgets/text-input/WithLabel.tsx
+++ b/src/examples/src/widgets/text-input/WithLabel.tsx
@@ -4,5 +4,5 @@ import TextInput from '@dojo/widgets/text-input';
 const factory = create();
 
 export default factory(function Basic() {
-	return <TextInput label="Input label" />;
+	return <TextInput>{{ label: 'Input label' }}</TextInput>;
 });

--- a/src/examples/src/widgets/time-picker/12HourTime.tsx
+++ b/src/examples/src/widgets/time-picker/12HourTime.tsx
@@ -4,5 +4,9 @@ import TimePicker from '@dojo/widgets/time-picker';
 const factory = create();
 
 export default factory(function Basic() {
-	return <TimePicker label="Time: " step={1800} format="12" />;
+	return (
+		<TimePicker step={1800} format="12">
+			{{ label: 'Time: ' }}
+		</TimePicker>
+	);
 });

--- a/src/examples/src/widgets/time-picker/Basic.tsx
+++ b/src/examples/src/widgets/time-picker/Basic.tsx
@@ -7,11 +7,9 @@ const factory = create({ icache });
 export default factory(function Basic({ middleware: { icache } }) {
 	return (
 		<virtual>
-			<TimePicker
-				label="Time: "
-				step={1800}
-				onValue={(value) => icache.set('value', value)}
-			/>
+			<TimePicker step={1800} onValue={(value) => icache.set('value', value)}>
+				{{ label: 'Time: ' }}
+			</TimePicker>
 			<div>The value is {icache.get('value') || 'not set'}</div>
 		</virtual>
 	);

--- a/src/examples/src/widgets/time-picker/Disabled.tsx
+++ b/src/examples/src/widgets/time-picker/Disabled.tsx
@@ -4,5 +4,5 @@ import TimePicker from '@dojo/widgets/time-picker';
 const factory = create();
 
 export default factory(function Basic() {
-	return <TimePicker label="Time: " disabled />;
+	return <TimePicker disabled />;
 });

--- a/src/examples/src/widgets/time-picker/DisabledMenuItems.tsx
+++ b/src/examples/src/widgets/time-picker/DisabledMenuItems.tsx
@@ -4,5 +4,5 @@ import TimePicker from '@dojo/widgets/time-picker';
 const factory = create();
 
 export default factory(function Basic() {
-	return <TimePicker label="Time: " step={3600} timeDisabled={(time) => time.getHours() > 12} />;
+	return <TimePicker step={3600} timeDisabled={(time) => time.getHours() > 12} />;
 });

--- a/src/examples/src/widgets/time-picker/Required.tsx
+++ b/src/examples/src/widgets/time-picker/Required.tsx
@@ -4,5 +4,9 @@ import TimePicker from '@dojo/widgets/time-picker';
 const factory = create();
 
 export default factory(function Basic() {
-	return <TimePicker label="Time: " required step={1800} />;
+	return (
+		<TimePicker required step={1800}>
+			{{ label: 'Time: ' }}
+		</TimePicker>
+	);
 });

--- a/src/examples/src/widgets/time-picker/SelectBySecond.tsx
+++ b/src/examples/src/widgets/time-picker/SelectBySecond.tsx
@@ -4,5 +4,9 @@ import TimePicker from '@dojo/widgets/time-picker';
 const factory = create();
 
 export default factory(function Basic() {
-	return <TimePicker label="Time: " min="12:00:00" max="12:00:59" step={1} />;
+	return (
+		<TimePicker min="12:00:00" max="12:00:59" step={1}>
+			{{ label: 'Time: ' }}
+		</TimePicker>
+	);
 });

--- a/src/examples/src/widgets/tooltip/Focus.tsx
+++ b/src/examples/src/widgets/tooltip/Focus.tsx
@@ -10,7 +10,6 @@ export default factory(function Basic({ middleware: { icache } }) {
 	return (
 		<Tooltip open={show} content="This tooltip shows on focus">
 			<TextInput
-				label="Focus me"
 				onFocus={() => {
 					icache.set('show', true);
 				}}
@@ -18,7 +17,7 @@ export default factory(function Basic({ middleware: { icache } }) {
 					icache.set('show', false);
 				}}
 			>
-				Click
+				{{ label: 'Focus me' }}
 			</TextInput>
 		</Tooltip>
 	);

--- a/src/form/tests/unit/Form.spec.tsx
+++ b/src/form/tests/unit/Form.spec.tsx
@@ -28,7 +28,6 @@ describe('Form', () => {
 		<form name="formName" classes={[undefined, css.root]} onsubmit={noop}>
 			<TextInput
 				key="firstName"
-				label="First Name"
 				placeholder="Enter first name (must be Billy)"
 				pattern="Billy"
 				required={true}
@@ -40,10 +39,11 @@ describe('Form', () => {
 				onValue={noop}
 				onValidate={noop}
 				disabled={false}
-			/>
+			>
+				{{ label: 'First Name' }}
+			</TextInput>
 			<TextInput
 				key="middleName"
-				label="Middle Name"
 				placeholder="Enter a middle name"
 				required={false}
 				initialValue={undefined}
@@ -55,10 +55,11 @@ describe('Form', () => {
 				onValidate={noop}
 				maxLength={5}
 				disabled={false}
-			/>
+			>
+				{{ label: 'Middle Name' }}
+			</TextInput>
 			<TextInput
 				key="lastName"
-				label="Last Name"
 				placeholder="Enter a last name"
 				required={true}
 				initialValue={undefined}
@@ -70,10 +71,11 @@ describe('Form', () => {
 				onValidate={noop}
 				minLength={2}
 				disabled={false}
-			/>
+			>
+				{{ label: 'Last Name' }}
+			</TextInput>
 			<TextInput
 				key="email"
-				label="Email"
 				placeholder="Enter an email address"
 				required={false}
 				initialValue={undefined}
@@ -86,7 +88,9 @@ describe('Form', () => {
 				type="email"
 				pattern="^[^\s@]+@[^\s@]+\.[^\s@]{2,}$"
 				disabled={false}
-			/>
+			>
+				{{ label: 'Email' }}
+			</TextInput>
 			<Button key="fill" type="button" disabled={false} onClick={noop}>
 				Fill
 			</Button>
@@ -128,7 +132,6 @@ describe('Form', () => {
 				return [
 					<TextInput
 						key="firstName"
-						label="First Name"
 						placeholder="Enter first name (must be Billy)"
 						pattern="Billy"
 						required={true}
@@ -137,10 +140,11 @@ describe('Form', () => {
 						onValue={firstName.value}
 						onValidate={firstName.valid}
 						disabled={firstName.disabled()}
-					/>,
+					>
+						{{ label: 'First Name' }}
+					</TextInput>,
 					<TextInput
 						key="middleName"
-						label="Middle Name"
 						placeholder="Enter a middle name"
 						required={middleName.required()}
 						initialValue={middleName.value()}
@@ -149,10 +153,11 @@ describe('Form', () => {
 						onValidate={middleName.valid}
 						maxLength={5}
 						disabled={middleName.disabled()}
-					/>,
+					>
+						{{ label: 'Middle Name' }}
+					</TextInput>,
 					<TextInput
 						key="lastName"
-						label="Last Name"
 						placeholder="Enter a last name"
 						required={true}
 						initialValue={lastName.value()}
@@ -161,10 +166,11 @@ describe('Form', () => {
 						onValidate={lastName.valid}
 						minLength={2}
 						disabled={lastName.disabled()}
-					/>,
+					>
+						{{ label: 'Last Name' }}
+					</TextInput>,
 					<TextInput
 						key="email"
-						label="Email"
 						placeholder="Enter an email address"
 						required={false}
 						initialValue={email.value()}
@@ -174,7 +180,9 @@ describe('Form', () => {
 						type="email"
 						pattern="^[^\s@]+@[^\s@]+\.[^\s@]{2,}$"
 						disabled={email.disabled()}
-					/>,
+					>
+						{{ label: 'Email' }}
+					</TextInput>,
 					<Button
 						key="fill"
 						type="button"

--- a/src/grid/Cell.tsx
+++ b/src/grid/Cell.tsx
@@ -109,24 +109,27 @@ export default class Cell extends I18nMixin(ThemedMixin(FocusMixin(WidgetBase)))
 			},
 			[
 				this._editing
-					? w(TextInput, {
-							key: 'input',
-							theme,
-							classes: {
-								...classes,
-								'@dojo/widgets/text-input': {
-									input: [this.theme(css.input)],
-									...passedInputClasses
-								}
+					? w(
+							TextInput,
+							{
+								key: 'input',
+								theme,
+								classes: {
+									...classes,
+									'@dojo/widgets/text-input': {
+										input: [this.theme(css.input)],
+										...passedInputClasses
+									}
+								},
+								labelHidden: true,
+								focus: this._focusKey === 'input' ? this.shouldFocus : () => false,
+								initialValue: this._editingValue,
+								onValue: this._onInput,
+								onBlur: this._onBlur,
+								onKeyDown: this._onKeyDown
 							},
-							label: format('editValue', { value: rawValue }),
-							labelHidden: true,
-							focus: this._focusKey === 'input' ? this.shouldFocus : () => false,
-							initialValue: this._editingValue,
-							onValue: this._onInput,
-							onBlur: this._onBlur,
-							onKeyDown: this._onKeyDown
-					  })
+							[{ label: format('editValue', { value: rawValue }) }]
+					  )
 					: this.renderContent(),
 				editable && !this._editing
 					? w(

--- a/src/grid/Header.tsx
+++ b/src/grid/Header.tsx
@@ -96,24 +96,27 @@ export default class Header extends I18nMixin(ThemedMixin(WidgetBase))<HeaderPro
 	) => {
 		const { theme, classes = {} } = this.properties;
 		const { format } = this.localizeBundle(bundle);
-		return w(TextInput, {
-			key: 'filter',
-			theme,
-			classes: {
-				...classes,
-				'@dojo/widgets/text-input': {
-					root: [this.theme(css.filter)],
-					input: [this.theme(css.filterInput)],
-					noLabel: [this.theme(css.filterNoLabel)],
-					...classes['@dojo/widgets/text-input']
-				}
+		return w(
+			TextInput,
+			{
+				key: 'filter',
+				theme,
+				classes: {
+					...classes,
+					'@dojo/widgets/text-input': {
+						root: [this.theme(css.filter)],
+						input: [this.theme(css.filterInput)],
+						noLabel: [this.theme(css.filterNoLabel)],
+						...classes['@dojo/widgets/text-input']
+					}
+				},
+				labelHidden: true,
+				type: 'search',
+				initialValue: filterValue || undefined,
+				onValue: doFilter
 			},
-			label: format('filterBy', { name: title }),
-			labelHidden: true,
-			type: 'search',
-			initialValue: filterValue || undefined,
-			onValue: doFilter
-		});
+			[{ label: format('filterBy', { name: title }) }]
+		);
 	};
 
 	protected render(): DNode {

--- a/src/grid/tests/unit/Cell.spec.tsx
+++ b/src/grid/tests/unit/Cell.spec.tsx
@@ -45,18 +45,21 @@ const expectedEditing = function() {
 			classes: [css.root, fixedCss.rootFixed]
 		},
 		[
-			w(TextInput, {
-				key: 'input',
-				label: 'Edit id',
-				labelHidden: true,
-				classes: { '@dojo/widgets/text-input': { input: [css.input] } },
-				focus: noop,
-				initialValue: 'id',
-				onValue: noop,
-				onBlur: noop,
-				onKeyDown: noop,
-				theme: undefined
-			})
+			w(
+				TextInput,
+				{
+					key: 'input',
+					labelHidden: true,
+					classes: { '@dojo/widgets/text-input': { input: [css.input] } },
+					focus: noop,
+					initialValue: 'id',
+					onValue: noop,
+					onBlur: noop,
+					onKeyDown: noop,
+					theme: undefined
+				},
+				[{ label: 'Edit id' }]
+			)
 		]
 	);
 };

--- a/src/grid/tests/unit/Header.spec.tsx
+++ b/src/grid/tests/unit/Header.spec.tsx
@@ -145,22 +145,25 @@ describe('Header', () => {
 								)
 							]
 						),
-						w(TextInput, {
-							key: 'filter',
-							classes: {
-								'@dojo/widgets/text-input': {
-									root: [css.filter],
-									input: [css.filterInput],
-									noLabel: [css.filterNoLabel]
-								}
+						w(
+							TextInput,
+							{
+								key: 'filter',
+								classes: {
+									'@dojo/widgets/text-input': {
+										root: [css.filter],
+										input: [css.filterInput],
+										noLabel: [css.filterNoLabel]
+									}
+								},
+								labelHidden: true,
+								type: 'search',
+								initialValue: undefined,
+								onValue: noop,
+								theme: undefined
 							},
-							label: 'Filter by Custom Title',
-							labelHidden: true,
-							type: 'search',
-							initialValue: undefined,
-							onValue: noop,
-							theme: undefined
-						})
+							[{ label: 'Filter by Custom Title' }]
+						)
 					]
 				)
 			])
@@ -229,22 +232,25 @@ describe('Header', () => {
 								)
 							]
 						),
-						w(TextInput, {
-							key: 'filter',
-							classes: {
-								'@dojo/widgets/text-input': {
-									root: [css.filter],
-									input: [css.filterInput],
-									noLabel: [css.filterNoLabel]
-								}
+						w(
+							TextInput,
+							{
+								key: 'filter',
+								classes: {
+									'@dojo/widgets/text-input': {
+										root: [css.filter],
+										input: [css.filterInput],
+										noLabel: [css.filterNoLabel]
+									}
+								},
+								labelHidden: true,
+								type: 'search',
+								initialValue: undefined,
+								onValue: noop,
+								theme: undefined
 							},
-							label: 'Filter by Custom Title',
-							labelHidden: true,
-							type: 'search',
-							initialValue: undefined,
-							onValue: noop,
-							theme: undefined
-						})
+							[{ label: 'Filter by Custom Title' }]
+						)
 					]
 				)
 			])
@@ -319,22 +325,25 @@ describe('Header', () => {
 								)
 							]
 						),
-						w(TextInput, {
-							key: 'filter',
-							classes: {
-								'@dojo/widgets/text-input': {
-									root: [css.filter],
-									input: [css.filterInput],
-									noLabel: [css.filterNoLabel]
-								}
+						w(
+							TextInput,
+							{
+								key: 'filter',
+								classes: {
+									'@dojo/widgets/text-input': {
+										root: [css.filter],
+										input: [css.filterInput],
+										noLabel: [css.filterNoLabel]
+									}
+								},
+								labelHidden: true,
+								type: 'search',
+								initialValue: undefined,
+								onValue: noop,
+								theme: undefined
 							},
-							label: 'Filter by Custom Title',
-							labelHidden: true,
-							type: 'search',
-							initialValue: undefined,
-							onValue: noop,
-							theme: undefined
-						})
+							[{ label: 'Filter by Custom Title' }]
+						)
 					]
 				)
 			])
@@ -402,22 +411,25 @@ describe('Header', () => {
 								)
 							]
 						),
-						w(TextInput, {
-							key: 'filter',
-							classes: {
-								'@dojo/widgets/text-input': {
-									root: [css.filter],
-									input: [css.filterInput],
-									noLabel: [css.filterNoLabel]
-								}
+						w(
+							TextInput,
+							{
+								key: 'filter',
+								classes: {
+									'@dojo/widgets/text-input': {
+										root: [css.filter],
+										input: [css.filterInput],
+										noLabel: [css.filterNoLabel]
+									}
+								},
+								labelHidden: true,
+								type: 'search',
+								initialValue: 'my filter',
+								onValue: noop,
+								theme: undefined
 							},
-							label: 'Filter by Custom Title',
-							labelHidden: true,
-							type: 'search',
-							initialValue: 'my filter',
-							onValue: noop,
-							theme: undefined
-						})
+							[{ label: 'Filter by Custom Title' }]
+						)
 					]
 				)
 			])
@@ -572,22 +584,25 @@ describe('Header', () => {
 									])
 								]
 							),
-							w(TextInput, {
-								key: 'filter',
-								classes: {
-									'@dojo/widgets/text-input': {
-										root: [css.filter],
-										input: [css.filterInput],
-										noLabel: [css.filterNoLabel]
-									}
+							w(
+								TextInput,
+								{
+									key: 'filter',
+									classes: {
+										'@dojo/widgets/text-input': {
+											root: [css.filter],
+											input: [css.filterInput],
+											noLabel: [css.filterNoLabel]
+										}
+									},
+									labelHidden: true,
+									type: 'search',
+									initialValue: undefined,
+									onValue: noop,
+									theme: undefined
 								},
-								label: 'Filter by Custom Title',
-								labelHidden: true,
-								type: 'search',
-								initialValue: undefined,
-								onValue: noop,
-								theme: undefined
-							})
+								[{ label: 'Filter by Custom Title' }]
+							)
 						]
 					)
 				])
@@ -657,22 +672,25 @@ describe('Header', () => {
 									])
 								]
 							),
-							w(TextInput, {
-								key: 'filter',
-								classes: {
-									'@dojo/widgets/text-input': {
-										root: [css.filter],
-										input: [css.filterInput],
-										noLabel: [css.filterNoLabel]
-									}
+							w(
+								TextInput,
+								{
+									key: 'filter',
+									classes: {
+										'@dojo/widgets/text-input': {
+											root: [css.filter],
+											input: [css.filterInput],
+											noLabel: [css.filterNoLabel]
+										}
+									},
+									labelHidden: true,
+									type: 'search',
+									initialValue: undefined,
+									onValue: noop,
+									theme: undefined
 								},
-								label: 'Filter by Custom Title',
-								labelHidden: true,
-								type: 'search',
-								initialValue: undefined,
-								onValue: noop,
-								theme: undefined
-							})
+								[{ label: 'Filter by Custom Title' }]
+							)
 						]
 					)
 				])

--- a/src/number-input/index.tsx
+++ b/src/number-input/index.tsx
@@ -1,7 +1,7 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 
 import theme from '../middleware/theme';
-import TextInput, { BaseInputProperties } from '../text-input';
+import TextInput, { BaseInputProperties, TextInputChildren } from '../text-input';
 import * as textInputCss from '../theme/default/text-input.m.css';
 import * as numberInputCss from '../theme/default/number-input.m.css';
 
@@ -16,9 +16,11 @@ export interface NumberInputProperties extends BaseInputProperties<{ value: numb
 	valid?: { valid?: boolean; message?: string } | boolean;
 }
 
-const factory = create({ theme }).properties<NumberInputProperties>();
+const factory = create({ theme })
+	.properties<NumberInputProperties>()
+	.children<TextInputChildren | undefined>();
 
-export default factory(function NumberInput({ properties, middleware: { theme } }) {
+export default factory(function NumberInput({ properties, children, middleware: { theme } }) {
 	const { initialValue, onValue } = properties();
 
 	const valueAsString =
@@ -47,6 +49,8 @@ export default factory(function NumberInput({ properties, middleware: { theme } 
 				textInputCss,
 				numberInputCss
 			)}
-		/>
+		>
+			{children()[0]}
+		</TextInput>
 	);
 });

--- a/src/number-input/tests/unit/NumberInput.spec.tsx
+++ b/src/number-input/tests/unit/NumberInput.spec.tsx
@@ -35,9 +35,7 @@ registerSuite('NumberInput', {
 				autocomplete: true,
 				disabled: true,
 				helperText: 'helper text',
-				label: 'label',
 				labelHidden: true,
-				leading: () => <div />,
 				name: 'name',
 				onBlur: noop,
 				onFocus: noop,
@@ -49,19 +47,29 @@ registerSuite('NumberInput', {
 				onOut: noop,
 				onValue: noop,
 				readOnly: true,
-				trailing: () => <div />,
 				initialValue: 42,
 				widgetId: 'widgetId'
 			};
 
-			const h = harness(() => <NumberInput {...baseProperties} />, [compareTheme]);
+			const h = harness(
+				() => (
+					<NumberInput {...baseProperties}>
+						{{ label: 'label', leading: <div />, trailing: <div /> }}
+					</NumberInput>
+				),
+				[compareTheme]
+			);
 			h.expect(
-				baseTemplate.setProperties(':root', {
-					...baseProperties,
-					initialValue: baseProperties.initialValue!.toString(),
-					type: 'number',
-					theme: { '@dojo/widgets/text-input': textInputCss }
-				})
+				baseTemplate
+					.setProperties(':root', {
+						...baseProperties,
+						initialValue: baseProperties.initialValue!.toString(),
+						type: 'number',
+						theme: { '@dojo/widgets/text-input': textInputCss }
+					})
+					.setChildren(':root', [
+						{ label: 'label', leading: <div />, trailing: <div /> }
+					] as any)
 			);
 		},
 		'passes correct value to underlying TextInput'() {

--- a/src/password-input/index.tsx
+++ b/src/password-input/index.tsx
@@ -7,7 +7,7 @@ import theme from '../middleware/theme';
 import * as buttonCss from '../theme/default/button.m.css';
 import * as css from '../theme/default/password-input.m.css';
 import * as textInputCss from '../theme/default/text-input.m.css';
-import TextInput from '../text-input';
+import TextInput, { TextInputChildren } from '../text-input';
 import { ValidationRules } from '../middleware/validation';
 
 export type Omit<T, E> = Pick<T, Exclude<keyof T, E>>;
@@ -25,10 +25,14 @@ export interface PasswordInputState {
 const factory = create({
 	icache: createICacheMiddleware<PasswordInputState>(),
 	theme
-}).properties<PasswordInputProperties>();
+})
+	.properties<PasswordInputProperties>()
+	.children<TextInputChildren | undefined>();
+
 export const PasswordInput = factory(function PasswordInput({
 	middleware: { theme, icache },
-	properties
+	properties,
+	children
 }) {
 	const props = properties();
 	const showPassword = icache.getOrSet('showPassword', false);
@@ -63,8 +67,9 @@ export const PasswordInput = factory(function PasswordInput({
 				textInputCss,
 				css
 			)}
-			trailing={() => trailing}
-		/>
+		>
+			{{ ...children()[0], trailing }}
+		</ConstrainedInput>
 	) : (
 		<TextInput
 			{...props}
@@ -74,10 +79,11 @@ export const PasswordInput = factory(function PasswordInput({
 				textInputCss,
 				css
 			)}
-			trailing={() => trailing}
 			onValidate={handleValidation}
 			valid={icache.get('valid')}
-		/>
+		>
+			{{ ...children()[0], trailing }}
+		</TextInput>
 	);
 });
 

--- a/src/password-input/tests/unit/password-input.spec.tsx
+++ b/src/password-input/tests/unit/password-input.spec.tsx
@@ -21,7 +21,9 @@ describe('PasswordInput', () => {
 				key="root"
 				type={'password'}
 				theme={{ '@dojo/widgets/text-input': textInputCss }}
-			/>
+			>
+				{{ trailing: undefined }}
+			</ConstrainedInput>
 		));
 	});
 
@@ -34,7 +36,9 @@ describe('PasswordInput', () => {
 				theme={{ '@dojo/widgets/text-input': textInputCss }}
 				onValidate={() => undefined}
 				valid={undefined}
-			/>
+			>
+				{{ trailing: undefined }}
+			</TextInput>
 		));
 	});
 
@@ -49,7 +53,9 @@ describe('PasswordInput', () => {
 				onValidate={() => undefined}
 				required
 				valid={{ valid: false, message: 'this is required' }}
-			/>
+			>
+				{{ trailing: undefined }}
+			</TextInput>
 		));
 	});
 
@@ -61,38 +67,15 @@ describe('PasswordInput', () => {
 				key="root"
 				type={'password'}
 				theme={{ '@dojo/widgets/text-input': textInputCss }}
-			/>
+			>
+				{{
+					trailing: (
+						<Button onClick={() => {}} theme={{}}>
+							<Icon type="eyeIcon" />
+						</Button>
+					)
+				}}
+			</ConstrainedInput>
 		));
-
-		const eyeRender = h.trigger('@root', 'trailing');
-		h.expect(
-			() => (
-				<Button onClick={() => {}} theme={{}}>
-					<Icon type="eyeIcon" />
-				</Button>
-			),
-			() => eyeRender
-		);
-
-		h.trigger('@root', (node: any) => node.properties.trailing().properties.onClick);
-
-		h.expect(() => (
-			<ConstrainedInput
-				rules={rules}
-				key="root"
-				type={'text'}
-				theme={{ '@dojo/widgets/text-input': textInputCss }}
-			/>
-		));
-
-		const slashRender = h.trigger('@root', 'trailing');
-		h.expect(
-			() => (
-				<Button onClick={() => {}} theme={{}}>
-					<Icon type="eyeSlashIcon" />
-				</Button>
-			),
-			() => slashRender
-		);
 	});
 });

--- a/src/password-input/tests/unit/password-input.spec.tsx
+++ b/src/password-input/tests/unit/password-input.spec.tsx
@@ -21,7 +21,6 @@ describe('PasswordInput', () => {
 				key="root"
 				type={'password'}
 				theme={{ '@dojo/widgets/text-input': textInputCss }}
-				trailing={() => undefined}
 			/>
 		));
 	});
@@ -33,7 +32,6 @@ describe('PasswordInput', () => {
 				key="root"
 				type={'password'}
 				theme={{ '@dojo/widgets/text-input': textInputCss }}
-				trailing={() => undefined}
 				onValidate={() => undefined}
 				valid={undefined}
 			/>
@@ -48,7 +46,6 @@ describe('PasswordInput', () => {
 				key="root"
 				type={'password'}
 				theme={{ '@dojo/widgets/text-input': textInputCss }}
-				trailing={() => undefined}
 				onValidate={() => undefined}
 				required
 				valid={{ valid: false, message: 'this is required' }}
@@ -64,7 +61,6 @@ describe('PasswordInput', () => {
 				key="root"
 				type={'password'}
 				theme={{ '@dojo/widgets/text-input': textInputCss }}
-				trailing={() => undefined}
 			/>
 		));
 
@@ -86,7 +82,6 @@ describe('PasswordInput', () => {
 				key="root"
 				type={'text'}
 				theme={{ '@dojo/widgets/text-input': textInputCss }}
-				trailing={() => undefined}
 			/>
 		));
 

--- a/src/text-input/tests/unit/TextInput.spec.tsx
+++ b/src/text-input/tests/unit/TextInput.spec.tsx
@@ -236,7 +236,7 @@ registerSuite('TextInput', {
 		},
 
 		label() {
-			const h = harness(() => <TextInput label="foo" />);
+			const h = harness(() => <TextInput>{{ label: 'foo' }}</TextInput>);
 
 			h.expect(() => expected({ label: true }));
 		},
@@ -534,7 +534,7 @@ registerSuite('TextInput', {
 		},
 
 		'leading property'() {
-			const leading = () => <span>A</span>;
+			const leading = <span>A</span>;
 			const leadingTemplate = baseAssertion
 				.setProperty('@wrapper', 'classes', [
 					css.wrapper,
@@ -550,15 +550,15 @@ registerSuite('TextInput', {
 				])
 				.prepend('@inputWrapper', () => [
 					<span key="leading" classes={css.leading}>
-						{leading()}
+						{leading}
 					</span>
 				]);
-			const h = harness(() => <TextInput leading={leading} />);
+			const h = harness(() => <TextInput>{{ leading }}</TextInput>);
 			h.expect(leadingTemplate);
 		},
 
 		'trailing property'() {
-			const trailing = () => <span>Z</span>;
+			const trailing = <span>Z</span>;
 			const trailingTemplate = baseAssertion
 				.setProperty('@wrapper', 'classes', [
 					css.wrapper,
@@ -574,10 +574,10 @@ registerSuite('TextInput', {
 				])
 				.append('@inputWrapper', () => [
 					<span key="trailing" classes={css.trailing}>
-						{trailing()}
+						{trailing}
 					</span>
 				]);
-			const h = harness(() => <TextInput trailing={trailing} />);
+			const h = harness(() => <TextInput>{{ trailing }}</TextInput>);
 			h.expect(trailingTemplate);
 		},
 
@@ -712,7 +712,7 @@ registerSuite('TextInput', {
 			clock.restore();
 		},
 		hiddenLabel() {
-			const h = harness(() => <TextInput label="foo" labelHidden={true} />);
+			const h = harness(() => <TextInput labelHidden={true}>{{ label: 'foo' }}</TextInput>);
 
 			h.expect(() => expected({ label: true, labelHidden: true }));
 		}

--- a/src/time-picker/index.tsx
+++ b/src/time-picker/index.tsx
@@ -13,6 +13,7 @@ import { Keys } from '../common/util';
 import bundle from './nls/TimePicker';
 import i18n from '@dojo/framework/core/middleware/i18n';
 import { createResource, DataTemplate } from '@dojo/framework/core/resource';
+import { RenderResult } from '@dojo/framework/core/interfaces';
 
 function createMemoryTemplate<S = void>(): DataTemplate<S> {
 	return {
@@ -32,9 +33,6 @@ export interface TimePickerProperties {
 
 	/** Callback to determine if a particular time entry should be disabled */
 	timeDisabled?: (time: Date) => boolean;
-
-	/** Adds a <label> element with the supplied text */
-	label?: string;
 
 	/** The name of the field */
 	name?: string;
@@ -64,6 +62,11 @@ export interface TimePickerProperties {
 	format?: '24' | '12';
 }
 
+export interface TimePickerChildren {
+	/** The label to be displayed above the input */
+	label?: RenderResult;
+}
+
 export interface TimePickerICache {
 	value?: string;
 	inputValue: string;
@@ -81,7 +84,9 @@ const factory = create({
 	i18n,
 	focus,
 	icache: createICacheMiddleware<TimePickerICache>()
-}).properties<TimePickerProperties>();
+})
+	.properties<TimePickerProperties>()
+	.children<TimePickerChildren | undefined>();
 
 export interface TimeParser {
 	regex: RegExp;
@@ -206,7 +211,8 @@ export function format24HourTime(dt: Date) {
 
 export const TimePicker = factory(function TimePicker({
 	middleware: { theme, icache, focus, i18n },
-	properties
+	properties,
+	children
 }) {
 	const classes = theme.classes(css);
 	const { messages } = i18n.localize(bundle);
@@ -329,6 +335,7 @@ export const TimePicker = factory(function TimePicker({
 	};
 
 	const { name } = properties();
+	const [{ label } = {} as TimePickerChildren] = children();
 
 	const options = generateOptions();
 
@@ -349,13 +356,12 @@ export const TimePicker = factory(function TimePicker({
 							toggleOpen();
 						}
 
-						const { disabled, required, label } = properties();
+						const { disabled, required } = properties();
 
 						return (
 							<div classes={classes.input}>
 								<TextInput
 									key="input"
-									label={label}
 									disabled={disabled}
 									required={required}
 									focus={() => shouldFocus && focusNode === 'input'}
@@ -363,20 +369,6 @@ export const TimePicker = factory(function TimePicker({
 										inputCss,
 										css,
 										'input'
-									)}
-									trailing={() => (
-										<button
-											disabled={disabled}
-											key="clockIcon"
-											onclick={(e) => {
-												e.stopPropagation();
-												openMenu();
-											}}
-											classes={classes.toggleMenuButton}
-											type="button"
-										>
-											<Icon type="clockIcon" />
-										</button>
 									)}
 									initialValue={icache.get('inputValue')}
 									onBlur={() => icache.set('shouldValidate', true)}
@@ -395,7 +387,25 @@ export const TimePicker = factory(function TimePicker({
 										}
 									}}
 									type="text"
-								/>
+								>
+									{{
+										label,
+										trailing: (
+											<button
+												disabled={disabled}
+												key="clockIcon"
+												onclick={(e) => {
+													e.stopPropagation();
+													openMenu();
+												}}
+												classes={classes.toggleMenuButton}
+												type="button"
+											>
+												<Icon type="clockIcon" />
+											</button>
+										)
+									}}
+								</TextInput>
 							</div>
 						);
 					},

--- a/src/time-picker/tests/unit/TimePicker.spec.tsx
+++ b/src/time-picker/tests/unit/TimePicker.spec.tsx
@@ -79,7 +79,9 @@ const buttonTemplate = assertionTemplate(() => {
 				helperText=""
 				onKeyDown={noop}
 				type="text"
-			/>
+			>
+				{{ label: undefined, trailing: undefined }}
+			</TextInput>
 		</div>
 	);
 });
@@ -173,7 +175,7 @@ describe('TimePicker', () => {
 		// Find the date icon & `click` it
 		const [dateIcon] = select(
 			'@clockIcon',
-			select('@input', triggerResult)[0].properties.trailing()
+			(select('@input', triggerResult)[0].children![0] as any).trailing
 		);
 		dateIcon.properties.onclick(stubEvent);
 		h.expect(baseTemplate());

--- a/src/time-picker/tests/unit/TimePicker.spec.tsx
+++ b/src/time-picker/tests/unit/TimePicker.spec.tsx
@@ -68,12 +68,10 @@ const buttonTemplate = assertionTemplate(() => {
 			<TextInput
 				disabled={undefined}
 				key="input"
-				label={undefined}
 				focus={() => false}
 				theme={{}}
 				onBlur={noop}
 				onValue={noop}
-				trailing={() => undefined}
 				initialValue={''}
 				onValidate={noop}
 				required={undefined}


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds child renderers for TextInput and all the places it's used.

Resolves #1271 
