### PR TITLE
Fixing chip material theme

### DIFF
--- a/src/chip/index.tsx
+++ b/src/chip/index.tsx
@@ -81,7 +81,12 @@ export default factory(function Chip({ properties, children, middleware: { theme
 						}
 					}}
 				>
-					{closeIcon || <Icon type="closeIcon" />}
+					{closeIcon || (
+						<Icon
+							type="closeIcon"
+							classes={{ '@dojo/widgets/icon': { icon: [themedCss.icon] } }}
+						/>
+					)}
 				</span>
 			)}
 		</div>

--- a/src/chip/tests/Chip.spec.tsx
+++ b/src/chip/tests/Chip.spec.tsx
@@ -12,6 +12,8 @@ import Icon from '../../icon/index';
 
 function noop() {}
 
+const iconClasses = { '@dojo/widgets/icon': { icon: [css.icon] } };
+
 describe('Chip', () => {
 	const label = 'Chip label';
 	const template = assertionTemplate(() => (
@@ -76,7 +78,7 @@ describe('Chip', () => {
 					onclick={noop}
 					onkeydown={noop}
 				>
-					<Icon type="closeIcon" />
+					<Icon type="closeIcon" classes={iconClasses} />
 				</span>
 			])
 		);
@@ -124,7 +126,7 @@ describe('Chip', () => {
 						onclick={noop}
 						onkeydown={noop}
 					>
-						<Icon type="closeIcon" />
+						<Icon type="closeIcon" classes={iconClasses} />
 					</span>
 				])
 				.prepend(':root', () => [
@@ -165,7 +167,7 @@ describe('Chip', () => {
 			<Chip onClose={onClose} onClick={onClick}>
 				{{
 					label,
-					icon: () => <Icon type="plusIcon" />
+					icon: () => <Icon type="plusIcon" classes={iconClasses} />
 				}}
 			</Chip>
 		));
@@ -184,12 +186,12 @@ describe('Chip', () => {
 						onclick={noop}
 						onkeydown={noop}
 					>
-						<Icon type="closeIcon" />
+						<Icon type="closeIcon" classes={iconClasses} />
 					</span>
 				])
 				.prepend(':root', () => [
 					<span classes={css.iconWrapper}>
-						<Icon type="plusIcon" />
+						<Icon type="plusIcon" classes={iconClasses} />
 					</span>
 				])
 		);
@@ -233,7 +235,7 @@ describe('Chip', () => {
 			<Chip onClose={onClose} onClick={onClick}>
 				{{
 					label,
-					icon: () => <Icon type="plusIcon" />
+					icon: () => <Icon type="plusIcon" classes={iconClasses} />
 				}}
 			</Chip>
 		));
@@ -252,12 +254,12 @@ describe('Chip', () => {
 						onclick={noop}
 						onkeydown={noop}
 					>
-						<Icon type="closeIcon" />
+						<Icon type="closeIcon" classes={iconClasses} />
 					</span>
 				])
 				.prepend(':root', () => [
 					<span classes={css.iconWrapper}>
-						<Icon type="plusIcon" />
+						<Icon type="plusIcon" classes={iconClasses} />
 					</span>
 				])
 		);

--- a/src/theme/default/chip.m.css
+++ b/src/theme/default/chip.m.css
@@ -23,3 +23,7 @@
 /* Added to disabled Chips */
 .disabled {
 }
+
+/* Added to the close icon */
+.icon {
+}

--- a/src/theme/default/chip.m.css.d.ts
+++ b/src/theme/default/chip.m.css.d.ts
@@ -4,3 +4,4 @@ export const label: string;
 export const closeIconWrapper: string;
 export const clickable: string;
 export const disabled: string;
+export const icon: string;

--- a/src/theme/material/chip.m.css
+++ b/src/theme/material/chip.m.css
@@ -27,3 +27,7 @@
 
 .disabled {
 }
+
+.root .icon {
+	font-size: 18px;
+}


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixing material theme for Chip. The close icon was too big!

![image](https://user-images.githubusercontent.com/2008858/79247829-ff0cde80-7e48-11ea-8f54-77003240f81e.png)

Resolves #1356 
