### PR TITLE
Optionally control select

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -131,6 +131,7 @@ import RequiredRangeSlider from './widgets/range-slider/Required';
 import LabelledRangeSlider from './widgets/range-slider/Labelled';
 import AdditionalText from './widgets/select/AdditionalText';
 import BasicSelect from './widgets/select/Basic';
+import ControlledSelect from './widgets/select/Controlled';
 import CustomRenderer from './widgets/select/CustomRenderer';
 import DisabledSelect from './widgets/select/DisabledSelect';
 import RequiredSelect from './widgets/select/RequiredSelect';
@@ -1130,6 +1131,13 @@ export const config = {
 				}
 			},
 			examples: [
+				{
+					filename: 'Controlled',
+					module: ControlledSelect,
+					sandbox: true,
+					title: 'Controlled Select',
+					size: 'medium'
+				},
 				{
 					filename: 'AdditionalText',
 					module: AdditionalText,

--- a/src/examples/src/widgets/select/Controlled.tsx
+++ b/src/examples/src/widgets/select/Controlled.tsx
@@ -12,7 +12,7 @@ const options = [
 
 const resource = createMemoryResourceWithData(options);
 
-export default factory(function Basic({ middleware: { icache } }) {
+export default factory(function Controlled({ middleware: { icache } }) {
 	return (
 		<virtual>
 			<Select

--- a/src/examples/src/widgets/select/Controlled.tsx
+++ b/src/examples/src/widgets/select/Controlled.tsx
@@ -1,0 +1,33 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Select, { defaultTransform } from '@dojo/widgets/select';
+import icache from '@dojo/framework/core/middleware/icache';
+import { createMemoryResourceWithData } from '../list/memoryTemplate';
+
+const factory = create({ icache });
+const options = [
+	{ value: 'cat', label: 'Cat' },
+	{ value: 'dog', label: 'Dog' },
+	{ value: 'fish', label: 'Fish' }
+];
+
+const resource = createMemoryResourceWithData(options);
+
+export default factory(function Basic({ middleware: { icache } }) {
+	return (
+		<virtual>
+			<Select
+				resource={resource}
+				transform={defaultTransform}
+				onValue={(value) => {
+					icache.set('value', value);
+				}}
+				value={icache.get('value')}
+			>
+				{{
+					label: 'Basic Select'
+				}}
+			</Select>
+			<pre>{icache.getOrSet('value', '')}</pre>
+		</virtual>
+	);
+});

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -31,6 +31,8 @@ export interface SelectProperties {
 	onValue(value: string): void;
 	/** The initial selected value */
 	initialValue?: string;
+	/** Controlled value property */
+	value?: string;
 	/** Property to determine how many items to render. Defaults to 6 */
 	itemsInView?: number;
 	/** placement of the select menu; 'above' or 'below' */
@@ -97,12 +99,16 @@ export const Select = factory(function Select({
 	} = properties();
 	const [{ items, label } = { items: undefined, label: undefined }] = children();
 
-	if (initialValue !== undefined && initialValue !== icache.get('initial')) {
-		icache.set('initial', initialValue);
-		icache.set('value', initialValue);
+	let { value } = properties();
+
+	if (value === undefined) {
+		if (initialValue !== undefined && initialValue !== icache.get('initial')) {
+			icache.set('initial', initialValue);
+			icache.set('value', initialValue);
+		}
+		value = icache.get('value');
 	}
 
-	const value = icache.get('value');
 	const menuId = icache.getOrSet('menuId', uuid());
 	const triggerId = icache.getOrSet('triggerId', uuid());
 	const focusNode = icache.getOrSet('focusNode', 'trigger');
@@ -182,7 +188,7 @@ export const Select = factory(function Select({
 						return (
 							<button
 								name={name}
-								value={icache.get('value')}
+								value={value}
 								focus={() => focusNode === 'trigger' && shouldFocus}
 								aria-controls={menuId}
 								aria-haspopup="listbox"

--- a/src/select/tests/Select.spec.tsx
+++ b/src/select/tests/Select.spec.tsx
@@ -350,6 +350,44 @@ describe('Select', () => {
 		);
 	});
 
+	it('renders with a value property', () => {
+		const onValueStub = stub();
+		const toggleOpenStub = stub();
+
+		const options = [{ value: 'dog', label: 'Dog' }, { value: 'cat' }, { value: 'fish' }];
+
+		const h = harness(
+			() => (
+				<Select
+					onValue={onValueStub}
+					resource={{
+						resource: () => createResource(memoryTemplate),
+						data: options
+					}}
+					transform={defaultTransform}
+					value="dog"
+				/>
+			),
+			[compareAriaControls, compareId]
+		);
+
+		const triggerRenderResult = h.trigger(
+			'@popup',
+			(node) => (node.children as any)[0].trigger,
+			toggleOpenStub
+		);
+
+		h.expect(
+			buttonTemplate.setProperty('@trigger', 'value', 'dog').setChildren('@trigger', () => [
+				<span classes={css.value}>Dog</span>,
+				<span classes={css.arrow}>
+					<Icon type="downIcon" theme={{}} classes={undefined} />
+				</span>
+			]),
+			() => triggerRenderResult
+		);
+	});
+
 	it('invalidates correctly', () => {
 		const onValidate = stub();
 		const h = harness(() => (


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds an optional `value` property to select
Resolves #1339 
