### PR TITLE
Fixing broken DateInput example

### DIFF
--- a/src/examples/src/widgets/date-input/Basic.tsx
+++ b/src/examples/src/widgets/date-input/Basic.tsx
@@ -1,9 +1,10 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import DateInput from '@dojo/widgets/date-input';
+import Example from '@dojo/widgets/examples/src/Example';
 
 const factory = create();
 
-export default factory(function Example() {
+export default factory(function Basic() {
 	return (
 		<Example>
 			<DateInput name="dateInput" />


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixing broken date input example
