### PR TITLE
v7 Migration guide updates for button and global-event

### DIFF
--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -60,6 +60,45 @@ Many of our form widgets are now capable of validating themselves. In many cases
 Latest example can be found on [widgets.dojo.io/#widget/accordion-pane/overview](https://widgets.dojo.io/#widget/accordion-pane/overview)
 
 
+### button
+
+#### Property changes
+##### Changed properties
+- onDown?(): void;
+	- Handler for events triggered by pointer down.
+	- Replaces previous down event handlers.
+##### Removed properties
+- popup?: { expanded?: boolean; id?: string } | boolean;
+	- Popup functionality was removed from `Button`.
+	- The `TriggerPopup` widget provides popup functionality.
+- onInput?(value?: string | number | boolean): void;
+	- Not applicable to a button.
+- onChange?(value?: string | number | boolean): void;
+	- Not applicable to a button.
+- The following interaction events were replaced by onDown:
+	- onMouseDown?(): void;
+	- onMouseUp?(): void;
+	- onTouchStart?(): void;
+	- onTouchEnd?(): void;
+	- onTouchCancel?(): void;
+	- onMouseDown?(): void;
+	- onMouseUp?(): void;
+	- onTouchStart?(): void;
+	- onTouchEnd?(): void;
+	- onTouchCancel?(): void;
+#### Changes in behaviour
+
+#### Example of migration from v6 to v7
+```
+<Button onMouseDown={() => {console.log('Down')}}>Example Button</Button>
+```
+```
+<Button onDown={() => {console.log('Down')}}>Example Button</Button>
+```
+
+Latest example can be found on [widgets.dojo.io/#widget/button/overview](https://widgets.dojo.io/#widget/button/overview)
+
+
 ### calendar
 #### Property changes
 ##### Changed properties

--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -60,27 +60,6 @@ Many of our form widgets are now capable of validating themselves. In many cases
 Latest example can be found on [widgets.dojo.io/#widget/accordion-pane/overview](https://widgets.dojo.io/#widget/accordion-pane/overview)
 
 
-### button
-
-#### Property changes
-##### Additional Mandatory Properties
-- foo: string
-	- this prop does x
-##### Changed properties
-- bar: string
-	- this prop replaced x
-	- this prop does foo bar baz
-	- more info
-##### Removed properties
-- baz: string
-	- replaced by foo
-	- any additional info
-#### Changes in behaviour
-#### Example of migration from v6 to v7
-
-Latest example can be found on [widgets.dojo.io/#widget/button/overview](https://widgets.dojo.io/#widget/button/overview)
-
-
 ### calendar
 #### Property changes
 ##### Changed properties
@@ -183,27 +162,6 @@ Latest example can be found on [widgets.dojo.io/#widget/checkbox/overview](https
 #### Example of migration from v6 to v7
 
 Latest example can be found on [widgets.dojo.io/#widget/dialog/overview](https://widgets.dojo.io/#widget/dialog/overview)
-
-
-### global-event
-
-#### Property changes
-##### Additional Mandatory Properties
-- foo: string
-	- this prop does x
-##### Changed properties
-- bar: string
-	- this prop replaced x
-	- this prop does foo bar baz
-	- more info
-##### Removed properties
-- baz: string
-	- replaced by foo
-	- any additional info
-#### Changes in behaviour
-#### Example of migration from v6 to v7
-
-Latest example can be found on [widgets.dojo.io/#widget/global-event/overview](https://widgets.dojo.io/#widget/global-event/overview)
 
 
 ### header


### PR DESCRIPTION
**Description:**

Removes button and global-event sections due to backwards compatibility. No changes needed.

Part of #1242 
