### PR TITLE
Update textarea to use a child renderer for its label

### DIFF
--- a/src/examples/src/widgets/text-area/Disabled.tsx
+++ b/src/examples/src/widgets/text-area/Disabled.tsx
@@ -4,5 +4,9 @@ import TextArea from '@dojo/widgets/text-area';
 const factory = create();
 
 export default factory(function Disabled() {
-	return <TextArea initialValue="Initial Value" label="Can't type here" disabled={true} />;
+	return (
+		<TextArea initialValue="Initial Value" disabled={true}>
+			Can't type here
+		</TextArea>
+	);
 });

--- a/src/examples/src/widgets/text-area/HelperText.tsx
+++ b/src/examples/src/widgets/text-area/HelperText.tsx
@@ -4,5 +4,5 @@ import TextArea from '@dojo/widgets/text-area';
 const factory = create();
 
 export default factory(function HelperText() {
-	return <TextArea label="Has helper text" helperText="Hi there, enter some text" />;
+	return <TextArea helperText="Hi there, enter some text">Has helper text</TextArea>;
 });

--- a/src/examples/src/widgets/text-area/HiddenLabel.tsx
+++ b/src/examples/src/widgets/text-area/HiddenLabel.tsx
@@ -4,5 +4,5 @@ import TextArea from '@dojo/widgets/text-area';
 const factory = create();
 
 export default factory(function HiddenLabel() {
-	return <TextArea label="Hidden label" labelHidden={true} />;
+	return <TextArea labelHidden={true}>Hidden label</TextArea>;
 });

--- a/src/examples/src/widgets/text-area/Label.tsx
+++ b/src/examples/src/widgets/text-area/Label.tsx
@@ -4,5 +4,5 @@ import TextArea from '@dojo/widgets/text-area';
 const factory = create();
 
 export default factory(function Label() {
-	return <TextArea label="Textarea with label" />;
+	return <TextArea>Textarea with label</TextArea>;
 });

--- a/src/examples/src/widgets/text-area/ValidatedCustom.tsx
+++ b/src/examples/src/widgets/text-area/ValidatedCustom.tsx
@@ -9,7 +9,6 @@ export default factory(function ValidateCustom({ middleware: { icache } }) {
 	return (
 		<TextArea
 			valid={valid}
-			label="Custom Validated"
 			helperText='Enter "valid" to be valid'
 			required={true}
 			customValidator={(value: string) => {
@@ -30,6 +29,8 @@ export default factory(function ValidateCustom({ middleware: { icache } }) {
 			onValidate={(valid?: boolean, message?: string) => {
 				icache.set('valid', { valid, message });
 			}}
-		/>
+		>
+			Custom Validated
+		</TextArea>
 	);
 });

--- a/src/examples/src/widgets/text-area/ValidatedRequired.tsx
+++ b/src/examples/src/widgets/text-area/ValidatedRequired.tsx
@@ -9,11 +9,12 @@ export default factory(function ValidateRequired({ middleware: { icache } }) {
 	return (
 		<TextArea
 			valid={valid}
-			label="Required"
 			required={true}
 			onValidate={(valid?: boolean, message?: string) => {
 				icache.set('valid', { valid, message });
 			}}
-		/>
+		>
+			Required
+		</TextArea>
 	);
 });

--- a/src/text-area/index.tsx
+++ b/src/text-area/index.tsx
@@ -8,6 +8,7 @@ import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import theme from '../middleware/theme';
 import focus from '@dojo/framework/core/middleware/focus';
 import validity from '@dojo/framework/core/middleware/validity';
+import { RenderResult } from '@dojo/framework/core/interfaces';
 
 export interface TextAreaProperties {
 	/** Custom aria attributes */
@@ -20,8 +21,6 @@ export interface TextAreaProperties {
 	disabled?: boolean;
 	/** Renders helper text to the user */
 	helperText?: string;
-	/** Adds a <label> element with the supplied text */
-	label?: string;
 	/** Hides the label from view while still remaining accessible for screen readers */
 	labelHidden?: boolean;
 	/** Maximum number of characters allowed in the input */
@@ -87,11 +86,14 @@ const factory = create({
 	theme,
 	focus,
 	validity
-}).properties<TextAreaProperties>();
+})
+	.properties<TextAreaProperties>()
+	.children<RenderResult | undefined>();
 export const TextArea = factory(function TextArea({
 	id,
 	middleware: { icache, theme, focus, validity },
-	properties
+	properties,
+	children
 }) {
 	const themeCss = theme.classes(css);
 
@@ -151,7 +153,6 @@ export const TextArea = factory(function TextArea({
 		columns = 20,
 		disabled,
 		widgetId = `textarea-${id}`,
-		label,
 		maxLength,
 		minLength,
 		name,
@@ -182,6 +183,7 @@ export const TextArea = factory(function TextArea({
 
 	const computedHelperText = (valid === false && message) || helperText;
 	const inputFocused = focus.isFocused('input');
+	const [label] = children();
 
 	return (
 		<div key="root" classes={[theme.variant(), themeCss.root]}>

--- a/src/text-area/tests/unit/TextArea.spec.tsx
+++ b/src/text-area/tests/unit/TextArea.spec.tsx
@@ -212,7 +212,7 @@ registerSuite('Textarea', {
 		},
 
 		label() {
-			const h = harness(() => <TextArea label="foo" />);
+			const h = harness(() => <TextArea>foo</TextArea>);
 
 			h.expect(() => expected(true));
 		},


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #1270 
