### PR TITLE
Moved content to child renderers

### DIFF
--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -406,6 +406,35 @@ Latest example can be found on [widgets.dojo.io/#widget/slide-pane/overview](htt
 
 Latest example can be found on [widgets.dojo.io/#widget/slider/overview](https://widgets.dojo.io/#widget/slider/overview)
 
+### snackbar
+#### Property changes
+##### Removed properties
+- messageRenderer: () => RenderResult
+	- replaced by children.message: RenderResult
+- actionsRenderer: () => RenderResult
+	- replaced by children.actions: RenderResult
+
+#### Example of migration from v6 to v7
+
+##### v6 implementation
+```tsx
+<Snackbar
+	messageRenderer={() => 'Snackbar'}
+	actionsRenderer={() => 'Actions'} open={true} 
+/>
+```
+
+##### v7 implementation
+```tsx
+<Snackbar open={true}>
+	{{
+		message: 'Snackbar',
+		actions: 'Actions'
+	}}
+</Snackbar>
+```
+
+Latest example can be found on [widgets.dojo.io/#widget/snackbar/overview](https://widgets.dojo.io/#widget/snackbar/overview)
 
 ### switch
  - Split out of checkbox

--- a/src/examples/src/widgets/snackbar/Basic.tsx
+++ b/src/examples/src/widgets/snackbar/Basic.tsx
@@ -4,5 +4,11 @@ import Snackbar from '@dojo/widgets/snackbar';
 const factory = create();
 
 export default factory(function Basic() {
-	return <Snackbar open={true} messageRenderer={() => 'Basic Snackbar'} />;
+	return (
+		<Snackbar open={true}>
+			{{
+				message: 'Basic Snackbar'
+			}}
+		</Snackbar>
+	);
 });

--- a/src/examples/src/widgets/snackbar/Error.tsx
+++ b/src/examples/src/widgets/snackbar/Error.tsx
@@ -4,5 +4,11 @@ import Snackbar from '@dojo/widgets/snackbar';
 const factory = create();
 
 export default factory(function Error() {
-	return <Snackbar type="error" open={true} messageRenderer={() => 'Error Snackbar'} />;
+	return (
+		<Snackbar type="error" open={true}>
+			{{
+				message: 'Error Snackbar'
+			}}
+		</Snackbar>
+	);
 });

--- a/src/examples/src/widgets/snackbar/Leading.tsx
+++ b/src/examples/src/widgets/snackbar/Leading.tsx
@@ -4,5 +4,11 @@ import Snackbar from '@dojo/widgets/snackbar';
 const factory = create();
 
 export default factory(function Leading() {
-	return <Snackbar leading open={true} messageRenderer={() => 'Leading Snackbar'} />;
+	return (
+		<Snackbar leading open={true}>
+			{{
+				message: 'Leading Snackbar'
+			}}
+		</Snackbar>
+	);
 });

--- a/src/examples/src/widgets/snackbar/Stacked.tsx
+++ b/src/examples/src/widgets/snackbar/Stacked.tsx
@@ -5,11 +5,11 @@ const factory = create();
 
 export default factory(function Stacked() {
 	return (
-		<Snackbar
-			stacked
-			open={true}
-			messageRenderer={() => 'Stacked Snackbar'}
-			actionsRenderer={() => 'A really long actions renderer'}
-		/>
+		<Snackbar stacked open={true}>
+			{{
+				message: 'Stacked Snackbar',
+				actions: 'A really long actions renderer'
+			}}
+		</Snackbar>
 	);
 });

--- a/src/examples/src/widgets/snackbar/Success.tsx
+++ b/src/examples/src/widgets/snackbar/Success.tsx
@@ -4,5 +4,11 @@ import Snackbar from '@dojo/widgets/snackbar';
 const factory = create();
 
 export default factory(function Success() {
-	return <Snackbar type="success" open={true} messageRenderer={() => 'Success Snackbar'} />;
+	return (
+		<Snackbar type="success" open={true}>
+			{{
+				message: 'Success Snackbar'
+			}}
+		</Snackbar>
+	);
 });

--- a/src/snackbar/index.tsx
+++ b/src/snackbar/index.tsx
@@ -6,10 +6,6 @@ import * as css from '../theme/default/snackbar.m.css';
 export interface SnackbarProperties {
 	/** If the snackbar is displayed */
 	open: boolean;
-	/** Renders the message portion of the snackbar */
-	messageRenderer: () => RenderResult;
-	/** If provided, render actions that the user may select */
-	actionsRenderer?: () => RenderResult;
 	/** The type of snackbar message */
 	type?: 'success' | 'error';
 	/** If the snackbar contents should be justified at the start */
@@ -18,11 +14,22 @@ export interface SnackbarProperties {
 	stacked?: boolean;
 }
 
-const factory = create({ theme }).properties<SnackbarProperties>();
+export interface SnackbarChildren {
+	/** Renders the message portion of the snackbar */
+	message: RenderResult;
+	/** If provided, render actions that the user may select */
+	actions?: RenderResult;
+}
 
-export const Snackbar = factory(function Snackbar({ middleware: { theme }, properties }) {
-	const { type, open, leading, stacked, messageRenderer, actionsRenderer } = properties();
+const factory = create({ theme })
+	.properties<SnackbarProperties>()
+	.children<SnackbarChildren>();
+
+export const Snackbar = factory(function Snackbar({ middleware: { theme }, properties, children }) {
+	const { type, open, leading, stacked } = properties();
+	const { message, actions } = children()[0];
 	const themeCss = theme.classes(css);
+
 	return (
 		<div
 			key="root"
@@ -37,11 +44,11 @@ export const Snackbar = factory(function Snackbar({ middleware: { theme }, prope
 		>
 			<div key="content" classes={themeCss.content}>
 				<div key="label" classes={themeCss.label} role="status" aria-live="polite">
-					{messageRenderer()}
+					{message}
 				</div>
-				{actionsRenderer && (
+				{actions && (
 					<div key="actions" classes={themeCss.actions}>
-						{actionsRenderer()}
+						{actions}
 					</div>
 				)}
 			</div>

--- a/src/snackbar/tests/unit/Snackbar.spec.tsx
+++ b/src/snackbar/tests/unit/Snackbar.spec.tsx
@@ -27,19 +27,35 @@ describe('Snackbar', () => {
 	});
 
 	it('renders', () => {
-		const h = harness(() => <Snackbar messageRenderer={() => 'test'} open={true} />);
+		const h = harness(() => (
+			<Snackbar open={true}>
+				{{
+					message: 'test'
+				}}
+			</Snackbar>
+		));
 		h.expect(template);
 	});
 
 	it('renders non string message', () => {
-		const h = harness(() => <Snackbar messageRenderer={() => <div>test</div>} open={true} />);
+		const h = harness(() => (
+			<Snackbar open={true}>
+				{{
+					message: <div>test</div>
+				}}
+			</Snackbar>
+		));
 		const nonStringTemplate = template.setChildren('@label', [<div>test</div>]);
 		h.expect(nonStringTemplate);
 	});
 
 	it('renders an array of non string messages', () => {
 		const h = harness(() => (
-			<Snackbar messageRenderer={() => [<div>test</div>, <div>test2</div>]} open={true} />
+			<Snackbar open={true}>
+				{{
+					message: [<div>test</div>, <div>test2</div>]
+				}}
+			</Snackbar>
 		));
 		const multipleNonStringTemplate = template.setChildren('@label', [
 			<div>test</div>,
@@ -49,7 +65,13 @@ describe('Snackbar', () => {
 	});
 
 	it('renders closed', () => {
-		const h = harness(() => <Snackbar messageRenderer={() => 'test'} open={false} />);
+		const h = harness(() => (
+			<Snackbar open={false}>
+				{{
+					message: 'test'
+				}}
+			</Snackbar>
+		));
 		const openTemplate = template.setProperty('@root', 'classes', [
 			undefined,
 			css.root,
@@ -63,7 +85,11 @@ describe('Snackbar', () => {
 
 	it('renders success', () => {
 		const h = harness(() => (
-			<Snackbar type="success" messageRenderer={() => 'test'} open={true} />
+			<Snackbar type="success" open={true}>
+				{{
+					message: 'test'
+				}}
+			</Snackbar>
 		));
 		const successTemplate = template.setProperty('@root', 'classes', [
 			undefined,
@@ -77,7 +103,13 @@ describe('Snackbar', () => {
 	});
 
 	it('renders leading', () => {
-		const h = harness(() => <Snackbar leading messageRenderer={() => 'test'} open={true} />);
+		const h = harness(() => (
+			<Snackbar leading open={true}>
+				{{
+					message: 'test'
+				}}
+			</Snackbar>
+		));
 		const successTemplate = template.setProperty('@root', 'classes', [
 			undefined,
 			css.root,
@@ -90,7 +122,13 @@ describe('Snackbar', () => {
 	});
 
 	it('renders stacked', () => {
-		const h = harness(() => <Snackbar stacked messageRenderer={() => 'test'} open={true} />);
+		const h = harness(() => (
+			<Snackbar stacked open={true}>
+				{{
+					message: 'test'
+				}}
+			</Snackbar>
+		));
 		const successTemplate = template.setProperty('@root', 'classes', [
 			undefined,
 			css.root,
@@ -104,7 +142,11 @@ describe('Snackbar', () => {
 
 	it('renders error', () => {
 		const h = harness(() => (
-			<Snackbar messageRenderer={() => 'test'} type="error" open={true} />
+			<Snackbar type="error" open={true}>
+				{{
+					message: 'test'
+				}}
+			</Snackbar>
 		));
 		const errorTemplate = template.setProperty('@root', 'classes', [
 			undefined,
@@ -119,11 +161,12 @@ describe('Snackbar', () => {
 
 	it('renders a single action', () => {
 		const h = harness(() => (
-			<Snackbar
-				messageRenderer={() => 'test'}
-				open={true}
-				actionsRenderer={() => <Button>Dismiss</Button>}
-			/>
+			<Snackbar open={true}>
+				{{
+					message: 'test',
+					actions: <Button>Dismiss</Button>
+				}}
+			</Snackbar>
 		));
 		const actionsTemplate = template.insertAfter('~label', [
 			<div key="actions" classes={css.actions}>
@@ -135,11 +178,12 @@ describe('Snackbar', () => {
 
 	it('renders more than one action', () => {
 		const h = harness(() => (
-			<Snackbar
-				messageRenderer={() => 'test'}
-				open={true}
-				actionsRenderer={() => [<Button>Retry</Button>, <Button>Close</Button>]}
-			/>
+			<Snackbar open={true}>
+				{{
+					message: 'test',
+					actions: [<Button>Retry</Button>, <Button>Close</Button>]
+				}}
+			</Snackbar>
 		));
 		const actionsTemplate = template.insertAfter('~label', [
 			<div key="actions" classes={css.actions}>


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Moved `messageRenderer` and `actionsRenderer` to children as `message` and `actions`

```tsx
<Snackbar open={true}>
	{{
		message: 'Snackbar',
		actions: 'Actions'
	}}
</Snackbar>
```

Resolves #1268