### PR TITLE
Update slider to use child renderers for label and output

### DIFF
--- a/src/examples/src/widgets/slider/DisabledSlider.tsx
+++ b/src/examples/src/widgets/slider/DisabledSlider.tsx
@@ -4,5 +4,9 @@ import Slider from '@dojo/widgets/slider';
 const factory = create();
 
 export default factory(function DisabledSlider() {
-	return <Slider min={0} initialValue={50} max={100} disabled label="Disabled" />;
+	return (
+		<Slider min={0} initialValue={50} max={100} disabled>
+			{{ label: 'Disabled' }}
+		</Slider>
+	);
 });

--- a/src/examples/src/widgets/slider/SliderWithCustomOutput.tsx
+++ b/src/examples/src/widgets/slider/SliderWithCustomOutput.tsx
@@ -5,26 +5,25 @@ const factory = create({});
 
 export default factory(function SliderWithCustomOutput({}) {
 	return (
-		<Slider
-			min={0}
-			initialValue={0}
-			max={100}
-			output={(value) => {
-				if (value < 20) {
-					return 'I am a Klingon';
-				}
-				if (value < 40) {
-					return 'Tribbles only cause trouble';
-				}
-				if (value < 60) {
-					return 'They\`re kind of cute';
-				}
-				if (value < 80) {
-					return 'Most of my salary goes to tribble food';
-				} else {
-					return 'I permanently altered the ecology of a planet for my tribbles';
+		<Slider min={0} initialValue={0} max={100}>
+			{{
+				output: (value) => {
+					if (value < 20) {
+						return 'I am a Klingon';
+					}
+					if (value < 40) {
+						return 'Tribbles only cause trouble';
+					}
+					if (value < 60) {
+						return 'They\`re kind of cute';
+					}
+					if (value < 80) {
+						return 'Most of my salary goes to tribble food';
+					} else {
+						return 'I permanently altered the ecology of a planet for my tribbles';
+					}
 				}
 			}}
-		/>
+		</Slider>
 	);
 });

--- a/src/examples/src/widgets/slider/SliderWithValidityCheck.tsx
+++ b/src/examples/src/widgets/slider/SliderWithValidityCheck.tsx
@@ -8,13 +8,11 @@ export default factory(function SliderWithValidityCheck({ middleware: { icache }
 	const value = icache.getOrSet<number>('value', 0);
 	const valid = value < 50;
 	return (
-		<Slider
-			label="Anything over 50 is invalid"
-			min={0}
-			max={100}
-			onValue={(value) => icache.set('value', value)}
-			valid={valid}
-			output={() => (valid ? 'Valid' : 'Invalid')}
-		/>
+		<Slider min={0} max={100} onValue={(value) => icache.set('value', value)} valid={valid}>
+			{{
+				label: 'Anything over 50 is invalid',
+				output: () => (valid ? 'Valid' : 'Invalid')
+			}}
+		</Slider>
 	);
 });

--- a/src/slider/index.tsx
+++ b/src/slider/index.tsx
@@ -1,4 +1,4 @@
-import { DNode } from '@dojo/framework/core/interfaces';
+import { RenderResult } from '@dojo/framework/core/interfaces';
 import focus from '@dojo/framework/core/middleware/focus';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import theme from '@dojo/framework/core/middleware/theme';
@@ -13,8 +13,6 @@ export interface SliderProperties {
 	aria?: { [key: string]: string | null };
 	/** Set the disabled property of the control */
 	disabled?: boolean;
-	/** Adds a <label> element with the supplied text */
-	label?: string;
 	/** Adds the label element after (true) or before (false) */
 	labelAfter?: boolean;
 	/** Hides the label from view while still remaining accessible for screen readers */
@@ -35,8 +33,6 @@ export interface SliderProperties {
 	onOver?(): void;
 	/** Handler for when the value of the widget changes */
 	onValue?(value?: number): void;
-	/** An optional function that returns a string or DNode for custom output format */
-	output?(value: number): DNode;
 	/** If the rendered output should be displayed as a tooltip */
 	outputIsTooltip?: boolean;
 	/** Makes the slider readonly (it may be focused but not changed) */
@@ -59,6 +55,13 @@ export interface SliderProperties {
 	widgetId?: string;
 }
 
+export interface SliderChildren {
+	/** Adds a <label> element with the supplied text */
+	label?: RenderResult;
+	/** An optional function that returns a string or DNode for custom output format */
+	output?(value: number): RenderResult;
+}
+
 export interface SliderICache {
 	value?: number;
 	initialValue?: number;
@@ -68,19 +71,21 @@ const factory = create({
 	theme,
 	focus,
 	icache: createICacheMiddleware<SliderICache>()
-}).properties<SliderProperties>();
+})
+	.properties<SliderProperties>()
+	.children<SliderChildren | undefined>();
 
 export const Slider = factory(function Slider({
 	id,
 	middleware: { theme, focus, icache },
-	properties
+	properties,
+	children
 }) {
 	const {
 		aria = {},
 		disabled,
 		widgetId = `slider-${id}}`,
 		valid,
-		label,
 		labelAfter,
 		labelHidden,
 		max = 100,
@@ -93,7 +98,6 @@ export const Slider = factory(function Slider({
 		vertical = false,
 		verticalHeight = '200px',
 		outputIsTooltip = false,
-		output,
 		theme: themeProp,
 		classes,
 		onOut,
@@ -102,6 +106,7 @@ export const Slider = factory(function Slider({
 		onFocus,
 		onValue
 	} = properties();
+	const [{ output, label } = { output: undefined, label: undefined }] = children();
 
 	const { initialValue = min } = properties();
 	const existingInitialValue = icache.getOrSet('initialValue', min);
@@ -191,7 +196,7 @@ export const Slider = factory(function Slider({
 		</div>
 	);
 
-	const children = [
+	const content = [
 		label ? (
 			<Label
 				theme={themeProp}
@@ -226,7 +231,7 @@ export const Slider = factory(function Slider({
 				fixedCss.rootFixed
 			]}
 		>
-			{labelAfter ? children.reverse() : children}
+			{labelAfter ? content.reverse() : content}
 		</div>
 	);
 });

--- a/src/slider/tests/unit/Slider.spec.tsx
+++ b/src/slider/tests/unit/Slider.spec.tsx
@@ -143,11 +143,14 @@ registerSuite('Slider', {
 					max={60}
 					min={10}
 					name="bar"
-					output={() => 'tribbles'}
 					outputIsTooltip
 					step={5}
 					initialValue={35}
-				/>
+				>
+					{{
+						output: () => 'tribbles'
+					}}
+				</Slider>
 			));
 
 			h.expect(
@@ -247,7 +250,7 @@ registerSuite('Slider', {
 		},
 
 		label() {
-			const h = harness(() => <Slider label="foo" />);
+			const h = harness(() => <Slider>{{ label: 'foo' }}</Slider>);
 
 			h.expect(expected(true));
 		},

--- a/src/slider/tests/unit/Slider.spec.tsx
+++ b/src/slider/tests/unit/Slider.spec.tsx
@@ -255,6 +255,14 @@ registerSuite('Slider', {
 			h.expect(expected(true));
 		},
 
+		'label after'() {
+			const h = harness(() => <Slider labelAfter={true}>{{ label: 'foo' }}</Slider>);
+
+			const assertion = expected(true);
+			const children = assertion.getChildren('@root');
+			h.expect(assertion.setChildren('@root', () => children.reverse()));
+		},
+
 		'state classes'() {
 			let properties = {
 				valid: false,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Updates the slider to use a child render result and render function for label and output respectively. 
Resolves #1267 
