### PR TITLE
Switch: use child properties for the labels

### DIFF
--- a/src/examples/src/widgets/switch/Basic.tsx
+++ b/src/examples/src/widgets/switch/Basic.tsx
@@ -10,10 +10,11 @@ export default factory(function Basic({ middleware: { icache } }) {
 		<Switch
 			value={switched}
 			name="Switch"
-			label="On/Off"
 			onValue={(value) => {
 				icache.set('switched', value);
 			}}
-		/>
+		>
+			{{ label: 'On/Off' }}
+		</Switch>
 	);
 });

--- a/src/examples/src/widgets/switch/Disabled.tsx
+++ b/src/examples/src/widgets/switch/Disabled.tsx
@@ -11,21 +11,23 @@ export default factory(function Basic({ middleware: { icache } }) {
 			<Switch
 				value={switched}
 				name="Switch"
-				label="Disabled off"
 				disabled={true}
 				onValue={(switched) => {
 					icache.set('checked', switched);
 				}}
-			/>
+			>
+				{{ label: 'Disabled Off' }}
+			</Switch>
 			<Switch
 				value={!switched}
 				name="Switch"
-				label="Disabled on"
 				disabled={true}
 				onValue={(switched) => {
 					icache.set('switched', switched);
 				}}
-			/>
+			>
+				{{ label: 'Disabled On' }}
+			</Switch>
 		</virtual>
 	);
 });

--- a/src/switch/index.tsx
+++ b/src/switch/index.tsx
@@ -1,4 +1,4 @@
-import { DNode } from '@dojo/framework/core/interfaces';
+import { RenderResult } from '@dojo/framework/core/interfaces';
 import focus from '@dojo/framework/core/middleware/focus';
 import theme from '@dojo/framework/core/middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
@@ -12,20 +12,14 @@ interface SwitchProperties {
 	aria?: { [key: string]: string | null };
 	/** Whether the switch is disabled or clickable */
 	disabled?: boolean;
-	/** The label to be displayed for the switch */
-	label?: string;
 	/** Whether the label is hidden or displayed */
 	labelHidden?: boolean;
 	/** The name attribute for the switch */
 	name?: string;
-	/** Label to show in the "off" position of the switch */
-	offLabel?: DNode;
 	/** Handler for events triggered by switch losing focus */
 	onBlur?(): void;
 	/** Handler for events triggered by "on focus" */
 	onFocus?(): void;
-	/** Label to show in the "on" position of the switch */
-	onLabel?: DNode;
 	/** Handler for events triggered by "on out" */
 	onOut?(): void;
 	/** Handler for events triggered by "on over" */
@@ -42,21 +36,29 @@ interface SwitchProperties {
 	value?: boolean;
 }
 
-const factory = create({ theme, focus }).properties<SwitchProperties>();
+export interface SwitchChildren {
+	/** The label to be displayed for the switch */
+	label?: RenderResult;
+	/** Label to show in the "off" position of the switch */
+	offLabel?: RenderResult;
+	/** Label to show in the "on" position of the switch */
+	onLabel?: RenderResult;
+}
 
-export default factory(function Switch({ properties, id, middleware: { theme, focus } }) {
+const factory = create({ theme, focus })
+	.properties<SwitchProperties>()
+	.children<SwitchChildren | undefined>();
+
+export default factory(function Switch({ children, properties, id, middleware: { theme, focus } }) {
 	const {
 		aria = {},
 		classes,
 		disabled,
-		label,
 		labelHidden,
 		name,
-		offLabel,
 		onBlur,
 		onFocus,
 		onValue,
-		onLabel,
 		onOut,
 		onOver,
 		readOnly,
@@ -66,6 +68,7 @@ export default factory(function Switch({ properties, id, middleware: { theme, fo
 		value = false
 	} = properties();
 
+	const [{ label, offLabel, onLabel } = {} as SwitchChildren] = children();
 	const themedCss = theme.classes(css);
 	const idBase = `switch-${id}`;
 

--- a/src/switch/tests/unit/Switch.spec.tsx
+++ b/src/switch/tests/unit/Switch.spec.tsx
@@ -122,13 +122,9 @@ registerSuite('Switch', {
 		'custom properties'() {
 			const h = harness(
 				() => (
-					<Switch
-						aria={{ describedBy: 'foo' }}
-						value={true}
-						name="bar"
-						onLabel={'on'}
-						offLabel={'off'}
-					/>
+					<Switch aria={{ describedBy: 'foo' }} value={true} name="bar">
+						{{ onLabel: 'on', offLabel: 'off' }}
+					</Switch>
 				),
 				[compareId]
 			);
@@ -143,7 +139,7 @@ registerSuite('Switch', {
 		},
 
 		label() {
-			const h = harness(() => <Switch label="foo" />, [compareId, compareForId]);
+			const h = harness(() => <Switch>{{ label: 'foo' }}</Switch>, [compareId, compareForId]);
 
 			h.expect(expected({ label: true }));
 		},
@@ -178,13 +174,9 @@ registerSuite('Switch', {
 		'state properties on label'() {
 			const h = harness(
 				() => (
-					<Switch
-						label="foo"
-						valid={false}
-						disabled={true}
-						readOnly={true}
-						required={true}
-					/>
+					<Switch valid={false} disabled={true} readOnly={true} required={true}>
+						{{ label: 'foo' }}
+					</Switch>
 				),
 				[compareId, compareForId]
 			);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #1269 

Remove `label`, `onLabel`, and `offLabel` from `<Switch>` in favor of an object child with those values.
