### PR TITLE
Updating chip typeahead to not select values on loss of focus

### DIFF
--- a/src/chip-typeahead/index.tsx
+++ b/src/chip-typeahead/index.tsx
@@ -205,13 +205,15 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 				disabled={disabled}
 				resource={resource}
 				onValue={(value) => {
-					const { onValue } = properties();
+					if (icache.get('focused')) {
+						const { onValue } = properties();
 
-					const values = [...icache.getOrSet('value', []), value];
-					icache.set('value', values);
-					onValue && onValue(values);
+						const values = [...icache.getOrSet('value', []), value];
+						icache.set('value', values);
+						onValue && onValue(values);
 
-					focus.focus();
+						focus.focus();
+					}
 				}}
 				transform={transform}
 				value=""

--- a/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
+++ b/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
@@ -292,7 +292,9 @@ registerSuite('ChipTypeahead', {
 				</ChipTypeahead>
 			));
 
+			h.trigger('@typeahead', 'onFocus');
 			h.trigger('@typeahead', 'onValue', 'cat');
+			h.trigger('@typeahead', 'onBlur');
 
 			assert.isTrue(valueStub.calledWith(['cat']));
 
@@ -513,6 +515,7 @@ registerSuite('ChipTypeahead', {
 				</ChipTypeahead>
 			));
 
+			h.trigger('@typeahead', 'onFocus');
 			h.trigger('@typeahead', (node: any) => () => {
 				node.properties.onValue('abc');
 			});

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -293,13 +293,14 @@ export const Typeahead = factory(function Typeahead({
 								onBlur={() => {
 									const { onBlur } = properties();
 
+									onBlur && onBlur();
+
 									if (!strict) {
 										const value = icache.getOrSet('value', '');
 										callOnValue(value);
 									}
 
 									closeMenu();
-									onBlur && onBlur();
 								}}
 								name={name}
 								initialValue={valueOption ? valueOption.label : value}


### PR DESCRIPTION
**Description:**

When the Typeahead loses focus, if not in strict mode, it's value gets passed out on the onValue callback. In the ChipTypeahead, this means that if you type something in, and then click outside the typeahead, the value in the text box gets added as a chip. This can be confusing if you type something in and then click on Chip thats part of the same control.

I'm not sure if this is the right fix or not, but this simply ignores values from the Typeahead if they happened from a blur event.