### PR TITLE
mobile improvements: Remove set widths from examples

### DIFF
--- a/src/examples/src/widgets/avatar/Basic.tsx
+++ b/src/examples/src/widgets/avatar/Basic.tsx
@@ -7,7 +7,7 @@ const factory = create();
 export default factory(function Basic() {
 	return (
 		<Example>
-			<div styles={{ width: '400px' }}>
+			<div styles={{ maxWidth: '400px' }}>
 				<Avatar>A</Avatar>
 			</div>
 		</Example>

--- a/src/examples/src/widgets/avatar/Icon.tsx
+++ b/src/examples/src/widgets/avatar/Icon.tsx
@@ -8,7 +8,7 @@ const factory = create();
 export default factory(function Basic() {
 	return (
 		<Example>
-			<div styles={{ width: '400px', display: 'flex', justifyContent: 'space-around' }}>
+			<div styles={{ maxWidth: '400px', display: 'flex', justifyContent: 'space-around' }}>
 				<Avatar variant="circle">
 					<Icon type="secureIcon" />
 				</Avatar>

--- a/src/examples/src/widgets/avatar/Image.tsx
+++ b/src/examples/src/widgets/avatar/Image.tsx
@@ -8,7 +8,7 @@ const factory = create();
 export default factory(function Basic() {
 	return (
 		<Example>
-			<div styles={{ width: '400px', display: 'flex', justifyContent: 'space-around' }}>
+			<div styles={{ maxWidth: '400px', display: 'flex', justifyContent: 'space-around' }}>
 				<Avatar src={avatar} alt="Dojo" />
 				<Avatar variant="rounded" src={avatar} alt="Dojo" />
 				<Avatar variant="square" src={avatar} alt="Dojo" />

--- a/src/examples/src/widgets/avatar/Secondary.tsx
+++ b/src/examples/src/widgets/avatar/Secondary.tsx
@@ -7,7 +7,7 @@ const factory = create();
 export default factory(function Basic() {
 	return (
 		<Example>
-			<div styles={{ width: '400px', display: 'flex', justifyContent: 'space-around' }}>
+			<div styles={{ maxWidth: '400px', display: 'flex', justifyContent: 'space-around' }}>
 				<Avatar secondary variant="circle">
 					A
 				</Avatar>

--- a/src/examples/src/widgets/avatar/Size.tsx
+++ b/src/examples/src/widgets/avatar/Size.tsx
@@ -9,7 +9,7 @@ export default factory(function Basic() {
 		<Example>
 			<div
 				styles={{
-					width: '400px',
+					maxWidth: '400px',
 					display: 'flex',
 					justifyContent: 'space-around',
 					alignItems: 'center'

--- a/src/examples/src/widgets/avatar/Variant.tsx
+++ b/src/examples/src/widgets/avatar/Variant.tsx
@@ -7,7 +7,7 @@ const factory = create();
 export default factory(function Basic() {
 	return (
 		<Example>
-			<div styles={{ width: '400px', display: 'flex', justifyContent: 'space-around' }}>
+			<div styles={{ maxWidth: '400px', display: 'flex', justifyContent: 'space-around' }}>
 				<Avatar variant="circle">A</Avatar>
 				<Avatar variant="rounded">A</Avatar>
 				<Avatar variant="square">A</Avatar>

--- a/src/examples/src/widgets/card/ActionButtons.tsx
+++ b/src/examples/src/widgets/card/ActionButtons.tsx
@@ -10,7 +10,7 @@ export default factory(function ActionButtons({ middleware: { icache } }) {
 	const clickCount = icache.getOrSet<number>('clickCount', 0);
 	return (
 		<Example>
-			<div styles={{ width: '400px' }}>
+			<div styles={{ maxWidth: '400px' }}>
 				<Card title="Hello, World">
 					{{
 						actionButtons: (

--- a/src/examples/src/widgets/card/ActionButtonsAndIcons.tsx
+++ b/src/examples/src/widgets/card/ActionButtonsAndIcons.tsx
@@ -11,7 +11,7 @@ export default factory(function ActionButtonsAndIcons({ middleware: { icache } }
 	const clickCount = icache.getOrSet<number>('clickCount', 0);
 	return (
 		<Example>
-			<div styles={{ width: '400px' }}>
+			<div styles={{ maxWidth: '400px' }}>
 				<Card title="Hello, World">
 					{{
 						content: <span>Lorem ipsum</span>,

--- a/src/examples/src/widgets/card/ActionIcons.tsx
+++ b/src/examples/src/widgets/card/ActionIcons.tsx
@@ -8,7 +8,7 @@ const factory = create();
 export default factory(function ActionIcons() {
 	return (
 		<Example>
-			<div styles={{ width: '400px' }}>
+			<div styles={{ maxWidth: '400px' }}>
 				<Card title="Hello, World">
 					{{
 						content: <h2>Hello, World</h2>,

--- a/src/examples/src/widgets/card/Basic.tsx
+++ b/src/examples/src/widgets/card/Basic.tsx
@@ -7,7 +7,7 @@ const factory = create();
 export default factory(function Basic() {
 	return (
 		<Example>
-			<div styles={{ width: '400px' }}>
+			<div styles={{ maxWidth: '400px' }}>
 				<Card title="Hello, World">
 					{{
 						content: <span>Lorem ipsum</span>

--- a/src/examples/src/widgets/card/CardCombined.tsx
+++ b/src/examples/src/widgets/card/CardCombined.tsx
@@ -10,7 +10,7 @@ const factory = create();
 export default factory(function CardWithMediaContent() {
 	return (
 		<Example>
-			<div styles={{ width: '400px' }}>
+			<div styles={{ maxWidth: '400px' }}>
 				<Card
 					onAction={() => {}}
 					mediaSrc={mediaSrc}

--- a/src/examples/src/widgets/card/CardWithMediaContent.tsx
+++ b/src/examples/src/widgets/card/CardWithMediaContent.tsx
@@ -8,7 +8,7 @@ const factory = create();
 export default factory(function CardWithMediaContent() {
 	return (
 		<Example>
-			<div styles={{ width: '400px' }}>
+			<div styles={{ maxWidth: '400px' }}>
 				<Card title="Hello, World" mediaSrc={mediaSrc}>
 					{{
 						content: <span>Lorem ipsum</span>

--- a/src/examples/src/widgets/card/CardWithMediaRectangle.tsx
+++ b/src/examples/src/widgets/card/CardWithMediaRectangle.tsx
@@ -8,7 +8,7 @@ const factory = create();
 export default factory(function CardWithMediaRectangle() {
 	return (
 		<Example>
-			<div styles={{ width: '400px' }}>
+			<div styles={{ maxWidth: '400px' }}>
 				<Card mediaSrc={mediaSrc} title="Hello, World" subtitle="Lorem ipsum">
 					{{
 						content: <span>Content goes here.</span>

--- a/src/examples/src/widgets/header-card/ActionCard.tsx
+++ b/src/examples/src/widgets/header-card/ActionCard.tsx
@@ -12,7 +12,7 @@ const factory = create();
 export default factory(function Basic() {
 	return (
 		<Example>
-			<div styles={{ width: '400px' }}>
+			<div styles={{ maxWidth: '400px' }}>
 				<HeaderCard title="Hello, World" subtitle="Lorem ipsum" mediaSrc={mediaSrc}>
 					{{
 						avatar: <Avatar src={avatar} />,

--- a/src/examples/src/widgets/header-card/Basic.tsx
+++ b/src/examples/src/widgets/header-card/Basic.tsx
@@ -8,7 +8,7 @@ const factory = create();
 export default factory(function Basic() {
 	return (
 		<Example>
-			<div styles={{ width: '400px' }}>
+			<div styles={{ maxWidth: '400px' }}>
 				<HeaderCard title="Hello, World" subtitle="Lorem ipsum">
 					{{
 						avatar: <Avatar>D</Avatar>,

--- a/src/examples/src/widgets/header-card/MediaCard.tsx
+++ b/src/examples/src/widgets/header-card/MediaCard.tsx
@@ -10,7 +10,7 @@ const factory = create();
 export default factory(function Basic() {
 	return (
 		<Example>
-			<div styles={{ width: '400px' }}>
+			<div styles={{ maxWidth: '400px' }}>
 				<HeaderCard title="Hello, World" subtitle="Lorem ipsum" mediaSrc={mediaSrc}>
 					{{
 						avatar: <Avatar src={avatar} />,


### PR DESCRIPTION
These set widths are causing issues with some example layouts.
This PR changes them to max-width instead.