### PR TITLE
Add hover style to date picker

### DIFF
--- a/src/theme/material/calendar.m.css
+++ b/src/theme/material/calendar.m.css
@@ -71,7 +71,8 @@
 }
 
 .todayDate:before,
-.selectedDate:before {
+.selectedDate:before,
+.date:not(.inactiveDate):hover:before {
 	position: absolute;
 	left: 2px;
 	top: 2px;
@@ -88,6 +89,11 @@
 
 .selectedDate:before {
 	background-color: var(--mdc-theme-primary);
+}
+
+.date:not(.selectedDate):not(.inactiveDate):hover:before {
+	background-color: var(--mdc-theme-primary);
+	opacity: 0.04;
 }
 
 .controls {

--- a/src/theme/material/calendar.m.css
+++ b/src/theme/material/calendar.m.css
@@ -93,7 +93,7 @@
 
 .date:not(.selectedDate):not(.inactiveDate):hover:before {
 	background-color: var(--mdc-theme-primary);
-	opacity: 0.04;
+	opacity: 0.15;
 }
 
 .controls {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds a 4% opacity background to hovered dates in the calendar material theme. To my eye I'm not sure if this looks exactly the same as the opacity in the spec for the calendar. But I don't believe they listed a specific value and this is the general value listed for a hover state.
Resolves #1361 
