### PR TITLE
Optionally control date input

### DIFF
--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -34,7 +34,7 @@ export interface DateInputProperties extends ThemeProperties, FocusProperties {
 }
 
 interface DateInputICache {
-	/** Current user-inputted value */
+	/** The most recent "initialValue" property passed */
 	initialValue: string;
 	/** Current user-inputted value */
 	inputValue: string;

--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -69,7 +69,9 @@ export default factory(function({ properties, middleware: { theme, icache, i18n,
 	) {
 		const parsed = initialValue && parseDate(initialValue);
 
-		icache.set('inputValue', formatDate(parsed || new Date()));
+		if (parsed) {
+			icache.set('inputValue', formatDate(parsed));
+		}
 		icache.set('initialValue', initialValue);
 		icache.set('shouldValidate', true);
 	}

--- a/src/date-input/tests/unit/DateInput.spec.tsx
+++ b/src/date-input/tests/unit/DateInput.spec.tsx
@@ -46,6 +46,7 @@ const baseTemplate = (date?: Date) =>
 		return (
 			<div classes={[undefined, css.root]}>
 				<input
+					assertion-key="input"
 					type="hidden"
 					name="dateInput"
 					value={formatDateISO(date || today)}
@@ -106,6 +107,21 @@ describe('DateInput', () => {
 	it('renders with default date', () => {
 		const h = harness(() => <DateInput name="dateInput" onValue={onValue} />);
 		h.expect(baseTemplate());
+		sinon.assert.calledWith(onValue, formatDateISO(today));
+	});
+
+	it('renders with default date when provided an invalid initial date', () => {
+		const h = harness(() => (
+			<DateInput name="dateInput" initialValue="not a date" onValue={onValue} />
+		));
+		h.expect(baseTemplate());
+	});
+
+	it('does not render a default date when value is provided and invalid', () => {
+		const h = harness(() => (
+			<DateInput name="dateInput" value="not a date" onValue={onValue} />
+		));
+		h.expect(baseTemplate().setProperty('@input', 'value', ''));
 		sinon.assert.calledWith(onValue, formatDateISO(today));
 	});
 

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -195,6 +195,7 @@ import ClickTooltip from './widgets/tooltip/Click';
 import FocusTooltip from './widgets/tooltip/Focus';
 import BasicNativeSelect from './widgets/native-select/Basic';
 import BasicDateInput from './widgets/date-input/Basic';
+import ControlledDateInput from './widgets/date-input/Controlled';
 import BasicLoadingIndicator from './widgets/loading-indicator/Basic';
 import BasicHeader from './widgets/header/Basic';
 import LeadingHeader from './widgets/header/Leading';
@@ -538,7 +539,16 @@ export const config = {
 					sandbox: true,
 					size: 'large'
 				}
-			}
+			},
+			examples: [
+				{
+					filename: 'Controlled',
+					module: ControlledDateInput,
+					sandbox: true,
+					size: 'large',
+					title: 'Controlled date input'
+				}
+			]
 		},
 		'context-popup': {
 			overview: {

--- a/src/examples/src/widgets/date-input/Controlled.tsx
+++ b/src/examples/src/widgets/date-input/Controlled.tsx
@@ -1,0 +1,19 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import DateInput from '@dojo/widgets/date-input';
+import icache from '@dojo/framework/core/middleware/icache';
+
+const factory = create({ icache });
+
+const Example = factory(function Controlled({ middleware: { icache } }) {
+	return (
+		<DateInput
+			value={icache.get('date')}
+			onValue={(date) => {
+				icache.set('date', date);
+			}}
+			name="dateInput"
+		/>
+	);
+});
+
+export default Example;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds `value` property to optionally control the date input
Resolves #1332
