### PR TITLE
Adding disabled property to list (#1392)

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -95,6 +95,7 @@ import DividedList from './widgets/list/Dividers';
 import ControlledList from './widgets/list/Controlled';
 import ItemRenderer from './widgets/list/ItemRenderer';
 import FetchedResource from './widgets/list/FetchedResource';
+import DisabledList from './widgets/list/Disabled';
 import Menu from './widgets/list/Menu';
 import CustomTransformer from './widgets/list/CustomTransformer';
 import BasicMultiSelectTypeahead from './widgets/multi-select-typeahead/Basic';
@@ -922,6 +923,13 @@ export const config = {
 					filename: 'Dividers',
 					module: DividedList,
 					title: 'Dividers'
+				},
+				{
+					description:
+						'This example shows how to disable a list item, even if the item is not marked as disabled in the resource.',
+					filename: 'Disabled',
+					module: DisabledList,
+					title: 'Disabled'
 				}
 			],
 			overview: {

--- a/src/examples/src/widgets/list/Disabled.tsx
+++ b/src/examples/src/widgets/list/Disabled.tsx
@@ -1,0 +1,24 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import List, { defaultTransform } from '@dojo/widgets/list';
+import icache from '@dojo/framework/core/middleware/icache';
+import { createMemoryResourceWithData } from './memoryTemplate';
+
+const factory = create({ icache });
+
+const animals = [{ value: 'cat' }, { value: 'dog' }, { value: 'mouse' }, { value: 'rat' }];
+const resource = createMemoryResourceWithData(animals);
+
+export default factory(function Disabled({ middleware: { icache } }) {
+	return (
+		<virtual>
+			<List
+				resource={resource}
+				transform={defaultTransform}
+				onValue={(value: string) => {
+					icache.set('value', value);
+				}}
+				disabled={(item) => item.value === 'mouse'}
+			/>
+		</virtual>
+	);
+});

--- a/src/examples/src/widgets/radio-group/CustomRenderer.tsx
+++ b/src/examples/src/widgets/radio-group/CustomRenderer.tsx
@@ -47,7 +47,6 @@ const App = factory(function({ middleware: { icache } }) {
 							);
 						});
 					}
-
 				}}
 			</RadioGroup>
 			<pre>{`${get('custom')}`}</pre>

--- a/src/list/tests/List.spec.tsx
+++ b/src/list/tests/List.spec.tsx
@@ -368,6 +368,41 @@ describe('List', () => {
 		h.expect(spacePressTemplate);
 		assert.isTrue(onValue.calledOnceWith('cat'));
 	});
+
+	it('disables items with the disabled property', () => {
+		const h = harness(() => (
+			<List
+				onValue={noop}
+				resource={{
+					resource: () => createResource(memoryTemplate),
+					data: animalOptions
+				}}
+				transform={defaultTransform}
+				disabled={(item) => item.value === 'cat'}
+			>
+				{}
+			</List>
+		));
+		const itemRendererTemplate = template.setChildren('@transformer', () =>
+			animalOptions.map(({ value, label, disabled = false }, index) => {
+				return (
+					<ListItem
+						key={`item-${index}`}
+						onSelect={noop}
+						active={index === 0}
+						onRequestActive={noop}
+						disabled={value === 'cat'}
+						widgetId={`menu-test-item-${index}`}
+						selected={false}
+						theme={{}}
+					>
+						{label || value}
+					</ListItem>
+				);
+			})
+		);
+		h.expect(itemRendererTemplate);
+	});
 });
 
 describe('List - Menu', () => {


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding a `disabled` property to List to give an injection point into disabling items.

Resolves #1392 
