### PR TITLE
Make form controlled

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -59,6 +59,7 @@ import ActionsDialog from './widgets/dialog/ActionsDialog';
 import BasicEmailInput from './widgets/email-input/Basic';
 import Advanced from './widgets/grid/Advanced';
 import BasicForm from './widgets/form/Basic';
+import ControlledForm from './widgets/form/Basic';
 import ValidationForm from './widgets/form/Validation';
 import InitialValueForm from './widgets/form/InitialValueForm';
 import FillingForm from './widgets/form/FillingForm';
@@ -626,6 +627,11 @@ export const config = {
 					title: 'Basic form with an initial value',
 					module: InitialValueForm,
 					filename: 'InitialValueForm'
+				},
+				{
+					title: 'Basic controlled form',
+					module: ControlledForm,
+					filename: 'Controlled'
 				},
 				{
 					title: 'Basic form with fill button',

--- a/src/examples/src/widgets/form/Controlled.tsx
+++ b/src/examples/src/widgets/form/Controlled.tsx
@@ -63,8 +63,8 @@ const App = factory(function({ middleware: { icache } }) {
 							<TextInput
 								key="email"
 								placeholder="Enter an email address"
-								initialValue={email.value()}
-								value={email.value}
+								value={email.value()}
+								onValue={email.value}
 								type="email"
 							>
 								{{ label: 'Email' }}

--- a/src/examples/src/widgets/form/Controlled.tsx
+++ b/src/examples/src/widgets/form/Controlled.tsx
@@ -1,0 +1,91 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
+
+import TextInput from '@dojo/widgets/text-input';
+import Form from '@dojo/widgets/form';
+import { FormMiddleware } from '@dojo/widgets/form/middleware';
+
+const icache = createICacheMiddleware<{
+	basic?: Partial<Fields>;
+}>();
+
+const factory = create({ icache });
+
+interface Fields {
+	firstName?: string;
+	middleName?: string;
+	lastName?: string;
+	email?: string;
+}
+
+const App = factory(function({ middleware: { icache } }) {
+	const results = icache.get('basic');
+
+	return (
+		<virtual>
+			<Form
+				name="basicForm"
+				onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}
+				value={results}
+			>
+				{({ field }: FormMiddleware<Fields>) => {
+					const firstName = field('firstName');
+					const middleName = field('middleName');
+					const lastName = field('lastName');
+					const email = field('email');
+
+					return (
+						<virtual>
+							<TextInput
+								key="firstName"
+								placeholder="Enter first name"
+								value={firstName.value()}
+								onValue={firstName.value}
+							>
+								{{ label: 'First Name' }}
+							</TextInput>
+							<TextInput
+								key="middleName"
+								placeholder="Enter a middle name"
+								value={middleName.value()}
+								onValue={middleName.value}
+							>
+								{{ label: 'Middle Name' }}
+							</TextInput>
+							<TextInput
+								key="lastName"
+								placeholder="Enter a last name"
+								value={lastName.value()}
+								onValue={lastName.value}
+							>
+								{{ label: 'Last Name' }}
+							</TextInput>
+							<TextInput
+								key="email"
+								placeholder="Enter an email address"
+								initialValue={email.value()}
+								value={email.value}
+								type="email"
+							>
+								{{ label: 'Email' }}
+							</TextInput>
+						</virtual>
+					);
+				}}
+			</Form>
+			{results && (
+				<div key="onValueResults">
+					<h2>onValue Results</h2>
+					<ul>
+						<li>First Name: {results.firstName}</li>
+						<li>Middle Name: {results.middleName}</li>
+						<li>Last Name: {results.lastName}</li>
+						<li>Email: {results.email}</li>
+					</ul>
+				</div>
+			)}
+		</virtual>
+	);
+});
+
+export default App;

--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -13,6 +13,8 @@ type Omit<T, E> = Pick<T, Exclude<keyof T, E>>;
 interface BaseFormProperties {
 	/** The initial form value */
 	initialValue?: FormValue;
+	/** Controlled form value component */
+	value?: FormValue;
 	/** Callback called when a form value changes */
 	onValue?(values: FormValue): void;
 	/** The name property of the form */
@@ -72,7 +74,7 @@ export default factory(function Form({
 		name: props.name
 	};
 
-	const { initialValue, onValue } = props;
+	const { initialValue, value, onValue } = props;
 
 	if (isSubmitForm(props)) {
 		formProps = {
@@ -95,7 +97,9 @@ export default factory(function Form({
 
 	onValue && form.onValue(onValue);
 
-	if (initialValue !== undefined && !valueEqual(initialValue, icache.get('initial'))) {
+	if (value) {
+		form.value(value);
+	} else if (initialValue !== undefined && !valueEqual(initialValue, icache.get('initial'))) {
 		icache.set('initial', initialValue, false);
 		form.value(initialValue);
 	}

--- a/src/form/tests/unit/Form.spec.tsx
+++ b/src/form/tests/unit/Form.spec.tsx
@@ -12,7 +12,7 @@ import TextInput from '../../../text-input';
 import { stubEvent } from '../../../common/tests/support/test-helpers';
 
 import * as css from '../../../theme/default/form.m.css';
-import { FormMiddleware } from '../../middleware';
+import { FormMiddleware, FormValue } from '../../middleware';
 import Form from '../../index';
 
 interface Fields {
@@ -114,11 +114,12 @@ describe('Form', () => {
 
 	const onSubmit = stub();
 	const onValue = stub();
-	const form = () => (
+	const form = (value?: FormValue) => (
 		<Form
 			initialValue={{
 				firstName: 'Billy'
 			}}
+			value={value}
 			onSubmit={onSubmit}
 			onValue={onValue}
 			name="formName"
@@ -340,6 +341,42 @@ describe('Form', () => {
 			valid: false,
 			message: 'Required'
 		});
+		h.expect(assertion);
+	});
+
+	it('it overrides value changes when controlled', () => {
+		const h = harness(() => form({ firstName: 'Billy', lastName: 'Bob' }));
+		const assertion = baseAssertion.setProperty('@lastName', 'initialValue', 'Bob');
+
+		h.expect(assertion);
+		assert.isTrue(
+			onValue.calledWith({ firstName: 'Billy', lastName: 'Bob' }),
+			'onValue called'
+		);
+
+		h.trigger('@firstName', 'onValidate', undefined);
+		h.trigger('@middleName', 'onValidate', undefined);
+		h.trigger('@lastName', 'onValidate', undefined);
+		h.trigger('@email', 'onValidate', undefined);
+
+		h.expect(assertion);
+
+		h.trigger('@firstName', 'onValidate', undefined);
+		h.trigger('@middleName', 'onValidate', undefined);
+		h.trigger('@lastName', 'onValidate', undefined);
+		h.trigger('@email', 'onValidate', undefined);
+
+		h.expect(assertion);
+
+		h.trigger('@firstName', 'onValue', 'Bobby');
+		assert.isTrue(onValue.calledWith({ firstName: 'Bobby' }), 'onValue called');
+		h.trigger('@middleName', 'onValue', 'Bo');
+		assert.isTrue(onValue.calledWith({ middleName: 'Bo' }), 'onValue called');
+		h.trigger('@lastName', 'onValue', 'Bob');
+		assert.isTrue(onValue.calledWith({ lastName: 'Bob' }), 'onValue called');
+		h.trigger('@email', 'onValue', 'test@example.com');
+		assert.isTrue(onValue.calledWith({ email: 'test@example.com' }), 'onValue called');
+
 		h.expect(assertion);
 	});
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds `value` property to the form widget for a controlled use case. Adds an example that uses the `value` property (which doesn't exist yet) on text inputs. 
Resolves #1333 
