### PR TITLE
Pagination: automatically remove sibling links as space permits

### DIFF
--- a/src/examples/src/widgets/pagination/SiblingCount.tsx
+++ b/src/examples/src/widgets/pagination/SiblingCount.tsx
@@ -17,7 +17,7 @@ const Example = factory(function Example({ middleware: { icache } }) {
 			<Pagination
 				initialPage={8}
 				total={25}
-				siblingCount={5}
+				siblingCount={2}
 				onPage={(value) => {
 					icache.set('currentPage', value);
 				}}

--- a/src/pagination/index.tsx
+++ b/src/pagination/index.tsx
@@ -1,9 +1,12 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
+import renderer, { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import i18n from '@dojo/framework/core/middleware/i18n';
 import theme from '@dojo/framework/core/middleware/theme';
-import { WNode } from '@dojo/framework/core/interfaces';
-import { createResource, DataTemplate } from '@dojo/framework/core/resource';
+import dimensions from '@dojo/framework/core/middleware/dimensions';
+import resize from '@dojo/framework/core/middleware/resize';
+import { RenderResult } from '@dojo/framework/core/interfaces';
+import { Resource } from '@dojo/framework/core/resource';
+import global from '@dojo/framework/shim/global';
 
 import Icon from '../icon';
 import Select, { defaultTransform } from '../select';
@@ -11,18 +14,7 @@ import { ListOption } from '../list';
 
 import bundle from './Pagination.nls';
 import * as css from '../theme/default/pagination.m.css';
-
-function createMemoryTemplate<S = void>(): DataTemplate<S> {
-	return {
-		read: (_, put, get) => {
-			let data: any[] = get();
-			put(0, data);
-			return { data, total: data.length };
-		}
-	};
-}
-
-const memoryTemplate = createMemoryTemplate();
+import { createMemoryResourceWithData } from '../examples/src/widgets/list/memoryTemplate';
 
 export interface PaginationProperties {
 	/** The initial page number */
@@ -53,20 +45,27 @@ interface PaginationCache {
 	currentPage: number;
 	pageSize: number;
 	pageSizes: number[];
-	pageSizesData: ListOption[];
+	pageSizesResource: { resource: () => Resource; data: ListOption[] };
 }
 
 const icache = createICacheMiddleware<PaginationCache>();
-const factory = create({ theme, icache, i18n }).properties<PaginationProperties>();
+const factory = create({ theme, icache, i18n, dimensions, resize }).properties<
+	PaginationProperties
+>();
 
-export default factory(function Pagination({ middleware: { theme, icache, i18n }, properties }) {
+export default factory(function Pagination({
+	middleware: { theme, icache, i18n, dimensions, resize },
+	properties
+}) {
+	resize.get('root');
+
 	const {
 		initialPage,
 		initialPageSize,
 		onPage,
 		onPageSize,
 		pageSizes,
-		siblingCount = 3,
+		siblingCount,
 		total
 	} = properties();
 	const classes = theme.classes(css);
@@ -84,105 +83,167 @@ export default factory(function Pagination({ middleware: { theme, icache, i18n }
 
 	if (pageSizes !== undefined && pageSizes !== icache.get('pageSizes')) {
 		icache.set('pageSizes', pageSizes);
-		icache.set('pageSizesData', pageSizes.map((ps) => ({ value: ps.toString() })));
+		icache.set(
+			'pageSizesResource',
+			createMemoryResourceWithData(pageSizes.map((ps) => ({ value: ps.toString() })))
+		);
 	}
 
 	const page = icache.getOrSet('currentPage', 1);
 	const pageSize = icache.getOrSet('pageSize', 10);
-	const pageSizesData = icache.get('pageSizesData');
+	const pageSizesResource = icache.get('pageSizesResource');
 
-	const leading: WNode[] = [];
-	const leadingCount = Math.min(siblingCount, page - 1);
-	for (let i = 1; i <= leadingCount; i++) {
-		const linkTo = page - i;
+	const getRenderedWidth = (dnode: RenderResult) => {
+		if (dnode === undefined) {
+			return 0;
+		}
 
-		leading.unshift(
+		const r = renderer(() => dnode);
+		const div = global.document.createElement('div');
+		div.className = theme.variant() || '';
+		div.style.position = 'absolute';
+		global.document.body.appendChild(div);
+		r.mount({ domNode: div, sync: true });
+		const dimensions = div.getBoundingClientRect();
+		global.document.body.removeChild(div);
+		return dimensions.width;
+	};
+
+	// If provided, use `siblingCount` as an upper bound for sibling links
+	const leadingCount = siblingCount ? Math.min(siblingCount, page - 1) : page - 1;
+	const trailingCount = siblingCount ? Math.min(siblingCount, total - page) : total - page;
+
+	const prevLink = leadingCount ? (
+		<button
+			type="button"
+			key="prev"
+			classes={[classes.prev, classes.link]}
+			onclick={(e) => {
+				e.stopPropagation();
+				icache.set('currentPage', page - 1);
+				onPage && onPage(page - 1);
+			}}
+		>
+			<div classes={classes.icon}>
+				<Icon type="leftIcon" />
+			</div>
+			<div classes={classes.label}>{messages.previous}</div>
+		</button>
+	) : (
+		undefined
+	);
+
+	const nextLink = trailingCount ? (
+		<button
+			type="button"
+			key="next"
+			classes={[classes.next, classes.link]}
+			onclick={(e) => {
+				e.stopPropagation();
+				icache.set('currentPage', page + 1);
+				onPage && onPage(page + 1);
+			}}
+		>
+			<div classes={classes.icon}>
+				<Icon type="rightIcon" />
+			</div>
+			<div classes={classes.label}>{messages.next}</div>
+		</button>
+	) : (
+		undefined
+	);
+
+	const leadingSiblings: RenderResult[] = [];
+	const trailingSiblings: RenderResult[] = [];
+	const containerWidth = dimensions.get('links').size.width;
+	let containerStyles: Partial<CSSStyleDeclaration> = {
+		opacity: containerWidth ? '1' : '0'
+	};
+
+	const current = (
+		<div key="current" classes={classes.currentPage}>
+			{page.toString()}
+		</div>
+	);
+
+	let availableWidth =
+		containerWidth -
+		getRenderedWidth(prevLink) -
+		getRenderedWidth(current) -
+		getRenderedWidth(nextLink);
+
+	for (let i = 1; i <= Math.max(leadingCount, trailingCount); i++) {
+		const leadingSibling = (
 			<button
 				type="button"
-				key={`numberedLink-${linkTo}`}
+				key={`numberedLink-${page - i}`}
 				classes={[classes.numberedLink, classes.link]}
 				onclick={(e) => {
 					e.stopPropagation();
-					icache.set('currentPage', linkTo);
-					onPage && onPage(linkTo);
+					icache.set('currentPage', page - i);
+					onPage && onPage(page - i);
 				}}
 			>
-				{linkTo.toString()}
+				{(page - i).toString()}
 			</button>
 		);
-	}
 
-	const trailing: WNode[] = [];
-	const trailingCount = Math.min(siblingCount, total - page);
-	for (let i = 1; i <= trailingCount; i++) {
-		const linkTo = page + i;
-
-		trailing.push(
+		const trailingSibling = (
 			<button
 				type="button"
-				key={`numberedLink-${linkTo}`}
+				key={`numberedLink-${page + i}`}
 				classes={[classes.numberedLink, classes.link]}
 				onclick={(e) => {
 					e.stopPropagation();
-					icache.set('currentPage', linkTo);
-					onPage && onPage(linkTo);
+					icache.set('currentPage', page + i);
+					onPage && onPage(page + i);
 				}}
 			>
-				{linkTo.toString()}
+				{(page + i).toString()}
 			</button>
 		);
+
+		let widthNeeded = 0;
+		if (i <= leadingCount) {
+			widthNeeded += getRenderedWidth(leadingSibling);
+		}
+
+		if (i <= trailingCount) {
+			widthNeeded += getRenderedWidth(trailingSibling);
+		}
+
+		if (containerWidth === 0 || availableWidth - widthNeeded >= 0) {
+			if (i <= leadingCount) {
+				leadingSiblings.unshift(leadingSibling);
+			}
+
+			if (i <= trailingCount) {
+				trailingSiblings.push(trailingSibling);
+			}
+
+			availableWidth -= widthNeeded;
+		} else {
+			break;
+		}
 	}
 
 	return (
 		total > 1 && (
 			<div key="root" classes={[theme.variant(), classes.root]}>
-				{leadingCount && (
-					<button
-						type="button"
-						key="prev"
-						classes={[classes.prev, classes.link]}
-						onclick={(e) => {
-							e.stopPropagation();
-							icache.set('currentPage', page - 1);
-							onPage && onPage(page - 1);
-						}}
-					>
-						<div classes={classes.icon}>
-							<Icon type="leftIcon" />
-						</div>
-						<div classes={classes.label}>{messages.previous}</div>
-					</button>
-				)}
-				{...leading}
-				<div classes={classes.currentPage}>{page.toString()}</div>
-				{...trailing}
-				{trailingCount && (
-					<button
-						type="button"
-						key="next"
-						classes={[classes.next, classes.link]}
-						onclick={(e) => {
-							e.stopPropagation();
-							icache.set('currentPage', page + 1);
-							onPage && onPage(page + 1);
-						}}
-					>
-						<div classes={classes.icon}>
-							<Icon type="rightIcon" />
-						</div>
-						<div classes={classes.label}>{messages.next}</div>
-					</button>
-				)}
-				{pageSizesData && pageSizesData.length > 0 && (
+				<div key="links" classes={classes.linksWrapper} styles={containerStyles}>
+					{prevLink}
+					{...leadingSiblings}
+					{current}
+					{...trailingSiblings}
+					{nextLink}
+				</div>
+				{pageSizes && pageSizes.length > 0 && pageSizesResource && (
 					<div classes={classes.selectWrapper}>
 						<Select
 							key="page-size-select"
-							transform={defaultTransform}
 							initialValue={pageSize.toString()}
-							resource={{
-								resource: () => createResource(memoryTemplate),
-								data: pageSizesData
-							}}
+							resource={pageSizesResource}
+							transform={defaultTransform}
 							onValue={(value) => {
 								onPageSize && onPageSize(parseInt(value, 10));
 							}}

--- a/src/pagination/index.tsx
+++ b/src/pagination/index.tsx
@@ -5,7 +5,12 @@ import theme from '@dojo/framework/core/middleware/theme';
 import dimensions from '@dojo/framework/core/middleware/dimensions';
 import resize from '@dojo/framework/core/middleware/resize';
 import { RenderResult } from '@dojo/framework/core/interfaces';
-import { Resource } from '@dojo/framework/core/resource';
+import {
+	Resource,
+	createResource,
+	ResourceQuery,
+	DataTemplate
+} from '@dojo/framework/core/resource';
 import global from '@dojo/framework/shim/global';
 
 import Icon from '../icon';
@@ -14,7 +19,28 @@ import { ListOption } from '../list';
 
 import bundle from './Pagination.nls';
 import * as css from '../theme/default/pagination.m.css';
-import { createMemoryResourceWithData } from '../examples/src/widgets/list/memoryTemplate';
+
+export function createMemoryTemplate<S = void>({
+	filter
+}: { filter?: (query: ResourceQuery[], v: S) => boolean } = {}): DataTemplate<S> {
+	return {
+		read: ({ query }, put, get) => {
+			let data: any[] = get();
+			const filteredData = filter && query ? data.filter((i) => filter(query, i)) : data;
+			put(0, filteredData);
+			return { data: filteredData, total: filteredData.length };
+		}
+	};
+}
+
+export function createMemoryResourceWithData<S = any>(data: S[]) {
+	const memoryTemplate = createMemoryTemplate<S>();
+
+	return {
+		resource: () => createResource(memoryTemplate),
+		data
+	};
+}
 
 export interface PaginationProperties {
 	/** The initial page number */
@@ -32,7 +58,7 @@ export interface PaginationProperties {
 	/** Page size options to display in the page size selector */
 	pageSizes?: number[];
 
-	/** Number of always visible page links before and after the current page */
+	/** Number of always visible page links before and after the current page. When unset, siblings will be added to consume the available space. */
 	siblingCount?: number;
 
 	/** Total number of pages */

--- a/src/pagination/tests/Pagination.spec.tsx
+++ b/src/pagination/tests/Pagination.spec.tsx
@@ -1,15 +1,20 @@
-const { describe, it } = intern.getInterface('bdd');
+const { describe, it, before, after } = intern.getInterface('bdd');
 
 import * as sinon from 'sinon';
 
-import { tsx } from '@dojo/framework/core/vdom';
+import { tsx, node } from '@dojo/framework/core/vdom';
+import global from '@dojo/framework/shim/global';
 import harness from '@dojo/framework/testing/harness';
-
+import resize from '@dojo/framework/core/middleware/resize';
+import { createResizeMock } from '@dojo/framework/testing/mocks/middleware/resize';
+import createNodeMock from '@dojo/framework/testing/mocks/middleware/node';
 import assertionTemplate from '@dojo/framework/testing/assertionTemplate';
+
 import { stubEvent } from '../../common/tests/support/test-helpers';
 
 import Icon from '../../icon';
 import Select, { defaultTransform } from '../../select';
+
 import Pagination from '..';
 import * as css from '../../theme/default/pagination.m.css';
 import bundle from '../Pagination.nls';
@@ -19,69 +24,46 @@ const { messages } = bundle;
 describe('Pagination', () => {
 	const noop = () => {};
 
+	const makeLinks = (start: number, end: number) => {
+		const links = [];
+
+		for (let i = start; i <= end; i++) {
+			links.push(
+				<button
+					key={`numberedLink-${i}`}
+					type="button"
+					onclick={noop}
+					classes={[css.numberedLink, css.link]}
+				>
+					{i.toString()}
+				</button>
+			);
+		}
+
+		return links;
+	};
+
 	const baseAssertion = assertionTemplate(() => (
 		<div key="root" classes={[undefined, css.root]}>
-			<button key="prev" type="button" onclick={noop} classes={[css.prev, css.link]}>
-				<div classes={css.icon}>
-					<Icon type="leftIcon" />
+			<div key="links" classes={css.linksWrapper} styles={{ opacity: '0' }}>
+				<button key="prev" type="button" onclick={noop} classes={[css.prev, css.link]}>
+					<div classes={css.icon}>
+						<Icon type="leftIcon" />
+					</div>
+					<div classes={css.label}>{messages.previous}</div>
+				</button>
+				{...makeLinks(1, 9)}
+				<div key="current" classes={css.currentPage}>
+					10
 				</div>
-				<div classes={css.label}>{messages.previous}</div>
-			</button>
-			<button
-				key="numberedLink-7"
-				type="button"
-				onclick={noop}
-				classes={[css.numberedLink, css.link]}
-			>
-				7
-			</button>
-			<button
-				key="numberedLink-8"
-				type="button"
-				onclick={noop}
-				classes={[css.numberedLink, css.link]}
-			>
-				8
-			</button>
-			<button
-				key="numberedLink-9"
-				type="button"
-				onclick={noop}
-				classes={[css.numberedLink, css.link]}
-			>
-				9
-			</button>
-			<div classes={css.currentPage}>10</div>
-			<button
-				key="numberedLink-11"
-				type="button"
-				onclick={noop}
-				classes={[css.numberedLink, css.link]}
-			>
-				11
-			</button>
-			<button
-				key="numberedLink-12"
-				type="button"
-				onclick={noop}
-				classes={[css.numberedLink, css.link]}
-			>
-				12
-			</button>
-			<button
-				key="numberedLink-13"
-				type="button"
-				onclick={noop}
-				classes={[css.numberedLink, css.link]}
-			>
-				13
-			</button>
-			<button key="next" type="button" onclick={noop} classes={[css.next, css.link]}>
-				<div classes={css.icon}>
-					<Icon type="rightIcon" />
-				</div>
-				<div classes={css.label}>{messages.next}</div>
-			</button>
+				{...makeLinks(11, 20)}
+				<button key="next" type="button" onclick={noop} classes={[css.next, css.link]}>
+					<div classes={css.icon}>
+						<Icon type="rightIcon" />
+					</div>
+					<div classes={css.label}>{messages.next}</div>
+				</button>
+			</div>
 		</div>
 	));
 
@@ -152,29 +134,23 @@ describe('Pagination', () => {
 		h.expect(
 			assertionTemplate(() => (
 				<div key="root" classes={[undefined, css.root]}>
-					<div classes={css.currentPage}>1</div>
-					<button
-						key="numberedLink-2"
-						type="button"
-						onclick={noop}
-						classes={[css.numberedLink, css.link]}
-					>
-						2
-					</button>
-					<button
-						key="numberedLink-3"
-						type="button"
-						onclick={noop}
-						classes={[css.numberedLink, css.link]}
-					>
-						3
-					</button>
-					<button key="next" type="button" onclick={noop} classes={[css.next, css.link]}>
-						<div classes={css.icon}>
-							<Icon type="rightIcon" />
+					<div key="links" classes={css.linksWrapper} styles={{ opacity: '0' }}>
+						<div key="current" classes={css.currentPage}>
+							1
 						</div>
-						<div classes={css.label}>Next</div>
-					</button>
+						{...makeLinks(2, 3)}
+						<button
+							key="next"
+							type="button"
+							onclick={noop}
+							classes={[css.next, css.link]}
+						>
+							<div classes={css.icon}>
+								<Icon type="rightIcon" />
+							</div>
+							<div classes={css.label}>Next</div>
+						</button>
+					</div>
 				</div>
 			))
 		);
@@ -185,35 +161,24 @@ describe('Pagination', () => {
 		h.expect(
 			assertionTemplate(() => (
 				<div key="root" classes={[undefined, css.root]}>
-					<button
-						assertion-key="prev"
-						key="prev"
-						type="button"
-						onclick={noop}
-						classes={[css.prev, css.link]}
-					>
-						<div classes={css.icon}>
-							<Icon type="leftIcon" />
+					<div key="links" classes={css.linksWrapper} styles={{ opacity: '0' }}>
+						<button
+							assertion-key="prev"
+							key="prev"
+							type="button"
+							onclick={noop}
+							classes={[css.prev, css.link]}
+						>
+							<div classes={css.icon}>
+								<Icon type="leftIcon" />
+							</div>
+							<div classes={css.label}>Previous</div>
+						</button>
+						{...makeLinks(1, 2)}
+						<div key="current" classes={css.currentPage}>
+							3
 						</div>
-						<div classes={css.label}>Previous</div>
-					</button>
-					<button
-						key="numberedLink-1"
-						type="button"
-						onclick={noop}
-						classes={[css.numberedLink, css.link]}
-					>
-						1
-					</button>
-					<button
-						key="numberedLink-2"
-						type="button"
-						onclick={noop}
-						classes={[css.numberedLink, css.link]}
-					>
-						2
-					</button>
-					<div classes={css.currentPage}>3</div>
+					</div>
 				</div>
 			))
 		);
@@ -224,47 +189,35 @@ describe('Pagination', () => {
 			<Pagination total={20} initialPage={10} siblingCount={5} onPage={noop} />
 		));
 		h.expect(
-			baseAssertion
-				.insertAfter('@prev', () => [
-					<button
-						key="numberedLink-5"
-						type="button"
-						onclick={noop}
-						classes={[css.numberedLink, css.link]}
-					>
-						5
-					</button>,
-					<button
-						key="numberedLink-6"
-						type="button"
-						onclick={noop}
-						classes={[css.numberedLink, css.link]}
-					>
-						6
-					</button>
-				])
-				.insertBefore('@next', () => [
-					<button
-						key="numberedLink-14"
-						type="button"
-						onclick={noop}
-						classes={[css.numberedLink, css.link]}
-					>
-						14
-					</button>,
-					<button
-						key="numberedLink-15"
-						type="button"
-						onclick={noop}
-						classes={[css.numberedLink, css.link]}
-					>
-						15
-					</button>
-				])
+			baseAssertion.replaceChildren('@links', [
+				<button
+					assertion-key="prev"
+					key="prev"
+					type="button"
+					onclick={noop}
+					classes={[css.prev, css.link]}
+				>
+					<div classes={css.icon}>
+						<Icon type="leftIcon" />
+					</div>
+					<div classes={css.label}>Previous</div>
+				</button>,
+				...makeLinks(5, 9),
+				<div key="current" classes={css.currentPage}>
+					10
+				</div>,
+				...makeLinks(11, 15),
+				<button key="next" type="button" onclick={noop} classes={[css.next, css.link]}>
+					<div classes={css.icon}>
+						<Icon type="rightIcon" />
+					</div>
+					<div classes={css.label}>Next</div>
+				</button>
+			])
 		);
 	});
 
-	describe('PageSizeSelector', () => {
+	describe('page size selector', () => {
 		const sizeSelectorAssertion = baseAssertion.append(':root', [
 			<div classes={css.selectWrapper}>
 				<Select
@@ -313,5 +266,86 @@ describe('Pagination', () => {
 			h.trigger('@page-size-select', 'onValue', '10');
 			sinon.assert.calledWith(onPageSizeChange, 10);
 		});
+	});
+
+	describe('sibling resizing', () => {
+		const sb = sinon.sandbox.create();
+		const resizeMock = createResizeMock();
+		let nodeMock: ReturnType<typeof createNodeMock>;
+
+		function mockWidth(key: string, width: number) {
+			nodeMock(key, {
+				getBoundingClientRect() {
+					return {
+						width
+					};
+				}
+			});
+		}
+
+		before(() => {
+			sb.stub(global.window.HTMLDivElement.prototype, 'getBoundingClientRect').callsFake(
+				() => ({
+					width: 45
+				})
+			);
+			nodeMock = createNodeMock();
+		});
+
+		after(() => {
+			sb.restore();
+		});
+
+		it('re-renders when sizing is available', () => {});
+
+		it('excludes siblings when insufficient space', () => {
+			const h = harness(() => <Pagination total={20} initialPage={10} onPage={noop} />, {
+				middleware: [[resize, resizeMock], [node, nodeMock]]
+			});
+			h.expect(baseAssertion);
+
+			// available width is 400
+			// available width after next/prev/current is 400 - (45*3) = 265
+			// leaving room for 265 / 45 = 5.8 => 5 total siblings => 2 siblings on each side
+			mockWidth('links', 400);
+			resizeMock(':root', {});
+
+			h.expect(
+				baseAssertion
+					.setProperty('@links', 'styles', { opacity: '1' })
+					.setChildren('@links', [
+						<button
+							assertion-key="prev"
+							key="prev"
+							type="button"
+							onclick={noop}
+							classes={[css.prev, css.link]}
+						>
+							<div classes={css.icon}>
+								<Icon type="leftIcon" />
+							</div>
+							<div classes={css.label}>Previous</div>
+						</button>,
+						...makeLinks(8, 9),
+						<div key="current" classes={css.currentPage}>
+							10
+						</div>,
+						...makeLinks(11, 12),
+						<button
+							key="next"
+							type="button"
+							onclick={noop}
+							classes={[css.next, css.link]}
+						>
+							<div classes={css.icon}>
+								<Icon type="rightIcon" />
+							</div>
+							<div classes={css.label}>Next</div>
+						</button>
+					])
+			);
+		});
+
+		it('excludes siblings unevenly when applicable', () => {});
 	});
 });

--- a/src/theme/default/index.ts
+++ b/src/theme/default/index.ts
@@ -28,6 +28,7 @@ import * as menuItem from './menu-item.m.css';
 import * as nativeSelect from './native-select.m.css';
 import * as listItem from './list-item.m.css';
 import * as outlinedButton from './outlined-button.m.css';
+import * as pagination from './pagination.m.css';
 import * as passwordInput from './password-input.m.css';
 import * as popup from './popup.m.css';
 import * as progress from './progress.m.css';
@@ -82,6 +83,7 @@ export default {
 		'@dojo/widgets/native-select': nativeSelect,
 		'@dojo/widgets/list-item': listItem,
 		'@dojo/widgets/outlined-button': outlinedButton,
+		'@dojo/widgets/pagination': pagination,
 		'@dojo/widgets/password-input': passwordInput,
 		'@dojo/widgets/popup': popup,
 		'@dojo/widgets/progress': progress,

--- a/src/theme/default/pagination.m.css
+++ b/src/theme/default/pagination.m.css
@@ -1,6 +1,10 @@
 .root {
 }
 
+/* Added to the parent of all page links */
+.linksWrapper {
+}
+
 /* Added to all page-changing links */
 .link {
 }

--- a/src/theme/default/pagination.m.css.d.ts
+++ b/src/theme/default/pagination.m.css.d.ts
@@ -1,4 +1,5 @@
 export const root: string;
+export const linksWrapper: string;
 export const link: string;
 export const prev: string;
 export const label: string;

--- a/src/theme/dojo/pagination.m.css
+++ b/src/theme/dojo/pagination.m.css
@@ -4,6 +4,13 @@
 	justify-content: center;
 }
 
+.linksWrapper {
+	display: flex;
+	flex-grow: 1;
+	justify-content: center;
+	overflow: hidden;
+}
+
 .prev,
 .next {
 	display: flex;

--- a/src/theme/dojo/pagination.m.css.d.ts
+++ b/src/theme/dojo/pagination.m.css.d.ts
@@ -1,4 +1,5 @@
 export const root: string;
+export const linksWrapper: string;
 export const prev: string;
 export const next: string;
 export const icon: string;

--- a/src/theme/material/pagination.m.css
+++ b/src/theme/material/pagination.m.css
@@ -4,6 +4,13 @@
 	justify-content: center;
 }
 
+.linksWrapper {
+	display: flex;
+	flex-grow: 1;
+	justify-content: center;
+	overflow: hidden;
+}
+
 .prev,
 .next {
 	display: flex;

--- a/src/theme/material/pagination.m.css.d.ts
+++ b/src/theme/material/pagination.m.css.d.ts
@@ -1,4 +1,5 @@
 export const root: string;
+export const linksWrapper: string;
 export const prev: string;
 export const next: string;
 export const icon: string;


### PR DESCRIPTION
DRAFT: some unit tests are missing an implementation

**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Pagination widget now responsive by automatically removing sibling links when space is insufficient to render `siblingCount` links.

When `siblingCount` is unset, all siblings are included which will fit the available space.

Resolves #1239 

### Full width

##### Dojo theme
![image](https://user-images.githubusercontent.com/41762295/78602541-a1630b80-7824-11ea-9f28-70bf20774f19.png)

##### Material theme
![image](https://user-images.githubusercontent.com/41762295/78602733-f010a580-7824-11ea-8c1b-6e8f55ace1df.png)

### Mid-sized

![image](https://user-images.githubusercontent.com/41762295/78602563-aa53dd00-7824-11ea-806e-f615e51c8c86.png)

### Min-sized

![image](https://user-images.githubusercontent.com/41762295/78602576-b049be00-7824-11ea-934c-335a19426a98.png)

