### PR TITLE
Fix typeahead

### DIFF
--- a/src/chip-typeahead/index.tsx
+++ b/src/chip-typeahead/index.tsx
@@ -225,11 +225,11 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 					}
 				}}
 				itemDisabled={(item) => {
-					const { duplicates = false } = properties();
+					const { duplicates = false, strict = true } = properties();
 
 					const selected = icache.getOrSet('value', []).indexOf(item.value) !== -1;
 
-					return item.disabled || (!duplicates && selected);
+					return item.disabled || (!duplicates && strict && selected);
 				}}
 			>
 				{{

--- a/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
+++ b/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
@@ -12,8 +12,6 @@ import * as chipCss from '../../../theme/default/chip.m.css';
 import * as labelCss from '../../../theme/default/label.m.css';
 import Chip from '../../../chip/index';
 import Label from '../../../label';
-import ChipTypeahead from '@dojo/widgets/chip-typeahead';
-import { defaultTransform } from '@dojo/widgets/list';
 
 const { assert } = intern.getPlugin('chai');
 

--- a/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
+++ b/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
@@ -507,6 +507,7 @@ registerSuite('ChipTypeahead', {
 					transform={defaultTransform}
 					initialValue={['cat']}
 					strict={false}
+					duplicates
 				>
 					{}
 				</ChipTypeahead>

--- a/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
+++ b/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
@@ -12,6 +12,8 @@ import * as chipCss from '../../../theme/default/chip.m.css';
 import * as labelCss from '../../../theme/default/label.m.css';
 import Chip from '../../../chip/index';
 import Label from '../../../label';
+import ChipTypeahead from '@dojo/widgets/chip-typeahead';
+import { defaultTransform } from '@dojo/widgets/list';
 
 const { assert } = intern.getPlugin('chai');
 
@@ -487,6 +489,26 @@ registerSuite('ChipTypeahead', {
 					transform={defaultTransform}
 					initialValue={['cat']}
 					duplicates
+				>
+					{}
+				</ChipTypeahead>
+			));
+
+			const disabled = h.trigger('@typeahead', (node: any) => () =>
+				node.properties.itemDisabled
+			);
+
+			assert.isFalse(disabled({ value: 'cat' }));
+			assert.isFalse(disabled({ value: 'dog' }));
+		},
+
+		'allows duplicate values if not strict'() {
+			const h = harness(() => (
+				<ChipTypeahead
+					resource={resource(animalOptions)}
+					transform={defaultTransform}
+					initialValue={['cat']}
+					strict={false}
 				>
 					{}
 				</ChipTypeahead>

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -203,6 +203,10 @@ export const Typeahead = factory(function Typeahead({
 							icache.set('value', activeItem.value);
 							onClose();
 							callOnValue(activeItem.value);
+						} else if (!strict) {
+							const value = icache.getOrSet('value', '');
+							onClose();
+							callOnValue(value);
 						}
 					} else {
 						if (strict) {
@@ -302,7 +306,9 @@ export const Typeahead = factory(function Typeahead({
 									onBlur && onBlur();
 								}}
 								name={name}
-								initialValue={valueOption ? valueOption.label : value}
+								initialValue={
+									valueOption ? valueOption.label || valueOption.value : value
+								}
 								focus={() =>
 									icache.get('focusNode') === 'trigger' && focus.shouldFocus()
 								}

--- a/src/typeahead/tests/unit/Typeahead.spec.tsx
+++ b/src/typeahead/tests/unit/Typeahead.spec.tsx
@@ -12,8 +12,6 @@ import TextInput from '../../../text-input';
 import * as listCss from '../../../theme/default/list.m.css';
 import * as inputCss from '../../../theme/default/text-input.m.css';
 import { Keys } from '../../../common/util';
-import Typeahead from '@dojo/widgets/typeahead';
-import { defaultTransform } from '@dojo/widgets/list';
 
 const { assert } = intern.getPlugin('chai');
 

--- a/src/typeahead/tests/unit/Typeahead.spec.tsx
+++ b/src/typeahead/tests/unit/Typeahead.spec.tsx
@@ -420,6 +420,36 @@ registerSuite('Typeahead', {
 
 			assert.isTrue(onValue.notCalled);
 		},
+		'does not call on value if option is disabled and in strict mode'() {
+			const onValue = stub();
+
+			const h = harness(() => (
+				<Typeahead
+					resource={createResource()(animalOptions)}
+					transform={defaultTransform}
+					onValue={onValue}
+				>
+					{{ label: 'Test' }}
+				</Typeahead>
+			));
+
+			const toggleOpenStub = stub();
+			const preventDefaultStub = stub();
+
+			const triggerRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].trigger,
+				toggleOpenStub
+			);
+
+			// first to open the popup
+			triggerRenderResult.properties.onKeyDown(Keys.Down, preventDefaultStub);
+			triggerRenderResult.properties.onKeyDown(Keys.Down, preventDefaultStub);
+			triggerRenderResult.properties.onKeyDown(Keys.Down, preventDefaultStub);
+			triggerRenderResult.properties.onKeyDown(Keys.Enter, preventDefaultStub);
+
+			assert.isTrue(onValue.notCalled);
+		},
 		'allows free text when not in strict mode'() {
 			const onValue = stub();
 			const onValidate = stub();

--- a/src/typeahead/tests/unit/Typeahead.spec.tsx
+++ b/src/typeahead/tests/unit/Typeahead.spec.tsx
@@ -389,6 +389,37 @@ registerSuite('Typeahead', {
 
 			assert.isTrue(onValue.calledWith(animalOptions[0].value));
 		},
+		'does not call on value if option is disabled'() {
+			const onValue = stub();
+
+			const h = harness(() => (
+				<Typeahead
+					resource={createResource()(animalOptions)}
+					strict={false}
+					transform={defaultTransform}
+					onValue={onValue}
+				>
+					{{ label: 'Test' }}
+				</Typeahead>
+			));
+
+			const toggleOpenStub = stub();
+			const preventDefaultStub = stub();
+
+			const triggerRenderResult = h.trigger(
+				'@popup',
+				(node) => (node.children as any)[0].trigger,
+				toggleOpenStub
+			);
+
+			// first to open the popup
+			triggerRenderResult.properties.onKeyDown(Keys.Down, preventDefaultStub);
+			triggerRenderResult.properties.onKeyDown(Keys.Down, preventDefaultStub);
+			triggerRenderResult.properties.onKeyDown(Keys.Down, preventDefaultStub);
+			triggerRenderResult.properties.onKeyDown(Keys.Enter, preventDefaultStub);
+
+			assert.isTrue(onValue.notCalled);
+		},
 		'allows free text when not in strict mode'() {
 			const onValue = stub();
 			const onValidate = stub();

--- a/src/typeahead/tests/unit/Typeahead.spec.tsx
+++ b/src/typeahead/tests/unit/Typeahead.spec.tsx
@@ -12,6 +12,8 @@ import TextInput from '../../../text-input';
 import * as listCss from '../../../theme/default/list.m.css';
 import * as inputCss from '../../../theme/default/text-input.m.css';
 import { Keys } from '../../../common/util';
+import Typeahead from '@dojo/widgets/typeahead';
+import { defaultTransform } from '@dojo/widgets/list';
 
 const { assert } = intern.getPlugin('chai');
 
@@ -163,6 +165,40 @@ registerSuite('Typeahead', {
 			triggerRenderResult.properties.onValue('value');
 
 			assert.isTrue(toggleOpenStub.calledOnce);
+		},
+
+		'shows an option label when the value is entered'() {
+			const h = harness(() => (
+				<Typeahead
+					initialValue="cat"
+					resource={resource}
+					transform={defaultTransform}
+					onValue={noop}
+				>
+					{{ label: 'Test' }}
+				</Typeahead>
+			));
+
+			h.expect(inputTemplate.setProperty('@trigger', 'initialValue', 'Cat'), () =>
+				h.trigger('@popup', (node) => (node.children as any)[0].trigger, stub)
+			);
+		},
+
+		'shows an option value when the value is entered and there is no label'() {
+			const h = harness(() => (
+				<Typeahead
+					initialValue="dog"
+					resource={resource}
+					transform={defaultTransform}
+					onValue={noop}
+				>
+					{{ label: 'Test' }}
+				</Typeahead>
+			));
+
+			h.expect(inputTemplate.setProperty('@trigger', 'initialValue', 'dog'), () =>
+				h.trigger('@popup', (node) => (node.children as any)[0].trigger, stub)
+			);
 		},
 
 		'opens the typeahead on input click'() {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Fixes behavior when a matched option does not have a label, and forces duplicates to be allowed when in non-strict mode for the chip typeahead.
