### PR TITLE
Fix pointer for Calendar in material theme

### DIFF
--- a/src/theme/material/calendar.m.css
+++ b/src/theme/material/calendar.m.css
@@ -43,13 +43,15 @@
 	text-align: center;
 	position: relative;
 	z-index: 0;
-}
-
-.date {
 	cursor: pointer;
 	display: inline-flex;
 	justify-content: center;
 	align-items: center;
+}
+
+.monthFields,
+.yearFields {
+	border: none;
 }
 
 .inactiveDate {

--- a/src/theme/material/calendar.m.css
+++ b/src/theme/material/calendar.m.css
@@ -47,6 +47,9 @@
 
 .date {
 	cursor: pointer;
+	display: inline-flex;
+	justify-content: center;
+	align-items: center;
 }
 
 .inactiveDate {

--- a/src/theme/material/calendar.m.css
+++ b/src/theme/material/calendar.m.css
@@ -6,6 +6,7 @@
 	color: var(--mdc-theme-on-surface);
 	padding-left: calc(var(--mdc-grid-base) * 2);
 	padding-right: calc(var(--mdc-grid-base) * 2);
+	user-select: none;
 }
 
 .monthTrigger,
@@ -19,6 +20,7 @@
 	font-size: inherit;
 	line-height: inherit;
 	padding: 0;
+	cursor: pointer;
 }
 
 .monthTrigger {
@@ -41,6 +43,10 @@
 	text-align: center;
 	position: relative;
 	z-index: 0;
+}
+
+.date {
+	cursor: pointer;
 }
 
 .inactiveDate {

--- a/src/theme/material/calendar.m.css
+++ b/src/theme/material/calendar.m.css
@@ -52,6 +52,8 @@
 .monthFields,
 .yearFields {
 	border: none;
+	padding: 0;
+	margin: 0;
 }
 
 .inactiveDate {

--- a/src/theme/material/calendar.m.css
+++ b/src/theme/material/calendar.m.css
@@ -110,6 +110,7 @@
 	margin-left: calc(var(--mdc-grid-base) * -0.5);
 	align-items: center;
 	justify-content: center;
+	cursor: pointer;
 }
 
 .yearRadioChecked,

--- a/src/theme/material/calendar.m.css.d.ts
+++ b/src/theme/material/calendar.m.css.d.ts
@@ -7,6 +7,8 @@ export const datePicker: string;
 export const topMatter: string;
 export const weekday: string;
 export const date: string;
+export const monthFields: string;
+export const yearFields: string;
 export const inactiveDate: string;
 export const abbr: string;
 export const selectedDate: string;


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

For material calendar theme:
- adds cursor: pointed where appropriate
- disable user selection
- remove fieldset borders
- center text in dates