### PR TITLE
Example should start `checked`

### DIFF
--- a/src/examples/src/widgets/checkbox/Basic.tsx
+++ b/src/examples/src/widgets/checkbox/Basic.tsx
@@ -6,7 +6,7 @@ import Example from '../../Example';
 const factory = create({ icache });
 
 export default factory(function Basic({ middleware: { icache } }) {
-	const checked = icache.getOrSet('checked', false);
+	const checked = icache.getOrSet('checked', true);
 	return (
 		<Example>
 			<Checkbox


### PR DESCRIPTION
**Type:** bug 

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Example description says
> Sample checkbox that starts checked

But checked was `false`
