### PR TITLE
Fixing typeahead examples

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -1632,7 +1632,7 @@ export const config = {
 					title: 'Custom Filter'
 				},
 				{
-					filename: 'Remote',
+					filename: 'RemoteSource',
 					module: RemoteTypeahead,
 					title: 'Remote Source'
 				},
@@ -1644,7 +1644,7 @@ export const config = {
 			],
 			overview: {
 				example: {
-					filename: 'Typeahead',
+					filename: 'Basic',
 					module: BasicTypeahead
 				}
 			}


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixing the Basic and Remote Source typeahead examples to include the actual example code 😄 
