### PR TITLE
Fixing snackbar and slide pane material styles

### DIFF
--- a/src/examples/src/widgets/snackbar/Stacked.tsx
+++ b/src/examples/src/widgets/snackbar/Stacked.tsx
@@ -1,6 +1,7 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Snackbar from '@dojo/widgets/snackbar';
 import Example from '../../Example';
+import Button from '@dojo/widgets/button';
 
 const factory = create();
 
@@ -10,7 +11,7 @@ export default factory(function Stacked() {
 			<Snackbar stacked open={true}>
 				{{
 					message: 'Stacked Snackbar',
-					actions: 'A really long actions renderer'
+					actions: <Button>Some Action</Button>
 				}}
 			</Snackbar>
 		</Example>

--- a/src/theme/material/raised-button.m.css.d.ts
+++ b/src/theme/material/raised-button.m.css.d.ts
@@ -1,2 +1,3 @@
 export const root: string;
 export const pressed: string;
+export const disabled: string;

--- a/src/theme/material/slide-pane.m.css
+++ b/src/theme/material/slide-pane.m.css
@@ -32,6 +32,7 @@
 }
 
 .right {
+	left: initial;
 	transform: translateX(calc(100% + 32px));
 }
 
@@ -41,4 +42,9 @@
 
 .bottom {
 	transform: translateY(calc(100% + 26px));
+}
+
+.underlayVisible {
+	background: var(--mdc-theme-elevation-1);
+	z-index: var(--zindex-dialog);
 }

--- a/src/theme/material/slide-pane.m.css.d.ts
+++ b/src/theme/material/slide-pane.m.css.d.ts
@@ -8,3 +8,4 @@ export const left: string;
 export const right: string;
 export const top: string;
 export const bottom: string;
+export const underlayVisible: string;


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixing some material theme issues with right side slide pane, underlay slide pane,  and stacked snackbar example.

![image](https://user-images.githubusercontent.com/2008858/79753919-b3dd4a80-82e4-11ea-832e-1b461ce4e5b6.png)

![image](https://user-images.githubusercontent.com/2008858/79754009-d53e3680-82e4-11ea-8911-a734f7d89e1f.png)

![image](https://user-images.githubusercontent.com/2008858/79754059-e8e99d00-82e4-11ea-9dba-8f3e30a285ba.png)


Resolves #1404 
