### PR TITLE
fix: SlidePane material theme

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2696,6 +2696,133 @@
         "tslib": "^1.9.3"
       }
     },
+    "@material/drawer": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@material/drawer/-/drawer-5.1.0.tgz",
+      "integrity": "sha512-Xh/kYkT8QWWXkbCI25ys6av0wrc0wXRfvnRdH34Rz4sZvWC51D6apK2bxGr+AV/uR88zwn6U8pb9cccnr+2Eqw==",
+      "requires": {
+        "@material/animation": "^5.1.0",
+        "@material/base": "^5.1.0",
+        "@material/dom": "^5.1.0",
+        "@material/elevation": "^5.1.0",
+        "@material/feature-targeting": "^5.1.0",
+        "@material/list": "^5.1.0",
+        "@material/ripple": "^5.1.0",
+        "@material/rtl": "^5.1.0",
+        "@material/shape": "^5.1.0",
+        "@material/theme": "^5.1.0",
+        "@material/typography": "^5.1.0",
+        "tslib": "^1.9.3"
+      },
+      "dependencies": {
+        "@material/animation": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@material/animation/-/animation-5.1.0.tgz",
+          "integrity": "sha512-qZuPCZkTsCQCzx5EtY2eNBcmYOMGMbFVq6VTmvQztDCYDykT8JfP8Hpk55Y5bGORHvBbIasUXzoAhfQs6w/Bdg==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/base": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@material/base/-/base-5.1.0.tgz",
+          "integrity": "sha512-UxVFKpSNaoKqd7hHxy9hrvwANp0WJy/BZqu8Rj/aRvKnBZnuHehFuOysI9WqdeTqgveJaQoj6EEkVEqLurR5Sg==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/density": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@material/density/-/density-5.1.0.tgz",
+          "integrity": "sha512-jmp6AgiNYosl+HicxWCa8vib9pg9tNxRcf+6f9LDkDYJ9jtO90PXuypyd0hO64JZ9Df7BywFj5hTWPERG1FBbw=="
+        },
+        "@material/dom": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@material/dom/-/dom-5.1.0.tgz",
+          "integrity": "sha512-tBbl3hG34Auv+2sboWhtstXeZ9rx3G7hb/jEXs5xZ5KIfZHwY4mbo0KqR/fSJZKaUsvk2Nc/UEOVcUx2mTNmYg==",
+          "requires": {
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/elevation": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-5.1.0.tgz",
+          "integrity": "sha512-NsWIT+L6x3BLouCOh3H8x885/nCrNNmzCwHEodz/0PcYQsxx9RiIVFkagmJWw/w//jej/D4NotD0xHGKOWTrFA==",
+          "requires": {
+            "@material/animation": "^5.1.0",
+            "@material/base": "^5.1.0",
+            "@material/feature-targeting": "^5.1.0",
+            "@material/theme": "^5.1.0"
+          }
+        },
+        "@material/feature-targeting": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@material/feature-targeting/-/feature-targeting-5.1.0.tgz",
+          "integrity": "sha512-z3JNWF7lP9WOzw1xBwul/HAOu4qC6EpK/8MkhjLNI9APvdYML82PWS1V0k0MiqA6Jk6uxm8DiVAk9VUqBa9/YA=="
+        },
+        "@material/list": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@material/list/-/list-5.1.0.tgz",
+          "integrity": "sha512-fcHMJLmmtFYeMU8CO9VsXoRRm3/2jhPVMWK3lpuARZxvkNyZqjQG0mGtpWgw4oekerM/B37TGGFmN3R5DSyGcg==",
+          "requires": {
+            "@material/base": "^5.1.0",
+            "@material/density": "^5.1.0",
+            "@material/dom": "^5.1.0",
+            "@material/feature-targeting": "^5.1.0",
+            "@material/ripple": "^5.1.0",
+            "@material/rtl": "^5.1.0",
+            "@material/shape": "^5.1.0",
+            "@material/theme": "^5.1.0",
+            "@material/typography": "^5.1.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/ripple": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@material/ripple/-/ripple-5.1.0.tgz",
+          "integrity": "sha512-mluIf+HaaCplszp9/MAl178FpfIJWi5hSyQOpF7w8RTzRSaH8J0uwgmn8VeNnwe1TAWio0vQzHrz4iEg2r7Ngw==",
+          "requires": {
+            "@material/animation": "^5.1.0",
+            "@material/base": "^5.1.0",
+            "@material/dom": "^5.1.0",
+            "@material/feature-targeting": "^5.1.0",
+            "@material/theme": "^5.1.0",
+            "tslib": "^1.9.3"
+          }
+        },
+        "@material/rtl": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@material/rtl/-/rtl-5.1.0.tgz",
+          "integrity": "sha512-Hij4KJIfjK63HArdQ3K1INMo0MbigDgL0JhjO1VDk5c+iYmYpjDI7wgPLmV5ISCBtenXRWpo1xbBO3uEmtCd4Q=="
+        },
+        "@material/shape": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@material/shape/-/shape-5.1.0.tgz",
+          "integrity": "sha512-/k27T9fhQ1zj7VCsS26nv0TzsOi142ncik2mycEXq8753PDBotob7Y19pbwivwt9QxkglhMGH0EaWdZPzBoQXw==",
+          "requires": {
+            "@material/feature-targeting": "^5.1.0",
+            "@material/rtl": "^5.1.0"
+          }
+        },
+        "@material/theme": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@material/theme/-/theme-5.1.0.tgz",
+          "integrity": "sha512-VoaCYAubn/oEG1/fu/yP4nxAw8sLEphFOGGBJxcPGQoLgQ9qcvibsV3G5H9S6AtmhJxgSGU0JnO9TaiuhQq5zA==",
+          "requires": {
+            "@material/feature-targeting": "^5.1.0"
+          }
+        },
+        "@material/typography": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/@material/typography/-/typography-5.1.0.tgz",
+          "integrity": "sha512-yh02koa6JLyPT5u7Zb31kyqhoZoppL0n9FmZK+eHXZcfeDF7ROL0UmtRsEjQxfnCNZRR+FIhAgrzdYxClwH05g==",
+          "requires": {
+            "@material/feature-targeting": "^5.1.0",
+            "@material/theme": "^5.1.0"
+          }
+        }
+      }
+    },
     "@material/elevation": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@material/elevation/-/elevation-1.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -103,6 +103,7 @@
     "typescript": "~3.4.5"
   },
   "dependencies": {
+    "@material/drawer": "^5.1.0",
     "tslib": "~1.9.1"
   },
   "lint-staged": {

--- a/src/examples/src/widgets/slide-pane/Basic.tsx
+++ b/src/examples/src/widgets/slide-pane/Basic.tsx
@@ -1,13 +1,22 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import SlidePane from '@dojo/widgets/slide-pane';
 import icache from '@dojo/framework/core/middleware/icache';
+import { DEMO_TEXT } from './common';
 
 const factory = create({ icache });
 
 export default factory(function Basic({ middleware: { icache } }) {
 	return (
 		<virtual>
-			<SlidePane open={icache.get('open')} onRequestClose={() => icache.set('open', false)} />
+			<SlidePane
+				title="Basic SlidePane"
+				open={icache.getOrSet('open', true)}
+				onRequestClose={() => {
+					icache.set('open', false);
+				}}
+			>
+				{DEMO_TEXT}
+			</SlidePane>
 			<button onclick={() => icache.set('open', !icache.get('open'))}>Toggle</button>
 		</virtual>
 	);

--- a/src/examples/src/widgets/slide-pane/BottomAlignSlidePane.tsx
+++ b/src/examples/src/widgets/slide-pane/BottomAlignSlidePane.tsx
@@ -1,6 +1,7 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import SlidePane from '@dojo/widgets/slide-pane';
 import icache from '@dojo/framework/core/middleware/icache';
+import { DEMO_TEXT } from './common';
 
 const factory = create({ icache });
 
@@ -14,30 +15,7 @@ export default factory(function BottomWidthSlidePane({ middleware: { icache } })
 				icache.set('open', false);
 			}}
 		>
-			{`Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.`}
+			{DEMO_TEXT}
 		</SlidePane>
 	);
 });

--- a/src/examples/src/widgets/slide-pane/FixedWidthSlidePane.tsx
+++ b/src/examples/src/widgets/slide-pane/FixedWidthSlidePane.tsx
@@ -1,44 +1,22 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import SlidePane from '@dojo/widgets/slide-pane';
 import icache from '@dojo/framework/core/middleware/icache';
+import { DEMO_TEXT } from './common';
 
 const factory = create({ icache });
 
 export default factory(function FixedWidthSlidePane({ middleware: { icache } }) {
 	return (
 		<SlidePane
-			title="Right Aligned SlidePane"
+			title="Fixed Width"
 			open={icache.getOrSet('open', true)}
-			width={200}
+			width={250}
 			align="right"
 			onRequestClose={() => {
 				icache.set('open', false);
 			}}
 		>
-			{`Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.`}
+			{DEMO_TEXT}
 		</SlidePane>
 	);
 });

--- a/src/examples/src/widgets/slide-pane/LeftAlignSlidePane.tsx
+++ b/src/examples/src/widgets/slide-pane/LeftAlignSlidePane.tsx
@@ -1,6 +1,7 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import SlidePane from '@dojo/widgets/slide-pane';
 import icache from '@dojo/framework/core/middleware/icache';
+import { DEMO_TEXT } from './common';
 
 const factory = create({ icache });
 
@@ -16,30 +17,7 @@ export default factory(function LeftAlignSlidePane({ middleware: { icache } }) {
 				icache.set('open', false);
 			}}
 		>
-			{`Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.`}
+			{DEMO_TEXT}
 		</SlidePane>
 	);
 });

--- a/src/examples/src/widgets/slide-pane/RightAlignSlidePane.tsx
+++ b/src/examples/src/widgets/slide-pane/RightAlignSlidePane.tsx
@@ -1,6 +1,7 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import SlidePane from '@dojo/widgets/slide-pane';
 import icache from '@dojo/framework/core/middleware/icache';
+import { DEMO_TEXT } from './common';
 
 const factory = create({ icache });
 
@@ -15,30 +16,7 @@ export default factory(function RightAlignSlidePane({ middleware: { icache } }) 
 				icache.set('open', false);
 			}}
 		>
-			{`Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.`}
+			{DEMO_TEXT}
 		</SlidePane>
 	);
 });

--- a/src/examples/src/widgets/slide-pane/UnderlaySlidePane.tsx
+++ b/src/examples/src/widgets/slide-pane/UnderlaySlidePane.tsx
@@ -1,13 +1,14 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import SlidePane from '@dojo/widgets/slide-pane';
 import icache from '@dojo/framework/core/middleware/icache';
+import { DEMO_TEXT } from './common';
 
 const factory = create({ icache });
 
 export default factory(function UnderlaySlidePane({ middleware: { icache } }) {
 	return (
 		<SlidePane
-			title="Right Aligned SlidePane"
+			title="Underlay SlidePane"
 			open={icache.getOrSet('open', true)}
 			underlay={true}
 			align="right"
@@ -15,30 +16,7 @@ export default factory(function UnderlaySlidePane({ middleware: { icache } }) {
 				icache.set('open', false);
 			}}
 		>
-			{`Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.
-			Lorem ipsum dolor sit amet, consectetur adipiscing elit.
-			Quisque id purus ipsum. Aenean ac purus purus.
-			Nam sollicitudin varius augue, sed lacinia felis tempor in.`}
+			{DEMO_TEXT}
 		</SlidePane>
 	);
 });

--- a/src/examples/src/widgets/slide-pane/common.ts
+++ b/src/examples/src/widgets/slide-pane/common.ts
@@ -1,0 +1,26 @@
+export const DEMO_TEXT = `
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+	Quisque id purus ipsum. Aenean ac purus purus.
+	Nam sollicitudin varius augue, sed lacinia felis tempor in.
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+	Quisque id purus ipsum. Aenean ac purus purus.
+	Nam sollicitudin varius augue, sed lacinia felis tempor in.
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+	Quisque id purus ipsum. Aenean ac purus purus.
+	Nam sollicitudin varius augue, sed lacinia felis tempor in.
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+	Quisque id purus ipsum. Aenean ac purus purus.
+	Nam sollicitudin varius augue, sed lacinia felis tempor in.
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+	Quisque id purus ipsum. Aenean ac purus purus.
+	Nam sollicitudin varius augue, sed lacinia felis tempor in.
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+	Quisque id purus ipsum. Aenean ac purus purus.
+	Nam sollicitudin varius augue, sed lacinia felis tempor in.
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+	Quisque id purus ipsum. Aenean ac purus purus.
+	Nam sollicitudin varius augue, sed lacinia felis tempor in.
+	Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+	Quisque id purus ipsum. Aenean ac purus purus.
+	Nam sollicitudin varius augue, sed lacinia felis tempor in.
+`;

--- a/src/slide-pane/index.tsx
+++ b/src/slide-pane/index.tsx
@@ -258,7 +258,9 @@ export const SlidePane = factory(function SlidePane({
 			>
 				{title ? (
 					<div classes={themeCss.title} key="title">
-						<div id={titleId}>{title}</div>
+						<div id={titleId} classes={themeCss.titleContent}>
+							{title}
+						</div>
 						<button classes={themeCss.close} type="button" onclick={onCloseClick}>
 							{closeText}
 							<span classes={themeCss.closeIcon}>

--- a/src/theme/default/slide-pane.m.css
+++ b/src/theme/default/slide-pane.m.css
@@ -34,6 +34,10 @@
 	position: relative;
 }
 
+/* The text content of the title */
+.titleContent {
+}
+
 /* Added to the close button */
 .close {
 	position: absolute;

--- a/src/theme/default/slide-pane.m.css.d.ts
+++ b/src/theme/default/slide-pane.m.css.d.ts
@@ -6,6 +6,7 @@ export const content: string;
 export const open: string;
 export const pane: string;
 export const title: string;
+export const titleContent: string;
 export const close: string;
 export const closeIcon: string;
 export const left: string;

--- a/src/theme/material/slide-pane.m.css
+++ b/src/theme/material/slide-pane.m.css
@@ -1,2 +1,26 @@
-.root {
+.pane {
+	composes: mdc-drawer mdc-drawer--modal from '@material/drawer/dist/mdc.drawer.css';
+	z-index: 400;
+}
+
+.open {
+	composes: mdc-drawer--open from '@material/drawer/dist/mdc.drawer.css';
+}
+
+.title {
+	composes: mdc-drawer__header from '@material/drawer/dist/mdc.drawer.css';
+	position: relative;
+}
+
+.titleContent {
+	composes: mdc-drawer__title from '@material/drawer/dist/mdc.drawer.css';
+}
+
+.content {
+	composes: mdc-drawer__content from '@material/drawer/dist/mdc.drawer.css';
+	padding: 0 16px 16px 16px;
+}
+
+.right {
+	left: auto;
 }


### PR DESCRIPTION
**Type:** bugfix

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request adds a material theme for the `SlidePane` widget.

Resolves #1317

**Preview:**

<img width="887" alt="preview" src="https://user-images.githubusercontent.com/334586/78910025-4c0c4180-7a52-11ea-98ee-f49ba8746f2f.png">
