### PR TITLE
Optionally control pagination

### DIFF
--- a/src/examples/src/widgets/pagination/Controlled.tsx
+++ b/src/examples/src/widgets/pagination/Controlled.tsx
@@ -26,7 +26,8 @@ const Example = factory(function Example({ middleware: { icache } }) {
 			</div>
 
 			<Pagination
-				initialPage={currentPage}
+				page={currentPage}
+				pageSize={10}
 				total={25}
 				onPage={(value) => {
 					icache.set('currentPage', value);

--- a/src/pagination/index.tsx
+++ b/src/pagination/index.tsx
@@ -18,8 +18,14 @@ export interface PaginationProperties {
 	/** The initial page number */
 	initialPage?: number;
 
+	/** Controlled page property */
+	page?: number;
+
 	/** The initial page size */
 	initialPageSize?: number;
+
+	/** Controlled page size property */
+	pageSize?: number;
 
 	/** Callback fired when the page number is changed */
 	onPage?(page: number): void;
@@ -102,15 +108,27 @@ export default factory(function Pagination({
 	const classes = theme.classes(css);
 	const { messages } = i18n.localize(bundle);
 
-	if (initialPage !== undefined && initialPage !== icache.get('initialPage')) {
+	let { page, pageSize } = properties();
+
+	if (
+		page === undefined &&
+		initialPage !== undefined &&
+		initialPage !== icache.get('initialPage')
+	) {
 		icache.set('initialPage', initialPage);
 		icache.set('currentPage', initialPage);
 	}
 
-	if (initialPageSize !== undefined && initialPageSize !== icache.get('initialPageSize')) {
+	const currentPage = page === undefined ? icache.getOrSet('currentPage', 1) : page;
+	if (
+		pageSize === undefined &&
+		initialPageSize !== undefined &&
+		initialPageSize !== icache.get('initialPageSize')
+	) {
 		icache.set('initialPageSize', initialPageSize);
 		icache.set('pageSize', initialPageSize);
 	}
+	const currentPageSize = pageSize === undefined ? icache.getOrSet('pageSize', 10) : pageSize;
 
 	if (pageSizes !== undefined && pageSizes !== icache.get('pageSizes')) {
 		icache.set('pageSizes', pageSizes);
@@ -263,7 +281,10 @@ export default factory(function Pagination({
 					<div classes={classes.selectWrapper}>
 						<Select
 							key="page-size-select"
-							initialValue={pageSize.toString()}
+							initialValue={
+								pageSize === undefined ? currentPageSize.toString() : undefined
+							}
+							value={pageSize === undefined ? undefined : pageSize}
 							resource={{
 								resource: () => pageSizesResource,
 								data: pageSizes.map((ps) => ({ value: ps.toString() }))

--- a/src/pagination/index.tsx
+++ b/src/pagination/index.tsx
@@ -284,7 +284,7 @@ export default factory(function Pagination({
 							initialValue={
 								pageSize === undefined ? currentPageSize.toString() : undefined
 							}
-							value={pageSize === undefined ? undefined : pageSize}
+							value={pageSize === undefined ? undefined : pageSize.toString()}
 							resource={{
 								resource: () => pageSizesResource,
 								data: pageSizes.map((ps) => ({ value: ps.toString() }))

--- a/src/pagination/index.tsx
+++ b/src/pagination/index.tsx
@@ -134,10 +134,7 @@ export default factory(function Pagination({
 		icache.set('pageSizes', pageSizes);
 	}
 
-	const page = icache.getOrSet('currentPage', 1);
-	const pageSize = icache.getOrSet('pageSize', 10);
-
-	const showPrev = page > 1;
+	const showPrev = currentPage > 1;
 	const prevLink = (
 		<button
 			type="button"
@@ -145,8 +142,8 @@ export default factory(function Pagination({
 			classes={[classes.prev, classes.link]}
 			onclick={(e) => {
 				e.stopPropagation();
-				icache.set('currentPage', page - 1);
-				onPage && onPage(page - 1);
+				icache.set('currentPage', currentPage - 1);
+				onPage && onPage(currentPage - 1);
 			}}
 		>
 			<div classes={classes.icon}>
@@ -156,7 +153,7 @@ export default factory(function Pagination({
 		</button>
 	);
 
-	const showNext = page < total;
+	const showNext = currentPage < total;
 	const nextLink = (
 		<button
 			type="button"
@@ -164,8 +161,8 @@ export default factory(function Pagination({
 			classes={[classes.next, classes.link]}
 			onclick={(e) => {
 				e.stopPropagation();
-				icache.set('currentPage', page + 1);
-				onPage && onPage(page + 1);
+				icache.set('currentPage', currentPage + 1);
+				onPage && onPage(currentPage + 1);
 			}}
 		>
 			<div classes={classes.icon}>
@@ -199,8 +196,10 @@ export default factory(function Pagination({
 
 		let availableSpace = (containerWidth - fixedWidth) / siblingWidth;
 
-		const maxLeading = siblingCount ? Math.min(siblingCount, page - 1) : page - 1;
-		const maxTrailing = siblingCount ? Math.min(siblingCount, total - page) : total - page;
+		const maxLeading = siblingCount ? Math.min(siblingCount, currentPage - 1) : currentPage - 1;
+		const maxTrailing = siblingCount
+			? Math.min(siblingCount, total - currentPage)
+			: total - currentPage;
 
 		for (let i = 1; i <= Math.max(maxLeading, maxTrailing); i++) {
 			const showLeading = i <= maxLeading;
@@ -215,8 +214,8 @@ export default factory(function Pagination({
 			}
 
 			if (availableSpace >= spaceNeeded) {
-				const leadingPageNumber = page - i;
-				const trailingPageNumber = page + i;
+				const leadingPageNumber = currentPage - i;
+				const trailingPageNumber = currentPage + i;
 
 				if (showLeading) {
 					leadingSiblings.unshift(
@@ -272,7 +271,7 @@ export default factory(function Pagination({
 					{showPrev && prevLink}
 					{...leadingSiblings}
 					<div key="current" classes={classes.currentPage}>
-						{page.toString()}
+						{currentPage.toString()}
 					</div>
 					{...trailingSiblings}
 					{showNext && nextLink}

--- a/src/pagination/tests/Pagination.spec.tsx
+++ b/src/pagination/tests/Pagination.spec.tsx
@@ -186,6 +186,15 @@ describe('Pagination', () => {
 
 			sinon.assert.calledWith(onPageChange, 9);
 		});
+
+		it('ignores page change events when controlled', () => {
+			const onPageChange = sinon.stub();
+			const h = harness(() => <Pagination total={20} page={10} onPage={onPageChange} />);
+
+			h.expect(baseAssertion);
+			h.trigger('@numberedLink-9', 'onclick', stubEvent);
+			h.expect(baseAssertion);
+		});
 	});
 
 	it('renders without "prev" button when there is no prev', () => {
@@ -262,6 +271,7 @@ describe('Pagination', () => {
 					}}
 					transform={defaultTransform}
 					onValue={noop}
+					value={undefined}
 				>
 					{noop as any}
 				</Select>
@@ -303,6 +313,28 @@ describe('Pagination', () => {
 				{ middleware: [[resize, resizeMock], [node, nodeMock]] }
 			);
 			h.expect(sizeSelectorAssertion);
+
+			h.trigger('@page-size-select', 'onValue', '10');
+			sinon.assert.calledWith(onPageSizeChange, 10);
+		});
+
+		it('passes a value when controlled', () => {
+			const onPageSizeChange = sinon.stub();
+			const h = harness(() => (
+				<Pagination
+					initialPage={10}
+					pageSize={20}
+					total={20}
+					onPage={noop}
+					onPageSize={onPageSizeChange}
+					pageSizes={pageSizes}
+				/>
+			));
+			h.expect(
+				sizeSelectorAssertion
+					.setProperty('@page-size-select', 'value', 20)
+					.setProperty('@page-size-select', 'initialValue', undefined)
+			);
 
 			h.trigger('@page-size-select', 'onValue', '10');
 			sinon.assert.calledWith(onPageSizeChange, 10);

--- a/src/pagination/tests/Pagination.spec.tsx
+++ b/src/pagination/tests/Pagination.spec.tsx
@@ -188,12 +188,15 @@ describe('Pagination', () => {
 		});
 
 		it('ignores page change events when controlled', () => {
+			mockWidth('links', 1000);
 			const onPageChange = sinon.stub();
-			const h = harness(() => <Pagination total={20} page={10} onPage={onPageChange} />);
+			const h = harness(() => <Pagination total={20} page={10} onPage={onPageChange} />, {
+				middleware: [[resize, resizeMock], [node, nodeMock]]
+			});
 
-			h.expect(baseAssertion);
+			h.expect(visibleAssertion);
 			h.trigger('@numberedLink-9', 'onclick', stubEvent);
-			h.expect(baseAssertion);
+			h.expect(visibleAssertion);
 		});
 	});
 
@@ -319,17 +322,21 @@ describe('Pagination', () => {
 		});
 
 		it('passes a value when controlled', () => {
+			mockWidth('links', 1000);
 			const onPageSizeChange = sinon.stub();
-			const h = harness(() => (
-				<Pagination
-					initialPage={10}
-					pageSize={20}
-					total={20}
-					onPage={noop}
-					onPageSize={onPageSizeChange}
-					pageSizes={pageSizes}
-				/>
-			));
+			const h = harness(
+				() => (
+					<Pagination
+						initialPage={10}
+						pageSize={20}
+						total={20}
+						onPage={noop}
+						onPageSize={onPageSizeChange}
+						pageSizes={pageSizes}
+					/>
+				),
+				{ middleware: [[resize, resizeMock], [node, nodeMock]] }
+			);
 			h.expect(
 				sizeSelectorAssertion
 					.setProperty('@page-size-select', 'value', '20')

--- a/src/pagination/tests/Pagination.spec.tsx
+++ b/src/pagination/tests/Pagination.spec.tsx
@@ -332,7 +332,7 @@ describe('Pagination', () => {
 			));
 			h.expect(
 				sizeSelectorAssertion
-					.setProperty('@page-size-select', 'value', 20)
+					.setProperty('@page-size-select', 'value', '20')
 					.setProperty('@page-size-select', 'initialValue', undefined)
 			);
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Allows pagination to be controlled using `page` and `pageSize` properties.
Resolves #1336 