### PR TITLE
Support theme variants in parade

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1682,9 +1682,9 @@
       }
     },
     "@dojo/parade": {
-      "version": "1.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dojo/parade/-/parade-1.0.0-rc.2.tgz",
-      "integrity": "sha512-7iLUCrkgCP6o002x6xIcIwI8hlhViFGPbglVpIM8vhhW/5Pe4ta5Ezso17oSwNokpbWh8iBhmQjcMb5ZB4ww/Q==",
+      "version": "1.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@dojo/parade/-/parade-1.0.0-rc.3.tgz",
+      "integrity": "sha512-5njcG0bzmRmoJsrI6Rs6oMKcnGUxW4+flSkClqzb2Zuah6ocpOIYnl3lhC70t6zd7rhlTWlKbr8ZubwMjrz/3Q==",
       "dev": true,
       "requires": {
         "canonical-path": "1.0.0",
@@ -4782,9 +4782,9 @@
       }
     },
     "@types/jquery": {
-      "version": "3.3.35",
-      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.35.tgz",
-      "integrity": "sha512-pnIELWhHXJ7RgoFylhiTxD+96QlKBJfEx8JCLj963/dh7zBOKFkZ6rlNqbaCcn2JZrsAxCI8WhgRXznBx2iDsA==",
+      "version": "3.3.36",
+      "resolved": "https://registry.npmjs.org/@types/jquery/-/jquery-3.3.36.tgz",
+      "integrity": "sha512-jHL8J5y5fJ0+C9zCTkeOvX4zqRnPug3r6JhAqAYl2YyBCYHiXTbZSH0MRCpayZADed5TigPjH92dEKczUFT2TQ==",
       "dev": true,
       "requires": {
         "@types/sizzle": "*"
@@ -8415,9 +8415,9 @@
       "dev": true
     },
     "cssstyle": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.2.0.tgz",
-      "integrity": "sha512-sEb3XFPx3jNnCAMtqrXPDeSgQr+jojtCeNf8cvMNMh1cG970+lljssvQDzPq6lmmJu2Vhqood/gtEomBiHOGnA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-2.3.0.tgz",
+      "integrity": "sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==",
       "dev": true,
       "requires": {
         "cssom": "~0.3.6"
@@ -9057,9 +9057,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.418",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.418.tgz",
-      "integrity": "sha512-i2QrQtHes5fK/F9QGG5XacM5WKEuR322fxTYF9e8O9Gu0mc0WmjjwGpV8c7Htso6Zf2Di18lc3SIPxmMeRFBug==",
+      "version": "1.3.423",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.423.tgz",
+      "integrity": "sha512-jXdnLcawJ/EMdN+j77TC3YyeAWiIjo1U63DFCKrjtLv4cu8ToyoF4HYXtFvkVVHhEtIl7lU1uDd307Xj1/YDjw==",
       "dev": true
     },
     "elegant-spinner": {
@@ -11476,9 +11476,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-      "integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.4.tgz",
+      "integrity": "sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==",
       "dev": true
     },
     "graceful-readlink": {
@@ -11680,9 +11680,9 @@
       },
       "dependencies": {
         "property-information": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.4.0.tgz",
-          "integrity": "sha512-nmMWAm/3vKFGmmOWOcdLjgq/Hlxa+hsuR/px1Lp/UGEyc5A22A6l78Shc2C0E71sPmAqglni+HrS7L7VJ7AUCA==",
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/property-information/-/property-information-5.5.0.tgz",
+          "integrity": "sha512-RgEbCx2HLa1chNgvChcx+rrCWD0ctBmGSE0M7lVm1yyv4UbvbrWoXp/BkVLZefzjrRBGW8/Js6uh/BnlHXFyjA==",
           "dev": true,
           "requires": {
             "xtend": "^4.0.0"
@@ -15144,9 +15144,9 @@
       }
     },
     "npm-registry-fetch": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.3.tgz",
-      "integrity": "sha512-WGvUx0lkKFhu9MbiGFuT9nG2NpfQ+4dCJwRwwtK2HK5izJEvwDxMeUyqbuMS7N/OkpVCqDorV6rO5E4V9F8lJw==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-4.0.4.tgz",
+      "integrity": "sha512-6jb34hX/iYNQebqWUHtU8YF6Cjb1H6ouTFPClYsyiW6lpFkljTpdeftm53rRojtja1rKAvKNIIiTS5Sjpw4wsA==",
       "dev": true,
       "requires": {
         "JSONStream": "^1.3.4",
@@ -17562,9 +17562,9 @@
       }
     },
     "postcss-value-parser": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.0.3.tgz",
-      "integrity": "sha512-N7h4pG+Nnu5BEIzyeaaIYWs0LI5XC40OrRh5L60z0QjFsqGWcHcbkBvpe1WYpcIS9yQ8sOi/vIPt1ejQCrMVrg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.1.0.tgz",
+      "integrity": "sha512-97DXOFbQJhk71ne5/Mt6cOu6yxsSfM0QGQyl0L25Gca4yGWEGJaig7l7gbCX623VqTBNGLRLaVUCnNkcedlRSQ==",
       "dev": true
     },
     "postcss-values-parser": {

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "@dojo/cli-build-widget": "7.0.0-rc.1",
     "@dojo/cli-test-intern": "7.0.0-rc.1",
     "@dojo/framework": "7.0.0-rc.2",
-    "@dojo/parade": "1.0.0-rc.2",
+    "@dojo/parade": "1.0.0-rc.3",
     "@dojo/scripts": "^4.0.3",
     "@material/button": "3.0.0",
     "@material/card": "5.1.0",

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -234,9 +234,26 @@ import ErrorResult from './widgets/result/Error';
 import SuccessResult from './widgets/result/Success';
 import CustomIconResult from './widgets/result/CustomIcon';
 
+import * as dojoDarkVariant from '@dojo/widgets/theme/dojo/variants/dark.m.css';
+import * as materialDarkVariant from '@dojo/widgets/theme/material/variants/dark.m.css';
+
 `!has('docs')`;
 import testsContext from './tests';
 const tests = typeof testsContext !== 'undefined' ? testsContext : { keys: () => [] };
+
+const dojoDarkTheme = {
+	theme: { ...dojoTheme.theme },
+	variants: {
+		default: dojoDarkVariant
+	}
+};
+
+const materialDarkTheme = {
+	theme: { ...materialTheme.theme },
+	variants: {
+		default: materialDarkVariant
+	}
+};
 
 export const config = {
 	name: '@dojo/widgets',
@@ -244,6 +261,8 @@ export const config = {
 	themes: [
 		{ label: 'dojo', theme: dojoTheme },
 		{ label: 'material', theme: materialTheme },
+		{ label: 'dojo-dark', theme: dojoDarkTheme },
+		{ label: 'material-dark', theme: materialDarkTheme },
 		{ label: 'default', theme: {} }
 	],
 	tests,

--- a/src/theme/dojo/variants/default.m.css
+++ b/src/theme/dojo/variants/default.m.css
@@ -1,4 +1,6 @@
 .root {
+	--example-background: var(--color-background);
+
 	/* Spacing */
 	--grid-base: 8px;
 	--spacing-regular: var(--grid-base);

--- a/src/theme/material/variants/default.m.css
+++ b/src/theme/material/variants/default.m.css
@@ -1,4 +1,6 @@
 .root {
+	--example-background: var(--mdc-theme-surface);
+
 	/* variables taken from @material/theme/dist/mdc.theme.css */
 	--mdc-theme-primary: #6200ee;
 	--mdc-theme-secondary: #018786;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Support theme variants in parade.