### PR TITLE
Theme compose and Password input fixes

### DIFF
--- a/src/middleware/tests/theme.spec.tsx
+++ b/src/middleware/tests/theme.spec.tsx
@@ -442,4 +442,104 @@ describe('theme middleware', () => {
 			}
 		});
 	});
+
+	it('should work with theme variants', () => {
+		const baseClasses = {
+			' _key': '@dojo/widgets/Base',
+			root: 'base_root',
+			selected: 'base_selected',
+			active: 'base_active'
+		};
+
+		const variantClasses = {
+			' _key': '@dojo/widgets/Variant',
+			active: 'variant_active',
+			extra: 'variant_extra'
+		};
+
+		properties.theme = {
+			theme: {
+				'@dojo/widgets/Base': {
+					root: 'base_theme_root'
+				},
+				'@dojo/widgets/Variant': {
+					extra: 'variant_theme_extra',
+					selected: 'variant_theme_selected'
+				}
+			},
+			variant: {
+				default: { root: 'foo' }
+			}
+		};
+
+		const composedClasses = composesInstance.compose(
+			baseClasses,
+			variantClasses
+		);
+		assert.deepEqual(composedClasses, {
+			theme: {
+				'@dojo/widgets/Base': {
+					root: 'base_theme_root',
+					selected: 'variant_theme_selected',
+					active: 'variant_active'
+				},
+				'@dojo/widgets/Variant': {
+					extra: 'variant_theme_extra',
+					selected: 'variant_theme_selected'
+				}
+			},
+			variant: {
+				default: { root: 'foo' }
+			}
+		});
+	});
+
+	it('should work with theme with variant and prefix', () => {
+		const baseClasses = {
+			' _key': '@dojo/widgets/Base',
+			root: 'base_root',
+			selected: 'base_selected',
+			active: 'base_active'
+		};
+
+		const variantClasses = {
+			' _key': '@dojo/widgets/Variant',
+			baseActive: 'variant_active'
+		};
+
+		properties.theme = {
+			theme: {
+				'@dojo/widgets/Base': {
+					active: 'base_theme_active'
+				},
+				'@dojo/widgets/Variant': {
+					baseActive: 'variant_theme_active'
+				}
+			},
+			variant: {
+				default: { root: 'foo' }
+			}
+		};
+
+		const composedClasses = composesInstance.compose(
+			baseClasses,
+			variantClasses,
+			'base'
+		);
+		assert.deepEqual(composedClasses, {
+			theme: {
+				'@dojo/widgets/Base': {
+					root: 'base_root',
+					selected: 'base_selected',
+					active: 'variant_theme_active'
+				},
+				'@dojo/widgets/Variant': {
+					baseActive: 'variant_theme_active'
+				}
+			},
+			variant: {
+				default: { root: 'foo' }
+			}
+		});
+	});
 });

--- a/src/middleware/theme.tsx
+++ b/src/middleware/theme.tsx
@@ -3,7 +3,7 @@ import coreTheme, {
 	ThemeProperties as CoreThemeProperties
 } from '@dojo/framework/core/middleware/theme';
 import { ClassNames, Theme } from '@dojo/framework/core/mixins/Themed';
-import { ThemeWithVariant } from '@dojo/framework/core/interfaces';
+import { ThemeWithVariant, ThemeWithVariants } from '@dojo/framework/core/interfaces';
 
 const factory = create({ coreTheme });
 export const THEME_KEY = ' _key';
@@ -14,6 +14,10 @@ function uppercaseFirstChar(value: string) {
 
 function lowercaseFirstChar(value: string) {
 	return `${value.charAt(0).toLowerCase()}${value.slice(1)}`;
+}
+
+function isThemeWithVariant(theme: any): theme is ThemeWithVariant {
+	return theme && theme.hasOwnProperty('variant');
 }
 
 export interface ThemeProperties extends CoreThemeProperties {}
@@ -69,6 +73,17 @@ export const theme = factory(function({ middleware: { coreTheme }, properties })
 					{} as ClassNames
 				);
 				baseTheme = { ...baseTheme, ...prefixedCss };
+
+				if (isThemeWithVariant(theme)) {
+					return {
+						theme: {
+							...theme.theme,
+							[baseKey]: baseTheme
+						},
+						variant: theme.variant
+					};
+				}
+
 				return {
 					...theme,
 					[baseKey]: baseTheme
@@ -90,6 +105,17 @@ export const theme = factory(function({ middleware: { coreTheme }, properties })
 				},
 				{ ...baseTheme } as ClassNames
 			);
+
+			if (isThemeWithVariant(theme)) {
+				return {
+					theme: {
+						...theme.theme,
+						[baseKey]: constructedTheme
+					},
+					variant: theme.variant
+				};
+			}
+
 			return {
 				...theme,
 				[baseKey]: constructedTheme

--- a/src/middleware/theme.tsx
+++ b/src/middleware/theme.tsx
@@ -3,7 +3,7 @@ import coreTheme, {
 	ThemeProperties as CoreThemeProperties
 } from '@dojo/framework/core/middleware/theme';
 import { ClassNames, Theme } from '@dojo/framework/core/mixins/Themed';
-import { ThemeWithVariant, ThemeWithVariants } from '@dojo/framework/core/interfaces';
+import { ThemeWithVariant } from '@dojo/framework/core/interfaces';
 
 const factory = create({ coreTheme });
 export const THEME_KEY = ' _key';

--- a/src/theme/default/index.ts
+++ b/src/theme/default/index.ts
@@ -8,6 +8,7 @@ import * as checkbox from './checkbox.m.css';
 import * as checkboxGroup from './checkbox-group.m.css';
 import * as chip from './chip.m.css';
 import * as constrainedInput from './constrained-input.m.css';
+import * as dateInput from './date-input.m.css';
 import * as dialog from './dialog.m.css';
 import * as emailInput from './email-input.m.css';
 import * as grid from './grid.m.css';
@@ -60,6 +61,7 @@ export default {
 		'@dojo/widgets/checkbox-group': checkboxGroup,
 		'@dojo/widgets/chip': chip,
 		'@dojo/widgets/constrained-input': constrainedInput,
+		'@dojo/widgets/date-input': dateInput,
 		'@dojo/widgets/dialog': dialog,
 		'@dojo/widgets/email-input': emailInput,
 		'@dojo/widgets/grid-body': gridBody,
@@ -79,7 +81,7 @@ export default {
 		'@dojo/widgets/native-select': nativeSelect,
 		'@dojo/widgets/list-item': listItem,
 		'@dojo/widgets/outlined-button': outlinedButton,
-		'@dojo/widget/password-input': passwordInput,
+		'@dojo/widgets/password-input': passwordInput,
 		'@dojo/widgets/popup': popup,
 		'@dojo/widgets/progress': progress,
 		'@dojo/widgets/radio': radio,


### PR DESCRIPTION
**Type:** bug 

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixes password-input styles by fixing theme.compose to work properly with theme variants.

Resolves https://github.com/dojo/widgets/issues/1313
