### PR TITLE
Remove icache deconstruct useage

### DIFF
--- a/src/email-input/index.tsx
+++ b/src/email-input/index.tsx
@@ -22,18 +22,17 @@ export const EmailInput = factory(function({
 	children,
 	middleware: { icache, theme }
 }) {
-	const { get, set } = icache;
 	const props = properties();
 	return (
 		<TextInput
 			{...props}
 			type={'email'}
 			onValidate={(valid, message) => {
-				set('valid', valid);
-				set('message', message);
+				icache.set('valid', valid);
+				icache.set('message', message);
 				props.onValidate && props.onValidate(valid, message);
 			}}
-			valid={{ valid: get('valid'), message: get('message') }}
+			valid={{ valid: icache.get('valid'), message: icache.get('message') }}
 			theme={theme.compose(
 				textInputCss,
 				emailInputCss

--- a/src/examples/src/widgets/checkbox-group/Basic.tsx
+++ b/src/examples/src/widgets/checkbox-group/Basic.tsx
@@ -6,22 +6,20 @@ import Example from '../../Example';
 const factory = create({ icache });
 
 const App = factory(function({ properties, middleware: { icache } }) {
-	const { get, set } = icache;
-
 	return (
 		<Example>
 			<CheckboxGroup
 				name="standard"
 				options={[{ value: 'cat' }, { value: 'dog' }, { value: 'fish' }]}
 				onValue={(value) => {
-					set('standard', value);
+					icache.set('standard', value);
 				}}
 			>
 				{{
 					label: 'pets'
 				}}
 			</CheckboxGroup>
-			<pre>{`${get('standard')}`}</pre>
+			<pre>{`${icache.get('standard')}`}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/checkbox-group/Controlled.tsx
+++ b/src/examples/src/widgets/checkbox-group/Controlled.tsx
@@ -6,23 +6,21 @@ import Example from '../../Example';
 const factory = create({ icache });
 
 const App = factory(function({ properties, middleware: { icache } }) {
-	const { get, set } = icache;
-
 	return (
 		<Example>
 			<CheckboxGroup
-				value={get('controlled')}
+				value={icache.get('controlled')}
 				name="initial-value"
 				options={[{ value: 'tom' }, { value: 'dick' }, { value: 'harry' }]}
 				onValue={(value) => {
-					set('controlled', value);
+					icache.set('controlled', value);
 				}}
 			>
 				{{
 					label: 'favourite names'
 				}}
 			</CheckboxGroup>
-			<pre>{`${get('controlled')}`}</pre>
+			<pre>{`${icache.get('controlled')}`}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/checkbox-group/CustomLabel.tsx
+++ b/src/examples/src/widgets/checkbox-group/CustomLabel.tsx
@@ -6,8 +6,6 @@ import Example from '../../Example';
 const factory = create({ icache });
 
 const App = factory(function({ properties, middleware: { icache } }) {
-	const { get, set } = icache;
-
 	return (
 		<Example>
 			<CheckboxGroup
@@ -18,14 +16,14 @@ const App = factory(function({ properties, middleware: { icache } }) {
 					{ value: 'blue', label: 'Bleu' }
 				]}
 				onValue={(value) => {
-					set('colours', value);
+					icache.set('colours', value);
 				}}
 			>
 				{{
 					label: 'colours'
 				}}
 			</CheckboxGroup>
-			<pre>{`${get('colours')}`}</pre>
+			<pre>{`${icache.get('colours')}`}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/checkbox-group/CustomRenderer.tsx
+++ b/src/examples/src/widgets/checkbox-group/CustomRenderer.tsx
@@ -7,15 +7,13 @@ import Example from '../../Example';
 const factory = create({ icache });
 
 const App = factory(function({ middleware: { icache } }) {
-	const { get, set } = icache;
-
 	return (
 		<Example>
 			<CheckboxGroup
 				name="custom"
 				options={[{ value: 'yes' }, { value: 'no' }, { value: 'maybe' }]}
 				onValue={(value) => {
-					set('custom', value);
+					icache.set('custom', value);
 				}}
 			>
 				{{
@@ -50,7 +48,7 @@ const App = factory(function({ middleware: { icache } }) {
 					}
 				}}
 			</CheckboxGroup>
-			<pre>{`${get('custom')}`}</pre>
+			<pre>{`${icache.get('custom')}`}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/checkbox-group/InitialValue.tsx
+++ b/src/examples/src/widgets/checkbox-group/InitialValue.tsx
@@ -6,8 +6,6 @@ import Example from '../../Example';
 const factory = create({ icache });
 
 const App = factory(function({ properties, middleware: { icache } }) {
-	const { get, set } = icache;
-
 	return (
 		<Example>
 			<CheckboxGroup
@@ -15,14 +13,14 @@ const App = factory(function({ properties, middleware: { icache } }) {
 				name="initial-value"
 				options={[{ value: 'tom' }, { value: 'dick' }, { value: 'harry' }]}
 				onValue={(value) => {
-					set('initial-value', value);
+					icache.set('initial-value', value);
 				}}
 			>
 				{{
 					label: 'favourite names'
 				}}
 			</CheckboxGroup>
-			<pre>{`${get('initial-value')}`}</pre>
+			<pre>{`${icache.get('initial-value')}`}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/chip/Closable.tsx
+++ b/src/examples/src/widgets/chip/Closable.tsx
@@ -6,15 +6,14 @@ import Example from '../../Example';
 const factory = create({ icache });
 
 const App = factory(function Closeable({ middleware: { icache } }) {
-	const { get, set } = icache;
-	const closed = get<boolean>('closed');
+	const closed = icache.get<boolean>('closed');
 
 	return (
 		<Example>
 			{!closed && (
 				<Chip
 					onClose={() => {
-						set('closed', true);
+						icache.set('closed', true);
 					}}
 				>
 					{{

--- a/src/examples/src/widgets/chip/ClosableRenderer.tsx
+++ b/src/examples/src/widgets/chip/ClosableRenderer.tsx
@@ -7,15 +7,14 @@ import Example from '../../Example';
 const factory = create({ icache });
 
 const App = factory(function ClosableRenderer({ middleware: { icache } }) {
-	const { get, set } = icache;
-	const closed = get<boolean>('closed');
+	const closed = icache.get<boolean>('closed');
 
 	return (
 		<Example>
 			{!closed && (
 				<Chip
 					onClose={() => {
-						set('closed', true);
+						icache.set('closed', true);
 					}}
 				>
 					{{

--- a/src/examples/src/widgets/radio-group/Basic.tsx
+++ b/src/examples/src/widgets/radio-group/Basic.tsx
@@ -6,22 +6,20 @@ import Example from '../../Example';
 const factory = create({ icache });
 
 const App = factory(function({ properties, middleware: { icache } }) {
-	const { get, set } = icache;
-
 	return (
 		<Example>
 			<RadioGroup
 				name="standard"
 				options={[{ value: 'cat' }, { value: 'dog' }, { value: 'fish' }]}
 				onValue={(value) => {
-					set('standard', value);
+					icache.set('standard', value);
 				}}
 			>
 				{{
 					label: 'pets'
 				}}
 			</RadioGroup>
-			<pre>{`${get('standard')}`}</pre>
+			<pre>{`${icache.get('standard')}`}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/radio-group/Controlled.tsx
+++ b/src/examples/src/widgets/radio-group/Controlled.tsx
@@ -6,23 +6,21 @@ import Example from '../../Example';
 const factory = create({ icache });
 
 const App = factory(function({ properties, middleware: { icache } }) {
-	const { get, set } = icache;
-
 	return (
 		<Example>
 			<RadioGroup
 				name="standard"
-				value={get('standard')}
+				value={icache.get('standard')}
 				options={[{ value: 'cat' }, { value: 'dog' }, { value: 'fish' }]}
 				onValue={(value) => {
-					set('standard', value);
+					icache.set('standard', value);
 				}}
 			>
 				{{
 					label: 'pets'
 				}}
 			</RadioGroup>
-			<pre>{`${get('standard')}`}</pre>
+			<pre>{`${icache.get('standard')}`}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/radio-group/CustomLabel.tsx
+++ b/src/examples/src/widgets/radio-group/CustomLabel.tsx
@@ -6,8 +6,6 @@ import Example from '../../Example';
 const factory = create({ icache });
 
 const App = factory(function({ properties, middleware: { icache } }) {
-	const { get, set } = icache;
-
 	return (
 		<Example>
 			<RadioGroup
@@ -18,14 +16,14 @@ const App = factory(function({ properties, middleware: { icache } }) {
 					{ value: 'blue', label: 'Bleu' }
 				]}
 				onValue={(value) => {
-					set('colours', value);
+					icache.set('colours', value);
 				}}
 			>
 				{{
 					label: 'colours'
 				}}
 			</RadioGroup>
-			<pre>{`${get('colours')}`}</pre>
+			<pre>{`${icache.get('colours')}`}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/radio-group/CustomRenderer.tsx
+++ b/src/examples/src/widgets/radio-group/CustomRenderer.tsx
@@ -7,15 +7,13 @@ import Example from '../../Example';
 const factory = create({ icache });
 
 const App = factory(function({ middleware: { icache } }) {
-	const { get, set } = icache;
-
 	return (
 		<Example>
 			<RadioGroup
 				name="custom"
 				options={[{ value: 'yes' }, { value: 'no' }, { value: 'maybe' }]}
 				onValue={(value) => {
-					set('custom', value);
+					icache.set('custom', value);
 				}}
 			>
 				{{
@@ -50,7 +48,7 @@ const App = factory(function({ middleware: { icache } }) {
 					}
 				}}
 			</RadioGroup>
-			<pre>{`${get('custom')}`}</pre>
+			<pre>{`${icache.get('custom')}`}</pre>
 		</Example>
 	);
 });


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Removes usage of `const { get, set } = icache`