### PR TITLE
feat: FormGroup and FormField

### DIFF
--- a/src/examples/src/widgets/form/ActionForm.tsx
+++ b/src/examples/src/widgets/form/ActionForm.tsx
@@ -1,9 +1,9 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-
-import TextInput from '@dojo/widgets/text-input';
-import Form from '@dojo/widgets/form';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Form, { FormField, FormGroup } from '@dojo/widgets/form';
 import { FormMiddleware } from '@dojo/widgets/form/middleware';
+import TextInput from '@dojo/widgets/text-input';
+
 import Example from '../../Example';
 
 const icache = createICacheMiddleware<{
@@ -37,39 +37,51 @@ const App = factory(function({ middleware: { icache } }) {
 
 					return (
 						<virtual>
-							<TextInput
-								key="firstName"
-								placeholder="Enter first name"
-								initialValue={firstName.value()}
-								onValue={firstName.value}
-							>
-								{{ label: 'First Name' }}
-							</TextInput>
-							<TextInput
-								key="middleName"
-								placeholder="Enter a middle name"
-								initialValue={middleName.value()}
-								onValue={middleName.value}
-							>
-								{{ label: 'Middle Name' }}
-							</TextInput>
-							<TextInput
-								key="lastName"
-								placeholder="Enter a last name"
-								initialValue={lastName.value()}
-								onValue={lastName.value}
-							>
-								{{ label: 'Last Name' }}
-							</TextInput>
-							<TextInput
-								key="email"
-								placeholder="Enter an email address"
-								initialValue={email.value()}
-								onValue={email.value}
-								type="email"
-							>
-								{{ label: 'Email' }}
-							</TextInput>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="firstName"
+										placeholder="Enter first name"
+										initialValue={firstName.value()}
+										onValue={firstName.value}
+									>
+										{{ label: 'First Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="middleName"
+										placeholder="Enter a middle name"
+										initialValue={middleName.value()}
+										onValue={middleName.value}
+									>
+										{{ label: 'Middle Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="lastName"
+										placeholder="Enter a last name"
+										initialValue={lastName.value()}
+										onValue={lastName.value}
+									>
+										{{ label: 'Last Name' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="email"
+										placeholder="Enter an email address"
+										initialValue={email.value()}
+										onValue={email.value}
+										type="email"
+									>
+										{{ label: 'Email' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
 						</virtual>
 					);
 				}}

--- a/src/examples/src/widgets/form/Basic.tsx
+++ b/src/examples/src/widgets/form/Basic.tsx
@@ -1,9 +1,9 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-
-import TextInput from '@dojo/widgets/text-input';
-import Form from '@dojo/widgets/form';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Form, { FormField, FormGroup } from '@dojo/widgets/form';
 import { FormMiddleware } from '@dojo/widgets/form/middleware';
+import TextInput from '@dojo/widgets/text-input';
+
 import Example from '../../Example';
 
 const icache = createICacheMiddleware<{
@@ -36,39 +36,51 @@ const App = factory(function({ middleware: { icache } }) {
 
 					return (
 						<virtual>
-							<TextInput
-								key="firstName"
-								placeholder="Enter first name"
-								initialValue={firstName.value()}
-								onValue={firstName.value}
-							>
-								{{ label: 'First Name' }}
-							</TextInput>
-							<TextInput
-								key="middleName"
-								placeholder="Enter a middle name"
-								initialValue={middleName.value()}
-								onValue={middleName.value}
-							>
-								{{ label: 'Middle Name' }}
-							</TextInput>
-							<TextInput
-								key="lastName"
-								placeholder="Enter a last name"
-								initialValue={lastName.value()}
-								onValue={lastName.value}
-							>
-								{{ label: 'Last Name' }}
-							</TextInput>
-							<TextInput
-								key="email"
-								placeholder="Enter an email address"
-								initialValue={email.value()}
-								onValue={email.value}
-								type="email"
-							>
-								{{ label: 'Email' }}
-							</TextInput>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="firstName"
+										placeholder="Enter first name"
+										initialValue={firstName.value()}
+										onValue={firstName.value}
+									>
+										{{ label: 'First Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="middleName"
+										placeholder="Enter a middle name"
+										initialValue={middleName.value()}
+										onValue={middleName.value}
+									>
+										{{ label: 'Middle Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="lastName"
+										placeholder="Enter a last name"
+										initialValue={lastName.value()}
+										onValue={lastName.value}
+									>
+										{{ label: 'Last Name' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="email"
+										placeholder="Enter an email address"
+										initialValue={email.value()}
+										onValue={email.value}
+										type="email"
+									>
+										{{ label: 'Email' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
 						</virtual>
 					);
 				}}

--- a/src/examples/src/widgets/form/Controlled.tsx
+++ b/src/examples/src/widgets/form/Controlled.tsx
@@ -1,9 +1,9 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-
-import TextInput from '@dojo/widgets/text-input';
-import Form from '@dojo/widgets/form';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Form, { FormField, FormGroup } from '@dojo/widgets/form';
 import { FormMiddleware } from '@dojo/widgets/form/middleware';
+import TextInput from '@dojo/widgets/text-input';
+
 import Example from '../../Example';
 
 const icache = createICacheMiddleware<{
@@ -37,39 +37,51 @@ const App = factory(function({ middleware: { icache } }) {
 
 					return (
 						<virtual>
-							<TextInput
-								key="firstName"
-								placeholder="Enter first name"
-								value={firstName.value()}
-								onValue={firstName.value}
-							>
-								{{ label: 'First Name' }}
-							</TextInput>
-							<TextInput
-								key="middleName"
-								placeholder="Enter a middle name"
-								value={middleName.value()}
-								onValue={middleName.value}
-							>
-								{{ label: 'Middle Name' }}
-							</TextInput>
-							<TextInput
-								key="lastName"
-								placeholder="Enter a last name"
-								value={lastName.value()}
-								onValue={lastName.value}
-							>
-								{{ label: 'Last Name' }}
-							</TextInput>
-							<TextInput
-								key="email"
-								placeholder="Enter an email address"
-								value={email.value()}
-								onValue={email.value}
-								type="email"
-							>
-								{{ label: 'Email' }}
-							</TextInput>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="firstName"
+										placeholder="Enter first name"
+										value={firstName.value()}
+										onValue={firstName.value}
+									>
+										{{ label: 'First Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="middleName"
+										placeholder="Enter a middle name"
+										value={middleName.value()}
+										onValue={middleName.value}
+									>
+										{{ label: 'Middle Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="lastName"
+										placeholder="Enter a last name"
+										value={lastName.value()}
+										onValue={lastName.value}
+									>
+										{{ label: 'Last Name' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="email"
+										placeholder="Enter an email address"
+										value={email.value()}
+										onValue={email.value}
+										type="email"
+									>
+										{{ label: 'Email' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
 						</virtual>
 					);
 				}}

--- a/src/examples/src/widgets/form/DisabledFieldsForm.tsx
+++ b/src/examples/src/widgets/form/DisabledFieldsForm.tsx
@@ -1,10 +1,10 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-
+import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
-import TextInput from '@dojo/widgets/text-input';
-import Form from '@dojo/widgets/form';
+import Form, { FormField, FormGroup } from '@dojo/widgets/form';
 import { FormMiddleware } from '@dojo/widgets/form/middleware';
+import TextInput from '@dojo/widgets/text-input';
+
 import Example from '../../Example';
 
 const icache = createICacheMiddleware<{
@@ -34,41 +34,53 @@ const App = factory(function({ middleware: { icache } }) {
 
 					return (
 						<virtual>
-							<TextInput
-								key="firstName"
-								placeholder="Enter first name	"
-								initialValue={firstName.value()}
-								onValue={firstName.value}
-							>
-								{{ label: 'First Name' }}
-							</TextInput>
-							<TextInput
-								key="middleName"
-								placeholder="Enter a middle name"
-								initialValue={middleName.value()}
-								onValue={middleName.value}
-								disabled={true}
-							>
-								{{ label: 'Middle Name' }}
-							</TextInput>
-							<TextInput
-								key="lastName"
-								placeholder="Enter a last name"
-								initialValue={lastName.value()}
-								onValue={lastName.value}
-							>
-								{{ label: 'Last Name' }}
-							</TextInput>
-							<TextInput
-								key="email"
-								placeholder="Enter an email address"
-								initialValue={email.value()}
-								onValue={email.value}
-								type="email"
-								disabled={email.disabled()}
-							>
-								{{ label: 'Email' }}
-							</TextInput>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="firstName"
+										placeholder="Enter first name	"
+										initialValue={firstName.value()}
+										onValue={firstName.value}
+									>
+										{{ label: 'First Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="middleName"
+										placeholder="Enter a middle name"
+										initialValue={middleName.value()}
+										onValue={middleName.value}
+										disabled={true}
+									>
+										{{ label: 'Middle Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="lastName"
+										placeholder="Enter a last name"
+										initialValue={lastName.value()}
+										onValue={lastName.value}
+									>
+										{{ label: 'Last Name' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="email"
+										placeholder="Enter an email address"
+										initialValue={email.value()}
+										onValue={email.value}
+										type="email"
+										disabled={email.disabled()}
+									>
+										{{ label: 'Email' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
 							<Button
 								key="disableEmail"
 								type="button"

--- a/src/examples/src/widgets/form/DisabledForm.tsx
+++ b/src/examples/src/widgets/form/DisabledForm.tsx
@@ -1,10 +1,10 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-
+import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
-import TextInput from '@dojo/widgets/text-input';
-import Form from '@dojo/widgets/form';
+import Form, { FormField, FormGroup } from '@dojo/widgets/form';
 import { FormMiddleware } from '@dojo/widgets/form/middleware';
+import TextInput from '@dojo/widgets/text-input';
+
 import Example from '../../Example';
 
 const icache = createICacheMiddleware<{
@@ -34,43 +34,55 @@ const App = factory(function({ middleware: { icache } }) {
 
 					return (
 						<virtual>
-							<TextInput
-								key="firstName"
-								placeholder="Enter first name"
-								initialValue={firstName.value()}
-								onValue={firstName.value}
-								disabled={firstName.disabled()}
-							>
-								{{ label: 'First Name' }}
-							</TextInput>
-							<TextInput
-								key="middleName"
-								placeholder="Enter a middle name"
-								initialValue={middleName.value()}
-								onValue={middleName.value}
-								disabled={middleName.disabled()}
-							>
-								{{ label: 'Middle Name' }}
-							</TextInput>
-							<TextInput
-								key="lastName"
-								placeholder="Enter a last name"
-								initialValue={lastName.value()}
-								onValue={lastName.value}
-								disabled={lastName.disabled()}
-							>
-								{{ label: 'Last Name' }}
-							</TextInput>
-							<TextInput
-								key="email"
-								placeholder="Enter an email address"
-								initialValue={email.value()}
-								onValue={email.value}
-								type="email"
-								disabled={email.disabled()}
-							>
-								{{ label: 'Email' }}
-							</TextInput>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="firstName"
+										placeholder="Enter first name"
+										initialValue={firstName.value()}
+										onValue={firstName.value}
+										disabled={firstName.disabled()}
+									>
+										{{ label: 'First Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="middleName"
+										placeholder="Enter a middle name"
+										initialValue={middleName.value()}
+										onValue={middleName.value}
+										disabled={middleName.disabled()}
+									>
+										{{ label: 'Middle Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="lastName"
+										placeholder="Enter a last name"
+										initialValue={lastName.value()}
+										onValue={lastName.value}
+										disabled={lastName.disabled()}
+									>
+										{{ label: 'Last Name' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="email"
+										placeholder="Enter an email address"
+										initialValue={email.value()}
+										onValue={email.value}
+										type="email"
+										disabled={email.disabled()}
+									>
+										{{ label: 'Email' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
 							<Button
 								key="disableForm"
 								type="button"

--- a/src/examples/src/widgets/form/FillingForm.tsx
+++ b/src/examples/src/widgets/form/FillingForm.tsx
@@ -1,10 +1,10 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-
+import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
-import TextInput from '@dojo/widgets/text-input';
-import Form from '@dojo/widgets/form';
+import Form, { FormField, FormGroup } from '@dojo/widgets/form';
 import { FormMiddleware } from '@dojo/widgets/form/middleware';
+import TextInput from '@dojo/widgets/text-input';
+
 import Example from '../../Example';
 
 const icache = createICacheMiddleware<{
@@ -34,39 +34,51 @@ const App = factory(function({ middleware: { icache } }) {
 
 					return (
 						<virtual>
-							<TextInput
-								key="firstName"
-								placeholder="Enter first name"
-								initialValue={firstName.value()}
-								onValue={firstName.value}
-							>
-								{{ label: 'First Name' }}
-							</TextInput>
-							<TextInput
-								key="middleName"
-								placeholder="Enter a middle name"
-								initialValue={middleName.value()}
-								onValue={middleName.value}
-							>
-								{{ label: 'Middle Name' }}
-							</TextInput>
-							<TextInput
-								key="lastName"
-								placeholder="Enter a last name"
-								initialValue={lastName.value()}
-								onValue={lastName.value}
-							>
-								{{ label: 'Last Name' }}
-							</TextInput>
-							<TextInput
-								key="email"
-								placeholder="Enter an email address"
-								initialValue={email.value()}
-								onValue={email.value}
-								type="email"
-							>
-								{{ label: 'Email' }}
-							</TextInput>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="firstName"
+										placeholder="Enter first name"
+										initialValue={firstName.value()}
+										onValue={firstName.value}
+									>
+										{{ label: 'First Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="middleName"
+										placeholder="Enter a middle name"
+										initialValue={middleName.value()}
+										onValue={middleName.value}
+									>
+										{{ label: 'Middle Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="lastName"
+										placeholder="Enter a last name"
+										initialValue={lastName.value()}
+										onValue={lastName.value}
+									>
+										{{ label: 'Last Name' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="email"
+										placeholder="Enter an email address"
+										initialValue={email.value()}
+										onValue={email.value}
+										type="email"
+									>
+										{{ label: 'Email' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
 							<Button
 								key="fill"
 								type="button"

--- a/src/examples/src/widgets/form/InitialValueForm.tsx
+++ b/src/examples/src/widgets/form/InitialValueForm.tsx
@@ -1,9 +1,9 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-
-import TextInput from '@dojo/widgets/text-input';
-import Form from '@dojo/widgets/form';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Form, { FormField, FormGroup } from '@dojo/widgets/form';
 import { FormMiddleware } from '@dojo/widgets/form/middleware';
+import TextInput from '@dojo/widgets/text-input';
+
 import Example from '../../Example';
 
 const icache = createICacheMiddleware<{
@@ -39,39 +39,51 @@ const App = factory(function({ middleware: { icache } }) {
 
 					return (
 						<virtual>
-							<TextInput
-								key="firstName"
-								placeholder="Enter first name"
-								initialValue={firstName.value()}
-								onValue={firstName.value}
-							>
-								{{ label: 'First Name' }}
-							</TextInput>
-							<TextInput
-								key="middleName"
-								placeholder="Enter a middle name"
-								initialValue={middleName.value()}
-								onValue={middleName.value}
-							>
-								{{ label: 'Middle Name' }}
-							</TextInput>
-							<TextInput
-								key="lastName"
-								placeholder="Enter a last name"
-								initialValue={lastName.value()}
-								onValue={lastName.value}
-							>
-								{{ label: 'Last Name' }}
-							</TextInput>
-							<TextInput
-								key="email"
-								placeholder="Enter an email address"
-								initialValue={email.value()}
-								onValue={email.value}
-								type="email"
-							>
-								{{ label: 'Email' }}
-							</TextInput>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="firstName"
+										placeholder="Enter first name"
+										initialValue={firstName.value()}
+										onValue={firstName.value}
+									>
+										{{ label: 'First Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="middleName"
+										placeholder="Enter a middle name"
+										initialValue={middleName.value()}
+										onValue={middleName.value}
+									>
+										{{ label: 'Middle Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="lastName"
+										placeholder="Enter a last name"
+										initialValue={lastName.value()}
+										onValue={lastName.value}
+									>
+										{{ label: 'Last Name' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="email"
+										placeholder="Enter an email address"
+										initialValue={email.value()}
+										onValue={email.value}
+										type="email"
+									>
+										{{ label: 'Email' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
 						</virtual>
 					);
 				}}

--- a/src/examples/src/widgets/form/KitchenSinkForm.tsx
+++ b/src/examples/src/widgets/form/KitchenSinkForm.tsx
@@ -1,10 +1,10 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-
+import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
-import TextInput from '@dojo/widgets/text-input';
-import Form from '@dojo/widgets/form';
+import Form, { FormField, FormGroup } from '@dojo/widgets/form';
 import { FormMiddleware } from '@dojo/widgets/form/middleware';
+import TextInput from '@dojo/widgets/text-input';
+
 import Example from '../../Example';
 
 const icache = createICacheMiddleware<{
@@ -44,59 +44,71 @@ const App = factory(function({ middleware: { icache } }) {
 
 					return (
 						<virtual>
-							<TextInput
-								key="firstName"
-								placeholder="Enter first name (must be Billy)"
-								pattern="Billy"
-								required={true}
-								initialValue={firstName.value()}
-								valid={firstName.valid()}
-								onValue={firstName.value}
-								onValidate={firstName.valid}
-								disabled={firstName.disabled()}
-							>
-								{{ label: 'First Name' }}
-							</TextInput>
-							<TextInput
-								key="middleName"
-								placeholder="Enter a middle name"
-								required={middleName.required()}
-								initialValue={middleName.value()}
-								valid={middleName.valid()}
-								onValue={middleName.value}
-								onValidate={middleName.valid}
-								maxLength={5}
-								disabled={middleName.disabled()}
-							>
-								{{ label: 'Middle Name' }}
-							</TextInput>
-							<TextInput
-								key="lastName"
-								placeholder="Enter a last name"
-								required={true}
-								initialValue={lastName.value()}
-								valid={lastName.valid()}
-								onValue={lastName.value}
-								onValidate={lastName.valid}
-								minLength={2}
-								disabled={lastName.disabled()}
-							>
-								{{ label: 'Last Name' }}
-							</TextInput>
-							<TextInput
-								key="email"
-								placeholder="Enter an email address"
-								required={false}
-								initialValue={email.value()}
-								valid={email.valid()}
-								onValue={email.value}
-								onValidate={email.valid}
-								type="email"
-								pattern="^[^\s@]+@[^\s@]+\.[^\s@]{2,}$"
-								disabled={email.disabled()}
-							>
-								{{ label: 'Email' }}
-							</TextInput>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="firstName"
+										placeholder="Enter first name (must be Billy)"
+										pattern="Billy"
+										required={true}
+										initialValue={firstName.value()}
+										valid={firstName.valid()}
+										onValue={firstName.value}
+										onValidate={firstName.valid}
+										disabled={firstName.disabled()}
+									>
+										{{ label: 'First Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="middleName"
+										placeholder="Enter a middle name"
+										required={middleName.required()}
+										initialValue={middleName.value()}
+										valid={middleName.valid()}
+										onValue={middleName.value}
+										onValidate={middleName.valid}
+										maxLength={5}
+										disabled={middleName.disabled()}
+									>
+										{{ label: 'Middle Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="lastName"
+										placeholder="Enter a last name"
+										required={true}
+										initialValue={lastName.value()}
+										valid={lastName.valid()}
+										onValue={lastName.value}
+										onValidate={lastName.valid}
+										minLength={2}
+										disabled={lastName.disabled()}
+									>
+										{{ label: 'Last Name' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="email"
+										placeholder="Enter an email address"
+										required={false}
+										initialValue={email.value()}
+										valid={email.valid()}
+										onValue={email.value}
+										onValidate={email.valid}
+										type="email"
+										pattern="^[^\s@]+@[^\s@]+\.[^\s@]{2,}$"
+										disabled={email.disabled()}
+									>
+										{{ label: 'Email' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
 							<Button
 								key="fill"
 								type="button"

--- a/src/examples/src/widgets/form/RequiredFieldsForm.tsx
+++ b/src/examples/src/widgets/form/RequiredFieldsForm.tsx
@@ -1,10 +1,10 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-
+import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
-import TextInput from '@dojo/widgets/text-input';
-import Form from '@dojo/widgets/form';
+import Form, { FormField, FormGroup } from '@dojo/widgets/form';
 import { FormMiddleware } from '@dojo/widgets/form/middleware';
+import TextInput from '@dojo/widgets/text-input';
+
 import Example from '../../Example';
 
 const icache = createICacheMiddleware<{
@@ -34,48 +34,60 @@ const App = factory(function({ middleware: { icache } }) {
 
 					return (
 						<virtual>
-							<TextInput
-								key="firstName"
-								placeholder="Enter first name (must be Billy)"
-								required={true}
-								initialValue={firstName.value()}
-								valid={firstName.valid()}
-								onValue={firstName.value}
-								onValidate={firstName.valid}
-							>
-								{{ label: 'First Name' }}
-							</TextInput>
-							<TextInput
-								key="middleName"
-								placeholder="Enter a middle name"
-								required={middleName.required()}
-								initialValue={middleName.value()}
-								valid={middleName.valid()}
-								onValue={middleName.value}
-								onValidate={middleName.valid}
-							>
-								{{ label: 'Middle Name' }}
-							</TextInput>
-							<TextInput
-								key="lastName"
-								placeholder="Enter a last name"
-								required={true}
-								initialValue={lastName.value()}
-								valid={lastName.valid()}
-								onValue={lastName.value}
-								onValidate={lastName.valid}
-							>
-								{{ label: 'Last Name' }}
-							</TextInput>
-							<TextInput
-								key="email"
-								placeholder="Enter an email address"
-								initialValue={email.value()}
-								onValue={email.value}
-								type="email"
-							>
-								{{ label: 'Email' }}
-							</TextInput>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="firstName"
+										placeholder="Enter first name (must be Billy)"
+										required={true}
+										initialValue={firstName.value()}
+										valid={firstName.valid()}
+										onValue={firstName.value}
+										onValidate={firstName.valid}
+									>
+										{{ label: 'First Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="middleName"
+										placeholder="Enter a middle name"
+										required={middleName.required()}
+										initialValue={middleName.value()}
+										valid={middleName.valid()}
+										onValue={middleName.value}
+										onValidate={middleName.valid}
+									>
+										{{ label: 'Middle Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="lastName"
+										placeholder="Enter a last name"
+										required={true}
+										initialValue={lastName.value()}
+										valid={lastName.valid()}
+										onValue={lastName.value}
+										onValidate={lastName.valid}
+									>
+										{{ label: 'Last Name' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="email"
+										placeholder="Enter an email address"
+										initialValue={email.value()}
+										onValue={email.value}
+										type="email"
+									>
+										{{ label: 'Email' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
 							<Button
 								key="requireMiddleName"
 								type="button"

--- a/src/examples/src/widgets/form/ResettingForm.tsx
+++ b/src/examples/src/widgets/form/ResettingForm.tsx
@@ -1,10 +1,10 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-
+import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
-import TextInput from '@dojo/widgets/text-input';
-import Form from '@dojo/widgets/form';
+import Form, { FormField, FormGroup } from '@dojo/widgets/form';
 import { FormMiddleware } from '@dojo/widgets/form/middleware';
+import TextInput from '@dojo/widgets/text-input';
+
 import Example from '../../Example';
 
 const icache = createICacheMiddleware<{
@@ -34,39 +34,51 @@ const App = factory(function({ middleware: { icache } }) {
 
 					return (
 						<virtual>
-							<TextInput
-								key="firstName"
-								placeholder="Enter first name"
-								initialValue={firstName.value()}
-								onValue={firstName.value}
-							>
-								{{ label: 'First Name' }}
-							</TextInput>
-							<TextInput
-								key="middleName"
-								placeholder="Enter a middle name"
-								initialValue={middleName.value()}
-								onValue={middleName.value}
-							>
-								{{ label: 'Middle Name' }}
-							</TextInput>
-							<TextInput
-								key="lastName"
-								placeholder="Enter a last name"
-								initialValue={lastName.value()}
-								onValue={lastName.value}
-							>
-								{{ label: 'Last Name' }}
-							</TextInput>
-							<TextInput
-								key="email"
-								placeholder="Enter an email address"
-								initialValue={email.value()}
-								onValue={email.value}
-								type="email"
-							>
-								{{ label: 'Email' }}
-							</TextInput>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="firstName"
+										placeholder="Enter first name"
+										initialValue={firstName.value()}
+										onValue={firstName.value}
+									>
+										{{ label: 'First Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="middleName"
+										placeholder="Enter a middle name"
+										initialValue={middleName.value()}
+										onValue={middleName.value}
+									>
+										{{ label: 'Middle Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="lastName"
+										placeholder="Enter a last name"
+										initialValue={lastName.value()}
+										onValue={lastName.value}
+									>
+										{{ label: 'Last Name' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="email"
+										placeholder="Enter an email address"
+										initialValue={email.value()}
+										onValue={email.value}
+										type="email"
+									>
+										{{ label: 'Email' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
 							<Button key="reset" type="button" onClick={() => reset()}>
 								Reset
 							</Button>

--- a/src/examples/src/widgets/form/SubmitForm.tsx
+++ b/src/examples/src/widgets/form/SubmitForm.tsx
@@ -1,10 +1,10 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-
+import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
-import TextInput from '@dojo/widgets/text-input';
-import Form from '@dojo/widgets/form';
+import Form, { FormField, FormGroup } from '@dojo/widgets/form';
 import { FormMiddleware } from '@dojo/widgets/form/middleware';
+import TextInput from '@dojo/widgets/text-input';
+
 import Example from '../../Example';
 
 const icache = createICacheMiddleware<{
@@ -34,45 +34,57 @@ const App = factory(function({ middleware: { icache } }) {
 
 					return (
 						<virtual>
-							<TextInput
-								key="firstName"
-								placeholder="Enter first name (must be Billy)"
-								required={true}
-								initialValue={firstName.value()}
-								valid={firstName.valid()}
-								onValue={firstName.value}
-								onValidate={firstName.valid}
-							>
-								{{ label: 'First Name' }}
-							</TextInput>
-							<TextInput
-								key="middleName"
-								placeholder="Enter a middle name"
-								initialValue={middleName.value()}
-								onValue={middleName.value}
-							>
-								{{ label: 'Middle Name' }}
-							</TextInput>
-							<TextInput
-								key="lastName"
-								placeholder="Enter a last name"
-								required={true}
-								initialValue={lastName.value()}
-								valid={lastName.valid()}
-								onValue={lastName.value}
-								onValidate={lastName.valid}
-							>
-								{{ label: 'Last Name' }}
-							</TextInput>
-							<TextInput
-								key="email"
-								placeholder="Enter an email address"
-								initialValue={email.value()}
-								onValue={email.value}
-								type="email"
-							>
-								{{ label: 'Email' }}
-							</TextInput>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="firstName"
+										placeholder="Enter first name (must be Billy)"
+										required={true}
+										initialValue={firstName.value()}
+										valid={firstName.valid()}
+										onValue={firstName.value}
+										onValidate={firstName.valid}
+									>
+										{{ label: 'First Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="middleName"
+										placeholder="Enter a middle name"
+										initialValue={middleName.value()}
+										onValue={middleName.value}
+									>
+										{{ label: 'Middle Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="lastName"
+										placeholder="Enter a last name"
+										required={true}
+										initialValue={lastName.value()}
+										valid={lastName.valid()}
+										onValue={lastName.value}
+										onValidate={lastName.valid}
+									>
+										{{ label: 'Last Name' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="email"
+										placeholder="Enter an email address"
+										initialValue={email.value()}
+										onValue={email.value}
+										type="email"
+									>
+										{{ label: 'Email' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
 							<Button key="submit" type="submit" disabled={!valid()}>
 								Submit
 							</Button>

--- a/src/examples/src/widgets/form/Validation.tsx
+++ b/src/examples/src/widgets/form/Validation.tsx
@@ -1,9 +1,9 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-
-import TextInput from '@dojo/widgets/text-input';
-import Form from '@dojo/widgets/form';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Form, { FormField, FormGroup } from '@dojo/widgets/form';
 import { FormMiddleware } from '@dojo/widgets/form/middleware';
+import TextInput from '@dojo/widgets/text-input';
+
 import Example from '../../Example';
 
 const icache = createICacheMiddleware<{
@@ -33,51 +33,63 @@ const App = factory(function({ middleware: { icache } }) {
 
 					return (
 						<virtual>
-							<TextInput
-								key="firstName"
-								placeholder="Enter first name (must be Billy)"
-								pattern="Billy"
-								initialValue={firstName.value()}
-								valid={firstName.valid()}
-								onValue={firstName.value}
-								onValidate={firstName.valid}
-							>
-								{{ label: 'First Name' }}
-							</TextInput>
-							<TextInput
-								key="middleName"
-								placeholder="Enter a middle name"
-								initialValue={middleName.value()}
-								valid={middleName.valid()}
-								onValue={middleName.value}
-								onValidate={middleName.valid}
-								maxLength={5}
-							>
-								{{ label: 'Middle Name' }}
-							</TextInput>
-							<TextInput
-								key="lastName"
-								placeholder="Enter a last name"
-								initialValue={lastName.value()}
-								valid={lastName.valid()}
-								onValue={lastName.value}
-								onValidate={lastName.valid}
-								minLength={2}
-							>
-								{{ label: 'Last Name' }}
-							</TextInput>
-							<TextInput
-								key="email"
-								placeholder="Enter an email address"
-								initialValue={email.value()}
-								valid={email.valid()}
-								onValue={email.value}
-								onValidate={email.valid}
-								type="email"
-								pattern="^[^\s@]+@[^\s@]+\.[^\s@]{2,}$"
-							>
-								{{ label: 'Email' }}
-							</TextInput>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="firstName"
+										placeholder="Enter first name (must be Billy)"
+										pattern="Billy"
+										initialValue={firstName.value()}
+										valid={firstName.valid()}
+										onValue={firstName.value}
+										onValidate={firstName.valid}
+									>
+										{{ label: 'First Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="middleName"
+										placeholder="Enter a middle name"
+										initialValue={middleName.value()}
+										valid={middleName.valid()}
+										onValue={middleName.value}
+										onValidate={middleName.valid}
+										maxLength={5}
+									>
+										{{ label: 'Middle Name' }}
+									</TextInput>
+								</FormField>
+								<FormField>
+									<TextInput
+										key="lastName"
+										placeholder="Enter a last name"
+										initialValue={lastName.value()}
+										valid={lastName.valid()}
+										onValue={lastName.value}
+										onValidate={lastName.valid}
+										minLength={2}
+									>
+										{{ label: 'Last Name' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
+							<FormGroup>
+								<FormField>
+									<TextInput
+										key="email"
+										placeholder="Enter an email address"
+										initialValue={email.value()}
+										valid={email.valid()}
+										onValue={email.value}
+										onValidate={email.valid}
+										type="email"
+										pattern="^[^\s@]+@[^\s@]+\.[^\s@]{2,}$"
+									>
+										{{ label: 'Email' }}
+									</TextInput>
+								</FormField>
+							</FormGroup>
 						</virtual>
 					);
 				}}

--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -1,10 +1,10 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
+import { RenderResult, VNodeProperties } from '@dojo/framework/core/interfaces';
 import icache from '@dojo/framework/core/middleware/icache';
 import theme from '@dojo/framework/core/middleware/theme';
-import { RenderResult, VNodeProperties } from '@dojo/framework/core/interfaces';
+import { create, tsx } from '@dojo/framework/core/vdom';
 
-import createFormMiddleware, { FormMiddleware, FormValue } from './middleware';
 import * as css from '../theme/default/form.m.css';
+import createFormMiddleware, { FormMiddleware, FormValue } from './middleware';
 
 const form = createFormMiddleware();
 
@@ -105,4 +105,48 @@ export default factory(function Form({
 	}
 
 	return <form {...formProps}>{renderer(form)}</form>;
+});
+
+export interface FormGroupProperties {
+	/** Render this grouping in a vertical column */
+	column?: boolean;
+}
+
+const formGroupFactory = create({ theme })
+	.properties<FormGroupProperties>()
+	.children();
+
+export const FormGroup = formGroupFactory(function FormRow({
+	properties,
+	children,
+	middleware: { theme }
+}) {
+	const { column } = properties();
+	const themedCss = theme.classes(css);
+
+	return (
+		<div
+			key="root"
+			classes={[
+				theme.variant(),
+				themedCss.groupRoot,
+				!column && themedCss.row,
+				column && themedCss.column
+			]}
+		>
+			{children()}
+		</div>
+	);
+});
+
+const formFieldFactory = create({ theme }).children();
+
+export const FormField = formFieldFactory(function FormField({ children, middleware: { theme } }) {
+	const themedCss = theme.classes(css);
+
+	return (
+		<div key="root" classes={[theme.variant(), themedCss.fieldRoot]}>
+			{children()}
+		</div>
+	);
 });

--- a/src/form/tests/unit/Form.spec.tsx
+++ b/src/form/tests/unit/Form.spec.tsx
@@ -1,19 +1,18 @@
 const { describe, it, beforeEach } = intern.getInterface('bdd');
+
 import { assert } from 'chai';
 import { stub } from 'sinon';
 
+import { tsx } from '@dojo/framework/core/vdom';
 import assertionTemplate from '@dojo/framework/testing/harness/assertionTemplate';
 import harness from '@dojo/framework/testing/harness/harness';
-import { tsx } from '@dojo/framework/core/vdom';
 
 import Button from '../../../button';
-import TextInput from '../../../text-input';
-
 import { stubEvent } from '../../../common/tests/support/test-helpers';
-
+import TextInput from '../../../text-input';
 import * as css from '../../../theme/default/form.m.css';
+import Form, { FormField, FormGroup, FormGroupProperties } from '../../index';
 import { FormMiddleware, FormValue } from '../../middleware';
-import Form from '../../index';
 
 interface Fields {
 	firstName: string;
@@ -572,5 +571,42 @@ describe('Form', () => {
 			</form>
 		));
 		h.expect(actionTemplate);
+	});
+});
+
+describe('FormGroup', () => {
+	const getTemplate = ({ column }: FormGroupProperties) => (
+		<div
+			key="root"
+			classes={[undefined, css.groupRoot, !column && css.row, column && css.column]}
+		>
+			foo
+		</div>
+	);
+
+	it('renders', () => {
+		const h = harness(() => <FormGroup>foo</FormGroup>);
+
+		h.expect(assertionTemplate(() => getTemplate({})));
+	});
+
+	it('renders column', () => {
+		const h = harness(() => <FormGroup column>foo</FormGroup>);
+
+		h.expect(assertionTemplate(() => getTemplate({ column: true })));
+	});
+});
+
+describe('FormField', () => {
+	it('renders', () => {
+		const h = harness(() => <FormField>foo</FormField>);
+
+		h.expect(
+			assertionTemplate(() => (
+				<div key="root" classes={[undefined, css.fieldRoot]}>
+					foo
+				</div>
+			))
+		);
 	});
 });

--- a/src/theme/default/form.m.css
+++ b/src/theme/default/form.m.css
@@ -1,3 +1,24 @@
 /* Root class of the form */
 .root {
 }
+
+/* Root class of form groups */
+.groupRoot {
+	align-items: flex-start;
+	display: flex;
+	flex-direction: row;
+}
+
+/* Root class of colum form groups */
+.column {
+	flex-direction: column;
+}
+
+/* Root class of row form groups */
+.row {
+}
+
+/* Root class of form fields within a group */
+.fieldRoot {
+	flex: 1;
+}

--- a/src/theme/default/index.ts
+++ b/src/theme/default/index.ts
@@ -4,30 +4,31 @@ import * as breadcrumbGroup from './breadcrumb-group.m.css';
 import * as button from './button.m.css';
 import * as calendar from './calendar.m.css';
 import * as card from './card.m.css';
-import * as checkbox from './checkbox.m.css';
 import * as checkboxGroup from './checkbox-group.m.css';
+import * as checkbox from './checkbox.m.css';
 import * as chip from './chip.m.css';
 import * as constrainedInput from './constrained-input.m.css';
 import * as dateInput from './date-input.m.css';
 import * as dialog from './dialog.m.css';
 import * as emailInput from './email-input.m.css';
 import * as floatingActionButton from './floating-action-button.m.css';
-import * as grid from './grid.m.css';
+import * as form from './form.m.css';
 import * as gridBody from './grid-body.m.css';
 import * as gridCell from './grid-cell.m.css';
 import * as gridFooter from './grid-footer.m.css';
 import * as gridHeader from './grid-header.m.css';
-import * as gridPlaceholderRow from './grid-placeholder-row.m.css';
 import * as gridPaginatedFooter from './grid-paginated-footer.m.css';
+import * as gridPlaceholderRow from './grid-placeholder-row.m.css';
 import * as gridRow from './grid-row.m.css';
+import * as grid from './grid.m.css';
 import * as helperText from './helper-text.m.css';
 import * as icon from './icon.m.css';
 import * as label from './label.m.css';
-import * as loadingIndicator from './loading-indicator.m.css';
+import * as listItem from './list-item.m.css';
 import * as list from './list.m.css';
+import * as loadingIndicator from './loading-indicator.m.css';
 import * as menuItem from './menu-item.m.css';
 import * as nativeSelect from './native-select.m.css';
-import * as listItem from './list-item.m.css';
 import * as outlinedButton from './outlined-button.m.css';
 import * as pagination from './pagination.m.css';
 import * as passwordInput from './password-input.m.css';
@@ -69,6 +70,7 @@ export default {
 		'@dojo/widgets/dialog': dialog,
 		'@dojo/widgets/email-input': emailInput,
 		'@dojo/widgets/floating-action-button': floatingActionButton,
+		'@dojo/widgets/form': form,
 		'@dojo/widgets/grid-body': gridBody,
 		'@dojo/widgets/grid-cell': gridCell,
 		'@dojo/widgets/grid-footer': gridFooter,

--- a/src/theme/dojo/form.m.css
+++ b/src/theme/dojo/form.m.css
@@ -1,0 +1,29 @@
+.groupRoot {
+	display: flex;
+	flex-direction: row;
+	left: calc(-1 * var(--grid-base));
+	margin-bottom: calc(var(--grid-base) * 2);
+	position: relative;
+	width: calc(100% + (var(--grid-base) * 2));
+}
+
+.groupRoot:last-child {
+	margin-bottom: 0;
+}
+
+.column {
+	flex-direction: column;
+}
+
+.column .fieldRoot {
+	margin-bottom: calc(var(--grid-base) * 2);
+}
+
+.column .fieldRoot:last-child {
+	margin-bottom: 0;
+}
+
+.fieldRoot {
+	flex: 1;
+	padding: 0 var(--grid-base);
+}

--- a/src/theme/dojo/form.m.css.d.ts
+++ b/src/theme/dojo/form.m.css.d.ts
@@ -1,5 +1,4 @@
-export const root: string;
-export const groupRoot: string;
+export const rowRoot: string;
 export const column: string;
 export const row: string;
 export const fieldRoot: string;

--- a/src/theme/dojo/index.ts
+++ b/src/theme/dojo/index.ts
@@ -6,30 +6,31 @@ import * as calendar from './calendar.m.css';
 import * as card from './card.m.css';
 import * as checkboxGroup from './checkbox-group.m.css';
 import * as checkbox from './checkbox.m.css';
+import * as chipTypeahead from './chip-typeahead.m.css';
 import * as chip from './chip.m.css';
 import * as dateInput from './date-input.m.css';
 import * as dialog from './dialog.m.css';
 import * as floatingActionButton from './floating-action-button.m.css';
-import * as grid from './grid.m.css';
+import * as form from './form.m.css';
 import * as gridBody from './grid-body.m.css';
 import * as gridCell from './grid-cell.m.css';
 import * as gridFooter from './grid-footer.m.css';
 import * as gridHeader from './grid-header.m.css';
-import * as gridPlaceholderRow from './grid-placeholder-row.m.css';
 import * as gridPaginatedFooter from './grid-paginated-footer.m.css';
+import * as gridPlaceholderRow from './grid-placeholder-row.m.css';
 import * as gridRow from './grid-row.m.css';
+import * as grid from './grid.m.css';
 import * as headerCard from './header-card.m.css';
 import * as header from './header.m.css';
 import * as helperText from './helper-text.m.css';
 import * as icon from './icon.m.css';
 import * as label from './label.m.css';
 import * as listItem from './list-item.m.css';
-import * as loadingIndicator from './loading-indicator.m.css';
 import * as list from './list.m.css';
+import * as loadingIndicator from './loading-indicator.m.css';
 import * as menuItem from './menu-item.m.css';
-import * as chipTypeahead from './chip-typeahead.m.css';
-import * as outlinedButton from './outlined-button.m.css';
 import * as nativeSelect from './native-select.m.css';
+import * as outlinedButton from './outlined-button.m.css';
 import * as pagination from './pagination.m.css';
 import * as passwordInput from './password-input.m.css';
 import * as progress from './progress.m.css';
@@ -52,8 +53,8 @@ import * as titlePane from './title-pane.m.css';
 import * as tooltip from './tooltip.m.css';
 import * as twoColumnLayout from './two-column-layout.m.css';
 import * as typeahead from './typeahead.m.css';
-import * as defaultVariant from './variants/default.m.css';
 import * as darkVariant from './variants/dark.m.css';
+import * as defaultVariant from './variants/default.m.css';
 
 export default {
 	theme: {
@@ -69,6 +70,7 @@ export default {
 		'@dojo/widgets/date-input': dateInput,
 		'@dojo/widgets/dialog': dialog,
 		'@dojo/widgets/floating-action-button': floatingActionButton,
+		'@dojo/widgets/form': form,
 		'@dojo/widgets/grid-body': gridBody,
 		'@dojo/widgets/grid-cell': gridCell,
 		'@dojo/widgets/grid-footer': gridFooter,

--- a/src/theme/material/form.m.css
+++ b/src/theme/material/form.m.css
@@ -1,0 +1,33 @@
+:root {
+	--spacing: 16px;
+}
+
+.groupRoot {
+	display: flex;
+	flex-direction: row;
+	left: calc(-1 * var(--spacing));
+	margin-bottom: calc(var(--spacing) * 2);
+	position: relative;
+	width: calc(100% + (var(--spacing) * 2));
+}
+
+.groupRoot:last-child {
+	margin-bottom: 0;
+}
+
+.column {
+	flex-direction: column;
+}
+
+.column .fieldRoot {
+	margin-bottom: calc(var(--spacing) * 2);
+}
+
+.column .fieldRoot:last-child {
+	margin-bottom: 0;
+}
+
+.fieldRoot {
+	flex: 1;
+	padding: 0 var(--spacing);
+}

--- a/src/theme/material/form.m.css.d.ts
+++ b/src/theme/material/form.m.css.d.ts
@@ -1,4 +1,3 @@
-export const root: string;
 export const groupRoot: string;
 export const column: string;
 export const row: string;

--- a/src/theme/material/index.ts
+++ b/src/theme/material/index.ts
@@ -2,14 +2,16 @@ import * as accordionPane from './accordion.m.css';
 import * as avatar from './avatar.m.css';
 import * as breadcrumbGroup from './breadcrumb-group.m.css';
 import * as button from './button.m.css';
-import * as card from './card.m.css';
 import * as calendar from './calendar.m.css';
+import * as card from './card.m.css';
 import * as checkboxGroup from './checkbox-group.m.css';
 import * as checkbox from './checkbox.m.css';
+import * as chipTypeahead from './chip-typeahead.m.css';
 import * as chip from './chip.m.css';
 import * as dateInput from './date-input.m.css';
 import * as dialog from './dialog.m.css';
 import * as floatingActionButton from './floating-action-button.m.css';
+import * as form from './form.m.css';
 import * as gridBody from './grid-body.m.css';
 import * as gridCell from './grid-cell.m.css';
 import * as gridFooter from './grid-footer.m.css';
@@ -24,10 +26,9 @@ import * as helperText from './helper-text.m.css';
 import * as icon from './icon.m.css';
 import * as label from './label.m.css';
 import * as listItem from './list-item.m.css';
-import * as loadingIndicator from './loading-indicator.m.css';
 import * as list from './list.m.css';
+import * as loadingIndicator from './loading-indicator.m.css';
 import * as menuItem from './menu-item.m.css';
-import * as chipTypeahead from './chip-typeahead.m.css';
 import * as nativeSelect from './native-select.m.css';
 import * as outlinedButton from './outlined-button.m.css';
 import * as pagination from './pagination.m.css';
@@ -68,6 +69,7 @@ export default {
 		'@dojo/widgets/date-input': dateInput,
 		'@dojo/widgets/dialog': dialog,
 		'@dojo/widgets/floating-action-button': floatingActionButton,
+		'@dojo/widgets/form': form,
 		'@dojo/widgets/grid-body': gridBody,
 		'@dojo/widgets/grid-cell': gridCell,
 		'@dojo/widgets/grid-footer': gridFooter,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request adds two supporting widgets meant to ease the layout of form fields: `FormGroup` and `FormField`. This initial implementation is straightforward: a form group can render its children horizontally or vertically with uniform spacing.

Resolves #1085 

**Preview:**

<img width="986" alt="preview" src="https://user-images.githubusercontent.com/334586/80022221-b937c200-84a9-11ea-915f-3df29cfe849d.png">

