### PR TITLE
Allow typeahead to take free text

### DIFF
--- a/src/chip-typeahead/index.tsx
+++ b/src/chip-typeahead/index.tsx
@@ -40,6 +40,8 @@ export interface ChipTypeaheadProperties {
 	placement?: 'inline' | 'bottom';
 	/** Allow duplicates of the same value to be selected. Default is false */
 	duplicates?: boolean;
+	/** Flag to indicate if values other than those in the resource can be entered, defaults to true */
+	strict?: boolean;
 }
 
 export interface ChipTypeaheadChildren {
@@ -96,7 +98,8 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 		itemsInView,
 		position,
 		name,
-		placement = 'inline'
+		placement = 'inline',
+		strict
 	} = properties();
 	const [{ label, items, selected } = {} as ChipTypeaheadChildren] = children();
 	const themeCss = theme.classes(css);
@@ -194,6 +197,7 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 					css,
 					'input'
 				)}
+				strict={strict}
 				itemsInView={itemsInView}
 				position={position}
 				name={name}

--- a/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
+++ b/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
@@ -31,6 +31,7 @@ const resource = createResource<ListOption>();
 const baseAssertion = assertionTemplate(() => (
 	<div key="root" classes={[undefined, themeCss.root, null, null, null]}>
 		<Typeahead
+			strict={undefined}
 			key="typeahead"
 			theme={{
 				'@dojo/widgets/typeahead': typeaheadCss
@@ -497,6 +498,26 @@ registerSuite('ChipTypeahead', {
 
 			assert.isFalse(disabled({ value: 'cat' }));
 			assert.isFalse(disabled({ value: 'dog' }));
+		},
+
+		'allows free text values if strict is set to false'() {
+			const onValueStub = stub();
+			const h = harness(() => (
+				<ChipTypeahead
+					resource={resource(animalOptions)}
+					transform={defaultTransform}
+					onValue={onValueStub}
+					strict={false}
+				>
+					{}
+				</ChipTypeahead>
+			));
+
+			h.trigger('@typeahead', (node: any) => () => {
+				node.properties.onValue('abc');
+			});
+
+			assert.isTrue(onValueStub.calledWith(['abc']));
 		}
 	}
 });

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -106,6 +106,7 @@ import DisabledChipTypeahead from './widgets/chip-typeahead/Disabled';
 import CustomRendererChipTypeahead from './widgets/chip-typeahead/CustomRenderer';
 import BottomChipTypeahead from './widgets/chip-typeahead/BottomPlacement';
 import DuplicatesChipTypeahead from './widgets/chip-typeahead/Duplicates';
+import FreeTextChipTypeahead from './widgets/chip-typeahead/FreeText';
 import BasicNumberInput from './widgets/number-input/Basic';
 import ValidatedNumberInput from './widgets/number-input/Validation';
 import BasicOutlinedButton from './widgets/outlined-button/Basic';
@@ -223,6 +224,7 @@ import BasicTypeahead from './widgets/typeahead/Basic';
 import RemoteTypeahead from './widgets/typeahead/RemoteSource';
 import CustomFilterTypeahead from './widgets/typeahead/CustomFilter';
 import ValidatedTypeahead from './widgets/typeahead/Validation';
+import FreeTextTypeahead from './widgets/typeahead/FreeText';
 import BasicTwoColumnLayout from './widgets/two-column-layout/Basic';
 import TrailingBiasTwoColumnLayout from './widgets/two-column-layout/TrailingBias';
 import CollapsingLayout from './widgets/two-column-layout/Collapsing';
@@ -1063,6 +1065,11 @@ export const config = {
 					title: 'Duplicates',
 					filename: 'Duplicates',
 					module: DuplicatesChipTypeahead
+				},
+				{
+					title: 'Free Text',
+					filename: 'FreeText',
+					module: FreeTextChipTypeahead
 				}
 			]
 		},
@@ -1738,6 +1745,11 @@ export const config = {
 					filename: 'Validation',
 					module: ValidatedTypeahead,
 					title: 'Validation'
+				},
+				{
+					filename: 'FreeText',
+					module: FreeTextTypeahead,
+					title: 'Free Text Typeahead'
 				}
 			],
 			overview: {

--- a/src/examples/src/widgets/chip-typeahead/FreeText.tsx
+++ b/src/examples/src/widgets/chip-typeahead/FreeText.tsx
@@ -1,0 +1,22 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import { defaultTransform } from '@dojo/widgets/select';
+import ChipTypeahead from '@dojo/widgets/chip-typeahead';
+import states from '@dojo/widgets/examples/src/widgets/list/states';
+import Example from '../../Example';
+import { createResource, createMemoryTemplate, defaultFilter } from '@dojo/framework/core/resource';
+
+const factory = create();
+
+const resource = createResource(createMemoryTemplate({ filter: defaultFilter }));
+
+export default factory(function FreeText() {
+	return (
+		<Example>
+			<ChipTypeahead strict={false} resource={resource(states)} transform={defaultTransform}>
+				{{
+					label: 'Select All States That Apply, or make up your own'
+				}}
+			</ChipTypeahead>
+		</Example>
+	);
+});

--- a/src/examples/src/widgets/typeahead/FreeText.tsx
+++ b/src/examples/src/widgets/typeahead/FreeText.tsx
@@ -1,0 +1,35 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import { defaultTransform } from '@dojo/widgets/select';
+import icache from '@dojo/framework/core/middleware/icache';
+import Typeahead from '@dojo/widgets/typeahead';
+import Example from '../../Example';
+import { createResource, createMemoryTemplate, defaultFilter } from '@dojo/framework/core/resource';
+
+const factory = create({ icache });
+const options = [
+	{ value: 'cat', label: 'Cat' },
+	{ value: 'dog', label: 'Dog' },
+	{ value: 'fish', label: 'Fish' }
+];
+
+const resource = createResource(createMemoryTemplate({ filter: defaultFilter }));
+
+export default factory(function FreeText({ middleware: { icache } }) {
+	return (
+		<Example>
+			<Typeahead
+				strict={false}
+				resource={resource(options)}
+				transform={defaultTransform}
+				onValue={(value) => {
+					icache.set('value', value);
+				}}
+			>
+				{{
+					label: 'Basic Typeahead'
+				}}
+			</Typeahead>
+			<pre>{icache.getOrSet('value', '')}</pre>
+		</Example>
+	);
+});

--- a/src/theme/dojo/form.m.css.d.ts
+++ b/src/theme/dojo/form.m.css.d.ts
@@ -1,4 +1,3 @@
-export const rowRoot: string;
+export const groupRoot: string;
 export const column: string;
-export const row: string;
 export const fieldRoot: string;

--- a/src/theme/material/form.m.css.d.ts
+++ b/src/theme/material/form.m.css.d.ts
@@ -1,4 +1,3 @@
 export const groupRoot: string;
 export const column: string;
-export const row: string;
 export const fieldRoot: string;

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -145,8 +145,13 @@ export const Typeahead = factory(function Typeahead({
 
 	function callOnValue(value: string) {
 		const { onValidate, onValue, required } = properties();
-		let valid = required ? true : undefined;
+		const lastValue = icache.get('lastValue');
 
+		if (lastValue === value) {
+			return;
+		}
+
+		let valid = required ? true : undefined;
 		if (required && !value) {
 			valid = false;
 		}
@@ -343,13 +348,13 @@ export const Typeahead = factory(function Typeahead({
 									transform={transform}
 									disabled={itemDisabled}
 									onValue={(value) => {
-										const { onValue, required } = properties();
 										focus.focus();
 										closeMenu();
 										value !== icache.get('value') && icache.set('value', value);
-										onValue(value);
-										icache.set('valid', required ? true : undefined);
-										icache.set('lastValue', value);
+										callOnValue(value);
+										// onValue(value);
+										// icache.set('valid', required ? true : undefined);
+										// icache.set('lastValue', value);
 									}}
 									onRequestClose={closeMenu}
 									onBlur={closeMenu}

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -269,7 +269,6 @@ export const Typeahead = factory(function Typeahead({
 								onValue={(value) => {
 									if (value !== icache.get('value')) {
 										openMenu();
-
 										setOptions({ query: { value: value } });
 										icache.set('value', value || '');
 									}

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -201,9 +201,11 @@ export const Typeahead = factory(function Typeahead({
 						}
 					} else {
 						if (strict) {
-							icache.set('valid', false);
-							const { onValidate } = properties();
-							onValidate && onValidate(false);
+							const { onValidate, required } = properties();
+							if (required) {
+								icache.set('valid', false);
+								onValidate && onValidate(false);
+							}
 						} else {
 							const value = icache.getOrSet('value', '');
 							callOnValue(value);

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -213,6 +213,7 @@ export const Typeahead = factory(function Typeahead({
 							}
 						} else {
 							const value = icache.getOrSet('value', '');
+							onClose();
 							callOnValue(value);
 						}
 					}
@@ -352,9 +353,6 @@ export const Typeahead = factory(function Typeahead({
 										closeMenu();
 										value !== icache.get('value') && icache.set('value', value);
 										callOnValue(value);
-										// onValue(value);
-										// icache.set('valid', required ? true : undefined);
-										// icache.set('lastValue', value);
 									}}
 									onRequestClose={closeMenu}
 									onBlur={closeMenu}

--- a/src/typeahead/tests/unit/Typeahead.spec.tsx
+++ b/src/typeahead/tests/unit/Typeahead.spec.tsx
@@ -357,6 +357,7 @@ registerSuite('Typeahead', {
 		},
 		'allows free text when not in strict mode'() {
 			const onValue = stub();
+			const onValidate = stub();
 
 			const h = harness(() => (
 				<Typeahead
@@ -364,6 +365,7 @@ registerSuite('Typeahead', {
 					resource={resource}
 					transform={defaultTransform}
 					onValue={onValue}
+					onValidate={onValidate}
 				>
 					{{ label: 'Test' }}
 				</Typeahead>
@@ -383,10 +385,49 @@ registerSuite('Typeahead', {
 
 			assert.isTrue(onValue.calledWith('abc'));
 
+			onValue.resetHistory();
 			triggerRenderResult.properties.onValue('xyz');
 			triggerRenderResult.properties.onBlur();
 
 			assert.isTrue(onValue.calledWith('xyz'));
+
+			onValue.resetHistory();
+			triggerRenderResult.properties.onValue('');
+			triggerRenderResult.properties.onBlur();
+
+			assert.isTrue(onValue.notCalled);
+			assert.isTrue(onValidate.calledWith(undefined));
+		},
+		'validates when using free text and required'() {
+			const onValue = stub();
+			const onValidate = stub();
+
+			const h = harness(() => (
+				<Typeahead
+					strict={false}
+					required
+					resource={resource}
+					transform={defaultTransform}
+					onValue={onValue}
+					onValidate={onValidate}
+				>
+					{{ label: 'Test' }}
+				</Typeahead>
+			));
+
+			const toggleOpenStub = stub();
+
+			const triggerRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].trigger,
+				toggleOpenStub
+			);
+
+			triggerRenderResult.properties.onValue('');
+			triggerRenderResult.properties.onBlur();
+
+			assert.isTrue(onValue.notCalled);
+			assert.isTrue(onValidate.calledWith(false));
 		},
 		'does not select a value on escape'() {
 			const onValue = stub();

--- a/src/typeahead/tests/unit/Typeahead.spec.tsx
+++ b/src/typeahead/tests/unit/Typeahead.spec.tsx
@@ -355,6 +355,39 @@ registerSuite('Typeahead', {
 
 			assert.isTrue(onValue.calledWith(animalOptions[0].value));
 		},
+		'allows free text when not in strict mode'() {
+			const onValue = stub();
+
+			const h = harness(() => (
+				<Typeahead
+					strict={false}
+					resource={resource}
+					transform={defaultTransform}
+					onValue={onValue}
+				>
+					{{ label: 'Test' }}
+				</Typeahead>
+			));
+
+			const toggleOpenStub = stub();
+			const preventDefaultStub = stub();
+
+			const triggerRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].trigger,
+				toggleOpenStub
+			);
+
+			triggerRenderResult.properties.onValue('abc');
+			triggerRenderResult.properties.onKeyDown(Keys.Enter, preventDefaultStub);
+
+			assert.isTrue(onValue.calledWith('abc'));
+
+			triggerRenderResult.properties.onValue('xyz');
+			triggerRenderResult.properties.onBlur();
+
+			assert.isTrue(onValue.calledWith('xyz'));
+		},
 		'does not select a value on escape'() {
 			const onValue = stub();
 

--- a/src/typeahead/tests/unit/Typeahead.spec.tsx
+++ b/src/typeahead/tests/unit/Typeahead.spec.tsx
@@ -389,7 +389,7 @@ registerSuite('Typeahead', {
 			triggerRenderResult.properties.onValue('xyz');
 			triggerRenderResult.properties.onBlur();
 
-			assert.isTrue(onValue.calledWith('xyz'));
+			assert.isTrue(onValue.calledOnceWith('xyz'));
 
 			onValue.resetHistory();
 			triggerRenderResult.properties.onValue('');


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

- Adds `strict` property to `Typeahead` and `ChipTypeahead`.
- Allows non-resource values to be entered.
- Adds examples
- Adds tests

Resolves #1416 
