### PR TITLE
Fix default value for number input example

### DIFF
--- a/src/examples/src/widgets/number-input/Basic.tsx
+++ b/src/examples/src/widgets/number-input/Basic.tsx
@@ -5,15 +5,16 @@ import icache from '@dojo/framework/core/middleware/icache';
 const factory = create({ icache });
 
 const Example = factory(function Example({ middleware: { icache } }) {
+	const initialValue = 42;
 	return (
 		<virtual>
 			<NumberInput
-				initialValue={42}
+				initialValue={initialValue}
 				onValue={(value) => {
 					icache.set('value', value);
 				}}
 			/>
-			<div>The number input value is: {`${icache.get('value')}`}</div>
+			<div>The number input value is: {`${icache.getOrSet('value', initialValue)}`}</div>
 		</virtual>
 	);
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Updates the number input example to initialize the displayed value using the same number as is passed as the input's `initialValue`.
Resolves #1286
