### PR TITLE
Make editable grid example editable

### DIFF
--- a/src/examples/src/widgets/grid/EditableCells.tsx
+++ b/src/examples/src/widgets/grid/EditableCells.tsx
@@ -14,12 +14,12 @@ const columnConfig: ColumnConfig[] = [
 	{
 		id: 'firstName',
 		title: 'First Name',
-		editable: false
+		editable: true
 	},
 	{
 		id: 'lastName',
 		title: 'Last Name',
-		editable: false
+		editable: true
 	}
 ];
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Updates the column config to be editable in the grid example. The data seems to be persisting fine, so I'm not sure that there's anything else that needs to be done here.
Resolves #1287 
