### PR TITLE
Run TSC before dev

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "url": "https://github.com/dojo/widgets.git"
   },
   "scripts": {
-    "dev": "dojo build app -m dev -w -s",
+    "dev": "tsc && dojo build app -m dev -w -s",
     "prettier": "prettier --write \"src/**/*.{ts,tsx,css}\"",
     "dojo-package": "dojo-package",
     "dojo-release": "dojo-release",


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR adds TSC call before dev so that type errors can be caught when running the dev command. 
This will not work on file changes ie. in watch mode.