### PR TITLE
Move checkbox group label to child renderer

### DIFF
--- a/src/checkbox-group/index.tsx
+++ b/src/checkbox-group/index.tsx
@@ -10,8 +10,6 @@ type CheckboxOptions = { value: string; label?: string }[];
 export interface CheckboxGroupProperties {
 	/** The name attribute for this form group */
 	name: string;
-	/** The label to be displayed in the legend */
-	label?: string;
 	/** Object containing the values / labels to create checkboxes for */
 	options: CheckboxOptions;
 	/** Callback for the current value */
@@ -22,11 +20,12 @@ export interface CheckboxGroupProperties {
 
 export interface CheckboxGroupChildren {
 	/** Custom renderer for the checkboxes, receives the checkbox group middleware and options */
-	(
+	checkboxes?(
 		name: string,
 		middleware: ReturnType<ReturnType<typeof checkboxGroup>['api']>,
 		options: CheckboxOptions
 	): RenderResult;
+	label?: RenderResult;
 }
 
 const factory = create({ checkboxGroup, theme })
@@ -38,15 +37,15 @@ export const CheckboxGroup = factory(function({
 	properties,
 	middleware: { checkboxGroup, theme }
 }) {
-	const { name, label, options, onValue, initialValue } = properties();
-	const [renderer] = children();
+	const { name, options, onValue, initialValue } = properties();
+	const [{ checkboxes, label } = { checkboxes: undefined, label: undefined }] = children();
 
 	const checkbox = checkboxGroup(onValue, initialValue);
 	const { root, legend } = theme.classes(css);
 
 	function renderCheckboxes() {
-		if (typeof renderer === 'function') {
-			return renderer(name, checkbox, options);
+		if (checkboxes) {
+			return checkboxes(name, checkbox, options);
 		}
 		return options.map(({ value, label }) => {
 			const { checked } = checkbox(value);

--- a/src/checkbox-group/tests/CheckboxGroup.spec.tsx
+++ b/src/checkbox-group/tests/CheckboxGroup.spec.tsx
@@ -37,12 +37,11 @@ describe('CheckboxGroup', () => {
 
 	it('renders with a label', () => {
 		const h = harness(() => (
-			<CheckboxGroup
-				onValue={noop}
-				name="test"
-				label="test label"
-				options={[{ value: 'cat' }]}
-			/>
+			<CheckboxGroup onValue={noop} name="test" options={[{ value: 'cat' }]}>
+				{{
+					label: 'test label'
+				}}
+			</CheckboxGroup>
 		));
 		const labelTemplate = template.setChildren('@root', () => [
 			<legend classes={css.legend}>test label</legend>,
@@ -78,20 +77,18 @@ describe('CheckboxGroup', () => {
 
 	it('renders with custom renderer', () => {
 		const h = harness(() => (
-			<CheckboxGroup
-				onValue={noop}
-				name="test"
-				label="custom render label"
-				options={[{ value: 'cat' }]}
-			>
-				{() => {
-					return [
-						<span>custom label</span>,
-						<Checkbox name="test" value="cat" checked={undefined} onValue={noop}>
-							cat
-						</Checkbox>,
-						<hr />
-					];
+			<CheckboxGroup onValue={noop} name="test" options={[{ value: 'cat' }]}>
+				{{
+					label: 'custom render label',
+					checkboxes: () => {
+						return [
+							<span>custom label</span>,
+							<Checkbox name="test" value="cat" checked={undefined} onValue={noop}>
+								cat
+							</Checkbox>,
+							<hr />
+						];
+					}
 				}}
 			</CheckboxGroup>
 		));

--- a/src/examples/src/widgets/checkbox-group/Basic.tsx
+++ b/src/examples/src/widgets/checkbox-group/Basic.tsx
@@ -10,13 +10,16 @@ const App = factory(function({ properties, middleware: { icache } }) {
 	return (
 		<virtual>
 			<CheckboxGroup
-				label="pets"
 				name="standard"
 				options={[{ value: 'cat' }, { value: 'dog' }, { value: 'fish' }]}
 				onValue={(value) => {
 					set('standard', value);
 				}}
-			/>
+			>
+				{{
+					label: 'pets'
+				}}
+			</CheckboxGroup>
 			<pre>{`${get('standard')}`}</pre>
 		</virtual>
 	);

--- a/src/examples/src/widgets/checkbox-group/CustomLabel.tsx
+++ b/src/examples/src/widgets/checkbox-group/CustomLabel.tsx
@@ -10,7 +10,6 @@ const App = factory(function({ properties, middleware: { icache } }) {
 	return (
 		<virtual>
 			<CheckboxGroup
-				label="colours"
 				name="colours"
 				options={[
 					{ value: 'red', label: 'Rouge' },
@@ -20,7 +19,11 @@ const App = factory(function({ properties, middleware: { icache } }) {
 				onValue={(value) => {
 					set('colours', value);
 				}}
-			/>
+			>
+				{{
+					label: 'colours'
+				}}
+			</CheckboxGroup>
 			<pre>{`${get('colours')}`}</pre>
 		</virtual>
 	);

--- a/src/examples/src/widgets/checkbox-group/CustomRenderer.tsx
+++ b/src/examples/src/widgets/checkbox-group/CustomRenderer.tsx
@@ -11,40 +11,42 @@ const App = factory(function({ middleware: { icache } }) {
 	return (
 		<virtual>
 			<CheckboxGroup
-				label="going?"
 				name="custom"
 				options={[{ value: 'yes' }, { value: 'no' }, { value: 'maybe' }]}
 				onValue={(value) => {
 					set('custom', value);
 				}}
 			>
-				{(name, checkboxGroup, options) => {
-					return options.map(({ value, label }) => {
-						const { checked } = checkboxGroup(value);
-						return (
-							<virtual>
-								<span>I'm custom!</span>
-								<Checkbox
-									name={name}
-									value={value}
-									checked={checked()}
-									onValue={checked}
-								>
-									{label || value}
-								</Checkbox>
-								<hr
-									styles={{
-										borderColor: '#d6dde2',
-										borderStyle: 'solid',
-										borderWidth: '1px 0 0',
-										height: '0',
-										margin: '0',
-										overflow: 'hidden'
-									}}
-								/>
-							</virtual>
-						);
-					});
+				{{
+					label: 'going?',
+					checkboxes: (name, checkboxGroup, options) => {
+						return options.map(({ value, label }) => {
+							const { checked } = checkboxGroup(value);
+							return (
+								<virtual>
+									<span>I'm custom!</span>
+									<Checkbox
+										name={name}
+										value={value}
+										checked={checked()}
+										onValue={checked}
+									>
+										{label || value}
+									</Checkbox>
+									<hr
+										styles={{
+											borderColor: '#d6dde2',
+											borderStyle: 'solid',
+											borderWidth: '1px 0 0',
+											height: '0',
+											margin: '0',
+											overflow: 'hidden'
+										}}
+									/>
+								</virtual>
+							);
+						});
+					}
 				}}
 			</CheckboxGroup>
 			<pre>{`${get('custom')}`}</pre>

--- a/src/examples/src/widgets/checkbox-group/InitialValue.tsx
+++ b/src/examples/src/widgets/checkbox-group/InitialValue.tsx
@@ -10,14 +10,17 @@ const App = factory(function({ properties, middleware: { icache } }) {
 	return (
 		<virtual>
 			<CheckboxGroup
-				label="favourite names"
 				initialValue={['tom']}
 				name="initial-value"
 				options={[{ value: 'tom' }, { value: 'dick' }, { value: 'harry' }]}
 				onValue={(value) => {
 					set('initial-value', value);
 				}}
-			/>
+			>
+				{{
+					label: 'favourite names'
+				}}
+			</CheckboxGroup>
 			<pre>{`${get('initial-value')}`}</pre>
 		</virtual>
 	);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds `label` child renderer. Moves previous default child renderer to `checkboxes`.

Resolves #1264 
