### PR TITLE
Make range-slider optionally controlled

### DIFF
--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -517,7 +517,7 @@ Latest example can be found on [widgets.dojo.io/#widget/radio/overview](https://
   - No longer supported
 #### Changes in behaviour
 
-The range slider widget now internally manages its own value by default and changed via the `initialValue` property. The range slider can be fully controlled using the `value` property.
+The range slider widget now internally manages its own value by default and can be changed via the `initialValue` property. The range slider can be fully controlled using the `value` property.
 
 #### Example of migration from v6 to v7
 
@@ -986,5 +986,4 @@ The `TitlePane` now uses a child renderer object to determine its title and cont
 ```
 
 Latest example can be found on [widgets.dojo.io/#widget/tooltip/overview](https://widgets.dojo.io/#widget/tooltip/overview)
-
 

--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -503,9 +503,11 @@ Latest example can be found on [widgets.dojo.io/#widget/radio/overview](https://
 
 #### Property changes
 ##### Changed properties
+- initialValue
+	- This property can be used to partially control the range slider by setting an initial value.
 - value
-	- This property has been replaced by `initialValue`
-	- The range-slider now internally manages its value and it is no longer necessary to pass the current value into the range slider from the parent
+	- The range-slider now internally manages its value by default and it is no longer necessary to pass the current value
+	- Passing a value allows the range-slider to be fully controlled
 - label
   - Replaced with a child renderer
 - output
@@ -515,7 +517,7 @@ Latest example can be found on [widgets.dojo.io/#widget/radio/overview](https://
   - No longer supported
 #### Changes in behaviour
 
-The range slider widget now internally manages its own value. The value can be changed via the `initialValue` property, and updates are exposed via the `onValue` callback.
+The range slider widget now internally manages its own value by default and changed via the `initialValue` property. The range slider can be fully controlled using the `value` property.
 
 #### Example of migration from v6 to v7
 

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -130,6 +130,7 @@ import EventsRangeSlider from './widgets/range-slider/Events';
 import DisabledRangeSlider from './widgets/range-slider/Disabled';
 import RequiredRangeSlider from './widgets/range-slider/Required';
 import LabelledRangeSlider from './widgets/range-slider/Labelled';
+import ControlledRangeSlider from './widgets/range-slider/Controlled';
 import AdditionalText from './widgets/select/AdditionalText';
 import BasicSelect from './widgets/select/Basic';
 import ControlledSelect from './widgets/select/Controlled';
@@ -1126,7 +1127,8 @@ export const config = {
 					title: 'Display Tooltip Output'
 				},
 				{ filename: 'Required', module: RequiredRangeSlider, title: 'Required' },
-				{ filename: 'Disabled', module: DisabledRangeSlider, title: 'Disabled' }
+				{ filename: 'Disabled', module: DisabledRangeSlider, title: 'Disabled' },
+				{ filename: 'Controlled', module: ControlledRangeSlider, title: 'Controlled' }
 			]
 		},
 		select: {

--- a/src/examples/src/widgets/range-slider/Controlled.tsx
+++ b/src/examples/src/widgets/range-slider/Controlled.tsx
@@ -1,0 +1,17 @@
+import RangeSlider from '@dojo/widgets/range-slider';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import icache from '@dojo/framework/core/middleware/icache';
+
+const factory = create({ icache });
+
+export default factory(function Controlled({ middleware: { icache } }) {
+	const value = icache.getOrSet('value', { min: 10, max: 90 });
+	return (
+		<RangeSlider
+			onValue={(value) => {
+				icache.set('value', value);
+			}}
+			value={value}
+		/>
+	);
+});

--- a/src/range-slider/index.tsx
+++ b/src/range-slider/index.tsx
@@ -55,8 +55,10 @@ export interface RangeSliderProperties {
 	step?: number;
 	/** If the values provided by the slider are valid */
 	valid?: boolean;
-	/** The current vlaue */
+	/** The initial value of the range slider */
 	initialValue?: RangeValue;
+	/** A controlled value for the range slider */
+	value?: RangeValue;
 	/** The id used for the form input element */
 	widgetId?: string;
 }
@@ -119,17 +121,20 @@ export const RangeSlider = factory(function RangeSlider({
 		widgetId = `range-slider-${id}`
 	} = properties();
 
-	let value = icache.get('value');
-	const existingInitialValue = icache.get('initialValue');
+	let { value } = properties();
 
-	if (
-		!existingInitialValue ||
-		initialValue.min !== existingInitialValue.min ||
-		initialValue.max !== existingInitialValue.max
-	) {
-		icache.set('value', initialValue);
-		icache.set('initialValue', initialValue);
-		value = initialValue;
+	if (value === undefined) {
+		value = icache.get('value');
+		const existingInitialValue = icache.get('initialValue');
+		if (
+			!existingInitialValue ||
+			initialValue.min !== existingInitialValue.min ||
+			initialValue.max !== existingInitialValue.max
+		) {
+			icache.set('value', initialValue);
+			icache.set('initialValue', initialValue);
+			value = initialValue;
+		}
 	}
 
 	const themeCss = theme.classes(css);
@@ -177,6 +182,7 @@ export const RangeSlider = factory(function RangeSlider({
 		const returnValues: RangeValue = isMinEvent
 			? { min: Math.min(parseFloat(value), max), max }
 			: { min, max: Math.max(min, parseFloat(value)) };
+
 		icache.set('value', returnValues);
 		onValue && onValue(returnValues);
 	};

--- a/src/range-slider/tests/unit/RangeSlider.spec.tsx
+++ b/src/range-slider/tests/unit/RangeSlider.spec.tsx
@@ -7,6 +7,9 @@ import RangeSlider from '../../index';
 import assertationTemplate from '@dojo/framework/testing/assertionTemplate';
 import harness from '@dojo/framework/testing/harness';
 import { tsx } from '@dojo/framework/core/vdom';
+import { stub } from 'sinon';
+import { stubEvent } from '../../../common/tests/support/test-helpers';
+const { assert } = intern.getPlugin('chai');
 
 const noop = () => {};
 
@@ -150,6 +153,28 @@ describe('RangeSlider', () => {
 		h.expect(testTemplate);
 	});
 
+	it('renders with initialValue', () => {
+		const h = harness(() => <RangeSlider initialValue={{ min: 10, max: 100 }} />);
+		const testTemplate = template
+			.setProperty('@track', 'styles', { left: '10%', width: '90%' })
+			.setProperty('@leftThumb', 'styles', { left: '10%' })
+			.setProperty('@slider1', 'value', '10')
+			.setProperty('@slider2', 'value', '100');
+		h.expect(testTemplate);
+	});
+
+	it('renders with controlled value', () => {
+		const value = { min: 10, max: 100 };
+
+		const h = harness(() => <RangeSlider initialValue={{ min: 20, max: 80 }} value={value} />);
+		const testTemplate = template
+			.setProperty('@track', 'styles', { left: '10%', width: '90%' })
+			.setProperty('@leftThumb', 'styles', { left: '10%' })
+			.setProperty('@slider1', 'value', '10')
+			.setProperty('@slider2', 'value', '100');
+		h.expect(testTemplate);
+	});
+
 	it('renders output', () => {
 		const h = harness(() => <RangeSlider showOutput />);
 		const testTemplate = template
@@ -202,5 +227,27 @@ describe('RangeSlider', () => {
 				</output>
 			]);
 		h.expect(testTemplate);
+	});
+
+	it('calls event callbacks', () => {
+		const onBlurStub = stub();
+		const onFocusStub = stub();
+		const onValueStub = stub();
+
+		const h = harness(() => (
+			<RangeSlider onBlur={onBlurStub} onFocus={onFocusStub} onValue={onValueStub} />
+		));
+
+		h.trigger('@slider1', 'onblur', stubEvent);
+		h.trigger('@slider2', 'onblur', stubEvent);
+		assert.isTrue(onBlurStub.calledTwice, 'onBlur called');
+
+		h.trigger('@slider1', 'onfocus', stubEvent);
+		h.trigger('@slider2', 'onfocus', stubEvent);
+		assert.isTrue(onFocusStub.called, 'onFocus called');
+
+		h.trigger('@slider1', 'oninput', stubEvent);
+		h.trigger('@slider2', 'oninput', stubEvent);
+		assert.isTrue(onValueStub.called, 'onValue called');
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds `value` prop to `RangeSlider` widget to allow the option for it to be controlled.

Resolves #1338 
