### PR TITLE
Update tooltip to use a child renderer for content

### DIFF
--- a/src/examples/src/widgets/tooltip/Basic.tsx
+++ b/src/examples/src/widgets/tooltip/Basic.tsx
@@ -8,17 +8,22 @@ const factory = create({ icache });
 export default factory(function Basic({ middleware: { icache } }) {
 	const show = icache.getOrSet('show', false);
 	return (
-		<Tooltip open={show} content="This tooltip shows on mouseover">
-			<Button
-				onOut={() => {
-					icache.set('show', false);
-				}}
-				onOver={() => {
-					icache.set('show', true);
-				}}
-			>
-				Click
-			</Button>
+		<Tooltip open={show}>
+			{{
+				content: 'This tooltip shows on mouseover',
+				target: (
+					<Button
+						onOut={() => {
+							icache.set('show', false);
+						}}
+						onOver={() => {
+							icache.set('show', true);
+						}}
+					>
+						Click
+					</Button>
+				)
+			}}
 		</Tooltip>
 	);
 });

--- a/src/examples/src/widgets/tooltip/Basic.tsx
+++ b/src/examples/src/widgets/tooltip/Basic.tsx
@@ -11,7 +11,7 @@ export default factory(function Basic({ middleware: { icache } }) {
 		<Tooltip open={show}>
 			{{
 				content: 'This tooltip shows on mouseover',
-				target: (
+				trigger: (
 					<Button
 						onOut={() => {
 							icache.set('show', false);

--- a/src/examples/src/widgets/tooltip/Click.tsx
+++ b/src/examples/src/widgets/tooltip/Click.tsx
@@ -8,14 +8,19 @@ const factory = create({ icache });
 export default factory(function Basic({ middleware: { icache } }) {
 	const show = icache.getOrSet('show', false);
 	return (
-		<Tooltip open={show} content="This tooltip is toggled on click">
-			<Button
-				onClick={() => {
-					icache.set('show', !icache.get<boolean>('show'));
-				}}
-			>
-				Click Me
-			</Button>
+		<Tooltip open={show}>
+			{{
+				content: 'This tooltip is toggled on click',
+				target: (
+					<Button
+						onClick={() => {
+							icache.set('show', !icache.get<boolean>('show'));
+						}}
+					>
+						Click Me
+					</Button>
+				)
+			}}
 		</Tooltip>
 	);
 });

--- a/src/examples/src/widgets/tooltip/Click.tsx
+++ b/src/examples/src/widgets/tooltip/Click.tsx
@@ -11,7 +11,7 @@ export default factory(function Basic({ middleware: { icache } }) {
 		<Tooltip open={show}>
 			{{
 				content: 'This tooltip is toggled on click',
-				target: (
+				trigger: (
 					<Button
 						onClick={() => {
 							icache.set('show', !icache.get<boolean>('show'));

--- a/src/examples/src/widgets/tooltip/Focus.tsx
+++ b/src/examples/src/widgets/tooltip/Focus.tsx
@@ -8,17 +8,22 @@ const factory = create({ icache });
 export default factory(function Basic({ middleware: { icache } }) {
 	const show = icache.getOrSet('show', false);
 	return (
-		<Tooltip open={show} content="This tooltip shows on focus">
-			<TextInput
-				onFocus={() => {
-					icache.set('show', true);
-				}}
-				onBlur={() => {
-					icache.set('show', false);
-				}}
-			>
-				{{ label: 'Focus me' }}
-			</TextInput>
+		<Tooltip open={show}>
+			{{
+				content: 'This tooltip shows on focus',
+				target: (
+					<TextInput
+						onFocus={() => {
+							icache.set('show', true);
+						}}
+						onBlur={() => {
+							icache.set('show', false);
+						}}
+					>
+						{{ label: 'Focus me' }}
+					</TextInput>
+				)
+			}}
 		</Tooltip>
 	);
 });

--- a/src/examples/src/widgets/tooltip/Focus.tsx
+++ b/src/examples/src/widgets/tooltip/Focus.tsx
@@ -11,7 +11,7 @@ export default factory(function Basic({ middleware: { icache } }) {
 		<Tooltip open={show}>
 			{{
 				content: 'This tooltip shows on focus',
-				target: (
+				trigger: (
 					<TextInput
 						onFocus={() => {
 							icache.set('show', true);

--- a/src/tooltip/index.tsx
+++ b/src/tooltip/index.tsx
@@ -16,7 +16,7 @@ export interface TooltipProperties {
 }
 
 export interface TooltipChildren {
-	target?: RenderResult;
+	trigger?: RenderResult;
 	content: RenderResult;
 }
 
@@ -36,7 +36,7 @@ export const Tooltip = factory(function Tooltip({ children, properties, middlewa
 	const { open, aria = {}, orientation = Orientation.right } = properties();
 	const classes = theme.classes(css);
 	const fixedClasses = theme.classes(fixedCss);
-	const [{ target, content }] = children();
+	const [{ trigger, content }] = children();
 
 	let fixedOrientation;
 	let classesOrientation;
@@ -65,7 +65,7 @@ export const Tooltip = factory(function Tooltip({ children, properties, middlewa
 			]}
 		>
 			<div key="target">
-				{target}
+				{trigger}
 				{open ? (
 					<div
 						key="content"

--- a/src/tooltip/index.tsx
+++ b/src/tooltip/index.tsx
@@ -1,20 +1,23 @@
-import { DNode } from '@dojo/framework/core/interfaces';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import theme from '../middleware/theme';
 
 import * as fixedCss from './styles/tooltip.m.css';
 import * as css from '../theme/default/tooltip.m.css';
 import { formatAriaProperties } from '../common/util';
+import { RenderResult } from '@dojo/framework/core/interfaces';
 
 export interface TooltipProperties {
 	/** Custom aria attributes */
 	aria?: { [key: string]: string | null };
-	/** Information to show within the tooltip */
-	content: DNode;
 	/** Determines if this tooltip is visible */
 	open?: boolean;
 	/** Where this tooltip should render relative to its child */
 	orientation?: Orientation;
+}
+
+export interface TooltipChildren {
+	target?: RenderResult;
+	content: RenderResult;
 }
 
 // Enum used to position the Tooltip
@@ -25,12 +28,15 @@ export enum Orientation {
 	top = 'top'
 }
 
-const factory = create({ theme }).properties<TooltipProperties>();
+const factory = create({ theme })
+	.properties<TooltipProperties>()
+	.children<TooltipChildren>();
 
 export const Tooltip = factory(function Tooltip({ children, properties, middleware: { theme } }) {
-	const { open, content, aria = {}, orientation = Orientation.right } = properties();
+	const { open, aria = {}, orientation = Orientation.right } = properties();
 	const classes = theme.classes(css);
 	const fixedClasses = theme.classes(fixedCss);
+	const [{ target, content }] = children();
 
 	let fixedOrientation;
 	let classesOrientation;
@@ -59,7 +65,7 @@ export const Tooltip = factory(function Tooltip({ children, properties, middlewa
 			]}
 		>
 			<div key="target">
-				{children()}
+				{target}
 				{open ? (
 					<div
 						key="content"

--- a/src/tooltip/tests/unit/Tooltip.spec.tsx
+++ b/src/tooltip/tests/unit/Tooltip.spec.tsx
@@ -4,13 +4,14 @@ import { tsx } from '@dojo/framework/core/vdom';
 import harness from '@dojo/framework/testing/harness';
 
 import Tooltip, { Orientation } from '../../index';
+import Button from '../../../button/index';
 import * as css from '../../../theme/default/tooltip.m.css';
 import * as fixedCss from '../../styles/tooltip.m.css';
 
 registerSuite('Tooltip', {
 	tests: {
 		'should construct Tooltip'() {
-			const h = harness(() => <Tooltip content="" />);
+			const h = harness(() => <Tooltip>{{ content: '' }}</Tooltip>);
 			h.expect(() => (
 				<div classes={[undefined, css.right, fixedCss.rootFixed, fixedCss.rightFixed]}>
 					<div key="target" />
@@ -19,7 +20,7 @@ registerSuite('Tooltip', {
 		},
 
 		'should render content if open'() {
-			const h = harness(() => <Tooltip content="foobar" open />);
+			const h = harness(() => <Tooltip open>{{ content: 'foobar' }}</Tooltip>);
 
 			h.expect(() => (
 				<div classes={[undefined, css.right, fixedCss.rootFixed, fixedCss.rightFixed]}>
@@ -32,9 +33,28 @@ registerSuite('Tooltip', {
 			));
 		},
 
+		'should render target'() {
+			const h = harness(() => (
+				<Tooltip open>
+					{{ target: <Button>Give me a tooltip</Button>, content: 'foobar' }}
+				</Tooltip>
+			));
+
+			h.expect(() => (
+				<div classes={[undefined, css.right, fixedCss.rootFixed, fixedCss.rightFixed]}>
+					<div key="target">
+						<Button>Give me a tooltip</Button>
+						<div key="content" classes={[css.content, fixedCss.contentFixed]}>
+							foobar
+						</div>
+					</div>
+				</div>
+			));
+		},
+
 		'should render correct orientation'() {
 			const h = harness(() => (
-				<Tooltip orientation={Orientation.bottom} content={'foobar'} />
+				<Tooltip orientation={Orientation.bottom}>{{ content: 'foobar' }}</Tooltip>
 			));
 
 			h.expect(() => (
@@ -45,7 +65,11 @@ registerSuite('Tooltip', {
 		},
 
 		'should render aria properties'() {
-			const h = harness(() => <Tooltip content="bar" open aria={{ describedBy: 'foo' }} />);
+			const h = harness(() => (
+				<Tooltip open aria={{ describedBy: 'foo' }}>
+					{{ content: 'bar' }}
+				</Tooltip>
+			));
 
 			h.expect(() => (
 				<div classes={[undefined, css.right, fixedCss.rootFixed, fixedCss.rightFixed]}>

--- a/src/tooltip/tests/unit/Tooltip.spec.tsx
+++ b/src/tooltip/tests/unit/Tooltip.spec.tsx
@@ -33,10 +33,10 @@ registerSuite('Tooltip', {
 			));
 		},
 
-		'should render target'() {
+		'should render trigger'() {
 			const h = harness(() => (
 				<Tooltip open>
-					{{ target: <Button>Give me a tooltip</Button>, content: 'foobar' }}
+					{{ trigger: <Button>Give me a tooltip</Button>, content: 'foobar' }}
 				</Tooltip>
 			));
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Updates the tooltip to use a child renderer for content, moves target element to a child renderer named `target`.
Resolves #1274 
