### PR TITLE
Card/Header Card child renderer updates

### DIFF
--- a/src/card/index.tsx
+++ b/src/card/index.tsx
@@ -13,10 +13,10 @@ export interface CardProperties {
 }
 
 export interface CardChildren {
-	header?: () => RenderResult;
-	content?: () => RenderResult;
-	actionButtons?: () => RenderResult;
-	actionIcons?: () => RenderResult;
+	header?: RenderResult;
+	content?: RenderResult;
+	actionButtons?: RenderResult;
+	actionIcons?: RenderResult;
 }
 
 const factory = create({ theme })
@@ -32,7 +32,7 @@ export const Card = factory(function Card({ children, properties, middleware: { 
 		<div key="root" classes={[theme.variant(), themeCss.root]}>
 			{header && (
 				<div key="header" classes={themeCss.header}>
-					{header()}
+					{header}
 				</div>
 			)}
 			<div
@@ -58,12 +58,12 @@ export const Card = factory(function Card({ children, properties, middleware: { 
 						{subtitle && <h3 classes={themeCss.subtitle}>{subtitle}</h3>}
 					</div>
 				)}
-				{content && <div classes={themeCss.contentWrapper}>{content()}</div>}
+				{content && <div classes={themeCss.contentWrapper}>{content}</div>}
 			</div>
 			{(actionButtons || actionIcons) && (
 				<div key="actions" classes={themeCss.actions}>
-					{actionButtons && <div classes={themeCss.actionButtons}>{actionButtons()}</div>}
-					{actionIcons && <div classes={themeCss.actionIcons}>{actionIcons()}</div>}
+					{actionButtons && <div classes={themeCss.actionButtons}>{actionButtons}</div>}
+					{actionIcons && <div classes={themeCss.actionIcons}>{actionIcons}</div>}
 				</div>
 			)}
 		</div>

--- a/src/card/tests/unit/Card.spec.tsx
+++ b/src/card/tests/unit/Card.spec.tsx
@@ -36,7 +36,7 @@ describe('Card', () => {
 			const h = harness(() => (
 				<Card>
 					{{
-						header: () => 'Hello, World'
+						header: 'Hello, World'
 					}}
 				</Card>
 			));
@@ -56,7 +56,7 @@ describe('Card', () => {
 			const h = harness(() => (
 				<Card>
 					{{
-						content: () => 'Hello, World'
+						content: 'Hello, World'
 					}}
 				</Card>
 			));
@@ -83,7 +83,7 @@ describe('Card', () => {
 			const h = harness(() => (
 				<Card title="Hello, World" subtitle="this is a test">
 					{{
-						content: () => 'test'
+						content: 'test'
 					}}
 				</Card>
 			));
@@ -138,7 +138,7 @@ describe('Card', () => {
 			const h = harness(() => (
 				<Card>
 					{{
-						actionButtons: () => <Button>test</Button>
+						actionButtons: <Button>test</Button>
 					}}
 				</Card>
 			));
@@ -154,7 +154,7 @@ describe('Card', () => {
 			const h = harness(() => (
 				<Card>
 					{{
-						actionIcons: () => <Icon type="upIcon" />
+						actionIcons: <Icon type="upIcon" />
 					}}
 				</Card>
 			));
@@ -170,8 +170,8 @@ describe('Card', () => {
 			const h = harness(() => (
 				<Card>
 					{{
-						actionButtons: () => <Button>test</Button>,
-						actionIcons: () => <Icon type="upIcon" />
+						actionButtons: <Button>test</Button>,
+						actionIcons: <Icon type="upIcon" />
 					}}
 				</Card>
 			));
@@ -197,10 +197,10 @@ describe('Card', () => {
 				square
 			>
 				{{
-					header: () => 'Header Content',
-					content: () => 'Content',
-					actionButtons: () => <Button>test</Button>,
-					actionIcons: () => <Icon type="upIcon" />
+					header: 'Header Content',
+					content: 'Content',
+					actionButtons: <Button>test</Button>,
+					actionIcons: <Icon type="upIcon" />
 				}}
 			</Card>
 		));

--- a/src/examples/src/widgets/card/ActionButtons.tsx
+++ b/src/examples/src/widgets/card/ActionButtons.tsx
@@ -11,14 +11,14 @@ export default factory(function ActionButtons({ middleware: { icache } }) {
 		<div styles={{ width: '400px' }}>
 			<Card title="Hello, World">
 				{{
-					actionButtons: () => (
+					actionButtons: (
 						<Button onClick={() => icache.set('clickCount', clickCount + 1)}>
 							{clickCount === 0
 								? 'Action'
 								: `Clicked: ${clickCount} time${clickCount > 1 ? 's' : ''}`}
 						</Button>
 					),
-					content: () => <span>Lorem ipsum</span>
+					content: <span>Lorem ipsum</span>
 				}}
 			</Card>
 		</div>

--- a/src/examples/src/widgets/card/ActionButtonsAndIcons.tsx
+++ b/src/examples/src/widgets/card/ActionButtonsAndIcons.tsx
@@ -12,15 +12,15 @@ export default factory(function ActionButtonsAndIcons({ middleware: { icache } }
 		<div styles={{ width: '400px' }}>
 			<Card title="Hello, World">
 				{{
-					content: () => <span>Lorem ipsum</span>,
-					actionButtons: () => (
+					content: <span>Lorem ipsum</span>,
+					actionButtons: (
 						<Button onClick={() => icache.set('clickCount', clickCount + 1)}>
 							{clickCount === 0
 								? 'Action'
 								: `Clicked: ${clickCount} time${clickCount > 1 ? 's' : ''}`}
 						</Button>
 					),
-					actionIcons: () => (
+					actionIcons: (
 						<virtual>
 							<Icon type="secureIcon" />
 							<Icon type="downIcon" />

--- a/src/examples/src/widgets/card/ActionIcons.tsx
+++ b/src/examples/src/widgets/card/ActionIcons.tsx
@@ -9,8 +9,8 @@ export default factory(function ActionIcons() {
 		<div styles={{ width: '400px' }}>
 			<Card title="Hello, World">
 				{{
-					content: () => <h2>Hello, World</h2>,
-					actionIcons: () => (
+					content: <h2>Hello, World</h2>,
+					actionIcons: (
 						<virtual>
 							<Icon type="secureIcon" />
 							<Icon type="downIcon" />

--- a/src/examples/src/widgets/card/Basic.tsx
+++ b/src/examples/src/widgets/card/Basic.tsx
@@ -8,7 +8,7 @@ export default factory(function Basic() {
 		<div styles={{ width: '400px' }}>
 			<Card title="Hello, World">
 				{{
-					content: () => <span>Lorem ipsum</span>
+					content: <span>Lorem ipsum</span>
 				}}
 			</Card>
 		</div>

--- a/src/examples/src/widgets/card/CardCombined.tsx
+++ b/src/examples/src/widgets/card/CardCombined.tsx
@@ -16,15 +16,15 @@ export default factory(function CardWithMediaContent() {
 				subtitle="A pretty picture"
 			>
 				{{
-					header: () => <div>Header Content</div>,
-					content: () => <span>Travel the world today.</span>,
-					actionButtons: () => (
+					header: <div>Header Content</div>,
+					content: <span>Travel the world today.</span>,
+					actionButtons: (
 						<virtual>
 							<Button>Read</Button>
 							<Button>Bookmark</Button>
 						</virtual>
 					),
-					actionIcons: () => (
+					actionIcons: (
 						<virtual>
 							<Icon type="secureIcon" />
 							<Icon type="downIcon" />

--- a/src/examples/src/widgets/card/CardWithMediaContent.tsx
+++ b/src/examples/src/widgets/card/CardWithMediaContent.tsx
@@ -9,7 +9,7 @@ export default factory(function CardWithMediaContent() {
 		<div styles={{ width: '400px' }}>
 			<Card title="Hello, World" mediaSrc={mediaSrc}>
 				{{
-					content: () => <span>Lorem ipsum</span>
+					content: <span>Lorem ipsum</span>
 				}}
 			</Card>
 		</div>

--- a/src/examples/src/widgets/card/CardWithMediaRectangle.tsx
+++ b/src/examples/src/widgets/card/CardWithMediaRectangle.tsx
@@ -9,7 +9,7 @@ export default factory(function CardWithMediaRectangle() {
 		<div styles={{ width: '400px' }}>
 			<Card mediaSrc={mediaSrc} title="Hello, World" subtitle="Lorem ipsum">
 				{{
-					content: () => <span>Content goes here.</span>
+					content: <span>Content goes here.</span>
 				}}
 			</Card>
 		</div>

--- a/src/examples/src/widgets/card/CardWithMediaSquare.tsx
+++ b/src/examples/src/widgets/card/CardWithMediaSquare.tsx
@@ -9,7 +9,7 @@ export default factory(function CardWithMediaSquare() {
 		<div styles={{ width: '200px' }}>
 			<Card title="Hello, World" square mediaSrc={mediaSrc}>
 				{{
-					content: () => <span>Lorem ipsum</span>
+					content: <span>Lorem ipsum</span>
 				}}
 			</Card>
 		</div>

--- a/src/examples/src/widgets/header-card/ActionCard.tsx
+++ b/src/examples/src/widgets/header-card/ActionCard.tsx
@@ -18,9 +18,9 @@ export default factory(function Basic() {
 				mediaSrc={mediaSrc}
 			>
 				{{
-					content: () => <p styles={{ margin: '0' }}>Lorem ipsum</p>,
-					actionButtons: () => <Button>Action</Button>,
-					actionIcons: () => (
+					content: <p styles={{ margin: '0' }}>Lorem ipsum</p>,
+					actionButtons: <Button>Action</Button>,
+					actionIcons: (
 						<virtual>
 							<Icon type="upIcon" />
 							<Icon type="downIcon" />

--- a/src/examples/src/widgets/header-card/ActionCard.tsx
+++ b/src/examples/src/widgets/header-card/ActionCard.tsx
@@ -11,13 +11,9 @@ const factory = create();
 export default factory(function Basic() {
 	return (
 		<div styles={{ width: '400px' }}>
-			<HeaderCard
-				avatar={() => <Avatar src={avatar} />}
-				title="Hello, World"
-				subtitle="Lorem ipsum"
-				mediaSrc={mediaSrc}
-			>
+			<HeaderCard title="Hello, World" subtitle="Lorem ipsum" mediaSrc={mediaSrc}>
 				{{
+					avatar: <Avatar src={avatar} />,
 					content: <p styles={{ margin: '0' }}>Lorem ipsum</p>,
 					actionButtons: <Button>Action</Button>,
 					actionIcons: (

--- a/src/examples/src/widgets/header-card/Basic.tsx
+++ b/src/examples/src/widgets/header-card/Basic.tsx
@@ -13,7 +13,7 @@ export default factory(function Basic() {
 				avatar={() => <Avatar>D</Avatar>}
 			>
 				{{
-					content: () => <p styles={{ margin: '0' }}>Lorem ipsum</p>
+					content: <p styles={{ margin: '0' }}>Lorem ipsum</p>
 				}}
 			</HeaderCard>
 		</div>

--- a/src/examples/src/widgets/header-card/Basic.tsx
+++ b/src/examples/src/widgets/header-card/Basic.tsx
@@ -7,12 +7,9 @@ const factory = create();
 export default factory(function Basic() {
 	return (
 		<div styles={{ width: '400px' }}>
-			<HeaderCard
-				title="Hello, World"
-				subtitle="Lorem ipsum"
-				avatar={() => <Avatar>D</Avatar>}
-			>
+			<HeaderCard title="Hello, World" subtitle="Lorem ipsum">
 				{{
+					avatar: <Avatar>D</Avatar>,
 					content: <p styles={{ margin: '0' }}>Lorem ipsum</p>
 				}}
 			</HeaderCard>

--- a/src/examples/src/widgets/header-card/MediaCard.tsx
+++ b/src/examples/src/widgets/header-card/MediaCard.tsx
@@ -16,7 +16,7 @@ export default factory(function Basic() {
 				mediaSrc={mediaSrc}
 			>
 				{{
-					content: () => <p styles={{ margin: '0' }}>Lorem ipsum</p>
+					content: <p styles={{ margin: '0' }}>Lorem ipsum</p>
 				}}
 			</HeaderCard>
 		</div>

--- a/src/examples/src/widgets/header-card/MediaCard.tsx
+++ b/src/examples/src/widgets/header-card/MediaCard.tsx
@@ -9,13 +9,9 @@ const factory = create();
 export default factory(function Basic() {
 	return (
 		<div styles={{ width: '400px' }}>
-			<HeaderCard
-				avatar={() => <Avatar src={avatar} />}
-				title="Hello, World"
-				subtitle="Lorem ipsum"
-				mediaSrc={mediaSrc}
-			>
+			<HeaderCard title="Hello, World" subtitle="Lorem ipsum" mediaSrc={mediaSrc}>
 				{{
+					avatar: <Avatar src={avatar} />,
 					content: <p styles={{ margin: '0' }}>Lorem ipsum</p>
 				}}
 			</HeaderCard>

--- a/src/header-card/index.tsx
+++ b/src/header-card/index.tsx
@@ -8,10 +8,11 @@ type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
 export interface HeaderCardProperties extends CardProperties {
 	title: string;
-	avatar?: () => RenderResult;
 }
 
-export interface HeaderCardChildren extends Omit<CardChildren, 'header'> {}
+export interface HeaderCardChildren extends Omit<CardChildren, 'header'> {
+	avatar?: RenderResult;
+}
 
 const factory = create({ theme })
 	.properties<HeaderCardProperties>()
@@ -23,14 +24,14 @@ export const HeaderCard = factory(function HeaderCard({
 	children
 }) {
 	const themeCss = theme.classes(css);
-	const { title, subtitle, avatar, ...cardProps } = properties();
-	const [cardChildren] = children();
+	const { title, subtitle, ...cardProps } = properties();
+	const [{ avatar, ...cardChildren } = {} as HeaderCardChildren] = children();
 	return (
 		<Card key="root" {...cardProps}>
 			{{
 				header: (
 					<div key="header" classes={themeCss.header}>
-						{avatar && <div classes={themeCss.avatar}>{avatar()}</div>}
+						{avatar && <div classes={themeCss.avatar}>{avatar}</div>}
 						<div key="headerContent" classes={themeCss.headerContent}>
 							{<h2 classes={themeCss.title}>{title}</h2>}
 							{subtitle && <h3 classes={themeCss.subtitle}>{subtitle}</h3>}

--- a/src/header-card/index.tsx
+++ b/src/header-card/index.tsx
@@ -28,7 +28,7 @@ export const HeaderCard = factory(function HeaderCard({
 	return (
 		<Card key="root" {...cardProps}>
 			{{
-				header: () => (
+				header: (
 					<div key="header" classes={themeCss.header}>
 						{avatar && <div classes={themeCss.avatar}>{avatar()}</div>}
 						<div key="headerContent" classes={themeCss.headerContent}>

--- a/src/header-card/tests/unit/HeaderCard.spec.tsx
+++ b/src/header-card/tests/unit/HeaderCard.spec.tsx
@@ -52,7 +52,9 @@ describe('HeaderCard', () => {
 	it('renders with a an avatar', () => {
 		const avatar = <Avatar>D</Avatar>;
 		const h = harness(() => (
-			<HeaderCard square title="title" subtitle="subtitle" avatar={() => avatar} />
+			<HeaderCard square title="title" subtitle="subtitle">
+				{{ avatar }}
+			</HeaderCard>
 		));
 		h.expect(
 			template.setProperty('@root', 'square', true).setChildren(

--- a/src/header-card/tests/unit/HeaderCard.spec.tsx
+++ b/src/header-card/tests/unit/HeaderCard.spec.tsx
@@ -11,7 +11,7 @@ describe('HeaderCard', () => {
 	const template = assertionTemplate(() => (
 		<Card key="root">
 			{{
-				header: () => (
+				header: (
 					<div key="header" classes={css.header}>
 						<div key="headerContent" classes={css.headerContent}>
 							<h2 classes={css.title}>title</h2>


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #1253 and resolves #1260 

- Change the `<Card>` child renderers from functions to static `RenderResult`s
- Convert the `<HeaderCard>` `avatar` from a property to a child property.

```tsx
<Card title="Title">
	{{
		content: <span>Lorem ipsum</span>
	}}
</Card>
```

```tsx
<HeaderCard title="Title" subtitle="Subtitle">
	{{
		avatar: <Avatar>Q</Avatar>,
		content: 'This widget is brought to you by the letter Q'
	}}
</HeaderCard>
```