### PR TITLE
Removed "fixed" styles to allow theme control over sliding

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -1294,7 +1294,7 @@ export const config = {
 					filename: 'Basic',
 					module: BasicSlidePane,
 					sandbox: true,
-					size: 'medium'
+					size: 'large'
 				}
 			},
 			examples: [
@@ -1303,35 +1303,35 @@ export const config = {
 					module: RightAlignSlidePane,
 					title: 'Right Aligned Slide Pane',
 					sandbox: true,
-					size: 'medium'
+					size: 'large'
 				},
 				{
 					filename: 'LeftAlignSlidePane',
 					module: LeftAlignSlidePane,
 					title: 'Left Aligned Slide Pane',
 					sandbox: true,
-					size: 'medium'
+					size: 'large'
 				},
 				{
 					filename: 'BottomAlignSlidePane',
 					module: BottomAlignSlidePane,
 					title: 'Bottom Aligned Slide Pane',
 					sandbox: true,
-					size: 'medium'
+					size: 'large'
 				},
 				{
 					filename: 'UnderlaySlidePane',
 					module: UnderlaySlidePane,
 					title: 'Underlaid Slide Pane',
 					sandbox: true,
-					size: 'medium'
+					size: 'large'
 				},
 				{
 					filename: 'FixedWidthSlidePane',
 					module: FixedWidthSlidePane,
 					title: 'Fixed Width Slide Pane',
 					sandbox: true,
-					size: 'medium'
+					size: 'large'
 				}
 			]
 		},

--- a/src/slide-pane/styles/slide-pane.m.css
+++ b/src/slide-pane/styles/slide-pane.m.css
@@ -32,56 +32,16 @@
 
 .leftFixed {
 	left: 0;
-	transform: translateX(-100%);
 }
 
 .rightFixed {
 	right: 0;
-	transform: translateX(100%);
 }
 
 .topFixed {
 	top: 0;
-	transform: translateY(-100%);
 }
 
 .bottomFixed {
 	bottom: 0;
-	transform: translateY(100%);
-}
-
-.leftFixed.slideOutFixed {
-	transform: translateX(-100%) !important;
-}
-
-.rightFixed.slideOutFixed {
-	transform: translateX(100%) !important;
-}
-
-.topFixed.slideOutFixed {
-	transform: translateY(-100%) !important;
-}
-
-.bottomFixed.slideOutFixed {
-	transform: translateY(100%) !important;
-}
-
-.leftFixed.slideInFixed {
-	transform: translateX(0%) !important;
-}
-
-.rightFixed.slideInFixed {
-	transform: translateX(0%) !important;
-}
-
-.topFixed.slideInFixed {
-	transform: translateY(0%) !important;
-}
-
-.bottomFixed.slideInFixed {
-	transform: translateY(0%) !important;
-}
-
-.openFixed {
-	transform: translateX(0%);
 }

--- a/src/theme/default/slide-pane.m.css
+++ b/src/theme/default/slide-pane.m.css
@@ -19,10 +19,6 @@
 .content {
 }
 
-/* Added to an open slide pane */
-.open {
-}
-
 /* Contains the pane */
 .pane {
 	background-color: var(--component-background);
@@ -57,16 +53,25 @@
 
 /* Added to a left-aligned pane */
 .left {
+	transform: translateX(-100%);
 }
 
 /* Added to a right-aligned pane */
 .right {
+	transform: translateX(100%);
 }
 
 /* Added to a top-aligned pane */
 .top {
+	transform: translateY(-100%);
 }
 
 /* Added to a bottom-aligned pane */
 .bottom {
+	transform: translateY(100%);
+}
+
+/* Added to an open slide pane */
+.open {
+	transform: translate(0, 0);
 }

--- a/src/theme/dojo/slide-pane.m.css
+++ b/src/theme/dojo/slide-pane.m.css
@@ -49,26 +49,22 @@
 }
 
 .left {
-	transform: translateX(calc(-100% - 10px));
+	transform: translateX(calc(-100% - var(--box-shadow-blur-large)));
 }
 
 .right {
-	transform: translateX(calc(100% + 10px));
+	transform: translateX(calc(100% + var(--box-shadow-blur-large)));
 }
 
 .top {
-	transform: translateY(calc(-100% - 20px));
+	transform: translateY(calc(-100% - var(--box-shadow-blur-large) - var(--box-shadow-voffset)));
 }
 
 .bottom {
-	transform: translateY(calc(100% + 10px));
+	transform: translateY(calc(100% + var(--box-shadow-blur-large)));
 }
 
 .slideIn,
 .slideOut {
 	transition: transform ease-in-out var(--transition-duration);
-}
-
-.open {
-	transform: translateX(0%);
 }

--- a/src/theme/dojo/variants/default.m.css
+++ b/src/theme/dojo/variants/default.m.css
@@ -42,8 +42,10 @@
 	--color-box-shadow-valid: rgba(24, 135, 1, 0.2);
 
 	/* Border and shadow */
+	--box-shadow-voffset-large: 9px;
+	--box-shadow-blur-large: 16px;
 	--box-shadow-dimensions-small: 0 2px 2px 0;
-	--box-shadow-dimensions-large: 0 9px 16px 0;
+	--box-shadow-dimensions-large: 0 var(--box-shadow-voffset-large) var(--box-shadow-blur-large) 0;
 	--border-width: 1px;
 	--border-width-emphasized: 2px;
 	--border-radius: 4px;

--- a/src/theme/material/slide-pane.m.css
+++ b/src/theme/material/slide-pane.m.css
@@ -3,10 +3,6 @@
 	z-index: 400;
 }
 
-.open {
-	composes: mdc-drawer--open from '@material/drawer/dist/mdc.drawer.css';
-}
-
 .title {
 	composes: mdc-drawer__header from '@material/drawer/dist/mdc.drawer.css';
 	position: relative;
@@ -21,6 +17,18 @@
 	padding: 0 16px 16px 16px;
 }
 
+.left {
+	transform: translateX(calc(-100% - 32px));
+}
+
 .right {
-	left: auto;
+	transform: translateX(calc(100% + 32px));
+}
+
+.top {
+	transform: translateY(calc(-100% - 26px));
+}
+
+.bottom {
+	transform: translateY(calc(100% + 26px));
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

There were some "fixed" styles that were inaccessible via theme composure. They have been moved to the default theme to allow theme overriding. As before, the slidepane is still functional with the default theme.

Increased sandbox size to better represent how slidepane looks/works in examples.

![2020-04-15_15-24-02](https://user-images.githubusercontent.com/41762295/79379669-3e146000-7f2d-11ea-950b-142221de0645.gif)

Resolves #1387 
