### PR TITLE
fix: simplify form examples

### DIFF
--- a/src/examples/src/widgets/form/ActionForm.tsx
+++ b/src/examples/src/widgets/form/ActionForm.tsx
@@ -14,7 +14,6 @@ const factory = create({ icache });
 
 interface Fields {
 	firstName?: string;
-	middleName?: string;
 	lastName?: string;
 	email?: string;
 }
@@ -31,7 +30,6 @@ const App = factory(function({ middleware: { icache } }) {
 			>
 				{({ field }: FormMiddleware<Fields>) => {
 					const firstName = field('firstName');
-					const middleName = field('middleName');
 					const lastName = field('lastName');
 					const email = field('email');
 
@@ -46,16 +44,6 @@ const App = factory(function({ middleware: { icache } }) {
 										onValue={firstName.value}
 									>
 										{{ label: 'First Name' }}
-									</TextInput>
-								</FormField>
-								<FormField>
-									<TextInput
-										key="middleName"
-										placeholder="Enter a middle name"
-										initialValue={middleName.value()}
-										onValue={middleName.value}
-									>
-										{{ label: 'Middle Name' }}
 									</TextInput>
 								</FormField>
 								<FormField>
@@ -91,7 +79,6 @@ const App = factory(function({ middleware: { icache } }) {
 					<h2>onValue Results</h2>
 					<ul>
 						<li>First Name: {results.firstName}</li>
-						<li>Middle Name: {results.middleName}</li>
 						<li>Last Name: {results.lastName}</li>
 						<li>Email: {results.email}</li>
 					</ul>

--- a/src/examples/src/widgets/form/Basic.tsx
+++ b/src/examples/src/widgets/form/Basic.tsx
@@ -14,7 +14,6 @@ const factory = create({ icache });
 
 interface Fields {
 	firstName?: string;
-	middleName?: string;
 	lastName?: string;
 	email?: string;
 }
@@ -30,7 +29,6 @@ const App = factory(function({ middleware: { icache } }) {
 			>
 				{({ field }: FormMiddleware<Fields>) => {
 					const firstName = field('firstName');
-					const middleName = field('middleName');
 					const lastName = field('lastName');
 					const email = field('email');
 
@@ -45,16 +43,6 @@ const App = factory(function({ middleware: { icache } }) {
 										onValue={firstName.value}
 									>
 										{{ label: 'First Name' }}
-									</TextInput>
-								</FormField>
-								<FormField>
-									<TextInput
-										key="middleName"
-										placeholder="Enter a middle name"
-										initialValue={middleName.value()}
-										onValue={middleName.value}
-									>
-										{{ label: 'Middle Name' }}
 									</TextInput>
 								</FormField>
 								<FormField>
@@ -90,7 +78,6 @@ const App = factory(function({ middleware: { icache } }) {
 					<h2>onValue Results</h2>
 					<ul>
 						<li>First Name: {results.firstName}</li>
-						<li>Middle Name: {results.middleName}</li>
 						<li>Last Name: {results.lastName}</li>
 						<li>Email: {results.email}</li>
 					</ul>

--- a/src/examples/src/widgets/form/Controlled.tsx
+++ b/src/examples/src/widgets/form/Controlled.tsx
@@ -14,7 +14,6 @@ const factory = create({ icache });
 
 interface Fields {
 	firstName?: string;
-	middleName?: string;
 	lastName?: string;
 	email?: string;
 }
@@ -31,7 +30,6 @@ const App = factory(function({ middleware: { icache } }) {
 			>
 				{({ field }: FormMiddleware<Fields>) => {
 					const firstName = field('firstName');
-					const middleName = field('middleName');
 					const lastName = field('lastName');
 					const email = field('email');
 
@@ -46,16 +44,6 @@ const App = factory(function({ middleware: { icache } }) {
 										onValue={firstName.value}
 									>
 										{{ label: 'First Name' }}
-									</TextInput>
-								</FormField>
-								<FormField>
-									<TextInput
-										key="middleName"
-										placeholder="Enter a middle name"
-										value={middleName.value()}
-										onValue={middleName.value}
-									>
-										{{ label: 'Middle Name' }}
 									</TextInput>
 								</FormField>
 								<FormField>
@@ -91,7 +79,6 @@ const App = factory(function({ middleware: { icache } }) {
 					<h2>onValue Results</h2>
 					<ul>
 						<li>First Name: {results.firstName}</li>
-						<li>Middle Name: {results.middleName}</li>
 						<li>Last Name: {results.lastName}</li>
 						<li>Email: {results.email}</li>
 					</ul>

--- a/src/examples/src/widgets/form/DisabledFieldsForm.tsx
+++ b/src/examples/src/widgets/form/DisabledFieldsForm.tsx
@@ -15,7 +15,6 @@ const factory = create({ icache });
 
 interface Fields {
 	firstName?: string;
-	middleName?: string;
 	lastName?: string;
 	email?: string;
 }
@@ -28,7 +27,6 @@ const App = factory(function({ middleware: { icache } }) {
 			<Form onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}>
 				{({ field }: FormMiddleware<Fields>) => {
 					const firstName = field('firstName');
-					const middleName = field('middleName');
 					const lastName = field('lastName');
 					const email = field('email');
 
@@ -43,17 +41,6 @@ const App = factory(function({ middleware: { icache } }) {
 										onValue={firstName.value}
 									>
 										{{ label: 'First Name' }}
-									</TextInput>
-								</FormField>
-								<FormField>
-									<TextInput
-										key="middleName"
-										placeholder="Enter a middle name"
-										initialValue={middleName.value()}
-										onValue={middleName.value}
-										disabled={true}
-									>
-										{{ label: 'Middle Name' }}
 									</TextInput>
 								</FormField>
 								<FormField>
@@ -97,7 +84,6 @@ const App = factory(function({ middleware: { icache } }) {
 					<h2>onValue Results</h2>
 					<ul>
 						<li>First Name: {results.firstName}</li>
-						<li>Middle Name: {results.middleName}</li>
 						<li>Last Name: {results.lastName}</li>
 						<li>Email: {results.email}</li>
 					</ul>

--- a/src/examples/src/widgets/form/DisabledForm.tsx
+++ b/src/examples/src/widgets/form/DisabledForm.tsx
@@ -15,7 +15,6 @@ const factory = create({ icache });
 
 interface Fields {
 	firstName?: string;
-	middleName?: string;
 	lastName?: string;
 	email?: string;
 }
@@ -28,7 +27,6 @@ const App = factory(function({ middleware: { icache } }) {
 			<Form onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}>
 				{({ disabled, field }: FormMiddleware<Fields>) => {
 					const firstName = field('firstName');
-					const middleName = field('middleName');
 					const lastName = field('lastName');
 					const email = field('email');
 
@@ -44,17 +42,6 @@ const App = factory(function({ middleware: { icache } }) {
 										disabled={firstName.disabled()}
 									>
 										{{ label: 'First Name' }}
-									</TextInput>
-								</FormField>
-								<FormField>
-									<TextInput
-										key="middleName"
-										placeholder="Enter a middle name"
-										initialValue={middleName.value()}
-										onValue={middleName.value}
-										disabled={middleName.disabled()}
-									>
-										{{ label: 'Middle Name' }}
 									</TextInput>
 								</FormField>
 								<FormField>
@@ -99,7 +86,6 @@ const App = factory(function({ middleware: { icache } }) {
 					<h2>onValue Results</h2>
 					<ul>
 						<li>First Name: {results.firstName}</li>
-						<li>Middle Name: {results.middleName}</li>
 						<li>Last Name: {results.lastName}</li>
 						<li>Email: {results.email}</li>
 					</ul>

--- a/src/examples/src/widgets/form/FillingForm.tsx
+++ b/src/examples/src/widgets/form/FillingForm.tsx
@@ -15,7 +15,6 @@ const factory = create({ icache });
 
 interface Fields {
 	firstName?: string;
-	middleName?: string;
 	lastName?: string;
 	email?: string;
 }
@@ -28,7 +27,6 @@ const App = factory(function({ middleware: { icache } }) {
 			<Form onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}>
 				{({ value, field }: FormMiddleware<Fields>) => {
 					const firstName = field('firstName');
-					const middleName = field('middleName');
 					const lastName = field('lastName');
 					const email = field('email');
 
@@ -43,16 +41,6 @@ const App = factory(function({ middleware: { icache } }) {
 										onValue={firstName.value}
 									>
 										{{ label: 'First Name' }}
-									</TextInput>
-								</FormField>
-								<FormField>
-									<TextInput
-										key="middleName"
-										placeholder="Enter a middle name"
-										initialValue={middleName.value()}
-										onValue={middleName.value}
-									>
-										{{ label: 'Middle Name' }}
 									</TextInput>
 								</FormField>
 								<FormField>
@@ -85,7 +73,7 @@ const App = factory(function({ middleware: { icache } }) {
 								onClick={() => {
 									value({
 										firstName: 'Billy',
-										middleName: '',
+										email: 'foo@bar.com',
 										lastName: 'Bob'
 									});
 								}}
@@ -101,7 +89,6 @@ const App = factory(function({ middleware: { icache } }) {
 					<h2>onValue Results</h2>
 					<ul>
 						<li>First Name: {results.firstName}</li>
-						<li>Middle Name: {results.middleName}</li>
 						<li>Last Name: {results.lastName}</li>
 						<li>Email: {results.email}</li>
 					</ul>

--- a/src/examples/src/widgets/form/InitialValueForm.tsx
+++ b/src/examples/src/widgets/form/InitialValueForm.tsx
@@ -14,7 +14,6 @@ const factory = create({ icache });
 
 interface Fields {
 	firstName?: string;
-	middleName?: string;
 	lastName?: string;
 	email?: string;
 }
@@ -27,13 +26,13 @@ const App = factory(function({ middleware: { icache } }) {
 			<Form
 				initialValue={{
 					firstName: 'Billy',
-					lastName: 'Bob'
+					lastName: 'Bob',
+					email: 'foo@bar.com'
 				}}
 				onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}
 			>
 				{({ field }: FormMiddleware<Fields>) => {
 					const firstName = field('firstName');
-					const middleName = field('middleName');
 					const lastName = field('lastName');
 					const email = field('email');
 
@@ -48,16 +47,6 @@ const App = factory(function({ middleware: { icache } }) {
 										onValue={firstName.value}
 									>
 										{{ label: 'First Name' }}
-									</TextInput>
-								</FormField>
-								<FormField>
-									<TextInput
-										key="middleName"
-										placeholder="Enter a middle name"
-										initialValue={middleName.value()}
-										onValue={middleName.value}
-									>
-										{{ label: 'Middle Name' }}
 									</TextInput>
 								</FormField>
 								<FormField>
@@ -93,7 +82,6 @@ const App = factory(function({ middleware: { icache } }) {
 					<h2>onValue Results</h2>
 					<ul>
 						<li>First Name: {results.firstName}</li>
-						<li>Middle Name: {results.middleName}</li>
 						<li>Last Name: {results.lastName}</li>
 						<li>Email: {results.email}</li>
 					</ul>

--- a/src/examples/src/widgets/form/KitchenSinkForm.tsx
+++ b/src/examples/src/widgets/form/KitchenSinkForm.tsx
@@ -16,7 +16,6 @@ const factory = create({ icache });
 
 interface Fields {
 	firstName: string;
-	middleName?: string;
 	lastName: string;
 	email?: string;
 }
@@ -38,7 +37,6 @@ const App = factory(function({ middleware: { icache } }) {
 			>
 				{({ value, valid, disabled, field, reset }: FormMiddleware<Fields>) => {
 					const firstName = field('firstName', true);
-					const middleName = field('middleName');
 					const lastName = field('lastName', true);
 					const email = field('email');
 
@@ -58,21 +56,6 @@ const App = factory(function({ middleware: { icache } }) {
 										disabled={firstName.disabled()}
 									>
 										{{ label: 'First Name' }}
-									</TextInput>
-								</FormField>
-								<FormField>
-									<TextInput
-										key="middleName"
-										placeholder="Enter a middle name"
-										required={middleName.required()}
-										initialValue={middleName.value()}
-										valid={middleName.valid()}
-										onValue={middleName.value}
-										onValidate={middleName.valid}
-										maxLength={5}
-										disabled={middleName.disabled()}
-									>
-										{{ label: 'Middle Name' }}
 									</TextInput>
 								</FormField>
 								<FormField>
@@ -116,22 +99,12 @@ const App = factory(function({ middleware: { icache } }) {
 								onClick={() => {
 									value({
 										firstName: 'Billy',
-										middleName: '',
+										email: 'foo@bar.com',
 										lastName: 'Bob'
 									});
 								}}
 							>
 								Fill
-							</Button>
-							<Button
-								key="requireMiddleName"
-								type="button"
-								disabled={disabled()}
-								onClick={() => middleName.required(!middleName.required())}
-							>
-								{`Make middle name ${
-									middleName.required() ? 'optional' : 'required'
-								}`}
 							</Button>
 							<Button
 								key="reset"
@@ -168,7 +141,6 @@ const App = factory(function({ middleware: { icache } }) {
 					<h2>onValue Results</h2>
 					<ul>
 						<li>First Name: {onValueResults.firstName}</li>
-						<li>Middle Name: {onValueResults.middleName}</li>
 						<li>Last Name: {onValueResults.lastName}</li>
 						<li>Email: {onValueResults.email}</li>
 					</ul>
@@ -179,7 +151,6 @@ const App = factory(function({ middleware: { icache } }) {
 					<h2>onSubmit Results</h2>
 					<ul>
 						<li>First Name: {results.firstName}</li>
-						<li>Middle Name: {results.middleName}</li>
 						<li>Last Name: {results.lastName}</li>
 						<li>Email: {results.email}</li>
 					</ul>

--- a/src/examples/src/widgets/form/RequiredFieldsForm.tsx
+++ b/src/examples/src/widgets/form/RequiredFieldsForm.tsx
@@ -1,6 +1,5 @@
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Button from '@dojo/widgets/button';
 import Form, { FormField, FormGroup } from '@dojo/widgets/form';
 import { FormMiddleware } from '@dojo/widgets/form/middleware';
 import TextInput from '@dojo/widgets/text-input';
@@ -15,7 +14,6 @@ const factory = create({ icache });
 
 interface Fields {
 	firstName: string;
-	middleName?: string;
 	lastName: string;
 	email?: string;
 }
@@ -28,7 +26,6 @@ const App = factory(function({ middleware: { icache } }) {
 			<Form onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}>
 				{({ field }: FormMiddleware<Fields>) => {
 					const firstName = field('firstName', true);
-					const middleName = field('middleName');
 					const lastName = field('lastName', true);
 					const email = field('email');
 
@@ -46,19 +43,6 @@ const App = factory(function({ middleware: { icache } }) {
 										onValidate={firstName.valid}
 									>
 										{{ label: 'First Name' }}
-									</TextInput>
-								</FormField>
-								<FormField>
-									<TextInput
-										key="middleName"
-										placeholder="Enter a middle name"
-										required={middleName.required()}
-										initialValue={middleName.value()}
-										valid={middleName.valid()}
-										onValue={middleName.value}
-										onValidate={middleName.valid}
-									>
-										{{ label: 'Middle Name' }}
 									</TextInput>
 								</FormField>
 								<FormField>
@@ -88,15 +72,6 @@ const App = factory(function({ middleware: { icache } }) {
 									</TextInput>
 								</FormField>
 							</FormGroup>
-							<Button
-								key="requireMiddleName"
-								type="button"
-								onClick={() => middleName.required(!middleName.required())}
-							>
-								{`Make middle name ${
-									middleName.required() ? 'optional' : 'required'
-								}`}
-							</Button>
 						</virtual>
 					);
 				}}
@@ -106,7 +81,6 @@ const App = factory(function({ middleware: { icache } }) {
 					<h2>onValue Results</h2>
 					<ul>
 						<li>First Name: {results.firstName}</li>
-						<li>Middle Name: {results.middleName}</li>
 						<li>Last Name: {results.lastName}</li>
 						<li>Email: {results.email}</li>
 					</ul>

--- a/src/examples/src/widgets/form/ResettingForm.tsx
+++ b/src/examples/src/widgets/form/ResettingForm.tsx
@@ -15,7 +15,6 @@ const factory = create({ icache });
 
 interface Fields {
 	firstName?: string;
-	middleName?: string;
 	lastName?: string;
 	email?: string;
 }
@@ -28,7 +27,6 @@ const App = factory(function({ middleware: { icache } }) {
 			<Form onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}>
 				{({ field, reset }: FormMiddleware<Fields>) => {
 					const firstName = field('firstName');
-					const middleName = field('middleName');
 					const lastName = field('lastName');
 					const email = field('email');
 
@@ -43,16 +41,6 @@ const App = factory(function({ middleware: { icache } }) {
 										onValue={firstName.value}
 									>
 										{{ label: 'First Name' }}
-									</TextInput>
-								</FormField>
-								<FormField>
-									<TextInput
-										key="middleName"
-										placeholder="Enter a middle name"
-										initialValue={middleName.value()}
-										onValue={middleName.value}
-									>
-										{{ label: 'Middle Name' }}
 									</TextInput>
 								</FormField>
 								<FormField>
@@ -91,7 +79,6 @@ const App = factory(function({ middleware: { icache } }) {
 					<h2>onSubmit Results</h2>
 					<ul>
 						<li>First Name: {results.firstName}</li>
-						<li>Middle Name: {results.middleName}</li>
 						<li>Last Name: {results.lastName}</li>
 						<li>Email: {results.email}</li>
 					</ul>

--- a/src/examples/src/widgets/form/SubmitForm.tsx
+++ b/src/examples/src/widgets/form/SubmitForm.tsx
@@ -15,7 +15,6 @@ const factory = create({ icache });
 
 interface Fields {
 	firstName: string;
-	middleName?: string;
 	lastName: string;
 	email?: string;
 }
@@ -28,7 +27,6 @@ const App = factory(function({ middleware: { icache } }) {
 			<Form onSubmit={(values) => icache.set('basic', values)}>
 				{({ valid, field }: FormMiddleware<Fields>) => {
 					const firstName = field('firstName', true);
-					const middleName = field('middleName');
 					const lastName = field('lastName', true);
 					const email = field('email');
 
@@ -46,16 +44,6 @@ const App = factory(function({ middleware: { icache } }) {
 										onValidate={firstName.valid}
 									>
 										{{ label: 'First Name' }}
-									</TextInput>
-								</FormField>
-								<FormField>
-									<TextInput
-										key="middleName"
-										placeholder="Enter a middle name"
-										initialValue={middleName.value()}
-										onValue={middleName.value}
-									>
-										{{ label: 'Middle Name' }}
 									</TextInput>
 								</FormField>
 								<FormField>
@@ -97,7 +85,6 @@ const App = factory(function({ middleware: { icache } }) {
 					<h2>onSubmit Results</h2>
 					<ul>
 						<li>First Name: {results.firstName}</li>
-						<li>Middle Name: {results.middleName}</li>
 						<li>Last Name: {results.lastName}</li>
 						<li>Email: {results.email}</li>
 					</ul>

--- a/src/examples/src/widgets/form/Validation.tsx
+++ b/src/examples/src/widgets/form/Validation.tsx
@@ -14,7 +14,6 @@ const factory = create({ icache });
 
 interface Fields {
 	firstName?: string;
-	middleName?: string;
 	lastName?: string;
 	email?: string;
 }
@@ -27,7 +26,6 @@ const App = factory(function({ middleware: { icache } }) {
 			<Form onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}>
 				{({ field }: FormMiddleware<Fields>) => {
 					const firstName = field('firstName');
-					const middleName = field('middleName');
 					const lastName = field('lastName');
 					const email = field('email');
 
@@ -45,19 +43,6 @@ const App = factory(function({ middleware: { icache } }) {
 										onValidate={firstName.valid}
 									>
 										{{ label: 'First Name' }}
-									</TextInput>
-								</FormField>
-								<FormField>
-									<TextInput
-										key="middleName"
-										placeholder="Enter a middle name"
-										initialValue={middleName.value()}
-										valid={middleName.valid()}
-										onValue={middleName.value}
-										onValidate={middleName.valid}
-										maxLength={5}
-									>
-										{{ label: 'Middle Name' }}
 									</TextInput>
 								</FormField>
 								<FormField>
@@ -99,7 +84,6 @@ const App = factory(function({ middleware: { icache } }) {
 					<h2>onValue Results</h2>
 					<ul>
 						<li>First Name: {results.firstName}</li>
-						<li>Middle Name: {results.middleName}</li>
 						<li>Last Name: {results.lastName}</li>
 						<li>Email: {results.email}</li>
 					</ul>

--- a/src/theme/dojo/form.m.css.d.ts
+++ b/src/theme/dojo/form.m.css.d.ts
@@ -1,4 +1,3 @@
-export const rowRoot: string;
+export const groupRoot: string;
 export const column: string;
-export const row: string;
 export const fieldRoot: string;

--- a/src/theme/material/form.m.css.d.ts
+++ b/src/theme/material/form.m.css.d.ts
@@ -1,4 +1,3 @@
 export const groupRoot: string;
 export const column: string;
-export const row: string;
 export const fieldRoot: string;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request simplifies all form examples (and by side effect, fixes styling on mobile) by removing the middle name field. After checking each example out, the middle name field wasn't demonstrating any behavior not demonstrated elsewhere, and both the boilerplate code and the example visuals were getting a bit cramped with four fields, three of which were now on the same row.

References #1419

**Preview:**

<img width="910" alt="preview" src="https://user-images.githubusercontent.com/334586/80366826-ec86a200-8857-11ea-9f93-205a22a17260.png">
