### PR TITLE
Controlled text area

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -158,6 +158,7 @@ import ButtonAlignmentTabController from './widgets/tab-controller/ButtonAlignme
 import CloseableTabController from './widgets/tab-controller/Closeable';
 import DisabledTabController from './widgets/tab-controller/Disabled';
 import BasicTextArea from './widgets/text-area/Basic';
+import ControlledTextArea from './widgets/text-area/Controlled';
 import TextAreaWithLabel from './widgets/text-area/Label';
 import DisabledTextArea from './widgets/text-area/Disabled';
 import HelperTextTextArea from './widgets/text-area/HelperText';
@@ -1320,6 +1321,11 @@ export const config = {
 		},
 		'text-area': {
 			examples: [
+				{
+					filename: 'Controlled',
+					module: ControlledTextArea,
+					title: 'Controlled text area'
+				},
 				{
 					filename: 'Label',
 					module: TextAreaWithLabel,

--- a/src/examples/src/widgets/text-area/Controlled.tsx
+++ b/src/examples/src/widgets/text-area/Controlled.tsx
@@ -1,0 +1,16 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import TextArea from '@dojo/widgets/text-area';
+import icache from '@dojo/framework/core/middleware/icache';
+
+const factory = create({ icache });
+
+export default factory(function Controlled({ middleware: { icache } }) {
+	return (
+		<TextArea
+			value={icache.getOrSet('value', '')}
+			onValue={(value) => {
+				icache.set('value', value);
+			}}
+		/>
+	);
+});

--- a/src/text-area/index.tsx
+++ b/src/text-area/index.tsx
@@ -171,9 +171,8 @@ export const TextArea = factory(function TextArea({
 	} = properties();
 
 	let { value } = properties();
-	const hasValue = typeof value !== 'undefined';
 
-	if (!hasValue) {
+	if (value === undefined) {
 		value = icache.get('value');
 		const existingInitialValue = icache.get('initialValue');
 
@@ -257,9 +256,7 @@ export const TextArea = factory(function TextArea({
 							const { onValue } = properties();
 							event.stopPropagation();
 							const value = (event.target as HTMLInputElement).value;
-							if (!hasValue) {
-								icache.set('value', value);
-							}
+							icache.set('value', value);
 							onValue && onValue(value);
 						}}
 						onkeydown={(event: KeyboardEvent) => {

--- a/src/text-area/index.tsx
+++ b/src/text-area/index.tsx
@@ -69,6 +69,8 @@ export interface TextAreaProperties {
 	valid?: { valid?: boolean; message?: string } | boolean;
 	/** The initial value */
 	initialValue?: string;
+	/** Controlled value property */
+	value?: string;
 	/** The id used for the form input element */
 	widgetId?: string;
 	/** Controls text wrapping. Can be "hard", "soft", or "off" */
@@ -112,8 +114,7 @@ export const TextArea = factory(function TextArea({
 	}
 
 	function validate() {
-		const { customValidator } = properties();
-		const value = icache.get('value') || '';
+		const { customValidator, value = icache.get('value') || '' } = properties();
 		const dirty = icache.getOrSet('dirty', false);
 
 		if (value === '' && !dirty) {
@@ -169,13 +170,18 @@ export const TextArea = factory(function TextArea({
 		onValidate
 	} = properties();
 
-	let value = icache.get('value');
-	const existingInitialValue = icache.get('initialValue');
+	let { value } = properties();
+	const hasValue = typeof value !== 'undefined';
 
-	if (initialValue !== existingInitialValue) {
-		icache.set('value', initialValue);
-		icache.set('initialValue', initialValue);
-		value = initialValue;
+	if (!hasValue) {
+		value = icache.get('value');
+		const existingInitialValue = icache.get('initialValue');
+
+		if (initialValue !== existingInitialValue) {
+			icache.set('value', initialValue);
+			icache.set('initialValue', initialValue);
+			value = initialValue;
+		}
 	}
 
 	onValidate && validate();
@@ -251,7 +257,9 @@ export const TextArea = factory(function TextArea({
 							const { onValue } = properties();
 							event.stopPropagation();
 							const value = (event.target as HTMLInputElement).value;
-							icache.set('value', value);
+							if (!hasValue) {
+								icache.set('value', value);
+							}
 							onValue && onValue(value);
 						}}
 						onkeydown={(event: KeyboardEvent) => {

--- a/src/text-area/tests/unit/TextArea.spec.tsx
+++ b/src/text-area/tests/unit/TextArea.spec.tsx
@@ -293,7 +293,7 @@ registerSuite('Textarea', {
 			h.trigger('@input', 'oninput', stubEvent);
 		},
 
-		'updates internal value when edited properties'() {
+		'updates internal value when edited'() {
 			const h = harness(() => (
 				<TextArea
 					aria={{ describedBy: 'foo' }}

--- a/src/text-area/tests/unit/TextArea.spec.tsx
+++ b/src/text-area/tests/unit/TextArea.spec.tsx
@@ -293,6 +293,89 @@ registerSuite('Textarea', {
 			h.trigger('@input', 'oninput', stubEvent);
 		},
 
+		'updates internal value when edited properties'() {
+			const h = harness(() => (
+				<TextArea
+					aria={{ describedBy: 'foo' }}
+					columns={15}
+					widgetId="foo"
+					maxLength={50}
+					minLength={10}
+					name="bar"
+					placeholder="baz"
+					rows={42}
+					initialValue="qux"
+					wrapText="soft"
+				/>
+			));
+
+			h.expect(() =>
+				expected(false, {
+					cols: '15',
+					'aria-describedby': 'foo',
+					id: 'foo',
+					maxlength: '50',
+					minlength: '10',
+					name: 'bar',
+					placeholder: 'baz',
+					rows: '42',
+					value: 'qux',
+					wrap: 'soft'
+				})
+			);
+
+			h.trigger('@input', 'oninput', { ...stubEvent, target: { value: 'newvalue' } });
+			h.expect(() =>
+				expected(false, {
+					cols: '15',
+					'aria-describedby': 'foo',
+					id: 'foo',
+					maxlength: '50',
+					minlength: '10',
+					name: 'bar',
+					placeholder: 'baz',
+					rows: '42',
+					value: 'newvalue',
+					wrap: 'soft'
+				})
+			);
+		},
+
+		'ignores changes when controlled'() {
+			const h = harness(() => (
+				<TextArea
+					aria={{ describedBy: 'foo' }}
+					columns={15}
+					widgetId="foo"
+					maxLength={50}
+					minLength={10}
+					name="bar"
+					placeholder="baz"
+					rows={42}
+					value="qux"
+					wrapText="soft"
+				/>
+			));
+
+			const assertion = () =>
+				expected(false, {
+					cols: '15',
+					'aria-describedby': 'foo',
+					id: 'foo',
+					maxlength: '50',
+					minlength: '10',
+					name: 'bar',
+					placeholder: 'baz',
+					rows: '42',
+					value: 'qux',
+					wrap: 'soft'
+				});
+			h.expect(assertion);
+
+			h.trigger('@input', 'oninput', { ...stubEvent, target: { value: 'newvalue' } });
+			h.expect(assertion);
+		},
+
 		onValidate() {
 			let mockValidity = createValidityMock();
 

--- a/src/text-area/tests/unit/TextArea.spec.tsx
+++ b/src/text-area/tests/unit/TextArea.spec.tsx
@@ -401,6 +401,19 @@ registerSuite('Textarea', {
 			assert.isTrue(validateSpy.calledWith(true, 'test'));
 		},
 
+		'validates as undefined with no initial value'() {
+			let mockValidity = createValidityMock();
+
+			let validateSpy = sinon.spy();
+
+			let h = harness(() => <TextArea onValidate={validateSpy} />, {
+				middleware: [[validity, mockValidity]]
+			});
+
+			h.expect(baseAssertion.setProperty('@helperText', 'valid', undefined));
+			assert.isTrue(validateSpy.calledWith(undefined));
+		},
+
 		'onValidate only called when validity or message changed'() {
 			const mockValidity = createValidityMock();
 			let validateSpy = sinon.spy();

--- a/src/text-area/tests/unit/TextArea.spec.tsx
+++ b/src/text-area/tests/unit/TextArea.spec.tsx
@@ -401,6 +401,31 @@ registerSuite('Textarea', {
 			assert.isTrue(validateSpy.calledWith(true, 'test'));
 		},
 
+		'onValidate with a value property'() {
+			let mockValidity = createValidityMock();
+
+			let validateSpy = sinon.spy();
+
+			mockValidity('input', { valid: false, message: 'test' });
+
+			let h = harness(() => <TextArea value="test value" onValidate={validateSpy} />, {
+				middleware: [[validity, mockValidity]]
+			});
+
+			h.expect(valueAssertion);
+			assert.isTrue(validateSpy.calledWith(false, 'test'));
+
+			mockValidity = createValidityMock();
+
+			h = harness(() => <TextArea value="test value" onValidate={validateSpy} />, {
+				middleware: [[validity, mockValidity]]
+			});
+			mockValidity('input', { valid: true, message: 'test' });
+			h.expect(valueAssertion);
+
+			assert.isTrue(validateSpy.calledWith(true, 'test'));
+		},
+
 		'validates as undefined with no initial value'() {
 			let mockValidity = createValidityMock();
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Allows a `value` property to be specified to control a text area component.
Resolves #1342 
