### PR TITLE
Adding dojo theme variant and fixing up missing vars in dojo theme

### DIFF
--- a/src/examples/src/widgets/context-menu/Basic.tsx
+++ b/src/examples/src/widgets/context-menu/Basic.tsx
@@ -2,7 +2,6 @@ import { create, tsx } from '@dojo/framework/core/vdom';
 import icache from '@dojo/framework/core/middleware/icache';
 import ContextMenu, { defaultTransform } from '@dojo/widgets/context-menu';
 import { createMemoryResourceWithData } from '../list/memoryTemplate';
-import Example from '../../Example';
 
 const factory = create({ icache });
 const options = [{ value: 'print', label: 'Print' }, { value: 'delete', label: 'Delete' }];
@@ -16,7 +15,7 @@ export default factory(function Basic({ middleware: { icache } }) {
 	const printedText = icache.getOrSet('printedText', '');
 
 	return (
-		<Example>
+		<virtual>
 			<ContextMenu
 				resource={resource}
 				transform={defaultTransform}
@@ -41,6 +40,6 @@ export default factory(function Basic({ middleware: { icache } }) {
 				{text}
 			</ContextMenu>
 			<div>Printed Text: {printedText}</div>
-		</Example>
+		</virtual>
 	);
 });

--- a/src/theme/dojo/accordion.m.css
+++ b/src/theme/dojo/accordion.m.css
@@ -1,2 +1,3 @@
 .root {
+	font-family: var(--font-family);
 }

--- a/src/theme/dojo/avatar.m.css
+++ b/src/theme/dojo/avatar.m.css
@@ -1,4 +1,5 @@
 .root {
+	font-family: var(--font-family);
 	font-size: 1.25rem;
 	display: flex;
 	position: relative;

--- a/src/theme/dojo/breadcrumb-group.m.css
+++ b/src/theme/dojo/breadcrumb-group.m.css
@@ -1,3 +1,9 @@
+.root {
+	font-family: var(--font-family);
+	background-color: var(--color-background);
+	color: var(--color-text-primary);
+}
+
 .listItem,
 .listItem::before {
 	margin-right: var(--grid-base);

--- a/src/theme/dojo/breadcrumb-group.m.css.d.ts
+++ b/src/theme/dojo/breadcrumb-group.m.css.d.ts
@@ -1,1 +1,2 @@
+export const root: string;
 export const listItem: string;

--- a/src/theme/dojo/button.m.css
+++ b/src/theme/dojo/button.m.css
@@ -2,6 +2,7 @@
 .root:before,
 .root:after {
 	box-sizing: border-box;
+	font: var(--font-family);
 }
 
 .root {
@@ -42,4 +43,8 @@
 	font-size: var(--font-size-base);
 	font-weight: bold;
 	line-height: var(--line-height-base);
+}
+
+.pressed .label {
+	color: var(--color-text-inverted);
 }

--- a/src/theme/dojo/calendar.m.css
+++ b/src/theme/dojo/calendar.m.css
@@ -3,6 +3,7 @@
 }
 
 .root {
+	font-family: var(--font-family);
 	border: var(--border-width) solid var(--color-border);
 	display: inline-block;
 	font-size: var(--font-size-base);
@@ -13,6 +14,8 @@
 
 .dateGrid {
 	width: 100%;
+	background-color: var(--color-background);
+	color: var(--color-text-primary);
 }
 
 /* Date grid */

--- a/src/theme/dojo/card.m.css
+++ b/src/theme/dojo/card.m.css
@@ -1,4 +1,7 @@
 .root {
+	font-family: var(--font-family);
+	background-color: var(--color-background);
+	color: var(--color-text-primary);
 	display: flex;
 	flex-direction: column;
 	border-radius: 4px;

--- a/src/theme/dojo/checkbox-group.m.css
+++ b/src/theme/dojo/checkbox-group.m.css
@@ -1,4 +1,5 @@
 .root {
+	font-family: var(--font-family);
 	border: 0;
 	margin: 0;
 	padding: var(--spacing-regular) 0;

--- a/src/theme/dojo/checkbox.m.css
+++ b/src/theme/dojo/checkbox.m.css
@@ -1,8 +1,6 @@
 .root {
+	font-family: var(--font-family);
 	box-sizing: border-box;
-}
-
-.root {
 	display: block;
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);

--- a/src/theme/dojo/chip-typeahead.m.css
+++ b/src/theme/dojo/chip-typeahead.m.css
@@ -1,3 +1,7 @@
+.root {
+	font-family: var(--font-family);
+}
+
 .value {
 	margin: 2px;
 }

--- a/src/theme/dojo/chip-typeahead.m.css.d.ts
+++ b/src/theme/dojo/chip-typeahead.m.css.d.ts
@@ -1,6 +1,6 @@
+export const root: string;
 export const value: string;
 export const selectedIcon: string;
-export const root: string;
 export const input: string;
 export const inputWrapper: string;
 export const values: string;

--- a/src/theme/dojo/chip.m.css
+++ b/src/theme/dojo/chip.m.css
@@ -1,4 +1,5 @@
 .root {
+	font-family: var(--font-family);
 	height: calc(var(--grid-base) * 4);
 	background-color: var(--color-background-inverted);
 	border-radius: calc(var(--grid-base) * 2);

--- a/src/theme/dojo/date-input.m.css
+++ b/src/theme/dojo/date-input.m.css
@@ -1,4 +1,5 @@
 .root {
+	font-family: var(--font-family);
 }
 
 .input {

--- a/src/theme/dojo/dialog.m.css
+++ b/src/theme/dojo/dialog.m.css
@@ -2,14 +2,13 @@
 	color: var(--color-text-primary);
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);
-}
-
-.root {
+	font-family: var(--font-family);
 	box-sizing: border-box;
 }
 
 .main {
-	background: #fff;
+	background-color: var(--color-background);
+	color: var(--color-text-primary);
 	border: var(--border-width) solid var(--color-border);
 	box-shadow: var(--box-shadow-dimensions-large) var(--color-box-shadow-strong);
 	display: flex;
@@ -58,6 +57,7 @@
 	right: calc(2 * var(--grid-base));
 	top: 50%;
 	transform: translateY(-50%);
+	color: var(--color-text-primary);
 }
 
 .close .closeIcon {

--- a/src/theme/dojo/floating-action-button.m.css
+++ b/src/theme/dojo/floating-action-button.m.css
@@ -1,4 +1,5 @@
 .root {
+	font-family: var(--font-family);
 	display: inline-flex;
 	box-shadow: var(--box-shadow-dimensions-small) var(--color-box-shadow);
 	position: relative;

--- a/src/theme/dojo/grid.m.css
+++ b/src/theme/dojo/grid.m.css
@@ -1,6 +1,7 @@
 .root {
 	border: var(--border-width) solid var(--color-border);
 	background: var(--color-background);
+	font-family: var(--font-family);
 }
 
 .header {

--- a/src/theme/dojo/header-card.m.css
+++ b/src/theme/dojo/header-card.m.css
@@ -1,3 +1,7 @@
+.root {
+	font-family: var(--font-family);
+}
+
 /* The wrapper around a header */
 .header {
 	display: flex;

--- a/src/theme/dojo/header-card.m.css.d.ts
+++ b/src/theme/dojo/header-card.m.css.d.ts
@@ -1,3 +1,4 @@
+export const root: string;
 export const header: string;
 export const headerContent: string;
 export const avatar: string;

--- a/src/theme/dojo/header.m.css
+++ b/src/theme/dojo/header.m.css
@@ -5,6 +5,7 @@
 	display: flex;
 	height: calc(var(--spacing-regular) * 9);
 	padding: 0 var(--spacing-large);
+	font-family: var(--font-family);
 }
 
 .row {

--- a/src/theme/dojo/helper-text.m.css
+++ b/src/theme/dojo/helper-text.m.css
@@ -1,5 +1,7 @@
 .root {
+	font-family: var(--font-family);
 }
+
 .text {
 	margin: 0;
 	color: var(--color-text-faded);

--- a/src/theme/dojo/index.ts
+++ b/src/theme/dojo/index.ts
@@ -53,6 +53,7 @@ import * as tooltip from './tooltip.m.css';
 import * as twoColumnLayout from './two-column-layout.m.css';
 import * as typeahead from './typeahead.m.css';
 import * as defaultVariant from './variants/default.m.css';
+import * as darkVariant from './variants/dark.m.css';
 
 export default {
 	theme: {
@@ -112,6 +113,7 @@ export default {
 		'@dojo/widgets/typeahead': typeahead
 	},
 	variants: {
-		default: defaultVariant
+		default: defaultVariant,
+		dark: darkVariant
 	}
 };

--- a/src/theme/dojo/label.m.css
+++ b/src/theme/dojo/label.m.css
@@ -2,6 +2,8 @@
 	transition: color var(--transition-duration) var(--transition-easing);
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);
+	color: var(--color-text-primary);
+	font-family: var(--font-family);
 }
 
 .secondary {

--- a/src/theme/dojo/list-item.m.css
+++ b/src/theme/dojo/list-item.m.css
@@ -1,6 +1,8 @@
 .root {
 	padding: var(--spacing-regular);
 	border: 1px solid transparent;
+	color: var(--color-text-primary);
+	font-family: var(--font-family);
 }
 
 .active {

--- a/src/theme/dojo/list.m.css
+++ b/src/theme/dojo/list.m.css
@@ -1,5 +1,6 @@
 .root {
 	background: var(--color-background);
+	font-family: var(--font-family);
 }
 
 .menu {

--- a/src/theme/dojo/loading-indicator.m.css
+++ b/src/theme/dojo/loading-indicator.m.css
@@ -3,6 +3,7 @@
 	height: calc(var(--grid-base) / 2);
 	position: relative;
 	overflow: hidden;
+	font-family: var(--font-family);
 }
 
 .buffer {

--- a/src/theme/dojo/menu-item.m.css
+++ b/src/theme/dojo/menu-item.m.css
@@ -1,6 +1,8 @@
 .root {
 	padding: var(--spacing-regular);
 	border: 1px solid transparent;
+	color: var(--color-text-primary);
+	font-family: var(--font-family);
 }
 
 .active {

--- a/src/theme/dojo/native-select.m.css
+++ b/src/theme/dojo/native-select.m.css
@@ -3,6 +3,7 @@
 	font-size: var(--font-size-base);
 	display: flex;
 	flex-direction: column;
+	font-family: var(--font-family);
 }
 
 /* Wrapper class for native select and dropdown arrow */
@@ -30,6 +31,7 @@
 	width: 100%;
 	border: var(--border-width) solid var(--color-border);
 	border-bottom-color: var(--color-border-strong);
+	color: var(--color-text-primary);
 }
 
 /* Class for dojo stylized dropdown arrow */

--- a/src/theme/dojo/outlined-button.m.css
+++ b/src/theme/dojo/outlined-button.m.css
@@ -10,6 +10,7 @@
 	min-width: calc(var(--grid-base) * 20);
 	padding: var(--spacing-regular);
 	margin: 0;
+	font-family: var(--font-family);
 }
 
 .root:hover {
@@ -24,10 +25,18 @@
 	color: var(--color-text-inverted);
 }
 
+.root:hover .label {
+	color: var(--color-text-inverted);
+}
+
 .disabled,
 .disabled:hover {
 	background-color: initial;
 	border-color: var(--color-border);
 	color: var(--color-text-faded);
 	cursor: default;
+}
+
+.disabled:hover .label {
+	color: var(--color-text-faded);
 }

--- a/src/theme/dojo/outlined-button.m.css.d.ts
+++ b/src/theme/dojo/outlined-button.m.css.d.ts
@@ -1,3 +1,4 @@
 export const root: string;
 export const pressed: string;
+export const label: string;
 export const disabled: string;

--- a/src/theme/dojo/pagination.m.css
+++ b/src/theme/dojo/pagination.m.css
@@ -2,6 +2,7 @@
 	align-items: center;
 	display: flex;
 	justify-content: center;
+	font-family: var(--font-family);
 }
 
 .linksWrapper {
@@ -38,7 +39,7 @@
 
 .link,
 .currentPage {
-	background-color: unset;
+	background-color: var(--color-background);
 	border: var(--border-width) solid var(--color-border);
 	border-right-width: 0;
 	border-bottom-color: var(--color-border-strong);
@@ -60,6 +61,7 @@
 .link {
 	cursor: pointer;
 	transition: box-shadow var(--transition-duration) var(--transition-easing);
+	color: var(--color-text-primary);
 }
 
 .link:last-of-type {

--- a/src/theme/dojo/password-input.m.css
+++ b/src/theme/dojo/password-input.m.css
@@ -1,5 +1,6 @@
 .root {
 	composes: root from './text-input.m.css';
+	font-family: var(--font-family);
 }
 
 .toggleButton {

--- a/src/theme/dojo/progress.m.css
+++ b/src/theme/dojo/progress.m.css
@@ -1,3 +1,7 @@
+.root {
+	font-family: var(--font-family);
+}
+
 .output {
 	display: inline-block;
 	padding: var(--spacing-regular);
@@ -7,6 +11,7 @@
 	border: var(--border-width) solid var(--color-border);
 	height: 24px;
 	border-radius: 3px;
+	background-color: var(--color-background);
 }
 
 .progress {

--- a/src/theme/dojo/progress.m.css.d.ts
+++ b/src/theme/dojo/progress.m.css.d.ts
@@ -1,3 +1,4 @@
+export const root: string;
 export const output: string;
 export const bar: string;
 export const progress: string;

--- a/src/theme/dojo/radio-group.m.css
+++ b/src/theme/dojo/radio-group.m.css
@@ -2,6 +2,7 @@
 	border: 0;
 	margin: 0;
 	padding: 0;
+	font-family: var(--font-family);
 }
 
 .legend {

--- a/src/theme/dojo/radio.m.css
+++ b/src/theme/dojo/radio.m.css
@@ -1,5 +1,6 @@
 .root {
 	box-sizing: border-box;
+	font-family: var(--font-family);
 }
 
 .root {

--- a/src/theme/dojo/raised-button.m.css
+++ b/src/theme/dojo/raised-button.m.css
@@ -1,19 +1,29 @@
 .root {
+	font-family: var(--font-family);
 	border: 0;
 	box-shadow: var(--box-shadow-dimensions-small) var(--color-box-shadow);
 	font-size: inherit;
 	line-height: var(--line-height-base);
 	min-width: calc(var(--grid-base) * 20);
 	padding: var(--spacing-regular);
-}
-
-.root:not(.pressed) {
-	background: none;
-	color: inherit;
+	background-color: var(--color-background);
 }
 
 .pressed {
-	composes: pressed from './button.m.css';
+	background-color: var(--color-highlight);
+	border-color: var(--color-highlight);
+	color: var(--color-text-inverted);
+}
+
+.label {
+	color: var(--color-highlight);
+	font-size: var(--font-size-base);
+	font-weight: bold;
+	line-height: var(--line-height-base);
+}
+
+.pressed .label {
+	color: var(--color-text-inverted);
 }
 
 .root:hover,

--- a/src/theme/dojo/raised-button.m.css.d.ts
+++ b/src/theme/dojo/raised-button.m.css.d.ts
@@ -1,3 +1,4 @@
 export const root: string;
 export const pressed: string;
+export const label: string;
 export const disabled: string;

--- a/src/theme/dojo/range-slider.m.css
+++ b/src/theme/dojo/range-slider.m.css
@@ -1,10 +1,8 @@
 .root {
 	box-sizing: border-box;
-}
-
-.root {
 	display: block;
-	font: var(--font-size-base);
+	font-family: var(--font-family);
+	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);
 }
 
@@ -19,7 +17,7 @@
 .filled {
 	height: 3px;
 	top: -1px;
-	background-color: var(--color-border-strong);
+	background-color: var(--color-highlight);
 }
 
 .thumb {

--- a/src/theme/dojo/result.m.css
+++ b/src/theme/dojo/result.m.css
@@ -2,6 +2,7 @@
 	display: flex;
 	flex-direction: column;
 	align-items: center;
+	font-family: var(--font-family);
 }
 
 .iconWrapper {
@@ -35,6 +36,7 @@
 
 .contentWrapper {
 	margin: var(--grid-base);
+	color: var(--color-text-primary);
 }
 
 .content {
@@ -50,6 +52,7 @@
 .title {
 	font-size: var(--font-size-title);
 	margin: 0;
+	color: var(--color-text-primary);
 }
 
 .subtitle {

--- a/src/theme/dojo/select.m.css
+++ b/src/theme/dojo/select.m.css
@@ -2,6 +2,7 @@
 	font-size: var(--font-size-base);
 	display: flex;
 	flex-direction: column;
+	font-family: var(--font-family);
 }
 
 /* custom input styles */
@@ -30,6 +31,7 @@
 .value {
 	padding: var(--spacing-regular) calc(var(--spacing-regular) * 3) var(--spacing-regular)
 		var(--spacing-regular);
+	color: var(--color-text-primary);
 }
 
 .trigger:focus {

--- a/src/theme/dojo/slide-pane.m.css
+++ b/src/theme/dojo/slide-pane.m.css
@@ -3,6 +3,7 @@
 	color: var(--color-text-primary);
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);
+	font-family: var(--font-family);
 }
 
 .underlayVisible {
@@ -42,6 +43,7 @@
 	right: var(--grid-base);
 	top: 50%;
 	transform: translateY(-50%);
+	color: var(--color-text-primary);
 }
 
 .close .closeIcon {

--- a/src/theme/dojo/slider.m.css
+++ b/src/theme/dojo/slider.m.css
@@ -1,8 +1,6 @@
 .root {
+	font-family: var(--font-family);
 	box-sizing: border-box;
-}
-
-.root {
 	display: block;
 	font: var(--font-size-base);
 	line-height: var(--line-height-base);

--- a/src/theme/dojo/snackbar.m.css
+++ b/src/theme/dojo/snackbar.m.css
@@ -11,6 +11,7 @@
 	-webkit-tap-highlight-color: rgba(0, 0, 0, 0);
 	margin: var(--spacing-regular);
 	z-index: var(--zindex-alert);
+	font-family: var(--font-family);
 }
 
 .content {
@@ -24,8 +25,8 @@
 	background-color: var(--color-dark);
 	padding: var(--spacing-regular);
 	border-radius: var(--border-radius);
-	box-shadow: 0 3px 5px -1px rgba(0, 0, 0, 0.2), 0 6px 10px 0 rgba(0, 0, 0, 0.14),
-		0 1px 18px 0 rgba(0, 0, 0, 0.12);
+	box-shadow: 0 3px 5px -1px var(--color-box-shadow), 0 6px 10px 0 var(--color-box-shadow),
+		0 1px 18px 0 var(--color-box-shadow);
 }
 
 .label {

--- a/src/theme/dojo/switch.m.css
+++ b/src/theme/dojo/switch.m.css
@@ -3,6 +3,7 @@
 	position: relative;
 	line-height: var(--line-height-base);
 	min-height: var(--line-height-base);
+	font-family: var(--font-family);
 }
 
 .inputWrapper {

--- a/src/theme/dojo/tab-controller.m.css
+++ b/src/theme/dojo/tab-controller.m.css
@@ -3,6 +3,7 @@
 	color: var(--color-text-primary);
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);
+	font-family: var(--font-family);
 }
 
 .tabButtons {
@@ -28,6 +29,7 @@
 	white-space: nowrap;
 	width: var(--tab-width);
 	margin: 0;
+	background-color: var(--color-background);
 }
 
 .tabButton:hover:not(.disabledTabButton):not(.activeTabButton) {
@@ -76,6 +78,7 @@
 
 .tab {
 	position: relative;
+	background-color: var(--color-background);
 }
 
 .alignLeft .tabs {

--- a/src/theme/dojo/text-area.m.css
+++ b/src/theme/dojo/text-area.m.css
@@ -1,11 +1,9 @@
 .root {
 	box-sizing: border-box;
-}
-
-.root {
 	display: block;
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);
+	font-family: var(--font-family);
 }
 
 .input {
@@ -18,6 +16,8 @@
 	width: 100%;
 	border-radius: 0;
 	margin: 0;
+	background-color: var(--color-background);
+	color: var(--color-text-primary);
 }
 
 .input:focus {

--- a/src/theme/dojo/text-input.m.css
+++ b/src/theme/dojo/text-input.m.css
@@ -1,4 +1,5 @@
 .root {
+	font-family: var(--font-family);
 }
 
 .wrapper {
@@ -20,6 +21,8 @@
 	line-height: var(--line-height-base);
 	padding: var(--grid-base);
 	box-sizing: border-box;
+	background-color: var(--color-background);
+	color: var(--color-text-primary);
 }
 
 .input:focus {
@@ -31,6 +34,8 @@
 }
 
 .inputWrapper {
+	background-color: var(--color-background);
+	color: var(--color-text-primary);
 	border: var(--border-width) solid var(--color-border);
 	border-bottom-color: var(--color-border-strong);
 	width: 100%;

--- a/src/theme/dojo/title-pane.m.css
+++ b/src/theme/dojo/title-pane.m.css
@@ -5,6 +5,7 @@
 	line-height: var(--line-height-base);
 	overflow: hidden;
 	min-height: calc(var(--font-size-title) + 2 * var(--grid-base));
+	font-family: var(--font-family);
 }
 
 .titleButton {
@@ -36,6 +37,8 @@
 	border-left: var(--border-width) solid var(--color-border);
 	border-right: var(--border-width) solid var(--color-border);
 	padding: var(--grid-base);
+	background-color: var(--color-background);
+	color: var(--color-text-primary);
 }
 
 .contentTransition {

--- a/src/theme/dojo/tooltip.m.css
+++ b/src/theme/dojo/tooltip.m.css
@@ -1,5 +1,6 @@
 .root {
 	color: var(--color-text-primary);
+	font-family: var(--font-family);
 	font-size: var(--font-size-base);
 	line-height: var(--line-height-base);
 }

--- a/src/theme/dojo/variants/dark.m.css
+++ b/src/theme/dojo/variants/dark.m.css
@@ -1,4 +1,6 @@
 .root {
+	--example-background: var(--color-background);
+
 	/* Spacing */
 	--grid-base: 8px;
 	--spacing-regular: var(--grid-base);
@@ -19,21 +21,21 @@
 	--bolder-font-weight: 600;
 
 	/* Color hex values */
-	--color-dark: #333;
-	--color-text-primary: #000000;
+	--color-dark: #cccccc;
+	--color-text-primary: #ffffff;
 	--color-text-faded: #5c6c7c;
-	--color-text-inverted: #ffffff;
-	--color-highlight: #006be6;
+	--color-text-inverted: #000000;
+	--color-highlight: #ff9419;
 	--color-highlight-border: hsl(212.08695652173913, 100%, 58.0980392157%);
-	--color-success: #188701;
-	--color-error: #eb1313;
-	--color-alert: #ffa500;
-	--color-info: #006be6;
-	--color-background: #ffffff;
-	--color-background-inverted: #5c6c7c;
-	--color-background-faded: #f4f6f7;
-	--color-border: #d6dde2;
-	--color-border-strong: #5c6c7c;
+	--color-success: #e778fe;
+	--color-error: #14ecec;
+	--color-alert: #005aff;
+	--color-info: #ff9419;
+	--color-background: #000000;
+	--color-background-inverted: #a39383;
+	--color-background-faded: #0b0908;
+	--color-border: #29221d;
+	--color-border-strong: #a39383;
 	--color-border-invalid: hsl(0, 76.0393700787%, 86.8039215686%);
 	--color-border-valid: hsl(109.70149253731344, 66.5294117647%, 81.6666666667%);
 	--color-box-shadow: rgba(0, 0, 0, 0.2);

--- a/src/theme/dojo/variants/dark.m.css.d.ts
+++ b/src/theme/dojo/variants/dark.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding a (admittedly horrible) dark variant of the dojo theme. The purpose of the dark theme is to surface missing styles on the current widget set.

Resolves #1406 
