### PR TITLE
fix: paginated grid row selection

### DIFF
--- a/src/grid/index.tsx
+++ b/src/grid/index.tsx
@@ -1,31 +1,31 @@
-import WidgetBase from '@dojo/framework/core/WidgetBase';
-import { v, w } from '@dojo/framework/core/vdom';
-import I18nMixin, { I18nProperties } from '@dojo/framework/core/mixins/I18n';
-import ThemedMixin, { theme, ThemedProperties } from '@dojo/framework/core/mixins/Themed';
-import diffProperty from '@dojo/framework/core/decorators/diffProperty';
-import { DNode } from '@dojo/framework/core/interfaces';
-import { reference } from '@dojo/framework/core/diff';
-import { Store } from '@dojo/framework/stores/Store';
-import Dimensions from '@dojo/framework/core/meta/Dimensions';
-import Resize from '@dojo/framework/core/meta/Resize';
 import './utils';
 
-import { Fetcher, ColumnConfig, GridState, Updater } from './interfaces';
-import {
-	fetcherProcess,
-	pageChangeProcess,
-	sortProcess,
-	filterProcess,
-	updaterProcess,
-	selectionProcess
-} from './processes';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import diffProperty from '@dojo/framework/core/decorators/diffProperty';
+import { reference } from '@dojo/framework/core/diff';
+import { DNode } from '@dojo/framework/core/interfaces';
+import Dimensions from '@dojo/framework/core/meta/Dimensions';
+import Resize from '@dojo/framework/core/meta/Resize';
+import I18nMixin, { I18nProperties } from '@dojo/framework/core/mixins/I18n';
+import ThemedMixin, { ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { v, w } from '@dojo/framework/core/vdom';
+import { Store } from '@dojo/framework/stores/Store';
 
-import Header, { SortRenderer, FilterRenderer } from './Header';
+import * as css from '../theme/default/grid.m.css';
 import Body from './Body';
 import Footer from './Footer';
-import PaginatedFooter from './PaginatedFooter';
+import Header, { FilterRenderer, SortRenderer } from './Header';
 import PaginatedBody from './PaginatedBody';
-import * as css from '../theme/default/grid.m.css';
+import PaginatedFooter from './PaginatedFooter';
+import { ColumnConfig, Fetcher, GridState, Updater } from './interfaces';
+import {
+	fetcherProcess,
+	filterProcess,
+	pageChangeProcess,
+	selectionProcess,
+	sortProcess,
+	updaterProcess
+} from './processes';
 import * as fixedCss from './styles/grid.m.css';
 
 const defaultGridMeta = {
@@ -175,10 +175,12 @@ export default class Grid<S> extends I18nMixin(ThemedMixin(WidgetBase))<GridProp
 			this._store.get(this._store.path(storeId, 'meta', 'selection')) || [];
 		const items = [];
 		const data = this._store.get(this._store.path(storeId, 'data', 'pages'));
+		const pageNumber = this._store.get(this._store.path(storeId, 'meta', 'page'));
+
 		for (let i = 0; i < selectedIndexes.length; i++) {
 			const selectedIndex = selectedIndexes[i];
-			const pageNumber = Math.floor(selectedIndex / this._pageSize) + 1;
-			const itemIndex = selectedIndex - (pageNumber - 1) * this._pageSize;
+			const offset = Math.floor(selectedIndex / this._pageSize) + 1;
+			const itemIndex = selectedIndex - (offset - 1) * this._pageSize;
 			if (data[`page-${pageNumber}`]) {
 				items.push(data[`page-${pageNumber}`][itemIndex]);
 			}

--- a/src/grid/index.tsx
+++ b/src/grid/index.tsx
@@ -19,6 +19,7 @@ import PaginatedBody from './PaginatedBody';
 import PaginatedFooter from './PaginatedFooter';
 import { ColumnConfig, Fetcher, GridState, Updater } from './interfaces';
 import {
+	clearSelectionProcess,
 	fetcherProcess,
 	filterProcess,
 	pageChangeProcess,
@@ -164,7 +165,10 @@ export default class Grid<S> extends I18nMixin(ThemedMixin(WidgetBase))<GridProp
 	}
 
 	private _pageChange(page: number) {
-		const { storeId } = this._getProperties();
+		const { pagination, storeId } = this._getProperties();
+		if (pagination) {
+			clearSelectionProcess(this._store)({ id: storeId });
+		}
 		pageChangeProcess(this._store)({ id: storeId, page });
 	}
 

--- a/src/grid/tests/unit/Grid.spec.tsx
+++ b/src/grid/tests/unit/Grid.spec.tsx
@@ -1,23 +1,26 @@
 const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 
-import harness from '@dojo/framework/testing/harness/harness';
-import { v, w } from '@dojo/framework/core/vdom';
+import { spy, stub } from 'sinon';
+
 import Dimensions from '@dojo/framework/core/meta/Dimensions';
 import Resize from '@dojo/framework/core/meta/Resize';
+import { v, w } from '@dojo/framework/core/vdom';
 import { Store } from '@dojo/framework/stores/Store';
 import { OperationType } from '@dojo/framework/stores/state/Patch';
 import { Pointer } from '@dojo/framework/stores/state/Pointer';
+import harness from '@dojo/framework/testing/harness/harness';
 
-import Grid from '../../index';
-import * as css from '../../../theme/default/grid.m.css';
-import * as fixedCss from '../../styles/grid.m.css';
-import { ColumnConfig } from '../../interfaces';
-import { stub, spy } from 'sinon';
 import { MockMetaMixin } from '../../../common/tests/support/test-helpers';
-import Header from '../../Header';
+import * as css from '../../../theme/default/grid.m.css';
 import Body from '../../Body';
 import Footer from '../../Footer';
+import Header from '../../Header';
+import PaginatedBody from '../../PaginatedBody';
+import PaginatedFooter from '../../PaginatedFooter';
+import Grid from '../../index';
+import { ColumnConfig } from '../../interfaces';
+import * as fixedCss from '../../styles/grid.m.css';
 
 const noop: any = () => {};
 
@@ -727,7 +730,8 @@ describe('Grid', () => {
 				updater: noop,
 				columnConfig,
 				height: 500,
-				onRowSelect: noop
+				onRowSelect: noop,
+				pagination: true
 			})
 		);
 
@@ -779,18 +783,16 @@ describe('Grid', () => {
 							)
 						]
 					),
-					w(Body, {
-						key: 'body',
+					w(PaginatedBody, {
+						key: 'paginated-body',
 						i18nBundle: undefined,
 						pages: {},
-						totalRows: undefined,
 						pageSize: 100,
 						columnConfig,
 						columnWidths: {
 							id: 500,
 							name: 500
 						},
-						pageChange: noop,
 						updater: noop,
 						fetcher: noop,
 						onScroll: noop,
@@ -799,11 +801,12 @@ describe('Grid', () => {
 						theme: undefined,
 						width: 1000,
 						onRowSelect: noop,
-						selectedRows: [1]
+						selectedRows: [1],
+						pageNumber: 1
 					}),
 					v('div', { key: 'footer' }, [
-						w(Footer, {
-							key: 'footer-row',
+						w(PaginatedFooter, {
+							onPageChange: noop,
 							i18nBundle: undefined,
 							total: undefined,
 							page: 1,

--- a/src/grid/tests/unit/Row.spec.tsx
+++ b/src/grid/tests/unit/Row.spec.tsx
@@ -1,15 +1,16 @@
 const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 
-import harness from '@dojo/framework/testing/harness/harness';
-import { v, w } from '@dojo/framework/core/vdom';
 import { stub } from 'sinon';
-import Row from '../../Row';
 
-import * as fixedCss from './../../styles/row.m.css';
+import { v, w } from '@dojo/framework/core/vdom';
+import harness from '@dojo/framework/testing/harness/harness';
+
 import * as css from '../../../theme/default/grid-row.m.css';
-import { ColumnConfig } from '../../interfaces';
+import * as fixedCss from './../../styles/row.m.css';
 import Cell from '../../Cell';
+import Row from '../../Row';
+import { ColumnConfig } from '../../interfaces';
 
 const noop = () => {};
 


### PR DESCRIPTION
**Type:** bugfix

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request updates the `Grid` widget by fixing a bug in paginated grids that prevented row selection from working properly.

Resolves #1436 

**Preview:**

![preview](https://i.gyazo.com/c8701b3b04be6a767cf987cc49405747.gif)