### PR TITLE
Update radio group to use a child renderer for its label

### DIFF
--- a/src/examples/src/widgets/radio-group/Basic.tsx
+++ b/src/examples/src/widgets/radio-group/Basic.tsx
@@ -10,13 +10,16 @@ const App = factory(function({ properties, middleware: { icache } }) {
 	return (
 		<virtual>
 			<RadioGroup
-				label="pets"
 				name="standard"
 				options={[{ value: 'cat' }, { value: 'dog' }, { value: 'fish' }]}
 				onValue={(value) => {
 					set('standard', value);
 				}}
-			/>
+			>
+				{{
+					label: 'pets'
+				}}
+			</RadioGroup>
 			<pre>{`${get('standard')}`}</pre>
 		</virtual>
 	);

--- a/src/examples/src/widgets/radio-group/CustomLabel.tsx
+++ b/src/examples/src/widgets/radio-group/CustomLabel.tsx
@@ -10,7 +10,6 @@ const App = factory(function({ properties, middleware: { icache } }) {
 	return (
 		<virtual>
 			<RadioGroup
-				label="colours"
 				name="colours"
 				options={[
 					{ value: 'red', label: 'Rouge' },
@@ -20,7 +19,11 @@ const App = factory(function({ properties, middleware: { icache } }) {
 				onValue={(value) => {
 					set('colours', value);
 				}}
-			/>
+			>
+				{{
+					label: 'colours'
+				}}
+			</RadioGroup>
 			<pre>{`${get('colours')}`}</pre>
 		</virtual>
 	);

--- a/src/examples/src/widgets/radio-group/CustomRenderer.tsx
+++ b/src/examples/src/widgets/radio-group/CustomRenderer.tsx
@@ -11,39 +11,41 @@ const App = factory(function({ middleware: { icache } }) {
 	return (
 		<virtual>
 			<RadioGroup
-				label="going?"
 				name="custom"
 				options={[{ value: 'yes' }, { value: 'no' }, { value: 'maybe' }]}
 				onValue={(value) => {
 					set('custom', value);
 				}}
 			>
-				{(name, radioGroup, options) => {
-					return options.map(({ value, label }) => {
-						const { checked } = radioGroup(value);
-						return (
-							<virtual>
-								<span>I'm custom!</span>
-								<Radio
-									checked={checked()}
-									label={label || value}
-									name={name}
-									onValue={checked}
-									value={value}
-								/>
-								<hr
-									styles={{
-										borderColor: '#d6dde2',
-										borderStyle: 'solid',
-										borderWidth: '1px 0 0',
-										height: '0',
-										margin: '0',
-										overflow: 'hidden'
-									}}
-								/>
-							</virtual>
-						);
-					});
+				{{
+					label: 'going?',
+					radios: (name, radioGroup, options) => {
+						return options.map(({ value, label }) => {
+							const { checked } = radioGroup(value);
+							return (
+								<virtual>
+									<span>I'm custom!</span>
+									<Radio
+										checked={checked()}
+										label={label || value}
+										name={name}
+										onValue={checked}
+										value={value}
+									/>
+									<hr
+										styles={{
+											borderColor: '#d6dde2',
+											borderStyle: 'solid',
+											borderWidth: '1px 0 0',
+											height: '0',
+											margin: '0',
+											overflow: 'hidden'
+										}}
+									/>
+								</virtual>
+							);
+						});
+					}
 				}}
 			</RadioGroup>
 			<pre>{`${get('custom')}`}</pre>

--- a/src/examples/src/widgets/radio-group/InitialValue.tsx
+++ b/src/examples/src/widgets/radio-group/InitialValue.tsx
@@ -5,20 +5,23 @@ import { icache } from '@dojo/framework/core/middleware/icache';
 const factory = create({ icache });
 
 const App = factory(function({ properties, middleware: { icache } }) {
-	const { get, set } = icache;
+	const initialValue = 'tom';
 
 	return (
 		<virtual>
 			<RadioGroup
-				initialValue="tom"
-				label="favourite names"
+				initialValue={initialValue}
 				name="initial-value"
 				options={[{ value: 'tom' }, { value: 'dick' }, { value: 'harry' }]}
 				onValue={(value) => {
-					set('initial-value', value);
+					icache.set('value', value);
 				}}
-			/>
-			<pre>{`${get('initial-value')}`}</pre>
+			>
+				{{
+					label: 'favourite names'
+				}}
+			</RadioGroup>
+			<pre>{`${icache.getOrSet('value', initialValue)}`}</pre>
 		</virtual>
 	);
 });

--- a/src/radio-group/index.tsx
+++ b/src/radio-group/index.tsx
@@ -10,8 +10,6 @@ type RadioOptions = { value: string; label?: string }[];
 export interface RadioGroupProperties {
 	/** Initial value of the radio group */
 	initialValue?: string;
-	/** The label to be displayed in the legend */
-	label?: string;
 	/** The name attribute for this form group */
 	name: string;
 	/** Callback for the current value */
@@ -22,11 +20,12 @@ export interface RadioGroupProperties {
 
 export interface RadioGroupChildren {
 	/** Custom renderer for the radios, receives the radio group middleware and options */
-	(
+	radios?(
 		name: string,
 		middleware: ReturnType<ReturnType<typeof radioGroup>['api']>,
 		options: RadioOptions
 	): RenderResult;
+	label?: RenderResult;
 }
 
 const factory = create({ radioGroup, theme })
@@ -38,14 +37,14 @@ export const RadioGroup = factory(function({
 	properties,
 	middleware: { radioGroup, theme }
 }) {
-	const { name, label, options, onValue, initialValue } = properties();
-	const [renderer] = children();
+	const { name, options, onValue, initialValue } = properties();
+	const [{ radios, label } = { radios: undefined, label: undefined }] = children();
 	const radio = radioGroup(onValue, initialValue || '');
 	const { root, legend } = theme.classes(css);
 
 	function renderRadios() {
-		if (renderer) {
-			return renderer(name, radio, options);
+		if (radios) {
+			return radios(name, radio, options);
 		}
 		return options.map(({ value, label }) => {
 			const { checked } = radio(value);

--- a/src/radio-group/tests/RadioGroup.spec.tsx
+++ b/src/radio-group/tests/RadioGroup.spec.tsx
@@ -31,12 +31,11 @@ describe('RadioGroup', () => {
 
 	it('renders with a label', () => {
 		const h = harness(() => (
-			<RadioGroup
-				label="test label"
-				name="test"
-				onValue={noop}
-				options={[{ value: 'cat' }]}
-			/>
+			<RadioGroup name="test" onValue={noop} options={[{ value: 'cat' }]}>
+				{{
+					label: 'test label'
+				}}
+			</RadioGroup>
 		));
 		const labelTemplate = template.setChildren('@root', () => [
 			<legend classes={css.legend}>test label</legend>,
@@ -64,24 +63,22 @@ describe('RadioGroup', () => {
 
 	it('renders with custom renderer', () => {
 		const h = harness(() => (
-			<RadioGroup
-				label="custom render label"
-				name="test"
-				onValue={noop}
-				options={[{ value: 'cat' }]}
-			>
-				{() => {
-					return [
-						<span>custom label</span>,
-						<Radio
-							name="test"
-							value="cat"
-							label="cat"
-							checked={false}
-							onValue={noop}
-						/>,
-						<hr />
-					];
+			<RadioGroup name="test" onValue={noop} options={[{ value: 'cat' }]}>
+				{{
+					label: 'custom render label',
+					radios: () => {
+						return [
+							<span>custom label</span>,
+							<Radio
+								name="test"
+								value="cat"
+								label="cat"
+								checked={false}
+								onValue={noop}
+							/>,
+							<hr />
+						];
+					}
 				}}
 			</RadioGroup>
 		));


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
The default child renderer becomes `radios` and the label child renderer is added.
Resolves #1263 
