### PR TITLE
Fix header child renderer types

### DIFF
--- a/src/examples/src/widgets/header/Basic.tsx
+++ b/src/examples/src/widgets/header/Basic.tsx
@@ -8,8 +8,8 @@ export default factory(function Basic() {
 	return (
 		<Header>
 			{{
-				title: () => 'My App',
-				actions: () => [
+				title: 'My App',
+				actions: [
 					<Link to="#foo">Foo</Link>,
 					<Link to="#bar">Bar</Link>,
 					<Link to="#baz">Baz</Link>

--- a/src/examples/src/widgets/header/Leading.tsx
+++ b/src/examples/src/widgets/header/Leading.tsx
@@ -9,9 +9,9 @@ export default factory(function Basic() {
 	return (
 		<Header>
 			{{
-				leading: () => <Icon type="barsIcon" />,
-				title: () => 'My App',
-				actions: () => [
+				leading: <Icon type="barsIcon" />,
+				title: 'My App',
+				actions: [
 					<Link to="#foo">Foo</Link>,
 					<Link to="#bar">Bar</Link>,
 					<Link to="#baz">Baz</Link>

--- a/src/examples/src/widgets/header/Sticky.tsx
+++ b/src/examples/src/widgets/header/Sticky.tsx
@@ -9,8 +9,8 @@ export default factory(function Basic() {
 		<virtual>
 			<Header sticky>
 				{{
-					title: () => 'My App',
-					actions: () => [
+					title: 'My App',
+					actions: [
 						<Link to="#foo">Foo</Link>,
 						<Link to="#bar">Bar</Link>,
 						<Link to="#baz">Baz</Link>

--- a/src/examples/src/widgets/header/Trailing.tsx
+++ b/src/examples/src/widgets/header/Trailing.tsx
@@ -9,13 +9,13 @@ export default factory(function Basic() {
 	return (
 		<Header>
 			{{
-				title: () => 'My App',
-				actions: () => [
+				title: 'My App',
+				actions: [
 					<Link to="#foo">Foo</Link>,
 					<Link to="#bar">Bar</Link>,
 					<Link to="#baz">Baz</Link>
 				],
-				trailing: () => <Icon type="searchIcon" />
+				trailing: <Icon type="searchIcon" />
 			}}
 		</Header>
 	);

--- a/src/header/index.tsx
+++ b/src/header/index.tsx
@@ -10,13 +10,13 @@ export interface HeaderProperties {
 
 export type HeaderChildren = {
 	/** Renderer for leading elements like icons */
-	leading?(): RenderResult;
+	leading?: RenderResult;
 	/** Renderer for the header title */
-	title(): RenderResult;
+	title: RenderResult;
 	/** Renderer for header actions like links */
-	actions?(): RenderResult;
+	actions?: RenderResult;
 	/** Renderer for trailing elements like search inputs */
-	trailing?(): RenderResult;
+	trailing?: RenderResult;
 };
 
 const factory = create({ theme })
@@ -27,27 +27,25 @@ export const Header = factory(function Header({ children, properties, middleware
 	const classes = theme.classes(css);
 	const { sticky } = properties();
 	const { actions, leading, title, trailing } = children()[0];
-	const actionElements = actions && actions();
 
 	return (
 		<header key="header" classes={[theme.variant(), sticky ? classes.spacer : undefined]}>
 			<div classes={[classes.root, sticky && classes.sticky]} key="root">
 				<div classes={classes.row}>
 					<div classes={classes.primary} key="primary">
-						{leading && <div classes={classes.leading}>{leading()}</div>}
+						{leading && <div classes={classes.leading}>{leading}</div>}
 						<div classes={classes.title} key="title">
-							{title && title()}
+							{title && title}
 						</div>
 					</div>
 					<div classes={classes.secondary} key="secondary">
 						<nav classes={classes.actions} key="actions">
 							{actions &&
-								(Array.isArray(actionElements)
-									? actionElements
-									: [actionElements]
-								).map((action) => <div classes={classes.action}>{action}</div>)}
+								(Array.isArray(actions) ? actions : [actions]).map((action) => (
+									<div classes={classes.action}>{action}</div>
+								))}
 						</nav>
-						{trailing && <div classes={classes.trailing}>{trailing()}</div>}
+						{trailing && <div classes={classes.trailing}>{trailing}</div>}
 					</div>
 				</div>
 			</div>

--- a/src/header/tests/unit/Header.spec.tsx
+++ b/src/header/tests/unit/Header.spec.tsx
@@ -91,6 +91,21 @@ describe('HeaderToolbar', () => {
 		h.expect(testTemplate);
 	});
 
+	it('Renders a single action element', () => {
+		const h = harness(() => (
+			<Header>
+				{{
+					title: 'title',
+					actions: 'action'
+				}}
+			</Header>
+		));
+		const testTemplate = baseTemplate.replaceChildren('@actions', () => [
+			<div classes={classes.action}>action</div>
+		]);
+		h.expect(testTemplate);
+	});
+
 	it('Renders a sticky header', () => {
 		const h = harness(() => (
 			<Header sticky>

--- a/src/header/tests/unit/Header.spec.tsx
+++ b/src/header/tests/unit/Header.spec.tsx
@@ -27,7 +27,7 @@ describe('HeaderToolbar', () => {
 		const h = harness(() => (
 			<Header>
 				{{
-					title: () => 'title'
+					title: 'title'
 				}}
 			</Header>
 		));
@@ -38,8 +38,8 @@ describe('HeaderToolbar', () => {
 		const h = harness(() => (
 			<Header>
 				{{
-					title: () => 'title',
-					leading: () => 'leading'
+					title: 'title',
+					leading: 'leading'
 				}}
 			</Header>
 		));
@@ -53,8 +53,8 @@ describe('HeaderToolbar', () => {
 		const h = harness(() => (
 			<Header>
 				{{
-					title: () => 'title',
-					trailing: () => 'trailing'
+					title: 'title',
+					trailing: 'trailing'
 				}}
 			</Header>
 		));
@@ -68,7 +68,7 @@ describe('HeaderToolbar', () => {
 		const h = harness(() => (
 			<Header>
 				{{
-					title: () => 'title'
+					title: 'title'
 				}}
 			</Header>
 		));
@@ -80,8 +80,8 @@ describe('HeaderToolbar', () => {
 		const h = harness(() => (
 			<Header>
 				{{
-					title: () => 'title',
-					actions: () => ['action']
+					title: 'title',
+					actions: ['action']
 				}}
 			</Header>
 		));
@@ -95,7 +95,7 @@ describe('HeaderToolbar', () => {
 		const h = harness(() => (
 			<Header sticky>
 				{{
-					title: () => 'title'
+					title: 'title'
 				}}
 			</Header>
 		));


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Changes all header child types to `RenderResult`
Resolves #1259 
