### PR TITLE
Allow calendar to optionally be controlled

### DIFF
--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -152,23 +152,24 @@ Latest example can be found on [widgets.dojo.io/#widget/button/overview](https:/
 #### Property changes
 ##### Changed properties
 - initialValue?: Date
+	- This property can be used to provide an initial value or can
+	  be used to partially control the component, which responds to changes in this value
+ - value?: Date
 	- This property replaced `selectedDate`
-	- This property can be used to simply provide an initial value or can
-	  be used together with `onValue` to control the value
 - onValue?(value: Date): void
     - This property replaced `onDateSelect`
     - The name was changed to follow a more consistent pattern
 - initialMonth?: number
-   - This property replaced `month`
    - This property can be used to specify the initial month that should be displayed
-     or can be used together with `onMonth` to control the month displayed
+     or can be used together with `onMonth` to partially control the month displayed,
+     which will responod to changes in this value
 - onMonth?(month: number): void
     - This property replaced `onMonthChange`
     - The name was changed to follow a more consistent pattern
 - initialYear?: number
-   - This property replaced `year`
    - This property can be used to specify the initial year that should be displayed
-     or can be used together with `onYear` to control the year displayed
+     or can be used together with `onYear` to partially control the year displayed,
+     which will respond to changes in this value
 - onYear?(year: number): void
     - This property replaced `onYearChange`
     - The name was changed to follow a more consistent pattern
@@ -176,8 +177,9 @@ Latest example can be found on [widgets.dojo.io/#widget/button/overview](https:/
 The calendar widget is now uncontrolled by default. Initial values can be
 provided but the calendar will maintain its own internal state, tracking the
 displayed month and year and the currently selected value. The calendar can
-still be controlled by using the callbacks and initial properties to track
-and update the value.
+be partially controlled using the `initial` properties as it will update when those
+values change. For use cases where the component needs to be fully controlled, the
+`value`, `month`, and `year` properties can be used.
 #### Example of migration from v6 to v7
 ```tsx
 const selectedDate = icache.getOrSet('date', new Date());

--- a/src/calendar/tests/unit/Calendar.spec.tsx
+++ b/src/calendar/tests/unit/Calendar.spec.tsx
@@ -434,6 +434,24 @@ registerSuite('Calendar', {
 			h.expect(expected);
 		},
 
+		'Controlled properties should always be rendered'() {
+			const h = harness(() => (
+				<Calendar
+					initialMonth={6}
+					initialYear={2018}
+					initialValue={new Date(2018, 6)}
+					value={testDate}
+					month={5}
+					year={2017}
+				/>
+			));
+
+			h.expect(() => expected(false, 8));
+			h.trigger('@date-picker', 'onRequestYearChange', 2018);
+			h.trigger(`.${css.previous}`, 'onclick', stubEvent);
+			h.expect(() => expected(false, 8));
+		},
+
 		'Render specific month and year with initialValue'() {
 			const h = harness(() => <Calendar initialValue={testDate} />);
 

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -17,6 +17,7 @@ import BasicCalendar from './widgets/calendar/Basic';
 import FirstDayOfWeekCalendar from './widgets/calendar/CustomFirstWeekDay';
 import LimitedRange from './widgets/calendar/LimitedRange';
 import InitialMonthAndYear from './widgets/calendar/InitialMonthAndYear';
+import FullyControlledCalendar from './widgets/calendar/FullyControlled';
 import ActionButtons from './widgets/card/ActionButtons';
 import ActionButtonsAndIcons from './widgets/card/ActionButtonsAndIcons';
 import ActionIcons from './widgets/card/ActionIcons';
@@ -332,6 +333,12 @@ export const config = {
 					filename: 'InitialMonthAndYear',
 					module: InitialMonthAndYear,
 					title: 'Initial month and year'
+				},
+				{
+					description: 'Shows a fully controlled calendar',
+					filename: 'FullyControlled',
+					module: FullyControlledCalendar,
+					title: 'Fully controlled'
 				}
 			],
 			filename: 'index',

--- a/src/examples/src/widgets/calendar/FullyControlled.tsx
+++ b/src/examples/src/widgets/calendar/FullyControlled.tsx
@@ -1,0 +1,23 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import icache from '@dojo/framework/core/middleware/icache';
+import Calendar from '@dojo/widgets/calendar';
+
+const factory = create({ icache });
+
+export default factory(function FullyControlled({ middleware: { icache } }) {
+	const date = icache.getOrSet('date', new Date(2019, 0, 11));
+
+	return (
+		<virtual>
+			<Calendar
+				value={date}
+				month={0}
+				year={2019}
+				onValue={(date) => {
+					icache.set('date', date);
+				}}
+			/>
+			<div>Selected date is {date.toLocaleDateString()}</div>
+		</virtual>
+	);
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds `value`, `month`, and `year` properties to optionally allow the calendar to be fully controlled.
Resolves #1347 