### PR TITLE
Move chip render props to children

### DIFF
--- a/src/chip/index.tsx
+++ b/src/chip/index.tsx
@@ -6,36 +6,33 @@ import Icon from '../icon/index';
 import { Keys } from '../common/util';
 
 export interface ChipProperties {
-	/** Renders an icon, provided with the value of the checked property */
-	iconRenderer?(checked?: boolean): RenderResult;
-	/** The label to be displayed in the widget */
-	label: string;
-	/** Renders a close icon, ignored if `onClose` is not provided */
-	closeRenderer?(): RenderResult;
 	/** A callback when the close icon is clicked, if `closeRenderer` is not provided a default X icon will be used */
 	onClose?(): void;
 	/** An optional callback for the the widget is clicked */
 	onClick?(): void;
 	/** Whether the widget is disabled, only affects the widget when `onClick` is provided */
 	disabled?: boolean;
-	/** Indicates whe "checked" state of the widget, will be passed to the iconRenderer */
+	/** Indicates whe "checked" state of the widget, will be passed to the icon renderer */
 	checked?: boolean;
 }
 
-const factory = create({ theme }).properties<ChipProperties>();
+export interface ChipChildren {
+	/** Renders an icon, provided with the value of the checked property */
+	icon?(checked?: boolean): RenderResult;
+	/** The label to be displayed in the widget */
+	label: RenderResult;
+	/** Renders a close icon, ignored if `onClose` is not provided */
+	closeIcon?: RenderResult;
+}
 
-export default factory(function Chip({ properties, middleware: { theme } }) {
-	const {
-		iconRenderer,
-		label,
-		closeRenderer,
-		onClose,
-		onClick,
-		disabled,
-		checked
-	} = properties();
+const factory = create({ theme })
+	.properties<ChipProperties>()
+	.children<ChipChildren>();
+
+export default factory(function Chip({ properties, children, middleware: { theme } }) {
+	const { onClose, onClick, disabled, checked } = properties();
 	const themedCss = theme.classes(css);
-
+	const [{ icon, label, closeIcon }] = children();
 	const clickable = !disabled && onClick;
 	return (
 		<div
@@ -64,7 +61,7 @@ export default factory(function Chip({ properties, middleware: { theme } }) {
 				}
 			}}
 		>
-			{iconRenderer && <span classes={themedCss.iconWrapper}>{iconRenderer(checked)}</span>}
+			{icon && <span classes={themedCss.iconWrapper}>{icon(checked)}</span>}
 			<span classes={themedCss.label}>{label}</span>
 			{onClose && (
 				<span
@@ -84,7 +81,7 @@ export default factory(function Chip({ properties, middleware: { theme } }) {
 						}
 					}}
 				>
-					{closeRenderer ? closeRenderer() : <Icon type="closeIcon" />}
+					{closeIcon || <Icon type="closeIcon" />}
 				</span>
 			)}
 		</div>

--- a/src/chip/tests/Chip.spec.tsx
+++ b/src/chip/tests/Chip.spec.tsx
@@ -210,6 +210,22 @@ describe('Chip', () => {
 		assert.isTrue(onClick.calledOnce);
 	});
 
+	it('does not trigger callback when disabled and clicked', () => {
+		const onClick = sinon.spy();
+		const h = harness(() => (
+			<Chip disabled onClick={onClick}>
+				{{ label }}
+			</Chip>
+		));
+
+		h.expect(
+			template.setProperty(':root', 'classes', [undefined, css.root, css.disabled, false])
+		);
+
+		h.trigger('@root', 'onclick');
+		assert.isFalse(onClick.called);
+	});
+
 	it('calls appropriate callbacks when enter or space is pressed', () => {
 		const onClose = sinon.spy();
 		const onClick = sinon.spy();

--- a/src/chip/tests/Chip.spec.tsx
+++ b/src/chip/tests/Chip.spec.tsx
@@ -28,15 +28,13 @@ describe('Chip', () => {
 	));
 
 	it('should render with a label', () => {
-		const h = harness(() => <Chip label={label} />);
+		const h = harness(() => <Chip>{{ label }}</Chip>);
 
 		h.expect(template);
 	});
 
-	it('should render with an iconRenderer', () => {
-		const h = harness(() => (
-			<Chip label={label} iconRenderer={() => <Icon type="plusIcon" />} />
-		));
+	it('should render with an icon renderer', () => {
+		const h = harness(() => <Chip>{{ label, icon: () => <Icon type="plusIcon" /> }}</Chip>);
 
 		h.expect(
 			template.prepend(':root', () => [
@@ -47,13 +45,14 @@ describe('Chip', () => {
 		);
 	});
 
-	it('should pass checked property to iconRenderer', () => {
+	it('should pass checked property to icon', () => {
 		const h = harness(() => (
-			<Chip
-				label={label}
-				checked={true}
-				iconRenderer={(checked) => <span>{String(checked)}</span>}
-			/>
+			<Chip checked={true}>
+				{{
+					label,
+					icon: (checked) => <span>{String(checked)}</span>
+				}}
+			</Chip>
 		));
 
 		h.expect(
@@ -66,7 +65,7 @@ describe('Chip', () => {
 	});
 
 	it('should render with a close icon when onClose is provided', () => {
-		const h = harness(() => <Chip label={label} onClose={noop} />);
+		const h = harness(() => <Chip onClose={noop}>{{ label }}</Chip>);
 		h.expect(
 			template.append(':root', () => [
 				<span
@@ -85,7 +84,7 @@ describe('Chip', () => {
 
 	it('should render with a closeRenderer when onClose is also provided', () => {
 		const h = harness(() => (
-			<Chip label={label} onClose={noop} closeRenderer={() => <Icon type="minusIcon" />} />
+			<Chip onClose={noop}>{{ label, closeIcon: <Icon type="minusIcon" /> }}</Chip>
 		));
 		h.expect(
 			template.append(':root', () => [
@@ -104,14 +103,14 @@ describe('Chip', () => {
 	});
 
 	it('should not use a closeIconRenderer if provided without a callback', () => {
-		const h = harness(() => <Chip label={label} closeRenderer={() => <span>Close</span>} />);
+		const h = harness(() => <Chip>{{ label, closeIcon: <span>Close</span> }}</Chip>);
 
 		h.expect(template);
 	});
 
-	it('should render with an iconRenderer and a close icon', () => {
+	it('should render with an icon and a close icon', () => {
 		const h = harness(() => (
-			<Chip label={label} onClose={noop} iconRenderer={() => <Icon type="plusIcon" />} />
+			<Chip onClose={noop}>{{ label, icon: () => <Icon type="plusIcon" /> }}</Chip>
 		));
 
 		h.expect(
@@ -137,7 +136,7 @@ describe('Chip', () => {
 	});
 
 	it('should add a clickable class and button attributes with an onClick callback', () => {
-		const h = harness(() => <Chip label={label} onClick={noop} />);
+		const h = harness(() => <Chip onClick={noop}>{{ label }}</Chip>);
 
 		h.expect(
 			template
@@ -148,7 +147,11 @@ describe('Chip', () => {
 	});
 
 	it('should add disabled class, and remove clickable class and button attributes if disabled', () => {
-		const h = harness(() => <Chip label={label} onClick={noop} disabled />);
+		const h = harness(() => (
+			<Chip onClick={noop} disabled>
+				{{ label }}
+			</Chip>
+		));
 
 		h.expect(
 			template.setProperty(':root', 'classes', [undefined, css.root, css.disabled, false])
@@ -159,12 +162,12 @@ describe('Chip', () => {
 		const onClose = sinon.spy();
 		const onClick = sinon.spy();
 		const h = harness(() => (
-			<Chip
-				label={label}
-				onClose={onClose}
-				onClick={onClick}
-				iconRenderer={() => <Icon type="plusIcon" />}
-			/>
+			<Chip onClose={onClose} onClick={onClick}>
+				{{
+					label,
+					icon: () => <Icon type="plusIcon" />
+				}}
+			</Chip>
 		));
 
 		h.expect(
@@ -211,12 +214,12 @@ describe('Chip', () => {
 		const onClose = sinon.spy();
 		const onClick = sinon.spy();
 		const h = harness(() => (
-			<Chip
-				label={label}
-				onClose={onClose}
-				onClick={onClick}
-				iconRenderer={() => <Icon type="plusIcon" />}
-			/>
+			<Chip onClose={onClose} onClick={onClick}>
+				{{
+					label,
+					icon: () => <Icon type="plusIcon" />
+				}}
+			</Chip>
 		));
 
 		h.expect(

--- a/src/examples/src/widgets/chip/Basic.tsx
+++ b/src/examples/src/widgets/chip/Basic.tsx
@@ -4,7 +4,7 @@ import Chip from '@dojo/widgets/chip';
 const factory = create();
 
 const App = factory(function Basic() {
-	return <Chip label="Chip Example" />;
+	return <Chip>{{ label: 'Chip Example' }}</Chip>;
 });
 
 export default App;

--- a/src/examples/src/widgets/chip/Clickable.tsx
+++ b/src/examples/src/widgets/chip/Clickable.tsx
@@ -9,11 +9,12 @@ const App = factory(function Clickable({ middleware: { icache } }) {
 	return (
 		<virtual>
 			<Chip
-				label="Clickable"
 				onClick={() => {
 					icache.set('clickable', icache.getOrSet<number>('clickable', 0) + 1);
 				}}
-			/>
+			>
+				{{ label: 'Clickable' }}
+			</Chip>
 			<div>Clicked {String(clickable)} times</div>
 		</virtual>
 	);

--- a/src/examples/src/widgets/chip/ClickableClosable.tsx
+++ b/src/examples/src/widgets/chip/ClickableClosable.tsx
@@ -12,7 +12,6 @@ const App = factory(function ClickableClosable({ middleware: { icache } }) {
 		<virtual>
 			{!clickableClosed && (
 				<Chip
-					label="Click or close"
 					onClick={() => {
 						icache.set(
 							'clickableClosedCount',
@@ -22,7 +21,9 @@ const App = factory(function ClickableClosable({ middleware: { icache } }) {
 					onClose={() => {
 						icache.set('clickableClosed', true);
 					}}
-				/>
+				>
+					{{ label: 'Click or close' }}
+				</Chip>
 			)}
 			<div>Clicked {String(clickableClosedCount)} times</div>
 		</virtual>

--- a/src/examples/src/widgets/chip/Closable.tsx
+++ b/src/examples/src/widgets/chip/Closable.tsx
@@ -11,11 +11,14 @@ const App = factory(function Closeable({ middleware: { icache } }) {
 	return (
 		!closed && (
 			<Chip
-				label="Close me"
 				onClose={() => {
 					set('closed', true);
 				}}
-			/>
+			>
+				{{
+					label: 'Close me'
+				}}
+			</Chip>
 		)
 	);
 });

--- a/src/examples/src/widgets/chip/ClosableRenderer.tsx
+++ b/src/examples/src/widgets/chip/ClosableRenderer.tsx
@@ -13,12 +13,15 @@ const App = factory(function ClosableRenderer({ middleware: { icache } }) {
 		<virtual>
 			{!closed && (
 				<Chip
-					label="Close me"
 					onClose={() => {
 						set('closed', true);
 					}}
-					closeRenderer={() => <Icon type="minusIcon" />}
-				/>
+				>
+					{{
+						label: 'Close me',
+						closeIcon: <Icon type="minusIcon" />
+					}}
+				</Chip>
 			)}
 		</virtual>
 	);

--- a/src/examples/src/widgets/chip/Disabled.tsx
+++ b/src/examples/src/widgets/chip/Disabled.tsx
@@ -6,12 +6,13 @@ const factory = create();
 const App = factory(function Disabled() {
 	return (
 		<Chip
-			label="Disabled"
 			disabled
 			onClick={() => {
 				window.alert('clicked');
 			}}
-		/>
+		>
+			{{ label: 'Disabled' }}
+		</Chip>
 	);
 });
 

--- a/src/examples/src/widgets/chip/Icon.tsx
+++ b/src/examples/src/widgets/chip/Icon.tsx
@@ -5,7 +5,14 @@ import Icon from '@dojo/widgets/icon';
 const factory = create();
 
 const App = factory(function IconExample() {
-	return <Chip label="Icon Example" iconRenderer={() => <Icon type="alertIcon" />} />;
+	return (
+		<Chip>
+			{{
+				label: 'Icon Example',
+				icon: () => <Icon type="alertIcon" />
+			}}
+		</Chip>
+	);
 });
 
 export default App;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Moves `iconRenderer`, `closeRenderer`, and `label` from being properties to being children.
`iconRenderer` and `closeRenderer` were renamed to `icon` and `closeIcon` be more consistent with other child interfaces. `closeIcon` and `label` both have `RenderResult` types now.
Resolves #1256
