### PR TITLE
Select: moved label to child renderer

### DIFF
--- a/src/examples/src/widgets/select/AdditionalText.tsx
+++ b/src/examples/src/widgets/select/AdditionalText.tsx
@@ -12,7 +12,6 @@ export default factory(function AdditionalText({ middleware: { icache } }) {
 	return (
 		<virtual>
 			<Select
-				label="Additional Text"
 				resource={resource}
 				transform={defaultTransform}
 				onValue={(value) => {
@@ -20,7 +19,11 @@ export default factory(function AdditionalText({ middleware: { icache } }) {
 				}}
 				helperText="I am the helper text"
 				placeholder="I am a placeholder"
-			/>
+			>
+				{{
+					label: 'Additional Text'
+				}}
+			</Select>
 			<pre>{`Value: ${icache.getOrSet('value', '')}`}</pre>
 		</virtual>
 	);

--- a/src/examples/src/widgets/select/Basic.tsx
+++ b/src/examples/src/widgets/select/Basic.tsx
@@ -16,13 +16,16 @@ export default factory(function Basic({ middleware: { icache } }) {
 	return (
 		<virtual>
 			<Select
-				label="Basic Select"
 				resource={resource}
 				transform={defaultTransform}
 				onValue={(value) => {
 					icache.set('value', value);
 				}}
-			/>
+			>
+				{{
+					label: 'Basic Select'
+				}}
+			</Select>
 			<pre>{icache.getOrSet('value', '')}</pre>
 		</virtual>
 	);

--- a/src/examples/src/widgets/select/CustomRenderer.tsx
+++ b/src/examples/src/widgets/select/CustomRenderer.tsx
@@ -12,7 +12,6 @@ export default factory(function CustomRenderer({ middleware: { icache } }) {
 	return (
 		<virtual>
 			<Select
-				label="Basic Select"
 				resource={{
 					resource: () => createResource(memoryTemplate),
 					data: options
@@ -22,13 +21,16 @@ export default factory(function CustomRenderer({ middleware: { icache } }) {
 					icache.set('value', value);
 				}}
 			>
-				{({ selected, value }) => {
-					return (
-						<div>
-							{selected && <span>✅ </span>}
-							{value}
-						</div>
-					);
+				{{
+					label: 'Basic Select',
+					itemRenderer: ({ selected, value }) => {
+						return (
+							<div>
+								{selected && <span>✅ </span>}
+								{value}
+							</div>
+						);
+					}
 				}}
 			</Select>
 			<pre>{icache.getOrSet('value', '')}</pre>

--- a/src/examples/src/widgets/select/CustomRenderer.tsx
+++ b/src/examples/src/widgets/select/CustomRenderer.tsx
@@ -23,7 +23,7 @@ export default factory(function CustomRenderer({ middleware: { icache } }) {
 			>
 				{{
 					label: 'Basic Select',
-					itemRenderer: ({ selected, value }) => {
+					items: ({ selected, value }) => {
 						return (
 							<div>
 								{selected && <span>✅ </span>}

--- a/src/examples/src/widgets/select/DisabledSelect.tsx
+++ b/src/examples/src/widgets/select/DisabledSelect.tsx
@@ -13,7 +13,6 @@ export default factory(function DisabledSelect() {
 	return (
 		<virtual>
 			<Select
-				label="Disabled Select"
 				resource={{
 					resource: () => createResource(memoryTemplate),
 					data: options
@@ -21,7 +20,11 @@ export default factory(function DisabledSelect() {
 				transform={defaultTransform}
 				disabled
 				onValue={() => {}}
-			/>
+			>
+				{{
+					label: 'Disabled Select'
+				}}
+			</Select>
 		</virtual>
 	);
 });

--- a/src/examples/src/widgets/select/RequiredSelect.tsx
+++ b/src/examples/src/widgets/select/RequiredSelect.tsx
@@ -13,7 +13,6 @@ export default factory(function RequiredSelect({ middleware: { icache } }) {
 	return (
 		<virtual>
 			<Select
-				label="Required Select"
 				resource={{
 					resource: () => createResource(memoryTemplate),
 					data: options
@@ -26,7 +25,11 @@ export default factory(function RequiredSelect({ middleware: { icache } }) {
 				onValidate={(valid) => {
 					icache.set('valid', valid);
 				}}
-			/>
+			>
+				{{
+					label: 'Required Select'
+				}}
+			</Select>
 			<pre>{`Value: ${icache.getOrSet('value', '')}, Valid: ${icache.get('valid')}`}</pre>
 		</virtual>
 	);

--- a/src/pagination/index.tsx
+++ b/src/pagination/index.tsx
@@ -188,7 +188,7 @@ export default factory(function Pagination({ middleware: { theme, icache, i18n }
 							}}
 						>
 							{{
-								itemRenderer: (itemProps) => itemProps.value
+								items: (itemProps) => itemProps.value
 							}}
 						</Select>
 					</div>

--- a/src/pagination/index.tsx
+++ b/src/pagination/index.tsx
@@ -187,7 +187,9 @@ export default factory(function Pagination({ middleware: { theme, icache, i18n }
 								onPageSize && onPageSize(parseInt(value, 10));
 							}}
 						>
-							{(itemProps) => itemProps.value}
+							{{
+								itemRenderer: (itemProps) => itemProps.value
+							}}
 						</Select>
 					</div>
 				)}

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -41,8 +41,6 @@ export interface SelectProperties {
 	disabled?: boolean;
 	/** Sets the helper text of the input */
 	helperText?: string;
-	/** The label to show */
-	label?: RenderResult;
 	/** Boolean to indicate if field is required */
 	required?: boolean;
 	/** Callabck when valid state has changed */
@@ -53,7 +51,9 @@ export interface SelectProperties {
 
 export interface SelectChildren {
 	/** Custom renderer for item contents */
-	(properties: ItemRendererProperties): RenderResult;
+	itemRenderer?(properties: ItemRendererProperties): RenderResult;
+	/** The label to show */
+	label?: RenderResult;
 }
 
 export const defaultTransform = listTransform;
@@ -86,7 +86,6 @@ export const Select = factory(function Select({
 		helperText,
 		initialValue,
 		itemsInView = 6,
-		label,
 		onValidate,
 		onValue,
 		placeholder = '',
@@ -96,7 +95,7 @@ export const Select = factory(function Select({
 		resource,
 		transform
 	} = properties();
-	const [itemRenderer] = children();
+	const { itemRenderer, label } = children()[0] || ({} as SelectChildren);
 
 	if (initialValue !== undefined && initialValue !== icache.get('initial')) {
 		icache.set('initial', initialValue);

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -51,7 +51,7 @@ export interface SelectProperties {
 
 export interface SelectChildren {
 	/** Custom renderer for item contents */
-	itemRenderer?(properties: ItemRendererProperties): RenderResult;
+	items?(properties: ItemRendererProperties): RenderResult;
 	/** The label to show */
 	label?: RenderResult;
 }
@@ -95,7 +95,7 @@ export const Select = factory(function Select({
 		resource,
 		transform
 	} = properties();
-	const [{ itemRenderer, label } = { itemRenderer: undefined, label: undefined }] = children();
+	const [{ items, label } = { items: undefined, label: undefined }] = children();
 
 	if (initialValue !== undefined && initialValue !== icache.get('initial')) {
 		icache.set('initial', initialValue);
@@ -256,7 +256,7 @@ export const Select = factory(function Select({
 									classes={classes}
 									widgetId={menuId}
 								>
-									{itemRenderer}
+									{items}
 								</List>
 							</div>
 						);

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -95,7 +95,7 @@ export const Select = factory(function Select({
 		resource,
 		transform
 	} = properties();
-	const { itemRenderer, label } = children()[0] || ({} as SelectChildren);
+	const [{ itemRenderer, label } = { itemRenderer: undefined, label: undefined }] = children();
 
 	if (initialValue !== undefined && initialValue !== icache.get('initial')) {
 		icache.set('initial', initialValue);

--- a/src/select/tests/Select.spec.tsx
+++ b/src/select/tests/Select.spec.tsx
@@ -120,9 +120,10 @@ describe('Select', () => {
 					position="above"
 					placeholder="test"
 					helperText="test-helper"
-					label="test-label"
 					required={true}
-				/>
+				>
+					{{ label: 'test-label' }}
+				</Select>
 			),
 			[compareForId]
 		);

--- a/src/select/tests/Select.spec.tsx
+++ b/src/select/tests/Select.spec.tsx
@@ -22,8 +22,10 @@ import { createResource } from '@dojo/framework/core/resource';
 import TriggerPopup from '../../trigger-popup';
 import * as css from '../../theme/default/select.m.css';
 import Select, { defaultTransform } from '../index';
+import bundle from '../select.nls';
 
 const options = [{ value: 'dog' }, { value: 'cat' }, { value: 'fish' }];
+const { messages } = bundle;
 
 const memoryTemplate = createMemoryTemplate();
 
@@ -346,5 +348,38 @@ describe('Select', () => {
 			]),
 			() => triggerRenderResult
 		);
+	});
+
+	it('invalidates correctly', () => {
+		const onValidate = stub();
+		const h = harness(() => (
+			<Select
+				onValue={() => {}}
+				resource={{
+					resource: () => createResource(memoryTemplate),
+					data: options
+				}}
+				transform={defaultTransform}
+				required={true}
+				onValidate={onValidate}
+			/>
+		));
+		h.expect(baseTemplate);
+
+		h.trigger('@popup', 'onClose');
+		h.expect(
+			baseTemplate
+				.setProperty(':root', 'classes', [
+					undefined,
+					css.root,
+					undefined,
+					false,
+					css.invalid
+				])
+				.setProperty('@helperText', 'text', messages.requiredMessage)
+				.setProperty('@helperText', 'valid', false)
+		);
+
+		assert.isTrue(onValidate.calledWith(false));
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Moves `label` from property to child renderer

Resolves #1266
