### PR TITLE
Fix material tooltip spacing

### DIFF
--- a/src/theme/default/tooltip.m.css
+++ b/src/theme/default/tooltip.m.css
@@ -21,3 +21,19 @@
 /* Added to a bottom-aligned tip */
 .bottom {
 }
+
+.bottom .content {
+	transform: translate(-50%, 100%);
+}
+
+.right .content {
+	transform: translate(100%, -50%);
+}
+
+.left .content {
+	transform: translate(-100%, -50%);
+}
+
+.top .content {
+	transform: translate(-50%, -100%);
+}

--- a/src/theme/dojo/tooltip.m.css
+++ b/src/theme/dojo/tooltip.m.css
@@ -16,7 +16,6 @@
 }
 
 .bottom .content {
-	margin: var(--spacing-regular) 0 0;
 	transform: translate(-50%, calc(100% + var(--grid-base)));
 }
 
@@ -32,7 +31,6 @@
 }
 
 .top .content {
-	margin: 0 0 var(--spacing-regular);
 	transform: translate(-50%, calc(-100% - var(--grid-base)));
 }
 
@@ -48,7 +46,6 @@
 }
 
 .left .content {
-	margin: 0 var(--spacing-regular) 0 0;
 	transform: translate(calc(-100% - var(--grid-base)), -50%);
 }
 
@@ -64,7 +61,6 @@
 }
 
 .right .content {
-	margin: 0 0 0 var(--spacing-regular);
 	transform: translate(calc(100% + var(--grid-base)), -50%);
 }
 

--- a/src/theme/material/tooltip.m.css
+++ b/src/theme/material/tooltip.m.css
@@ -26,21 +26,17 @@
 }
 
 .bottom .content {
-	margin: var(--mdc-tooltip-spacing-regular) 0 0;
 	transform: translate(-50%, calc(100% + var(--mdc-tooltip-grid-base)));
 }
 
 .top .content {
-	margin: 0 0 var(--mdc-tooltip-spacing-regular);
 	transform: translate(-50%, calc(-100% - var(--mdc-tooltip-grid-base)));
 }
 
 .left .content {
-	margin: 0 var(--mdc-tooltip-spacing-regular) 0 0;
 	transform: translate(calc(-100% - var(--mdc-tooltip-grid-base)), -50%);
 }
 
 .right .content {
-	margin: 0 0 0 var(--mdc-tooltip-spacing-regular);
 	transform: translate(calc(100% + var(--mdc-tooltip-grid-base)), -50%);
 }

--- a/src/theme/material/tooltip.m.css
+++ b/src/theme/material/tooltip.m.css
@@ -22,6 +22,7 @@
 	font-size: var(--mdc-theme-font-size-small);
 	line-height: calc(var(--mdc-tooltip-font-size) * 1.6);
 	z-index: var(--zindex-tooltip);
+	white-space: nowrap;
 }
 
 .bottom .content {

--- a/src/tooltip/styles/tooltip.m.css
+++ b/src/tooltip/styles/tooltip.m.css
@@ -13,23 +13,19 @@
 .bottomFixed .contentFixed {
 	bottom: 0;
 	left: 50%;
-	transform: translate(-50%, 100%);
 }
 
 .leftFixed .contentFixed {
 	left: 0;
 	top: 50%;
-	transform: translate(-100%, -50%);
 }
 
 .rightFixed .contentFixed {
 	right: 0;
 	top: 50%;
-	transform: translate(100%, -50%);
 }
 
 .topFixed .contentFixed {
 	top: 0;
 	left: 50%;
-	transform: translate(-50%, -100%);
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds `whitespace: nowrap` to keep the tooltip to a single line. Moves the transform styles to the default theme so that the dojo and material theme overrides actually take effect. Removes the margin styles that don't have any effect on the tooltip given its absolute positioning.
Resolves #1385 
