### PR TITLE
Update References to TabController to TabContainer

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -48,7 +48,7 @@
 			"src/slider",
 			"src/snackbar",
 			"src/switch",
-			"src/tab-controller",
+			"src/tab-container",
 			"src/text-area",
 			"src/text-input",
 			"src/three-column-layout",

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -168,11 +168,11 @@ import StackedSnackbar from './widgets/snackbar/Stacked';
 import SuccessSnackbar from './widgets/snackbar/Success';
 import BasicSwitch from './widgets/switch/Basic';
 import DisabledSwitch from './widgets/switch/Disabled';
-import BasicTabController from './widgets/tab-container/Basic';
-import ControlledTabController from './widgets/tab-container/Controlled';
-import ButtonAlignmentTabController from './widgets/tab-container/ButtonAlignment';
-import CloseableTabController from './widgets/tab-container/Closeable';
-import DisabledTabController from './widgets/tab-container/Disabled';
+import BasicTabContainer from './widgets/tab-container/Basic';
+import ControlledTabContainer from './widgets/tab-container/Controlled';
+import ButtonAlignmentTabContainer from './widgets/tab-container/ButtonAlignment';
+import CloseableTabContainer from './widgets/tab-container/Closeable';
+import DisabledTabContainer from './widgets/tab-container/Disabled';
 import BasicTextArea from './widgets/text-area/Basic';
 import ControlledTextArea from './widgets/text-area/Controlled';
 import TextAreaWithLabel from './widgets/text-area/Label';
@@ -1486,30 +1486,30 @@ export const config = {
 			examples: [
 				{
 					filename: 'Controlled',
-					module: ControlledTabController,
-					title: 'Controlled TabController'
+					module: ControlledTabContainer,
+					title: 'Controlled TabContainer'
 				},
 				{
 					filename: 'Disabled',
-					module: DisabledTabController,
-					title: 'TabController with disabled tabs'
+					module: DisabledTabContainer,
+					title: 'TabContainer with disabled tabs'
 				},
 				{
 					filename: 'ButtonAlignment',
-					module: ButtonAlignmentTabController,
-					title: 'TabController with adjustable button alignment'
+					module: ButtonAlignmentTabContainer,
+					title: 'TabContainer with adjustable button alignment'
 				},
 				{
 					filename: 'Closeable',
-					module: CloseableTabController,
-					title: 'TabController with closeable tab'
+					module: CloseableTabContainer,
+					title: 'TabContainer with closeable tab'
 				}
 			],
 			filename: 'index',
 			overview: {
 				example: {
 					filename: 'Basic',
-					module: BasicTabController
+					module: BasicTabContainer
 				}
 			}
 		},

--- a/src/tab-container/index.tsx
+++ b/src/tab-container/index.tsx
@@ -44,7 +44,7 @@ const factory = create({
 	.properties<TabContainerProperties>()
 	.children();
 
-export const TabContainer = factory(function TabController({
+export const TabContainer = factory(function TabContainer({
 	children,
 	id,
 	middleware: { focus, i18n, icache, theme },

--- a/src/tab-container/tests/TabContainer.spec.tsx
+++ b/src/tab-container/tests/TabContainer.spec.tsx
@@ -72,7 +72,7 @@ const tabButtonProperties = {
 	tabIndex: 0
 };
 
-registerSuite('TabController', {
+registerSuite('TabContainer', {
 	tests: {
 		'renders with aria'() {
 			const tabs = [{ name: 'test' }];

--- a/src/theme/default/tab-container.m.css
+++ b/src/theme/default/tab-container.m.css
@@ -53,7 +53,7 @@
 	z-index: calc(var(--zindex-base) + 1);
 }
 
-/* The root class of the TabController */
+/* The root class of the TabContainer */
 .root {
 	box-sizing: border-box;
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

The `TabController` was renamed `TabContainer` but lots of references were missed, including the widget in the `.dojorc`