### PR TITLE
Fixing tooltip material style

### DIFF
--- a/src/theme/material/tooltip.m.css
+++ b/src/theme/material/tooltip.m.css
@@ -1,7 +1,7 @@
 :root {
 	/* Spacing */
 	--mdc-tooltip-grid-base: 8px;
-	--mdc-tooltip-spacing-regular: var(--grid-base);
+	--mdc-tooltip-spacing-regular: calc(var(--mdc-tooltip-grid-base) / 2);
 
 	/* Color */
 	--mdc-tooltip-grey-background: rgba(97, 97, 97, 0.9); /* The theme grey background color */


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixing Tooltip material styles.

![image](https://user-images.githubusercontent.com/2008858/79252391-84938d00-7e4f-11ea-9ad9-02e2446ea069.png)

