### PR TITLE
Update migration guide for TextArea and TextInput

### DIFF
--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -745,20 +745,22 @@ Latest example can be found on [widgets.dojo.io/#widget/tab-controller/overview]
 ### text-area
 
 #### Property changes
-##### Additional Mandatory Properties
-- foo: string
-	- this prop does x
-##### Changed properties
-- bar: string
-	- this prop replaced x
-	- this prop does foo bar baz
-	- more info
 ##### Removed properties
-- baz: string
-	- replaced by foo
-	- any additional info
-#### Changes in behaviour
+- `label`: string
+	- `<TextArea>` now takes an optional child that will be rendered as its label.
 #### Example of migration from v6 to v7
+
+##### v6 example
+
+```tsx
+<TextArea label="Textarea with label" />
+```
+
+##### v7 example
+
+```tsx
+<TextArea>Textarea with label</TextArea>
+```
 
 Latest example can be found on [widgets.dojo.io/#widget/text-area/overview](https://widgets.dojo.io/#widget/text-area/overview)
 
@@ -766,20 +768,40 @@ Latest example can be found on [widgets.dojo.io/#widget/text-area/overview](http
 ### text-input
 
 #### Property changes
-##### Additional Mandatory Properties
-- foo: string
-	- this prop does x
-##### Changed properties
-- bar: string
-	- this prop replaced x
-	- this prop does foo bar baz
-	- more info
 ##### Removed properties
-- baz: string
-	- replaced by foo
-	- any additional info
-#### Changes in behaviour
+- `label`: string
+	- Specifying a label is now done with a `label` key on a child renderer object (see the example below)
+- `leading`: () => DNode
+	- Specifying leading content is now done with a `leading` key on a child renderer object (see the example below)
+	- Since the original property function receives no arguments, the child renderer object expects a static value instead of a function.
+- `trailing`: () => DNode
+	- Specifying trailing content is now done with a `trailing` key on a child renderer object (see the example below)
+	- Since the original property function receives no arguments, the child renderer object expects a static value instead of a function.
 #### Example of migration from v6 to v7
+
+##### v6 example
+
+```tsx
+<TextInput
+	type="text"
+	label="Input Label"
+	value="Initial value"
+	leading={() => <span>A</span>}
+	trailing={() => <span>Z</span>}
+/>
+```
+
+##### v7 example
+
+```tsx
+<TextInput type="text" value="Initial value">
+	{{
+		label: 'Input Label',
+		leading: <span>A</span>,
+		trailing: <span>Z</span>
+	}}
+</TextInput>
+```
 
 Latest example can be found on [widgets.dojo.io/#widget/text-input/overview](https://widgets.dojo.io/#widget/text-input/overview)
 

--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -746,8 +746,13 @@ Latest example can be found on [widgets.dojo.io/#widget/tab-controller/overview]
 
 #### Property changes
 ##### Removed properties
-- `label`: string
+- `label`: `string`
 	- `<TextArea>` now takes an optional child that will be rendered as its label.
+- `value`: `string`
+	- Removed as the widget is now uncontrolled.
+	- Replaced by `initialValue: string` for setting the initial value.
+#### Changes in behavior
+- `TextArea` is now uncontrolled, meaning parent widgets are no longer responsible for updating the the current value in response to changes or events.
 #### Example of migration from v6 to v7
 
 ##### v6 example
@@ -769,14 +774,19 @@ Latest example can be found on [widgets.dojo.io/#widget/text-area/overview](http
 
 #### Property changes
 ##### Removed properties
-- `label`: string
+- `label`: `string`
 	- Specifying a label is now done with a `label` key on a child renderer object (see the example below)
-- `leading`: () => DNode
+- `leading`: `() => DNode`
 	- Specifying leading content is now done with a `leading` key on a child renderer object (see the example below)
 	- Since the original property function receives no arguments, the child renderer object expects a static value instead of a function.
-- `trailing`: () => DNode
+- `trailing`: `() => DNode`
 	- Specifying trailing content is now done with a `trailing` key on a child renderer object (see the example below)
 	- Since the original property function receives no arguments, the child renderer object expects a static value instead of a function.
+- `value`: `string`
+	- Removed as the widget is now uncontrolled.
+	- Replaced by `initialValue: string` for setting the initial value.
+#### Changes in behavior
+- `TextInput` is now uncontrolled, meaning parent widgets are no longer responsible for updating the the current value in response to changes or events.
 #### Example of migration from v6 to v7
 
 ##### v6 example


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Continues #1247 
