### PR TITLE
Optionally control radio group

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -116,6 +116,7 @@ import EventsRadio from './widgets/radio/Events';
 import DisabledRadio from './widgets/radio/Disabled';
 import LabelledRadio from './widgets/radio/Labelled';
 import BasicRadioGroup from './widgets/radio-group/Basic';
+import ControlledRadioGroup from './widgets/radio-group/Basic';
 import CustomLabelRadioGroup from './widgets/radio-group/CustomLabel';
 import CustomRendererRadioGroup from './widgets/radio-group/CustomRenderer';
 import InitialValueRadioGroup from './widgets/radio-group/InitialValue';
@@ -1052,6 +1053,11 @@ export const config = {
 		},
 		'radio-group': {
 			examples: [
+				{
+					filename: 'Controlled',
+					module: ControlledRadioGroup,
+					title: 'Controlled radio group'
+				},
 				{
 					filename: 'InitialValue',
 					module: InitialValueRadioGroup,

--- a/src/examples/src/widgets/radio-group/Controlled.tsx
+++ b/src/examples/src/widgets/radio-group/Controlled.tsx
@@ -1,0 +1,29 @@
+import RadioGroup from '@dojo/widgets/radio-group';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import { icache } from '@dojo/framework/core/middleware/icache';
+
+const factory = create({ icache });
+
+const App = factory(function({ properties, middleware: { icache } }) {
+	const { get, set } = icache;
+
+	return (
+		<virtual>
+			<RadioGroup
+				name="standard"
+				value={get('standard')}
+				options={[{ value: 'cat' }, { value: 'dog' }, { value: 'fish' }]}
+				onValue={(value) => {
+					set('standard', value);
+				}}
+			>
+				{{
+					label: 'pets'
+				}}
+			</RadioGroup>
+			<pre>{`${get('standard')}`}</pre>
+		</virtual>
+	);
+});
+
+export default App;

--- a/src/radio-group/index.tsx
+++ b/src/radio-group/index.tsx
@@ -10,6 +10,8 @@ type RadioOptions = { value: string; label?: string }[];
 export interface RadioGroupProperties {
 	/** Initial value of the radio group */
 	initialValue?: string;
+	/** Controlled value property */
+	value?: string;
 	/** The name attribute for this form group */
 	name: string;
 	/** Callback for the current value */
@@ -37,9 +39,9 @@ export const RadioGroup = factory(function({
 	properties,
 	middleware: { radioGroup, theme }
 }) {
-	const { name, options, onValue, initialValue } = properties();
+	const { name, options, onValue, value, initialValue } = properties();
 	const [{ radios, label } = { radios: undefined, label: undefined }] = children();
-	const radio = radioGroup(onValue, initialValue || '');
+	const radio = radioGroup(onValue, initialValue || '', value);
 	const { root, legend } = theme.classes(css);
 
 	function renderRadios() {

--- a/src/radio-group/middleware.ts
+++ b/src/radio-group/middleware.ts
@@ -10,17 +10,19 @@ const icache = createICacheMiddleware<RadioGroupICache>();
 const factory = create({ icache });
 
 export const radioGroup = factory(({ middleware: { icache } }) => {
-	return (onValue: (value: string) => void, initialValue: string) => {
-		const existingInitialValue = icache.get('initial');
+	return (onValue: (value: string) => void, initialValue: string, value?: string) => {
+		if (value === undefined) {
+			const existingInitialValue = icache.get('initial');
 
-		if (existingInitialValue !== initialValue) {
-			icache.set('value', initialValue);
-			icache.set('initial', initialValue);
+			if (existingInitialValue !== initialValue) {
+				icache.set('value', initialValue);
+				icache.set('initial', initialValue);
+			}
 		}
 
 		return (key: string) => ({
 			checked(checked?: boolean) {
-				const existingValue = icache.get('value');
+				const existingValue = value === undefined ? icache.get('value') : value;
 
 				if (!checked && existingValue === key) {
 					return existingValue === key && true;

--- a/src/radio-group/tests/RadioGroup.spec.tsx
+++ b/src/radio-group/tests/RadioGroup.spec.tsx
@@ -73,6 +73,32 @@ describe('RadioGroup', () => {
 			</Radio>
 		]);
 		h.expect(optionTemplate);
+		h.trigger('[value="cat"]', 'onValue', true);
+	});
+
+	it('renders with a value', () => {
+		const h = harness(() => (
+			<RadioGroup
+				value="fish"
+				name="test"
+				onValue={noop}
+				options={[{ value: 'cat' }, { value: 'fish' }, { value: 'dog' }]}
+			/>
+		));
+		const optionTemplate = template.setChildren('@root', () => [
+			<Radio name="test" value="cat" checked={undefined} onValue={noop}>
+				cat
+			</Radio>,
+			<Radio name="test" value="fish" checked={true} onValue={noop}>
+				fish
+			</Radio>,
+			<Radio name="test" value="dog" checked={undefined} onValue={noop}>
+				dog
+			</Radio>
+		]);
+		h.expect(optionTemplate);
+		h.trigger('[value="cat"]', 'onValue', true);
+		h.expect(optionTemplate);
 	});
 
 	it('renders with custom renderer', () => {
@@ -83,12 +109,7 @@ describe('RadioGroup', () => {
 					radios: () => {
 						return [
 							<span>custom label</span>,
-							<Radio
-								name="test"
-								value="cat"
-								checked={false}
-								onValue={noop}
-							>
+							<Radio name="test" value="cat" checked={false} onValue={noop}>
 								cat
 							</Radio>,
 							<hr />


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds back a `value` property to allow optionally controlling the radio group.

Resolves #1337 
