### PR TITLE
Fixing parade examples for various widgets

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -417,12 +417,12 @@ export const config = {
 				{
 					title: 'Basic HeaderCard with Action Buttons',
 					module: ActionHeaderCard,
-					filename: 'ActionHeaderCard'
+					filename: 'ActionCard'
 				},
 				{
 					title: 'Header Card with media',
 					module: MediaHeaderCard,
-					filename: 'MediaHeaderCard'
+					filename: 'MediaCard'
 				}
 			],
 			filename: 'index',
@@ -1519,7 +1519,7 @@ export const config = {
 		'three-column-layout': {
 			overview: {
 				example: {
-					filename: 'BasicThreeColumnLayout',
+					filename: 'Basic',
 					module: BasicThreeColumnLayout
 				}
 			}
@@ -1567,7 +1567,7 @@ export const config = {
 		'title-pane': {
 			examples: [
 				{
-					filename: 'AriaHeadingLevel',
+					filename: 'HeadingLevel',
 					module: HeadingLevel,
 					title: 'Defined aria heading level'
 				},


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixing missing code in parade examples for 

- HeaderCard
- ThreeColumnLayout
- TitlePane

