### PR TITLE
Optionally controlled native select

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -202,6 +202,7 @@ import BasicTooltip from './widgets/tooltip/Basic';
 import ClickTooltip from './widgets/tooltip/Click';
 import FocusTooltip from './widgets/tooltip/Focus';
 import BasicNativeSelect from './widgets/native-select/Basic';
+import ControlledNativeSelect from './widgets/native-select/ControlledNativeSelect';
 import BasicDateInput from './widgets/date-input/Basic';
 import ControlledDateInput from './widgets/date-input/Controlled';
 import BasicLoadingIndicator from './widgets/loading-indicator/Basic';
@@ -930,7 +931,14 @@ export const config = {
 					filename: 'Basic',
 					module: BasicNativeSelect
 				}
-			}
+			},
+			examples: [
+				{
+					title: 'Contolled Native Select',
+					filename: 'ControlledNativeSelect',
+					module: ControlledNativeSelect
+				}
+			]
 		},
 		'password-input': {
 			overview: {

--- a/src/examples/src/widgets/native-select/ControlledNativeSelect.tsx
+++ b/src/examples/src/widgets/native-select/ControlledNativeSelect.tsx
@@ -1,0 +1,22 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import NativeSelect from '@dojo/widgets/native-select';
+import icache from '@dojo/framework/core/middleware/icache';
+
+const factory = create({ icache });
+const options = [{ value: 'cat' }, { value: 'dog' }, { value: 'fish' }, { value: 'unicorn' }];
+
+export default factory(function Controlled({ middleware: { icache } }) {
+	return (
+		<virtual>
+			<NativeSelect
+				label="Basic Select"
+				options={options}
+				onValue={(value) => {
+					icache.set('value', value);
+				}}
+				value={icache.getOrSet('value', 'dog')}
+			/>
+			<pre>{icache.get('value')}</pre>
+		</virtual>
+	);
+});

--- a/src/examples/src/widgets/native-select/ControlledNativeSelect.tsx
+++ b/src/examples/src/widgets/native-select/ControlledNativeSelect.tsx
@@ -9,13 +9,14 @@ export default factory(function Controlled({ middleware: { icache } }) {
 	return (
 		<virtual>
 			<NativeSelect
-				label="Basic Select"
 				options={options}
 				onValue={(value) => {
 					icache.set('value', value);
 				}}
 				value={icache.getOrSet('value', 'dog')}
-			/>
+			>
+				Basic Select
+			</NativeSelect>
 			<pre>{icache.get('value')}</pre>
 		</virtual>
 	);

--- a/src/native-select/index.tsx
+++ b/src/native-select/index.tsx
@@ -18,6 +18,8 @@ export interface NativeSelectProperties {
 	onValue?(value: string): void;
 	/** The initial selected value */
 	initialValue?: string;
+	/** A controlled value */
+	value?: string;
 	/** Options to display within the menu */
 	options: MenuOption[];
 	/** Property to determine if the input is disabled */
@@ -68,13 +70,20 @@ export const NativeSelect = factory(function NativeSelect({
 	} = properties();
 
 	const [label] = children();
+	let { value } = properties();
 
-	if (initialValue !== undefined && initialValue !== icache.get('initial')) {
-		icache.set('initial', initialValue);
-		icache.set('value', initialValue);
+	if (value === undefined) {
+		value = icache.get('value');
+		const existingInitialValue = icache.get('initial');
+
+		if (initialValue !== undefined && initialValue !== existingInitialValue) {
+			icache.set('initial', initialValue);
+			icache.set('value', initialValue);
+			value = initialValue;
+		}
 	}
 
-	const selectedValue = icache.get('value');
+	const selectedValue = value;
 	const themedCss = theme.classes(css);
 	const inputFocused = focus.isFocused('native-select');
 
@@ -129,7 +138,7 @@ export const NativeSelect = factory(function NativeSelect({
 					}}
 					classes={themedCss.select}
 				>
-					{!initialValue && <option key="blank-option" value="" />}
+					{value === undefined && <option key="blank-option" value="" />}
 					{options.map(({ value, label, disabled = false }, index) => {
 						return (
 							<option

--- a/src/native-select/index.tsx
+++ b/src/native-select/index.tsx
@@ -41,6 +41,7 @@ export interface NativeSelectProperties {
 interface NativeSelectICache {
 	initial: string;
 	value: string;
+	prependBlank: boolean;
 }
 
 const icache = createICacheMiddleware<NativeSelectICache>();
@@ -75,11 +76,15 @@ export const NativeSelect = factory(function NativeSelect({
 	if (value === undefined) {
 		value = icache.get('value');
 		const existingInitialValue = icache.get('initial');
+		icache.set('prependBlank', true);
 
-		if (initialValue !== undefined && initialValue !== existingInitialValue) {
-			icache.set('initial', initialValue);
-			icache.set('value', initialValue);
-			value = initialValue;
+		if (initialValue !== undefined) {
+			icache.set('prependBlank', false);
+			if (initialValue !== existingInitialValue) {
+				icache.set('initial', initialValue);
+				icache.set('value', initialValue);
+				value = initialValue;
+			}
 		}
 	}
 
@@ -138,7 +143,7 @@ export const NativeSelect = factory(function NativeSelect({
 					}}
 					classes={themedCss.select}
 				>
-					{value === undefined && <option key="blank-option" value="" />}
+					{icache.get('prependBlank') && <option key="blank-option" value="" />}
 					{options.map(({ value, label, disabled = false }, index) => {
 						return (
 							<option

--- a/src/native-select/tests/NativeSelect.spec.tsx
+++ b/src/native-select/tests/NativeSelect.spec.tsx
@@ -127,12 +127,13 @@ describe('Native Select', () => {
 					options={options}
 					disabled={true}
 					helperText="Pick a pet type"
-					label="Pets"
 					required={true}
 					name="Pet select"
 					size={3}
 					value="dog"
-				/>
+				>
+					Pets
+				</NativeSelect>
 			),
 			[compareForId, compareId]
 		);
@@ -144,13 +145,27 @@ describe('Native Select', () => {
 			.setProperty('@native-select', 'size', 3)
 			.setProperty('@helperText', 'text', 'Pick a pet type')
 			.setProperty('@option-0', 'selected', true)
-			.setProperty('@root', 'classes', [undefined, css.root, css.disabled, css.required])
-			.setProperty('~label', 'disabled', true)
-			.setProperty('~label', 'required', true)
-			.setProperty('~label', 'active', true)
-			.replaceChildren('~label', () => {
-				return ['Pets'];
-			})
+			.setProperty('@root', 'classes', [
+				undefined,
+				css.root,
+				css.disabled,
+				css.required,
+				undefined
+			])
+			.prepend('@root', () => [
+				<Label
+					assertion-key="label"
+					theme={{}}
+					classes={undefined}
+					disabled={true}
+					forId={'something'}
+					required={true}
+					active={true}
+					focused={false}
+				>
+					Pets
+				</Label>
+			])
 			.remove('@blank-option');
 
 		h.expect(controlledTemplate);

--- a/src/native-select/tests/NativeSelect.spec.tsx
+++ b/src/native-select/tests/NativeSelect.spec.tsx
@@ -118,6 +118,43 @@ describe('Native Select', () => {
 		h.expect(optionalPropertyTemplate);
 	});
 
+	it('controlled value', () => {
+		const h = harness(
+			() => (
+				<NativeSelect
+					onValue={() => {}}
+					options={options}
+					disabled={true}
+					helperText="Pick a pet type"
+					label="Pets"
+					required={true}
+					name="Pet select"
+					size={3}
+					value="dog"
+				/>
+			),
+			[compareForId, compareId]
+		);
+
+		const controlledTemplate = baseTemplate
+			.setProperty('@native-select', 'disabled', true)
+			.setProperty('@native-select', 'required', true)
+			.setProperty('@native-select', 'name', 'Pet select')
+			.setProperty('@native-select', 'size', 3)
+			.setProperty('@helperText', 'text', 'Pick a pet type')
+			.setProperty('@option-0', 'selected', true)
+			.setProperty('@root', 'classes', [undefined, css.root, css.disabled, css.required])
+			.setProperty('~label', 'disabled', true)
+			.setProperty('~label', 'required', true)
+			.setProperty('~label', 'active', true)
+			.replaceChildren('~label', () => {
+				return ['Pets'];
+			})
+			.remove('@blank-option');
+
+		h.expect(controlledTemplate);
+	});
+
 	it('calls onValue when a select item is selected', () => {
 		const changeEvent = {
 			target: {

--- a/src/native-select/tests/NativeSelect.spec.tsx
+++ b/src/native-select/tests/NativeSelect.spec.tsx
@@ -6,7 +6,8 @@ import {
 	compareTheme,
 	createHarness,
 	noop,
-	compareForId
+	compareForId,
+	stubEvent
 } from '../../common/tests/support/test-helpers';
 import HelperText from '../../helper-text';
 import * as css from '../../theme/default/native-select.m.css';
@@ -172,5 +173,31 @@ describe('Native Select', () => {
 		h.trigger('@native-select', 'onchange', changeEvent);
 
 		assert.isTrue(onValueStub.calledOnceWith('cat'));
+	});
+
+	it('calls onBlur when select loses focus', () => {
+		const onBlurStub = stub();
+
+		const h = harness(() => <NativeSelect onBlur={onBlurStub} options={options} />, [
+			compareForId,
+			compareId
+		]);
+
+		h.trigger('@native-select', 'onblur', stubEvent);
+
+		assert.isTrue(onBlurStub.calledOnce);
+	});
+
+	it('calls onFocus when select gains focus', () => {
+		const onFocusStub = stub();
+
+		const h = harness(() => <NativeSelect onFocus={onFocusStub} options={options} />, [
+			compareForId,
+			compareId
+		]);
+
+		h.trigger('@native-select', 'onfocus', stubEvent);
+
+		assert.isTrue(onFocusStub.calledOnce);
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Will need to update migration guide PR #1329 

Allows native-select to be controlled. Adds `value` property.

Resolves #1335 

![Screen Shot 2020-04-07 at 10 36 18 PM](https://user-images.githubusercontent.com/1054198/78742013-76f67880-7920-11ea-85bb-8a12d3c3850e.png)

