### PR TITLE
Fix child renderer types for title pane

### DIFF
--- a/src/accordion-pane/tests/unit/AccordionPane.spec.tsx
+++ b/src/accordion-pane/tests/unit/AccordionPane.spec.tsx
@@ -14,14 +14,14 @@ describe('AccordionPane', () => {
 			<div classes={[undefined, themeCss.root]}>
 				<TitlePane key="foo">
 					{{
-						title: () => 'foo title',
-						content: () => 'foo content'
+						title: 'foo title',
+						content: 'foo content'
 					}}
 				</TitlePane>
 				<TitlePane key="bar">
 					{{
-						title: () => 'bar title',
-						content: () => 'bar content'
+						title: 'bar title',
+						content: 'bar content'
 					}}
 				</TitlePane>
 			</div>
@@ -35,14 +35,14 @@ describe('AccordionPane', () => {
 					return [
 						<TitlePane key="foo" onOpen={onOpen('foo')} onClose={onClose('foo')}>
 							{{
-								title: () => 'foo title',
-								content: () => 'foo content'
+								title: 'foo title',
+								content: 'foo content'
 							}}
 						</TitlePane>,
 						<TitlePane key="bar" onOpen={onOpen('bar')} onClose={onClose('bar')}>
 							{{
-								title: () => 'bar title',
-								content: () => 'bar content'
+								title: 'bar title',
+								content: 'bar content'
 							}}
 						</TitlePane>
 					];
@@ -75,8 +75,8 @@ describe('AccordionPane', () => {
 							initialOpen={initialOpen('foo')}
 						>
 							{{
-								title: () => 'foo title',
-								content: () => 'foo content'
+								title: 'foo title',
+								content: 'foo content'
 							}}
 						</TitlePane>,
 						<TitlePane
@@ -85,8 +85,8 @@ describe('AccordionPane', () => {
 							initialOpen={initialOpen('bar')}
 						>
 							{{
-								title: () => 'bar title',
-								content: () => 'bar content'
+								title: 'bar title',
+								content: 'bar content'
 							}}
 						</TitlePane>
 					];
@@ -117,8 +117,8 @@ describe('AccordionPane', () => {
 							initialOpen={initialOpen('foo')}
 						>
 							{{
-								title: () => 'foo title',
-								content: () => 'foo content'
+								title: 'foo title',
+								content: 'foo content'
 							}}
 						</TitlePane>,
 						<TitlePane
@@ -127,8 +127,8 @@ describe('AccordionPane', () => {
 							initialOpen={initialOpen('bar')}
 						>
 							{{
-								title: () => 'bar title',
-								content: () => 'bar content'
+								title: 'bar title',
+								content: 'bar content'
 							}}
 						</TitlePane>
 					];

--- a/src/examples/src/widgets/accordion-pane/Basic.tsx
+++ b/src/examples/src/widgets/accordion-pane/Basic.tsx
@@ -17,8 +17,8 @@ export default factory(function Basic() {
 						theme={theme}
 					>
 						{{
-							title: () => 'Pane 1',
-							content: () => (
+							title: 'Pane 1',
+							content: (
 								<div>
 									Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
 									id purus ipsum. Aenean ac purus purus. Nam sollicitudin varius
@@ -35,8 +35,8 @@ export default factory(function Basic() {
 						theme={theme}
 					>
 						{{
-							title: () => 'Pane 2',
-							content: () => (
+							title: 'Pane 2',
+							content: (
 								<div>
 									Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
 									id purus ipsum. Aenean ac purus purus. Nam sollicitudin varius
@@ -53,8 +53,8 @@ export default factory(function Basic() {
 						theme={theme}
 					>
 						{{
-							title: () => 'Pane 3',
-							content: () => (
+							title: 'Pane 3',
+							content: (
 								<div>
 									Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque
 									id purus ipsum. Aenean ac purus purus. Nam sollicitudin varius

--- a/src/examples/src/widgets/accordion-pane/Exclusive.tsx
+++ b/src/examples/src/widgets/accordion-pane/Exclusive.tsx
@@ -15,8 +15,8 @@ export default factory(function Basic() {
 					initialOpen={initialOpen('foo')}
 				>
 					{{
-						title: () => 'Pane 1',
-						content: () => (
+						title: 'Pane 1',
+						content: (
 							<div>
 								Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id
 								purus ipsum. Aenean ac purus purus. Nam sollicitudin varius augue,
@@ -32,8 +32,8 @@ export default factory(function Basic() {
 					initialOpen={initialOpen('bar')}
 				>
 					{{
-						title: () => 'Pane 2',
-						content: () => (
+						title: 'Pane 2',
+						content: (
 							<div>
 								Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id
 								purus ipsum. Aenean ac purus purus. Nam sollicitudin varius augue,
@@ -49,8 +49,8 @@ export default factory(function Basic() {
 					initialOpen={initialOpen('baz')}
 				>
 					{{
-						title: () => 'Pane 3',
-						content: () => (
+						title: 'Pane 3',
+						content: (
 							<div>
 								Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id
 								purus ipsum. Aenean ac purus purus. Nam sollicitudin varius augue,

--- a/src/examples/src/widgets/title-pane/Basic.tsx
+++ b/src/examples/src/widgets/title-pane/Basic.tsx
@@ -7,8 +7,8 @@ export default factory(function Basic() {
 	return (
 		<TitlePane>
 			{{
-				title: () => 'Basic Title Pane',
-				content: () => (
+				title: 'Basic Title Pane',
+				content: (
 					<div>
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id purus
 						ipsum. Aenean ac purus purus. Nam sollicitudin varius augue, sed lacinia

--- a/src/examples/src/widgets/title-pane/HeadingLevel.tsx
+++ b/src/examples/src/widgets/title-pane/HeadingLevel.tsx
@@ -7,8 +7,8 @@ export default factory(function Basic() {
 	return (
 		<TitlePane headingLevel={2}>
 			{{
-				title: () => 'Aria Heading Level 2',
-				content: () => (
+				title: 'Aria Heading Level 2',
+				content: (
 					<div>
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id purus
 						ipsum. Aenean ac purus purus. Nam sollicitudin varius augue, sed lacinia

--- a/src/examples/src/widgets/title-pane/NonCloseable.tsx
+++ b/src/examples/src/widgets/title-pane/NonCloseable.tsx
@@ -5,10 +5,10 @@ const factory = create();
 
 export default factory(function Basic() {
 	return (
-		<TitlePane closeable={false}>
+		<TitlePane initialOpen={true} closeable={false}>
 			{{
-				title: () => "I can't be closed",
-				content: () => (
+				title: "I can't be closed",
+				content: (
 					<div>
 						Lorem ipsum dolor sit amet, consectetur adipiscing elit. Quisque id purus
 						ipsum. Aenean ac purus purus. Nam sollicitudin varius augue, sed lacinia

--- a/src/title-pane/index.tsx
+++ b/src/title-pane/index.tsx
@@ -28,9 +28,9 @@ export interface TitlePaneICache {
 
 export type TitlePaneChildren = {
 	/** Renderer for the pane content */
-	content?(): RenderResult;
+	content?: RenderResult;
 	/** Renderer for the pane title */
-	title(): RenderResult;
+	title: RenderResult;
 };
 
 const factory = create({
@@ -109,7 +109,7 @@ export const TitlePane = factory(function TitlePane({
 					<span classes={themeCss.arrow}>
 						<Icon type={open ? 'downIcon' : 'rightIcon'} theme={themeProp} />
 					</span>
-					{title()}
+					{title}
 				</button>
 			</div>
 			<div
@@ -126,7 +126,7 @@ export const TitlePane = factory(function TitlePane({
 					marginTop: open ? '0px' : `-${dimensions.get('content').offset.height}px`
 				}}
 			>
-				{content && content()}
+				{content}
 			</div>
 		</div>
 	);

--- a/src/title-pane/tests/unit/TitlePane.spec.tsx
+++ b/src/title-pane/tests/unit/TitlePane.spec.tsx
@@ -79,8 +79,8 @@ describe('TitlePane', () => {
 		const h = harness(() => (
 			<TitlePane>
 				{{
-					title: () => 'title',
-					content: () => 'content'
+					title: 'title',
+					content: 'content'
 				}}
 			</TitlePane>
 		));
@@ -91,8 +91,8 @@ describe('TitlePane', () => {
 		const h = harness(() => (
 			<TitlePane initialOpen>
 				{{
-					title: () => 'title',
-					content: () => 'content'
+					title: 'title',
+					content: 'content'
 				}}
 			</TitlePane>
 		));
@@ -107,8 +107,8 @@ describe('TitlePane', () => {
 		const h = harness(() => (
 			<TitlePane headingLevel={3}>
 				{{
-					title: () => 'title',
-					content: () => 'content'
+					title: 'title',
+					content: 'content'
 				}}
 			</TitlePane>
 		));
@@ -123,8 +123,8 @@ describe('TitlePane', () => {
 		const h = harness(() => (
 			<TitlePane closeable={false}>
 				{{
-					title: () => 'title',
-					content: () => 'content'
+					title: 'title',
+					content: 'content'
 				}}
 			</TitlePane>
 		));
@@ -139,8 +139,8 @@ describe('TitlePane', () => {
 		const h = harness(() => (
 			<TitlePane>
 				{{
-					title: () => 'title',
-					content: () => 'content'
+					title: 'title',
+					content: 'content'
 				}}
 			</TitlePane>
 		));
@@ -160,8 +160,8 @@ describe('TitlePane', () => {
 		const h = harness(() => (
 			<TitlePane initialOpen>
 				{{
-					title: () => 'title',
-					content: () => 'content'
+					title: 'title',
+					content: 'content'
 				}}
 			</TitlePane>
 		));
@@ -177,8 +177,8 @@ describe('TitlePane', () => {
 		const h = harness(() => (
 			<TitlePane onOpen={onOpen}>
 				{{
-					title: () => 'title',
-					content: () => 'content'
+					title: 'title',
+					content: 'content'
 				}}
 			</TitlePane>
 		));
@@ -193,8 +193,8 @@ describe('TitlePane', () => {
 		const h = harness(() => (
 			<TitlePane initialOpen onClose={onClose}>
 				{{
-					title: () => 'title',
-					content: () => 'content'
+					title: 'title',
+					content: 'content'
 				}}
 			</TitlePane>
 		));


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #1273 
