### PR TITLE
Update RangeSlider to use child renderers

### DIFF
--- a/src/examples/src/widgets/range-slider/Labelled.tsx
+++ b/src/examples/src/widgets/range-slider/Labelled.tsx
@@ -10,7 +10,8 @@ export default factory(function LabelledRangeSlider() {
 				min: 0,
 				max: 100
 			}}
-			label="A Labelled Slider"
-		/>
+		>
+			{{ label: 'A Labelled Slider' }}
+		</RangeSlider>
 	);
 });

--- a/src/examples/src/widgets/range-slider/Required.tsx
+++ b/src/examples/src/widgets/range-slider/Required.tsx
@@ -10,8 +10,9 @@ export default factory(function RequiredRangeSlider() {
 				min: 0,
 				max: 100
 			}}
-			label="A Required Slider"
 			required
-		/>
+		>
+			{{ label: 'A Required Slider' }}
+		</RangeSlider>
 	);
 });

--- a/src/range-slider/index.tsx
+++ b/src/range-slider/index.tsx
@@ -5,7 +5,7 @@ import Label from '../label/index';
 import dimensions from '@dojo/framework/core/middleware/dimensions';
 import focus from '@dojo/framework/core/middleware/focus';
 import theme from '@dojo/framework/core/middleware/theme';
-import { DNode } from '@dojo/framework/core/interfaces';
+import { RenderResult } from '@dojo/framework/core/interfaces';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { formatAriaProperties } from '../common/util';
@@ -17,8 +17,6 @@ export interface RangeSliderProperties {
 	aria?: { [key: string]: string | null };
 	/** Set the disabled property of the control */
 	disabled?: boolean;
-	/** Adds a <label> element with the supplied text */
-	label?: string;
 	/** Hides the label from view while still remaining accessible for screen readers */
 	labelHidden?: boolean;
 	/** The maximum value allowed */
@@ -45,8 +43,6 @@ export interface RangeSliderProperties {
 	onOver?(): void;
 	/** Handler for when the value of the widget changes */
 	onValue?(value: RangeValue): void;
-	/** A renderer used to display the output values (min, max) */
-	output?(value: RangeValue): DNode;
 	/** If the rendered output should be displayed as a tooltip */
 	outputIsTooltip?: boolean;
 	/** Makes the slider readonly (it may be focused but not changed) */
@@ -65,6 +61,13 @@ export interface RangeSliderProperties {
 	widgetId?: string;
 }
 
+export interface RangeSliderChildren {
+	/** Adds a <label> element with the supplied text */
+	label?: RenderResult;
+	/** A renderer used to display the output values (min, max) */
+	output?(value: RangeValue): RenderResult;
+}
+
 export interface RangeSliderICache {
 	initialValue?: RangeValue;
 	value?: RangeValue;
@@ -75,20 +78,23 @@ const factory = create({
 	focus,
 	icache: createICacheMiddleware<RangeSliderICache>(),
 	theme
-}).properties<RangeSliderProperties>();
+})
+	.properties<RangeSliderProperties>()
+	.children<RangeSliderChildren | undefined>();
 
 export const RangeSlider = factory(function RangeSlider({
+	children,
 	id,
 	middleware: { dimensions, focus, icache, theme },
 	properties
 }) {
 	const { name = '', max: maxRestraint = 100, min: minRestraint = 0 } = properties();
 
+	const [{ label, output } = {} as RangeSliderChildren] = children();
 	const {
 		aria = {},
 		classes,
 		disabled,
-		label,
 		labelHidden,
 		maxName = `${name}_max`,
 		maximumLabel = 'Maximum',
@@ -99,7 +105,6 @@ export const RangeSlider = factory(function RangeSlider({
 		onOut,
 		onOver,
 		onValue,
-		output,
 		outputIsTooltip,
 		readOnly,
 		required,

--- a/src/range-slider/tests/unit/RangeSlider.spec.tsx
+++ b/src/range-slider/tests/unit/RangeSlider.spec.tsx
@@ -117,8 +117,8 @@ describe('RangeSlider', () => {
 	});
 
 	it('renders a label', () => {
-		const h = harness(() => <RangeSlider label="label" />);
-		const testTemplate = template.prepend('@root', [
+		const h = harness(() => <RangeSlider>{{ label: 'label' }}</RangeSlider>);
+		const testTemplate = template.prepend('@root', () => [
 			<Label
 				classes={undefined}
 				disabled={undefined}
@@ -163,7 +163,7 @@ describe('RangeSlider', () => {
 				null,
 				themeCss.hasOutput
 			])
-			.insertAfter('@rightThumb', [
+			.insertAfter('@rightThumb', () => [
 				<output
 					classes={[themeCss.output, null]}
 					for="range-slider-test"
@@ -189,7 +189,7 @@ describe('RangeSlider', () => {
 				null,
 				themeCss.hasOutput
 			])
-			.insertAfter('@rightThumb', [
+			.insertAfter('@rightThumb', () => [
 				<output
 					classes={[themeCss.output, themeCss.outputTooltip]}
 					for="range-slider-test"


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #1265 

Remove the `label` and `output` properties from `RangeSlider` in favor of specifying them as children.
