### PR TITLE
Three column layout

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -49,6 +49,7 @@
 			"src/tab-controller",
 			"src/text-area",
 			"src/text-input",
+			"src/three-column-layout",
 			"src/time-picker",
 			"src/title-pane",
 			"src/tooltip",

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -172,6 +172,7 @@ import PlaceholderTextInput from './widgets/text-input/Placeholder';
 import LeadingTrailingTextInput from './widgets/text-input/LeadingTrailing';
 import ValidatedTextInput from './widgets/text-input/Validated';
 import TextInputWithLabel from './widgets/text-input/WithLabel';
+import BasicThreeColumnLayout from './widgets/three-column-layout/Basic';
 import TwelveHourTimePicker from './widgets/time-picker/12HourTime';
 import BasicTimePicker from './widgets/time-picker/Basic';
 import DisabledTimePicker from './widgets/time-picker/Disabled';
@@ -1400,6 +1401,14 @@ export const config = {
 				example: {
 					filename: 'Basic',
 					module: BasicTextInput
+				}
+			}
+		},
+		'three-column-layout': {
+			overview: {
+				example: {
+					filename: 'BasicThreeColumnLayout',
+					module: BasicThreeColumnLayout
 				}
 			}
 		},

--- a/src/examples/src/widgets/three-column-layout/Basic.tsx
+++ b/src/examples/src/widgets/three-column-layout/Basic.tsx
@@ -7,9 +7,17 @@ export default factory(function Basic() {
 	return (
 		<ThreeColumnLayout>
 			{{
-				leading: <div>This is the leading content</div>,
-				center: <div>This is the center content</div>,
-				trailing: <div>This is the trailing content</div>
+				leading: (
+					<div styles={{ textAlign: 'center', borderRight: '1px solid black' }}>
+						This is the leading content
+					</div>
+				),
+				center: <div styles={{ textAlign: 'center' }}>This is the center content</div>,
+				trailing: (
+					<div styles={{ textAlign: 'center', borderLeft: '1px solid black' }}>
+						This is the trailing content
+					</div>
+				)
 			}}
 		</ThreeColumnLayout>
 	);

--- a/src/examples/src/widgets/three-column-layout/Basic.tsx
+++ b/src/examples/src/widgets/three-column-layout/Basic.tsx
@@ -1,0 +1,16 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import ThreeColumnLayout from '@dojo/widgets/three-column-layout';
+
+const factory = create();
+
+export default factory(function Basic() {
+	return (
+		<ThreeColumnLayout>
+			{{
+				leading: <div>This is the leading content</div>,
+				center: <div>This is the center content</div>,
+				trailing: <div>This is the trailing content</div>
+			}}
+		</ThreeColumnLayout>
+	);
+});

--- a/src/theme/default/index.ts
+++ b/src/theme/default/index.ts
@@ -41,6 +41,7 @@ import * as switchControl from './switch.m.css';
 import * as tabController from './tab-controller.m.css';
 import * as textArea from './text-area.m.css';
 import * as textInput from './text-input.m.css';
+import * as threeColumnLayout from './three-column-layout.m.css';
 import * as timePicker from './time-picker.m.css';
 import * as titlePane from './title-pane.m.css';
 import * as tooltip from './tooltip.m.css';
@@ -93,6 +94,7 @@ export default {
 		'@dojo/widgets/tab-controller': tabController,
 		'@dojo/widgets/text-area': textArea,
 		'@dojo/widgets/text-input': textInput,
+		'@dojo/widgets/three-column-layout': threeColumnLayout,
 		'@dojo/widgets/time-picker': timePicker,
 		'@dojo/widgets/title-pane': titlePane,
 		'@dojo/widgets/tooltip': tooltip,

--- a/src/theme/default/three-column-layout.m.css
+++ b/src/theme/default/three-column-layout.m.css
@@ -1,0 +1,8 @@
+.root {
+}
+.center {
+}
+.leading {
+}
+.trailing {
+}

--- a/src/theme/default/three-column-layout.m.css
+++ b/src/theme/default/three-column-layout.m.css
@@ -1,8 +1,12 @@
+/* Added to the root element */
 .root {
 }
-.center {
-}
+/* Added to the leading column */
 .leading {
 }
+/* Added to the center column */
+.center {
+}
+/* Added to the trailing column */
 .trailing {
 }

--- a/src/theme/default/three-column-layout.m.css.d.ts
+++ b/src/theme/default/three-column-layout.m.css.d.ts
@@ -1,4 +1,4 @@
 export const root: string;
-export const center: string;
 export const leading: string;
+export const center: string;
 export const trailing: string;

--- a/src/theme/default/three-column-layout.m.css.d.ts
+++ b/src/theme/default/three-column-layout.m.css.d.ts
@@ -1,0 +1,4 @@
+export const root: string;
+export const center: string;
+export const leading: string;
+export const trailing: string;

--- a/src/theme/dojo/index.ts
+++ b/src/theme/dojo/index.ts
@@ -43,6 +43,7 @@ import * as switchControl from './switch.m.css';
 import * as tabController from './tab-controller.m.css';
 import * as textArea from './text-area.m.css';
 import * as textInput from './text-input.m.css';
+import * as threeColumnLayout from './three-column-layout.m.css';
 import * as timePicker from './time-picker.m.css';
 import * as titlePane from './title-pane.m.css';
 import * as tooltip from './tooltip.m.css';
@@ -97,6 +98,7 @@ export default {
 		'@dojo/widgets/tab-controller': tabController,
 		'@dojo/widgets/text-area': textArea,
 		'@dojo/widgets/text-input': textInput,
+		'@dojo/widgets/three-column-layout': threeColumnLayout,
 		'@dojo/widgets/time-picker': timePicker,
 		'@dojo/widgets/title-pane': titlePane,
 		'@dojo/widgets/tooltip': tooltip,

--- a/src/theme/dojo/three-column-layout.m.css
+++ b/src/theme/dojo/three-column-layout.m.css
@@ -1,0 +1,7 @@
+.leading {
+	width: calc(var(--grid-base) * 40);
+}
+
+.trailing {
+	width: calc(var(--grid-base) * 40);
+}

--- a/src/theme/dojo/three-column-layout.m.css.d.ts
+++ b/src/theme/dojo/three-column-layout.m.css.d.ts
@@ -1,0 +1,2 @@
+export const leading: string;
+export const trailing: string;

--- a/src/theme/material/index.ts
+++ b/src/theme/material/index.ts
@@ -42,6 +42,7 @@ import * as switchControl from './switch.m.css';
 import * as tabController from './tab-controller.m.css';
 import * as textArea from './text-area.m.css';
 import * as textInput from './text-input.m.css';
+import * as threeColumnLayout from './three-column-layout.m.css';
 import * as timePicker from './time-picker.m.css';
 import * as titlePane from './title-pane.m.css';
 import * as tooltip from './tooltip.m.css';
@@ -95,6 +96,7 @@ export default {
 		'@dojo/widgets/tab-controller': tabController,
 		'@dojo/widgets/text-area': textArea,
 		'@dojo/widgets/text-input': textInput,
+		'@dojo/widgets/three-column-layout': threeColumnLayout,
 		'@dojo/widgets/time-picker': timePicker,
 		'@dojo/widgets/title-pane': titlePane,
 		'@dojo/widgets/tooltip': tooltip,

--- a/src/theme/material/three-column-layout.m.css
+++ b/src/theme/material/three-column-layout.m.css
@@ -1,0 +1,7 @@
+.leading {
+	width: calc(var(--mdc-grid-base) * 40);
+}
+
+.trailing {
+	width: calc(var(--mdc-grid-base) * 40);
+}

--- a/src/theme/material/three-column-layout.m.css.d.ts
+++ b/src/theme/material/three-column-layout.m.css.d.ts
@@ -1,0 +1,2 @@
+export const leading: string;
+export const trailing: string;

--- a/src/three-column-layout/README.md
+++ b/src/three-column-layout/README.md
@@ -3,5 +3,5 @@
 Dojo's three column layout can be used to show two side panels and a central content section that will resize and collapse responsively.
 
 ## Features
-- Automatically collapses to a two column, and then one column layout at configurable breakpoints
+- Automatically collapses to a two column and then one column layout at configurable breakpoints
 

--- a/src/three-column-layout/README.md
+++ b/src/three-column-layout/README.md
@@ -1,0 +1,7 @@
+# @dojo/widgest/three-column-layout
+
+Dojo's three column layout can be used to show two side panels and a central content section that will resize and collapse responsively.
+
+## Features
+- Automatically collapses to a two column, and then one column layout at configurable breakpoints
+

--- a/src/three-column-layout/index.tsx
+++ b/src/three-column-layout/index.tsx
@@ -1,0 +1,68 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import { RenderResult } from '@dojo/framework/core/interfaces';
+import breakpoint from '@dojo/framework/core/middleware/breakpoint';
+import theme from '../middleware/theme';
+import * as fixedCss from './styles/three-column-layout.m.css';
+import * as baseCss from '../common/styles/base.m.css';
+import * as css from '../theme/default/three-column-layout.m.css';
+
+export interface ThreeColumnLayoutProperties {
+	twoColumnBreakpoint?: number;
+	oneColumnBreakpoint?: number;
+	bias?: 'leading' | 'trailing';
+}
+
+export interface ThreeColumnLayoutChildren {
+	leading: RenderResult;
+	trailing: RenderResult;
+	center: RenderResult;
+}
+
+const factory = create({ breakpoint, theme })
+	.properties<ThreeColumnLayoutProperties>()
+	.children<ThreeColumnLayoutChildren>();
+
+export const ThreeColumnLayout = factory(function({
+	properties,
+	children,
+	middleware: { breakpoint, theme }
+}) {
+	const {
+		twoColumnBreakpoint = 1024,
+		oneColumnBreakpoint = 600,
+		bias = 'leading'
+	} = properties();
+	const [{ leading, center, trailing }] = children();
+	const classes = theme.classes(css);
+	const { breakpoint: currentBreakpoint } = breakpoint.get('root', {
+		LARGE: twoColumnBreakpoint,
+		MEDIUM: oneColumnBreakpoint,
+		SMALL: 0
+	}) || { breakpoint: 'LARGE' };
+	const shouldCollapseLeading =
+		currentBreakpoint === 'SMALL' || (currentBreakpoint === 'MEDIUM' && bias === 'trailing');
+	const shouldCollapseTrailing =
+		currentBreakpoint === 'SMALL' || (currentBreakpoint === 'MEDIUM' && bias === 'leading');
+
+	return (
+		<div classes={[theme.variant(), fixedCss.root, classes.root]}>
+			<div
+				key="leading"
+				classes={[classes.leading, shouldCollapseLeading && baseCss.visuallyHidden]}
+			>
+				{leading}
+			</div>
+			<div key="center" classes={[fixedCss.center, classes.center]}>
+				{center}
+			</div>
+			<div
+				key="trailing"
+				classes={[classes.trailing, shouldCollapseTrailing && baseCss.visuallyHidden]}
+			>
+				{trailing}
+			</div>
+		</div>
+	);
+});
+
+export default ThreeColumnLayout;

--- a/src/three-column-layout/index.tsx
+++ b/src/three-column-layout/index.tsx
@@ -7,15 +7,24 @@ import * as baseCss from '../common/styles/base.m.css';
 import * as css from '../theme/default/three-column-layout.m.css';
 
 export interface ThreeColumnLayoutProperties {
+	/** The breakpoint at which one column should collapse. Defaults to 1024px.
+	 * The column that collapses will be the trailing column by default or the column that is not specified by the
+	 * `bias` property if it is provided
+	 */
 	twoColumnBreakpoint?: number;
+	/** The breakpoint at which both side columns will collapse. Defaults to 600px. */
 	oneColumnBreakpoint?: number;
+	/** Determines which column is more important, and will remain at the `twoColumnBreakpoint`. Defaults to `'leading'`. */
 	bias?: 'leading' | 'trailing';
 }
 
 export interface ThreeColumnLayoutChildren {
+	/** The content for the leading column */
 	leading: RenderResult;
-	trailing: RenderResult;
+	/** The content for the center column */
 	center: RenderResult;
+	/** The content for the trailing column */
+	trailing: RenderResult;
 }
 
 const factory = create({ breakpoint, theme })
@@ -45,7 +54,7 @@ export const ThreeColumnLayout = factory(function({
 		currentBreakpoint === 'SMALL' || (currentBreakpoint === 'MEDIUM' && bias === 'leading');
 
 	return (
-		<div classes={[theme.variant(), fixedCss.root, classes.root]}>
+		<div key="root" classes={[theme.variant(), fixedCss.root, classes.root]}>
 			<div
 				key="leading"
 				classes={[classes.leading, shouldCollapseLeading && baseCss.visuallyHidden]}

--- a/src/three-column-layout/styles/three-column-layout.m.css
+++ b/src/three-column-layout/styles/three-column-layout.m.css
@@ -1,0 +1,7 @@
+.root {
+	display: flex;
+}
+
+.center {
+	flex-grow: 1;
+}

--- a/src/three-column-layout/styles/three-column-layout.m.css.d.ts
+++ b/src/three-column-layout/styles/three-column-layout.m.css.d.ts
@@ -1,0 +1,2 @@
+export const root: string;
+export const center: string;

--- a/src/three-column-layout/tests/ThreeColumnLayout.spec.tsx
+++ b/src/three-column-layout/tests/ThreeColumnLayout.spec.tsx
@@ -1,0 +1,42 @@
+const { describe, it } = intern.getInterface('bdd');
+import harness from '@dojo/framework/testing/harness';
+import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
+import { tsx } from '@dojo/framework/core/vdom';
+import fixedCss from '../styles/three-column-layout.m.css';
+import baseCss from '../../common/styles/base.m.css';
+import css from '../../theme/default/three-column-layout.m.css';
+
+import ThreeColumnLayout from '../index';
+
+describe('ThreeColumnLayout', () => {
+	const leading = <div>Leading</div>;
+	const center = <div>Center</div>;
+	const trailing = <div>Trailing</div>;
+	const baseAssertion = assertionTemplate(() => (
+		<div classes={[undefined, fixedCss.root, css.root]}>
+			<div key="leading" classes={[css.leading, false]}>
+				{leading}
+			</div>
+			<div key="center" classes={[fixedCss.center, css.center]}>
+				{center}
+			</div>
+			<div key="trailing" classes={[css.trailing, false]}>
+				{trailing}
+			</div>
+		</div>
+	));
+
+	it('renders', () => {
+		const h = harness(() => (
+			<ThreeColumnLayout>
+				{{
+					leading,
+					center,
+					trailing
+				}}
+			</ThreeColumnLayout>
+		));
+
+		h.expect(baseAssertion);
+	});
+});

--- a/src/three-column-layout/tests/ThreeColumnLayout.spec.tsx
+++ b/src/three-column-layout/tests/ThreeColumnLayout.spec.tsx
@@ -1,19 +1,40 @@
-const { describe, it } = intern.getInterface('bdd');
-import harness from '@dojo/framework/testing/harness';
+import { WNode } from '@dojo/framework/core/interfaces';
+
+const { describe, it, beforeEach } = intern.getInterface('bdd');
+import testHarness from '@dojo/framework/testing/harness';
 import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
-import { tsx } from '@dojo/framework/core/vdom';
-import fixedCss from '../styles/three-column-layout.m.css';
-import baseCss from '../../common/styles/base.m.css';
-import css from '../../theme/default/three-column-layout.m.css';
+import breakpointMiddleware from '@dojo/framework/core/middleware/breakpoint';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import * as fixedCss from '../styles/three-column-layout.m.css';
+import * as baseCss from '../../common/styles/base.m.css';
+import * as css from '../../theme/default/three-column-layout.m.css';
 
 import ThreeColumnLayout from '../index';
 
 describe('ThreeColumnLayout', () => {
+	let breakpoint = 'LARGE';
+	// TODO - Fix test context so resize mock works and remove this
+	const factory = create();
+	const mockBreakpoint = factory(() => {
+		return {
+			get() {
+				return { breakpoint, contentRect: {} };
+			}
+		};
+	});
+	const harness = (renderFunc: () => WNode) =>
+		testHarness(renderFunc, {
+			middleware: [[breakpointMiddleware, () => mockBreakpoint()]] as any
+		});
+
+	beforeEach(() => {
+		breakpoint = 'LARGE';
+	});
 	const leading = <div>Leading</div>;
 	const center = <div>Center</div>;
 	const trailing = <div>Trailing</div>;
 	const baseAssertion = assertionTemplate(() => (
-		<div classes={[undefined, fixedCss.root, css.root]}>
+		<div key="root" classes={[undefined, fixedCss.root, css.root]}>
 			<div key="leading" classes={[css.leading, false]}>
 				{leading}
 			</div>
@@ -38,5 +59,61 @@ describe('ThreeColumnLayout', () => {
 		));
 
 		h.expect(baseAssertion);
+	});
+
+	it('renders at medium breakpoint', () => {
+		breakpoint = 'MEDIUM';
+		const h = harness(() => (
+			<ThreeColumnLayout>
+				{{
+					leading,
+					center,
+					trailing
+				}}
+			</ThreeColumnLayout>
+		));
+
+		h.expect(
+			baseAssertion.setProperty('@trailing', 'classes', [
+				css.trailing,
+				baseCss.visuallyHidden
+			])
+		);
+	});
+
+	it('renders at medium breakpoint with trailing bias', () => {
+		breakpoint = 'MEDIUM';
+		const h = harness(() => (
+			<ThreeColumnLayout bias="trailing">
+				{{
+					leading,
+					center,
+					trailing
+				}}
+			</ThreeColumnLayout>
+		));
+
+		h.expect(
+			baseAssertion.setProperty('@leading', 'classes', [css.leading, baseCss.visuallyHidden])
+		);
+	});
+
+	it('renders at small breakpoint', () => {
+		breakpoint = 'SMALL';
+		const h = harness(() => (
+			<ThreeColumnLayout>
+				{{
+					leading,
+					center,
+					trailing
+				}}
+			</ThreeColumnLayout>
+		));
+
+		h.expect(
+			baseAssertion
+				.setProperty('@leading', 'classes', [css.leading, baseCss.visuallyHidden])
+				.setProperty('@trailing', 'classes', [css.trailing, baseCss.visuallyHidden])
+		);
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds a three column layout. This collapses to a two column layout at a configurable breakpoint that defaults to 1024px. It collapses to only the central column at a configurable breakpoint defaulting to 600px. The Dojo and Material themes both separately size the leading and trailing columns to 320px wide (40 * grid size). Which column collapses first is configurable by specifying the `bias` property but defaults to the trailing column.

Resolves #1151 
