### PR TITLE
Allow tab controller to be controlled

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -156,6 +156,7 @@ import SuccessSnackbar from './widgets/snackbar/Success';
 import BasicSwitch from './widgets/switch/Basic';
 import DisabledSwitch from './widgets/switch/Disabled';
 import BasicTabController from './widgets/tab-controller/Basic';
+import ControlledTabController from './widgets/tab-controller/Controlled';
 import ButtonAlignmentTabController from './widgets/tab-controller/ButtonAlignment';
 import CloseableTabController from './widgets/tab-controller/Closeable';
 import DisabledTabController from './widgets/tab-controller/Disabled';
@@ -1310,6 +1311,11 @@ export const config = {
 		},
 		'tab-controller': {
 			examples: [
+				{
+					filename: 'Controlled',
+					module: ControlledTabController,
+					title: 'Controlled TabController'
+				},
 				{
 					filename: 'Disabled',
 					module: DisabledTabController,

--- a/src/examples/src/widgets/tab-controller/Controlled.tsx
+++ b/src/examples/src/widgets/tab-controller/Controlled.tsx
@@ -1,0 +1,39 @@
+import { tsx, create } from '@dojo/framework/core/vdom';
+
+import TabController from '@dojo/widgets/tab-controller';
+import TabContent from '@dojo/widgets/tab-controller/TabContent';
+import { icache } from '@dojo/framework/core/middleware/icache';
+
+const factory = create({ icache });
+
+export default factory(function Basic({ middleware: { icache } }) {
+	const tabs = [
+		{ id: 'tab0', label: 'Tab One' },
+		{ id: 'tab1', label: 'Tab Two' },
+		{ id: 'tab2', label: 'Tab Three' },
+		{ id: 'tab3', label: 'Tab Four' }
+	];
+
+	return (
+		<TabController
+			activeTab={icache.getOrSet('activeTab', 'tab2')}
+			onActiveTab={(activeTab) => icache.set('activeTab', activeTab)}
+			tabs={tabs}
+		>
+			{(_tabs, isActive) => [
+				<TabContent key="tab0" active={isActive('tab0')}>
+					Hello Tab One
+				</TabContent>,
+				<TabContent key="tab1" active={isActive('tab1')}>
+					Hello Tab Two
+				</TabContent>,
+				<TabContent key="tab2" active={isActive('tab2')}>
+					Hello Tab Three
+				</TabContent>,
+				<TabContent key="tab3" active={isActive('tab3')}>
+					Hello Tab Four
+				</TabContent>
+			]}
+		</TabController>
+	);
+});

--- a/src/tab-controller/tests/unit/TabController.spec.tsx
+++ b/src/tab-controller/tests/unit/TabController.spec.tsx
@@ -205,22 +205,32 @@ registerSuite('TabController', {
 				{ disabled: true, id: 'tab1', label: 'Tab 2' },
 				{ id: 'tab2', label: 'Tab 3' }
 			];
+			let currentActiveTab = 'tab2';
 
 			const h = harness(() => (
-				<TabController initialActiveTab="tab2" tabs={tabs}>
+				<TabController
+					initialActiveTab="tab2"
+					onActiveTab={(tabId) => {
+						currentActiveTab = tabId;
+					}}
+					tabs={tabs}
+				>
 					{tabChildren(tabs)}
 				</TabController>
 			));
 
 			h.trigger('@0-tabbutton', 'onclick');
 			h.expect(() => expected([expectedTabButtons(tabs), expectedTabContent(tabs)]));
+			assert.equal(currentActiveTab, 'tab0');
 
 			h.trigger('@1-tabbutton', 'onclick');
 			// nothing happens on disabled tabs
 			h.expect(() => expected([expectedTabButtons(tabs), expectedTabContent(tabs)]));
+			assert.equal(currentActiveTab, 'tab0');
 
 			h.trigger('@2-tabbutton', 'onclick');
 			h.expect(() => expected([expectedTabButtons(tabs, 2), expectedTabContent(tabs, 2)]));
+			assert.equal(currentActiveTab, 'tab2');
 		},
 
 		'Closing a tab should change tabs'() {

--- a/src/tab-controller/tests/unit/TabController.spec.tsx
+++ b/src/tab-controller/tests/unit/TabController.spec.tsx
@@ -207,7 +207,7 @@ registerSuite('TabController', {
 			];
 
 			const h = harness(() => (
-				<TabController initialId="tab2" tabs={tabs}>
+				<TabController initialActiveTab="tab2" tabs={tabs}>
 					{tabChildren(tabs)}
 				</TabController>
 			));
@@ -230,7 +230,7 @@ registerSuite('TabController', {
 				{ closeable: true, id: 'tab2', label: 'Tab 3' }
 			];
 			const h = harness(() => (
-				<TabController initialId="tab2" tabs={tabs}>
+				<TabController initialActiveTab="tab2" tabs={tabs}>
 					{tabChildren(tabs)}
 				</TabController>
 			));
@@ -248,7 +248,7 @@ registerSuite('TabController', {
 				.split('')
 				.map((n) => ({ id: `tab${n}`, label: `Tab ${n + 1}` }));
 			const h = harness(() => (
-				<TabController initialId="tab2" tabs={tabs}>
+				<TabController initialActiveTab="tab2" tabs={tabs}>
 					{tabChildren(tabs)}
 				</TabController>
 			));
@@ -267,19 +267,58 @@ registerSuite('TabController', {
 			h.expect(() => expected([expectedTabButtons(tabs, 4), expectedTabContent(tabs, 4)]));
 		},
 
+		'activeTab is specified'() {
+			const tabs: TabItem[] = '01234'
+				.split('')
+				.map((n) => ({ id: `tab${n}`, label: `Tab ${n + 1}` }));
+			let currentActive = 'tab2';
+			const h = harness(() => (
+				<TabController
+					activeTab="tab2"
+					tabs={tabs}
+					onActiveTab={(tabId) => {
+						currentActive = tabId;
+					}}
+				>
+					{tabChildren(tabs)}
+				</TabController>
+			));
+
+			// Navigation shouldn't have an effect if activeTab isn't changed
+			h.expect(() => expected([expectedTabButtons(tabs, 2), expectedTabContent(tabs, 2)]));
+			h.trigger('@2-tabbutton', 'onkeydown', createMockKeydownEvent(Keys.Right));
+			h.expect(() => expected([expectedTabButtons(tabs, 2), expectedTabContent(tabs, 2)]));
+			assert.equal(currentActive, 'tab3');
+			h.trigger('@2-tabbutton', 'onkeydown', createMockKeydownEvent(Keys.Down));
+			h.expect(() => expected([expectedTabButtons(tabs, 2), expectedTabContent(tabs, 2)]));
+			assert.equal(currentActive, 'tab3');
+			h.trigger('@2-tabbutton', 'onkeydown', createMockKeydownEvent(Keys.Left));
+			h.expect(() => expected([expectedTabButtons(tabs, 2), expectedTabContent(tabs, 2)]));
+			assert.equal(currentActive, 'tab1');
+			h.trigger('@2-tabbutton', 'onkeydown', createMockKeydownEvent(Keys.Up));
+			h.expect(() => expected([expectedTabButtons(tabs, 2), expectedTabContent(tabs, 2)]));
+			assert.equal(currentActive, 'tab1');
+			h.trigger('@2-tabbutton', 'onkeydown', createMockKeydownEvent(Keys.Home));
+			h.expect(() => expected([expectedTabButtons(tabs, 2), expectedTabContent(tabs, 2)]));
+			assert.equal(currentActive, 'tab0');
+			h.trigger('@2-tabbutton', 'onkeydown', createMockKeydownEvent(Keys.End));
+			h.expect(() => expected([expectedTabButtons(tabs, 2), expectedTabContent(tabs, 2)]));
+			assert.equal(currentActive, 'tab4');
+		},
+
 		'Arrow keys wrap to first and last tab'() {
 			const tabs = [
 				{ id: 'tab0', label: 'Tab 1' },
 				{ id: 'tab1', label: 'Tab 2' },
 				{ id: 'tab2', label: 'Tab 3' }
 			];
-			let properties: any = { initialId: 'tab0', tabs };
+			let properties: any = { initialActiveTab: 'tab0', tabs };
 			const h = harness(() => (
 				<TabController {...properties}>{tabChildren(tabs)}</TabController>
 			));
 			h.trigger('@0-tabbutton', 'onkeydown', createMockKeydownEvent(Keys.Left));
 			h.expect(() => expected([expectedTabButtons(tabs, 2), expectedTabContent(tabs, 2)]));
-			properties = { initialId: 'tab2', tabs };
+			properties = { initialActiveTab: 'tab2', tabs };
 			h.trigger('@2-tabbutton', 'onkeydown', createMockKeydownEvent(Keys.Right));
 			h.expect(() => expected([expectedTabButtons(tabs), expectedTabContent(tabs)]));
 		},
@@ -348,14 +387,14 @@ registerSuite('TabController', {
 			);
 		},
 
-		'Should default to last tab if invalid initialId passed'() {
+		'Should default to last tab if invalid initialActiveTab passed'() {
 			const tabs = [
 				{ id: 'tab0', label: 'Tab 1' },
 				{ id: 'tab1', label: 'Tab 2' },
 				{ id: 'tab2', label: 'Tab 3' }
 			];
 			const h = harness(() => (
-				<TabController initialId="tab3" tabs={tabs}>
+				<TabController initialActiveTab="tab3" tabs={tabs}>
 					{tabChildren(tabs)}
 				</TabController>
 			));
@@ -364,14 +403,14 @@ registerSuite('TabController', {
 			h.expect(() => expected([tabButtons, tabContent]));
 		},
 
-		'Should skip tab if initialId tab is disabled'() {
+		'Should skip tab if initialActiveTab tab is disabled'() {
 			const tabs = [
 				{ id: 'tab0', label: 'Tab 1' },
 				{ disabled: true, id: 'tab1', label: 'Tab 2' },
 				{ id: 'tab2', label: 'Tab 3' }
 			];
 			const h = harness(() => (
-				<TabController initialId="tab1" tabs={tabs}>
+				<TabController initialActiveTab="tab1" tabs={tabs}>
 					{tabChildren(tabs)}
 				</TabController>
 			));


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
In addition to the changes mentioned in the ticket, I added an `onActiveTab` callback.
Resolves #1341 
