### PR TITLE
Fixes the theme structure returned by theme composes

### DIFF
--- a/src/middleware/tests/theme.spec.tsx
+++ b/src/middleware/tests/theme.spec.tsx
@@ -459,34 +459,58 @@ describe('theme middleware', () => {
 
 		properties.theme = {
 			theme: {
-				'@dojo/widgets/Base': {
-					root: 'base_theme_root'
+				theme: {
+					'@dojo/widgets/Base': {
+						root: 'base_theme_root'
+					},
+					'@dojo/widgets/Variant': {
+						extra: 'variant_theme_extra',
+						selected: 'variant_theme_selected'
+					}
 				},
-				'@dojo/widgets/Variant': {
-					extra: 'variant_theme_extra',
-					selected: 'variant_theme_selected'
+				variants: {
+					default: {
+						root: 'default root variant'
+					}
 				}
 			},
-			variant: { root: 'foo' }
+			variant: {
+				name: 'default',
+				value: {
+					root: 'default root variant'
+				}
+			}
 		};
 
 		const composedClasses = composesInstance.compose(
 			baseClasses,
 			variantClasses
 		);
-		assert.deepEqual<any>(composedClasses, {
+		assert.deepEqual(composedClasses, {
 			theme: {
-				'@dojo/widgets/Base': {
-					root: 'base_theme_root',
-					selected: 'variant_theme_selected',
-					active: 'variant_active'
+				theme: {
+					'@dojo/widgets/Base': {
+						root: 'base_theme_root',
+						selected: 'variant_theme_selected',
+						active: 'variant_active'
+					},
+					'@dojo/widgets/Variant': {
+						extra: 'variant_theme_extra',
+						selected: 'variant_theme_selected'
+					}
 				},
-				'@dojo/widgets/Variant': {
-					extra: 'variant_theme_extra',
-					selected: 'variant_theme_selected'
+				variants: {
+					default: {
+						root: 'default root variant'
+					}
 				}
 			},
-			variant: { root: 'foo' }
+			variant: {
+				name: 'default',
+				value: {
+					root: 'default root variant'
+				}
+			}
 		});
 	});
 
@@ -505,15 +529,25 @@ describe('theme middleware', () => {
 
 		properties.theme = {
 			theme: {
-				'@dojo/widgets/Base': {
-					active: 'base_theme_active'
+				theme: {
+					'@dojo/widgets/Base': {
+						active: 'base_theme_active'
+					},
+					'@dojo/widgets/Variant': {
+						baseActive: 'variant_theme_active'
+					}
 				},
-				'@dojo/widgets/Variant': {
-					baseActive: 'variant_theme_active'
+				variants: {
+					default: {
+						root: 'default root variant'
+					}
 				}
 			},
 			variant: {
-				root: 'foo'
+				name: 'default',
+				value: {
+					root: 'default root variant'
+				}
 			}
 		};
 
@@ -522,18 +556,30 @@ describe('theme middleware', () => {
 			variantClasses,
 			'base'
 		);
-		assert.deepEqual<any>(composedClasses, {
+		assert.deepEqual(composedClasses, {
 			theme: {
-				'@dojo/widgets/Base': {
-					root: 'base_root',
-					selected: 'base_selected',
-					active: 'variant_theme_active'
+				theme: {
+					'@dojo/widgets/Base': {
+						root: 'base_root',
+						selected: 'base_selected',
+						active: 'variant_theme_active'
+					},
+					'@dojo/widgets/Variant': {
+						baseActive: 'variant_theme_active'
+					}
 				},
-				'@dojo/widgets/Variant': {
-					baseActive: 'variant_theme_active'
+				variants: {
+					default: {
+						root: 'default root variant'
+					}
 				}
 			},
-			variant: { root: 'foo' }
+			variant: {
+				name: 'default',
+				value: {
+					root: 'default root variant'
+				}
+			}
 		});
 	});
 });

--- a/src/middleware/theme.tsx
+++ b/src/middleware/theme.tsx
@@ -77,8 +77,11 @@ export const theme = factory(function({ middleware: { coreTheme }, properties })
 				if (isThemeWithVariant(theme)) {
 					return {
 						theme: {
-							...theme.theme,
-							[baseKey]: baseTheme
+							theme: {
+								...theme.theme.theme,
+								[baseKey]: baseTheme
+							},
+							variants: theme.theme.variants
 						},
 						variant: theme.variant
 					};
@@ -109,8 +112,11 @@ export const theme = factory(function({ middleware: { coreTheme }, properties })
 			if (isThemeWithVariant(theme)) {
 				return {
 					theme: {
-						...theme.theme,
-						[baseKey]: constructedTheme
+						theme: {
+							...theme.theme.theme,
+							[baseKey]: constructedTheme
+						},
+						variants: theme.theme.variants
 					},
 					variant: theme.variant
 				};


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Theme composes needs fixing with the latest changes to themes with variants.
