### PR TITLE
Make context popup trigger child render property a `RenderResult` 

### DIFF
--- a/src/context-menu/index.tsx
+++ b/src/context-menu/index.tsx
@@ -22,7 +22,7 @@ export const ContextMenu = factory(function({ properties, children, middleware: 
 	return (
 		<ContextPopup>
 			{{
-				trigger: () => children(),
+				trigger: children(),
 				content: ({ close, shouldFocus }) => (
 					<List
 						key="menu"

--- a/src/context-menu/tests/ContextMenu.spec.tsx
+++ b/src/context-menu/tests/ContextMenu.spec.tsx
@@ -23,7 +23,7 @@ describe('ContextMenu', () => {
 	const template = assertionTemplate(() => (
 		<ContextPopup>
 			{{
-				trigger: () => null as any,
+				trigger: null as any,
 				content: null as any
 			}}
 		</ContextPopup>
@@ -54,7 +54,7 @@ describe('ContextMenu', () => {
 		h.expect(template);
 	});
 
-	it('passes a function that returns children as `trigger`', () => {
+	it('passes children as `trigger`', () => {
 		const h = harness(() => (
 			<ContextMenu
 				resource={{
@@ -71,7 +71,7 @@ describe('ContextMenu', () => {
 		h.expect(template);
 		h.expect(
 			() => [children],
-			() => h.trigger(':root', (node: any) => node.children[0].trigger)
+			() => h.trigger(':root', (node: any) => () => node.children[0].trigger)
 		);
 	});
 

--- a/src/context-popup/index.tsx
+++ b/src/context-popup/index.tsx
@@ -12,7 +12,7 @@ export interface ContextPopupProperties {
 }
 
 export interface ContextPopupChildren {
-	trigger: () => RenderResult;
+	trigger: RenderResult;
 	content: (callbacks: { close(): void; shouldFocus(): boolean }) => RenderResult;
 }
 
@@ -61,7 +61,7 @@ export const ContextPopup = factory(function({
 					onOpen && onOpen();
 				}}
 			>
-				{trigger()}
+				{trigger}
 			</div>
 			<Popup
 				key="popup"

--- a/src/context-popup/tests/ContextPopup.spec.tsx
+++ b/src/context-popup/tests/ContextPopup.spec.tsx
@@ -41,7 +41,7 @@ describe('ContextPopup', () => {
 		const h = harness(() => (
 			<ContextPopup>
 				{{
-					trigger: () => <div>Some text with a context menu</div>,
+					trigger: <div>Some text with a context menu</div>,
 					content: () => 'hello world'
 				}}
 			</ContextPopup>
@@ -57,7 +57,7 @@ describe('ContextPopup', () => {
 		const h = harness(() => (
 			<ContextPopup onClose={onClose}>
 				{{
-					trigger: () => undefined,
+					trigger: undefined,
 					content: ({ close, shouldFocus }) => (
 						<div key="content" tabIndex={0} onblur={close} focus={shouldFocus}>
 							hello world
@@ -86,7 +86,7 @@ describe('ContextPopup', () => {
 		const h = harness(() => (
 			<ContextPopup onOpen={onOpen} onClose={onClose}>
 				{{
-					trigger: () => undefined,
+					trigger: undefined,
 					content: () => 'hello world'
 				}}
 			</ContextPopup>

--- a/src/examples/src/widgets/context-popup/Basic.tsx
+++ b/src/examples/src/widgets/context-popup/Basic.tsx
@@ -8,7 +8,7 @@ export default factory(function Basic() {
 		<virtual>
 			<ContextPopup>
 				{{
-					trigger: () => <div>This text has a context popup</div>,
+					trigger: <div>This text has a context popup</div>,
 					content: ({ close, shouldFocus }) => (
 						<div
 							focus={shouldFocus}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
`trigger` is now a simple `RenderResult` instead of a render function with no arguments.
Resolves #1257 