### PR TITLE
Adding dialog widget migration guide (#1246)

### DIFF
--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -167,19 +167,25 @@ Latest example can be found on [widgets.dojo.io/#widget/checkbox/overview](https
 ### dialog
 
 #### Property changes
-##### Additional Mandatory Properties
-- foo: string
-	- this prop does x
+
 ##### Changed properties
-- bar: string
-	- this prop replaced x
-	- this prop does foo bar baz
-	- more info
+- title
+  - Title is now specified in the child function and not passed as a property.
+- modal
+  - The modal property is now only valid when role="dialog"
 ##### Removed properties
-- baz: string
-	- replaced by foo
-	- any additional info
+- underlayEnterAnimation
+	- Replaced by themeing `underlayEnter` class.
+- underlayExitAnimation
+  - Replaced by themeing `underlayExit` class.
+- enterAnimation
+  - Replaced by themeing `enter` class
+- exitAnimation
+  - Replaced by themeing `exit` class
 #### Changes in behaviour
+
+Dialog contents, title, and actions are now specified via a child function. Previously, the title was specified via a property and the dialog contents where passed as the children of the Dialog. Dialog actions are nodes that appear below the dialog contents, like cancel / ok buttons.
+
 #### Example of migration from v6 to v7
 
 Latest example can be found on [widgets.dojo.io/#widget/dialog/overview](https://widgets.dojo.io/#widget/dialog/overview)


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Migration guide for Dialog widget

Related to #1246 
