### PR TITLE
Update popup child renderer

### DIFF
--- a/src/context-popup/index.tsx
+++ b/src/context-popup/index.tsx
@@ -72,9 +72,7 @@ export const ContextPopup = factory(function({
 				position="below"
 				open={icache.get('open')}
 			>
-				{{
-					content: () => <div>{content({ close, shouldFocus: focus.shouldFocus })}</div>
-				}}
+				<div>{content({ close, shouldFocus: focus.shouldFocus })}</div>
 			</Popup>
 		</virtual>
 	);

--- a/src/context-popup/tests/ContextPopup.spec.tsx
+++ b/src/context-popup/tests/ContextPopup.spec.tsx
@@ -19,9 +19,7 @@ const baseTemplate = assertionTemplate(() => (
 			onClose={() => {}}
 			position="below"
 			open={undefined}
-		>
-			{{ content: () => undefined }}
-		</Popup>
+		/>
 	</virtual>
 ));
 
@@ -46,9 +44,9 @@ describe('ContextPopup', () => {
 				}}
 			</ContextPopup>
 		));
-		const contextContentTemplate = baseTemplate.setChildren('@trigger', () => [
-			<div>Some text with a context menu</div>
-		]);
+		const contextContentTemplate = baseTemplate
+			.setChildren('@trigger', () => [<div>Some text with a context menu</div>])
+			.setChildren('@popup', () => [<div>hello world</div>]);
 		h.expect(contextContentTemplate);
 	});
 
@@ -66,17 +64,19 @@ describe('ContextPopup', () => {
 				}}
 			</ContextPopup>
 		));
-		h.expect(baseTemplate);
+		h.expect(
+			baseTemplate.setChildren('@popup', () => [
+				<div>
+					<div key="content" tabIndex={0} onblur={() => {}} focus={onClose}>
+						hello world
+					</div>
+				</div>
+			])
+		);
 		assert.isFalse(
-			h.trigger(
-				'@popup',
-				(node: any) => node.children[0].content().children[0].properties.focus
-			)
+			h.trigger('@popup', (node: any) => node.children[0].children[0].properties.focus)
 		);
-		h.trigger(
-			'@popup',
-			(node: any) => node.children[0].content().children[0].properties.onblur
-		);
+		h.trigger('@popup', (node: any) => node.children[0].children[0].properties.onblur);
 		assert.isTrue(onClose.calledOnce);
 	});
 
@@ -105,6 +105,7 @@ describe('ContextPopup', () => {
 				.setProperty('@popup', 'x', 98)
 				.setProperty('@popup', 'yTop', 96)
 				.setProperty('@popup', 'open', true)
+				.setChildren('@popup', () => [<div>hello world</div>])
 		);
 		h.trigger('@popup', 'onClose');
 		assert.isTrue(onClose.calledOnce);
@@ -113,6 +114,7 @@ describe('ContextPopup', () => {
 				.setProperty('@popup', 'x', 98)
 				.setProperty('@popup', 'yTop', 96)
 				.setProperty('@popup', 'open', false)
+				.setChildren('@popup', () => [<div>hello world</div>])
 		);
 	});
 });

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -28,13 +28,9 @@ export interface PopupProperties extends BasePopupProperties {
 	open?: boolean;
 }
 
-export interface PopupChildren {
-	content: () => RenderResult;
-}
-
 const factory = create({ dimensions, theme, bodyScroll })
 	.properties<PopupProperties>()
-	.children<PopupChildren>();
+	.children<RenderResult | undefined>();
 
 export const Popup = factory(function({
 	properties,
@@ -87,7 +83,6 @@ export const Popup = factory(function({
 	}
 
 	const classes = theme.classes(css);
-	const { content } = children()[0];
 
 	bodyScroll(!open);
 
@@ -108,7 +103,7 @@ export const Popup = factory(function({
 					classes={[theme.variant(), fixedCss.root]}
 					styles={wrapperStyles}
 				>
-					{content()}
+					{children()}
 				</div>
 			</body>
 		)

--- a/src/popup/tests/Popup.spec.tsx
+++ b/src/popup/tests/Popup.spec.tsx
@@ -33,9 +33,7 @@ describe('Popup', () => {
 	it('renders nothing if not open', () => {
 		const h = harness(() => (
 			<Popup x={0} yTop={0} yBottom={0} onClose={() => {}} open={false}>
-				{{
-					content: () => 'hello world'
-				}}
+				hello world
 			</Popup>
 		));
 
@@ -45,9 +43,7 @@ describe('Popup', () => {
 	it('initially renders with opacity 0 while height is calculated', () => {
 		const h = harness(() => (
 			<Popup x={0} yTop={0} yBottom={0} onClose={() => {}} open={true}>
-				{{
-					content: () => 'hello world'
-				}}
+				hello world
 			</Popup>
 		));
 
@@ -58,9 +54,7 @@ describe('Popup', () => {
 		const onClose = stub();
 		const h = harness(() => (
 			<Popup x={0} yTop={0} yBottom={0} open={true} onClose={onClose}>
-				{{
-					content: () => 'hello world'
-				}}
+				hello world
 			</Popup>
 		));
 
@@ -85,9 +79,7 @@ describe('Popup', () => {
 		const h = harness(
 			() => (
 				<Popup x={50} yTop={100} yBottom={0} open={true} onClose={() => {}}>
-					{{
-						content: () => 'hello world'
-					}}
+					hello world
 				</Popup>
 			),
 			{ middleware: [[node, mockNode]] }
@@ -126,9 +118,7 @@ describe('Popup', () => {
 		const h = harness(
 			() => (
 				<Popup x={50} yTop={901} yBottom={300} open={true} onClose={() => {}}>
-					{{
-						content: () => 'hello world'
-					}}
+					hello world
 				</Popup>
 			),
 			{ middleware: [[node, mockNode]] }
@@ -168,9 +158,7 @@ describe('Popup', () => {
 		const h = harness(
 			() => (
 				<Popup x={50} yTop={300} yBottom={50} open={true} onClose={() => {}}>
-					{{
-						content: () => 'hello world'
-					}}
+					hello world
 				</Popup>
 			),
 			{ middleware: [[node, mockNode]] }
@@ -196,9 +184,7 @@ describe('Popup', () => {
 	it('Renders with an underlay', () => {
 		const h = harness(() => (
 			<Popup x={0} yTop={0} yBottom={0} onClose={() => {}} underlayVisible={true} open={true}>
-				{{
-					content: () => 'hello world'
-				}}
+				hello world
 			</Popup>
 		));
 

--- a/src/trigger-popup/index.tsx
+++ b/src/trigger-popup/index.tsx
@@ -67,13 +67,9 @@ export const TriggerPopup = factory(function({
 				onClose={close}
 				open={icache.get('open')}
 			>
-				{{
-					content: () => (
-						<div key="trigger-wrapper" styles={wrapperStyles}>
-							{content(close)}
-						</div>
-					)
-				}}
+				<div key="trigger-wrapper" styles={wrapperStyles}>
+					{content(close)}
+				</div>
 			</Popup>
 		</virtual>
 	);

--- a/src/trigger-popup/tests/TriggerPopup.spec.tsx
+++ b/src/trigger-popup/tests/TriggerPopup.spec.tsx
@@ -13,7 +13,9 @@ const baseTemplate = assertionTemplate(() => (
 	<virtual>
 		<span key="trigger" classes={fixedCss.trigger} />
 		<Popup key="popup" x={0} yTop={0} yBottom={0} onClose={() => {}} open={undefined}>
-			{{ content: () => undefined }}
+			<div key="trigger-wrapper" styles={{ width: '0px' }}>
+				hello world
+			</div>
 		</Popup>
 	</virtual>
 ));
@@ -100,7 +102,8 @@ describe('TriggerPopup', () => {
 		const contentTemplate = baseTemplate
 			.setProperty('@popup', 'x', 50)
 			.setProperty('@popup', 'yTop', 100)
-			.setProperty('@popup', 'yBottom', 50);
+			.setProperty('@popup', 'yBottom', 50)
+			.setProperty('@trigger-wrapper', 'styles', { width: '150px' });
 
 		h.expect(contentTemplate);
 
@@ -110,7 +113,7 @@ describe('TriggerPopup', () => {
 					hello world
 				</div>
 			),
-			() => h.trigger('@popup', (node: any) => node.children[0].content)
+			() => h.trigger('@popup', (node: any) => () => node.children[0])
 		);
 	});
 	it('renders with unmatched size', () => {
@@ -123,7 +126,7 @@ describe('TriggerPopup', () => {
 			</TriggerPopup>
 		));
 
-		h.expect(baseTemplate);
+		h.expect(baseTemplate.setProperty('@trigger-wrapper', 'styles', { width: 'auto' }));
 
 		h.expect(
 			() => (
@@ -131,7 +134,7 @@ describe('TriggerPopup', () => {
 					hello world
 				</div>
 			),
-			() => h.trigger('@popup', (node: any) => node.children[0].content)
+			() => h.trigger('@popup', (node: any) => () => node.children[0])
 		);
 	});
 


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Simplifies the `Popup` child rendering by removing the child render typing and removing the render function.

Also updates the `Popup` usage in `ContextPopup` and `TriggerPopup`

Resolves #1261 
