### PR TITLE
Deploy ie11 compatible docs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14,19 +14,19 @@
       }
     },
     "@babel/core": {
-      "version": "7.9.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-      "integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.6.tgz",
+      "integrity": "sha512-nD3deLvbsApbHAHttzIssYqgb883yU/d9roe4RZymBCDaZryMJDbptVpEpeQuRh4BJ+SYI8le9YGxKvFEvl1Wg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.0",
+        "@babel/generator": "^7.9.6",
         "@babel/helper-module-transforms": "^7.9.0",
-        "@babel/helpers": "^7.9.0",
-        "@babel/parser": "^7.9.0",
+        "@babel/helpers": "^7.9.6",
+        "@babel/parser": "^7.9.6",
         "@babel/template": "^7.8.6",
-        "@babel/traverse": "^7.9.0",
-        "@babel/types": "^7.9.0",
+        "@babel/traverse": "^7.9.6",
+        "@babel/types": "^7.9.6",
         "convert-source-map": "^1.7.0",
         "debug": "^4.1.0",
         "gensync": "^1.0.0-beta.1",
@@ -64,12 +64,12 @@
       }
     },
     "@babel/generator": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
-      "integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+      "integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.9.5",
+        "@babel/types": "^7.9.6",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
@@ -152,15 +152,15 @@
       }
     },
     "@babel/helper-replace-supers": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
-      "integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz",
+      "integrity": "sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==",
       "dev": true,
       "requires": {
         "@babel/helper-member-expression-to-functions": "^7.8.3",
         "@babel/helper-optimise-call-expression": "^7.8.3",
-        "@babel/traverse": "^7.8.6",
-        "@babel/types": "^7.8.6"
+        "@babel/traverse": "^7.9.6",
+        "@babel/types": "^7.9.6"
       }
     },
     "@babel/helper-simple-access": {
@@ -189,14 +189,14 @@
       "dev": true
     },
     "@babel/helpers": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
-      "integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.6.tgz",
+      "integrity": "sha512-tI4bUbldloLcHWoRUMAj4g1bF313M/o6fBKhIsb3QnGVPwRm9JsNf/gqMkQ7zjqReABiffPV6RWj7hEglID5Iw==",
       "dev": true,
       "requires": {
         "@babel/template": "^7.8.3",
-        "@babel/traverse": "^7.9.0",
-        "@babel/types": "^7.9.0"
+        "@babel/traverse": "^7.9.6",
+        "@babel/types": "^7.9.6"
       }
     },
     "@babel/highlight": {
@@ -219,15 +219,15 @@
       }
     },
     "@babel/parser": {
-      "version": "7.9.4",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-      "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+      "integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q==",
       "dev": true
     },
     "@babel/runtime": {
-      "version": "7.9.2",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
-      "integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.6.tgz",
+      "integrity": "sha512-64AF1xY3OAkFHqOb9s4jpgk1Mm5vDZ4L3acHvAml+53nO1XbXLuDodsVpO4OIUsmemlUHMxNdYMNJmsvOwLrvQ==",
       "dev": true,
       "requires": {
         "regenerator-runtime": "^0.13.4"
@@ -253,17 +253,17 @@
       }
     },
     "@babel/traverse": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
-      "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+      "integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.5",
+        "@babel/generator": "^7.9.6",
         "@babel/helper-function-name": "^7.9.5",
         "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.9.0",
-        "@babel/types": "^7.9.5",
+        "@babel/parser": "^7.9.6",
+        "@babel/types": "^7.9.6",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
@@ -287,9 +287,9 @@
       }
     },
     "@babel/types": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-      "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+      "version": "7.9.6",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+      "integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
       "dev": true,
       "requires": {
         "@babel/helper-validator-identifier": "^7.9.5",
@@ -358,12 +358,12 @@
       }
     },
     "@dojo/cli-build-app": {
-      "version": "7.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@dojo/cli-build-app/-/cli-build-app-7.0.0-rc.1.tgz",
-      "integrity": "sha512-/80z3fpUBv8nxztZL07P+K8r9Yt5nb3sN5fsW0xwA4vifRYWenzOd8TsS0FUJdIA+SebRBnPZ6CVloox6IV9tg==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@dojo/cli-build-app/-/cli-build-app-7.0.0-rc.2.tgz",
+      "integrity": "sha512-JTgY0dSjaRASn8N1xMMOWN7mjud9u9yonCqrdY/7TtyZqXiawCn4dtG22/bFwaK2cEX5OmFDx+qqWX8AKYgQmw==",
       "dev": true,
       "requires": {
-        "@dojo/webpack-contrib": "7.0.0-rc.1",
+        "@dojo/webpack-contrib": "7.0.0-rc.2",
         "brotli-webpack-plugin": "1.0.0",
         "caniuse-lite": "1.0.30000973",
         "chalk": "2.4.1",
@@ -385,7 +385,6 @@
         "html-webpack-plugin": "3.2.0",
         "http-proxy-middleware": "^0.19.0",
         "identity-loader": "1.0.1",
-        "ie11-custom-properties": "3.0.6",
         "imports-loader": "0.8.0",
         "istanbul-instrumenter-loader": "3.0.1",
         "json-css-module-loader": "1.0.2",
@@ -480,10 +479,121 @@
         "webpack": "4.25.1"
       },
       "dependencies": {
+        "@dojo/framework": {
+          "version": "7.0.0-rc.1",
+          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-rc.1.tgz",
+          "integrity": "sha512-R5XvxD6Dvpv3CgbiHHBbRJJvSrp1Z73xRwozAKRI2iH3HuG+5UyXJEVfnE6MhtENXJlNkVvkihxbKlyH88CUIg==",
+          "dev": true,
+          "requires": {
+            "@types/cldrjs": "0.4.20",
+            "@types/globalize": "0.0.34",
+            "@webcomponents/webcomponentsjs": "1.1.0",
+            "cldr-core": "36.0.0",
+            "cldrjs": "^0.5.0",
+            "cross-fetch": "3.0.2",
+            "css-select-umd": "1.3.0-rc0",
+            "diff": "3.5.0",
+            "globalize": "1.4.0",
+            "immutable": "3.8.2",
+            "intersection-observer": "0.4.2",
+            "pepjs": "0.4.2",
+            "requirejs-text": "2.0.15",
+            "resize-observer-polyfill": "1.5.0",
+            "tslib": "1.9.3",
+            "web-animations-js": "2.3.1",
+            "wicg-inert": "3.0.0"
+          }
+        },
+        "@dojo/webpack-contrib": {
+          "version": "7.0.0-rc.1",
+          "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-rc.1.tgz",
+          "integrity": "sha512-lr/hTGsqwbpV9iOB5Bge6aa1TLRAQdlkpIs3vUORjy1ywDwFBspWAF4PHdx6jVfb/s98VyIyoTEc/2UYIsbYTA==",
+          "dev": true,
+          "requires": {
+            "@dojo/framework": "7.0.0-rc.1",
+            "acorn": "6.1.1",
+            "acorn-dynamic-import": "4.0.0",
+            "acorn-walk": "6.1.1",
+            "bfj": "6.1.1",
+            "chalk": "2.3.0",
+            "cldr-core": "36.0.0",
+            "clear-module": "3.1.0",
+            "commander": "2.13.0",
+            "connect-history-api-fallback": "1.6.0",
+            "copy-webpack-plugin": "4.6.0",
+            "cssnano": "4.1.7",
+            "electron": "~7.1.7",
+            "eventsource-polyfill": "0.9.6",
+            "express": "4.16.2",
+            "filesize": "3.5.11",
+            "filter-css": "0.1.2",
+            "fs-extra": "7.0.0",
+            "get-port": "4.0.0",
+            "glob": "^7.1.2",
+            "gzip-size": "4.1.0",
+            "html-webpack-include-assets-plugin": "1.0.6",
+            "istanbul-lib-instrument": "1.10.1",
+            "jsdom": "15.2.0",
+            "loader-utils": "1.1.0",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "node-html-parser": "1.1.11",
+            "opener": "1.4.3",
+            "postcss": "7.0.7",
+            "puppeteer": "1.11.0",
+            "recast": "0.12.7",
+            "source-map": "0.6.1",
+            "ts-loader": "5.4.5",
+            "ts-node": "^8.0.3",
+            "typed-css-modules": "0.3.7",
+            "webpack-hot-middleware": "2.24.3",
+            "workbox-webpack-plugin": "3.6.3",
+            "wrapper-webpack-plugin": "2.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+              "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.1.0",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^4.0.0"
+              }
+            },
+            "cssnano": {
+              "version": "4.1.7",
+              "resolved": "https://registry.npmjs.org/cssnano/-/cssnano-4.1.7.tgz",
+              "integrity": "sha512-AiXL90l+MDuQmRNyypG2P7ux7K4XklxYzNNUd5HXZCNcH8/N9bHPcpN97v8tXgRVeFL/Ed8iP8mVmAAu0ZpT7A==",
+              "dev": true,
+              "requires": {
+                "cosmiconfig": "^5.0.0",
+                "cssnano-preset-default": "^4.0.5",
+                "is-resolvable": "^1.0.0",
+                "postcss": "^7.0.0"
+              }
+            },
+            "ts-loader": {
+              "version": "5.4.5",
+              "resolved": "https://registry.npmjs.org/ts-loader/-/ts-loader-5.4.5.tgz",
+              "integrity": "sha512-XYsjfnRQCBum9AMRZpk2rTYSVpdZBpZK+kDh0TeT3kxmQNBDVIeUjdPjY5RZry4eIAb8XHc4gYSUiUWPYvzSRw==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.3.0",
+                "enhanced-resolve": "^4.0.0",
+                "loader-utils": "^1.0.2",
+                "micromatch": "^3.1.4",
+                "semver": "^5.0.1"
+              }
+            }
+          }
+        },
         "ansi-regex": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
-          "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
           "dev": true
         },
         "braces": {
@@ -511,6 +621,30 @@
           "integrity": "sha512-Xs2Hf2nzrvJMFKimOR7YR0QwZ8fc0u98kdtwN1eNAZzNQgH3vK2pXzff6GJtKh7S5hoJ87ECiAiZFS2fb5Ii2w==",
           "dev": true
         },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            }
+          }
+        },
         "color-convert": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -524,6 +658,12 @@
           "version": "1.1.4",
           "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
           "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "connect-history-api-fallback": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+          "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
           "dev": true
         },
         "cssnano": {
@@ -557,27 +697,68 @@
             "to-regex-range": "^5.0.1"
           }
         },
-        "find-up": {
-          "version": "4.1.0",
-          "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
-          "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
           "dev": true,
           "requires": {
-            "locate-path": "^5.0.0",
-            "path-exists": "^4.0.0"
+            "number-is-nan": "^1.0.0"
           }
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
         },
         "is-number": {
           "version": "7.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
           "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
           "dev": true
+        },
+        "jsdom": {
+          "version": "15.2.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.0.tgz",
+          "integrity": "sha512-+hRyEfjRPFwTYMmSQ3/f7U9nP8ZNZmbkmUek760ZpxnCPWJIhaaLRuUSvpJ36fZKCGENxLwxClzwpOpnXNfChQ==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.0",
+            "acorn": "^7.1.0",
+            "acorn-globals": "^4.3.2",
+            "array-equal": "^1.0.0",
+            "cssom": "^0.4.1",
+            "cssstyle": "^2.0.0",
+            "data-urls": "^1.1.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.11.1",
+            "html-encoding-sniffer": "^1.0.2",
+            "nwsapi": "^2.1.4",
+            "parse5": "5.1.0",
+            "pn": "^1.1.0",
+            "request": "^2.88.0",
+            "request-promise-native": "^1.0.7",
+            "saxes": "^3.1.9",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^3.0.1",
+            "w3c-hr-time": "^1.0.1",
+            "w3c-xmlserializer": "^1.1.2",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^7.0.0",
+            "ws": "^7.0.0",
+            "xml-name-validator": "^3.0.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "7.1.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+              "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+              "dev": true
+            }
+          }
         },
         "jsonfile": {
           "version": "5.0.0",
@@ -589,6 +770,18 @@
             "universalify": "^0.1.2"
           }
         },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
         "locate-path": {
           "version": "5.0.0",
           "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-5.0.0.tgz",
@@ -597,6 +790,12 @@
           "requires": {
             "p-locate": "^4.1.0"
           }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "log-symbols": {
           "version": "3.0.0",
@@ -644,16 +843,51 @@
             "ansi-escapes": "^3.2.0",
             "cli-cursor": "^2.1.0",
             "wrap-ansi": "^5.0.0"
-          }
-        },
-        "micromatch": {
-          "version": "4.0.2",
-          "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
-          "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-          "dev": true,
-          "requires": {
-            "braces": "^3.0.1",
-            "picomatch": "^2.0.5"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+              "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+              "dev": true
+            },
+            "is-fullwidth-code-point": {
+              "version": "2.0.0",
+              "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+              "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+              "dev": true
+            },
+            "string-width": {
+              "version": "3.1.0",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+              "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+              "dev": true,
+              "requires": {
+                "emoji-regex": "^7.0.1",
+                "is-fullwidth-code-point": "^2.0.0",
+                "strip-ansi": "^5.1.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "5.2.0",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+              "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^4.1.0"
+              }
+            },
+            "wrap-ansi": {
+              "version": "5.1.0",
+              "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
+              "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.2.0",
+                "string-width": "^3.0.0",
+                "strip-ansi": "^5.0.0"
+              }
+            }
           }
         },
         "mimic-fn": {
@@ -672,6 +906,21 @@
             "normalize-url": "1.9.1",
             "schema-utils": "^1.0.0",
             "webpack-sources": "^1.1.0"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
           }
         },
         "mute-stream": {
@@ -727,6 +976,12 @@
             "wcwidth": "^1.0.1"
           },
           "dependencies": {
+            "ansi-regex": {
+              "version": "5.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.0.tgz",
+              "integrity": "sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==",
+              "dev": true
+            },
             "ansi-styles": {
               "version": "4.2.1",
               "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
@@ -756,6 +1011,12 @@
                 "restore-cursor": "^3.1.0"
               }
             },
+            "has-flag": {
+              "version": "4.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+              "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+              "dev": true
+            },
             "strip-ansi": {
               "version": "6.0.0",
               "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -763,6 +1024,15 @@
               "dev": true,
               "requires": {
                 "ansi-regex": "^5.0.0"
+              }
+            },
+            "supports-color": {
+              "version": "7.1.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+              "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^4.0.0"
               }
             }
           }
@@ -791,10 +1061,34 @@
           "integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
           "dev": true
         },
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
+          "dev": true,
+          "requires": {
+            "error-ex": "^1.2.0"
+          }
+        },
         "path-exists": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
           "integrity": "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==",
+          "dev": true
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
           "dev": true
         },
         "pkg-dir": {
@@ -804,6 +1098,39 @@
           "dev": true,
           "requires": {
             "find-up": "^4.0.0"
+          },
+          "dependencies": {
+            "find-up": {
+              "version": "4.1.0",
+              "resolved": "https://registry.npmjs.org/find-up/-/find-up-4.1.0.tgz",
+              "integrity": "sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==",
+              "dev": true,
+              "requires": {
+                "locate-path": "^5.0.0",
+                "path-exists": "^4.0.0"
+              }
+            }
+          }
+        },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
           }
         },
         "restore-cursor": {
@@ -816,30 +1143,28 @@
             "signal-exit": "^3.0.2"
           }
         },
-        "semver": {
-          "version": "6.3.0",
-          "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-          "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-          "dev": true
-        },
-        "string-width": {
-          "version": "3.1.0",
-          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
-          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+        "strip-ansi": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
           "dev": true,
           "requires": {
-            "emoji-regex": "^7.0.1",
-            "is-fullwidth-code-point": "^2.0.0",
-            "strip-ansi": "^5.1.0"
+            "ansi-regex": "^2.0.0"
           }
         },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
         "supports-color": {
-          "version": "7.1.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-          "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
           "dev": true,
           "requires": {
-            "has-flag": "^4.0.0"
+            "has-flag": "^2.0.0"
           }
         },
         "to-regex-range": {
@@ -862,17 +1187,97 @@
             "loader-utils": "^1.0.2",
             "micromatch": "^4.0.0",
             "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "micromatch": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
+              "integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+              "dev": true,
+              "requires": {
+                "braces": "^3.0.1",
+                "picomatch": "^2.0.5"
+              }
+            },
+            "semver": {
+              "version": "6.3.0",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+              "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
+              "dev": true
+            }
           }
         },
-        "wrap-ansi": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-5.1.0.tgz",
-          "integrity": "sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==",
+        "ts-node": {
+          "version": "8.9.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.9.1.tgz",
+          "integrity": "sha512-yrq6ODsxEFTLz0R3BX2myf0WBCSQh9A+py8PBo1dCzWIOcvisbyH6akNKqDHMgXePF2kir5mm5JXJTH3OUJYOQ==",
           "dev": true,
           "requires": {
-            "ansi-styles": "^3.2.0",
-            "string-width": "^3.0.0",
-            "strip-ansi": "^5.0.0"
+            "arg": "^4.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "source-map-support": "^0.5.17",
+            "yn": "3.1.1"
+          },
+          "dependencies": {
+            "diff": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+              "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+              "dev": true
+            }
+          }
+        },
+        "typed-css-modules": {
+          "version": "0.3.7",
+          "resolved": "https://registry.npmjs.org/typed-css-modules/-/typed-css-modules-0.3.7.tgz",
+          "integrity": "sha512-KR1VG/U0rgFWaiQtXKtFMgKaurs80nvlBvZ7BfuYGLldw6kss/97sd+aMG4CI73BbujvefG7DBjnsBqq2Aowcw==",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0",
+            "chalk": "^2.1.0",
+            "chokidar": "^2.0.3",
+            "css-modules-loader-core": "^1.1.0",
+            "glob": "^7.1.2",
+            "is-there": "^4.4.2",
+            "mkdirp": "^0.5.1",
+            "yargs": "^8.0.2"
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -951,6 +1356,89 @@
             "wicg-inert": "3.0.0"
           }
         },
+        "@dojo/webpack-contrib": {
+          "version": "7.0.0-rc.1",
+          "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-rc.1.tgz",
+          "integrity": "sha512-lr/hTGsqwbpV9iOB5Bge6aa1TLRAQdlkpIs3vUORjy1ywDwFBspWAF4PHdx6jVfb/s98VyIyoTEc/2UYIsbYTA==",
+          "dev": true,
+          "requires": {
+            "@dojo/framework": "7.0.0-rc.1",
+            "acorn": "6.1.1",
+            "acorn-dynamic-import": "4.0.0",
+            "acorn-walk": "6.1.1",
+            "bfj": "6.1.1",
+            "chalk": "2.3.0",
+            "cldr-core": "36.0.0",
+            "clear-module": "3.1.0",
+            "commander": "2.13.0",
+            "connect-history-api-fallback": "1.6.0",
+            "copy-webpack-plugin": "4.6.0",
+            "cssnano": "4.1.7",
+            "electron": "~7.1.7",
+            "eventsource-polyfill": "0.9.6",
+            "express": "4.16.2",
+            "filesize": "3.5.11",
+            "filter-css": "0.1.2",
+            "fs-extra": "7.0.0",
+            "get-port": "4.0.0",
+            "glob": "^7.1.2",
+            "gzip-size": "4.1.0",
+            "html-webpack-include-assets-plugin": "1.0.6",
+            "istanbul-lib-instrument": "1.10.1",
+            "jsdom": "15.2.0",
+            "loader-utils": "1.1.0",
+            "lodash": "4.17.4",
+            "minimatch": "3.0.4",
+            "mkdirp": "0.5.1",
+            "node-html-parser": "1.1.11",
+            "opener": "1.4.3",
+            "postcss": "7.0.7",
+            "puppeteer": "1.11.0",
+            "recast": "0.12.7",
+            "source-map": "0.6.1",
+            "ts-loader": "5.4.5",
+            "ts-node": "^8.0.3",
+            "typed-css-modules": "0.3.7",
+            "webpack-hot-middleware": "2.24.3",
+            "workbox-webpack-plugin": "3.6.3",
+            "wrapper-webpack-plugin": "2.0.0"
+          },
+          "dependencies": {
+            "chalk": {
+              "version": "2.3.0",
+              "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.0.tgz",
+              "integrity": "sha512-Az5zJR2CBujap2rqXGaJKaPHyJ0IrUimvYNX+ncCy8PJP4ltOGTrHUIo097ZaL2zMeKYpiCdqDvS6zdrTFok3Q==",
+              "dev": true,
+              "requires": {
+                "ansi-styles": "^3.1.0",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^4.0.0"
+              }
+            },
+            "typed-css-modules": {
+              "version": "0.3.7",
+              "resolved": "https://registry.npmjs.org/typed-css-modules/-/typed-css-modules-0.3.7.tgz",
+              "integrity": "sha512-KR1VG/U0rgFWaiQtXKtFMgKaurs80nvlBvZ7BfuYGLldw6kss/97sd+aMG4CI73BbujvefG7DBjnsBqq2Aowcw==",
+              "dev": true,
+              "requires": {
+                "camelcase": "^4.1.0",
+                "chalk": "^2.1.0",
+                "chokidar": "^2.0.3",
+                "css-modules-loader-core": "^1.1.0",
+                "glob": "^7.1.2",
+                "is-there": "^4.4.2",
+                "mkdirp": "^0.5.1",
+                "yargs": "^8.0.2"
+              }
+            }
+          }
+        },
+        "ansi-regex": {
+          "version": "2.1.1",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+          "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+          "dev": true
+        },
         "autoprefixer": {
           "version": "8.6.5",
           "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-8.6.5.tgz",
@@ -963,6 +1451,34 @@
             "num2fraction": "^1.2.2",
             "postcss": "^6.0.23",
             "postcss-value-parser": "^3.2.3"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "browserslist": {
@@ -975,6 +1491,39 @@
             "electron-to-chromium": "^1.3.47"
           }
         },
+        "cliui": {
+          "version": "3.2.0",
+          "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
+          "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
+          "dev": true,
+          "requires": {
+            "string-width": "^1.0.1",
+            "strip-ansi": "^3.0.1",
+            "wrap-ansi": "^2.0.0"
+          },
+          "dependencies": {
+            "string-width": {
+              "version": "1.0.2",
+              "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+              "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+              "dev": true,
+              "requires": {
+                "code-point-at": "^1.0.0",
+                "is-fullwidth-code-point": "^1.0.0",
+                "strip-ansi": "^3.0.0"
+              }
+            },
+            "strip-ansi": {
+              "version": "3.0.1",
+              "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+              "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+              "dev": true,
+              "requires": {
+                "ansi-regex": "^2.0.0"
+              }
+            }
+          }
+        },
         "color": {
           "version": "1.0.3",
           "resolved": "https://registry.npmjs.org/color/-/color-1.0.3.tgz",
@@ -984,6 +1533,12 @@
             "color-convert": "^1.8.2",
             "color-string": "^1.4.0"
           }
+        },
+        "connect-history-api-fallback": {
+          "version": "1.6.0",
+          "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
+          "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+          "dev": true
         },
         "cssdb": {
           "version": "3.2.1",
@@ -1019,7 +1574,90 @@
             "ignore": "^3.3.5",
             "pify": "^3.0.0",
             "slash": "^1.0.0"
+          },
+          "dependencies": {
+            "pify": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+              "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
+              "dev": true
+            }
           }
+        },
+        "has-flag": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-2.0.0.tgz",
+          "integrity": "sha1-6CB68cx7MNRGzHC3NLXovhj4jVE=",
+          "dev": true
+        },
+        "is-fullwidth-code-point": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+          "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+          "dev": true,
+          "requires": {
+            "number-is-nan": "^1.0.0"
+          }
+        },
+        "jsdom": {
+          "version": "15.2.0",
+          "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-15.2.0.tgz",
+          "integrity": "sha512-+hRyEfjRPFwTYMmSQ3/f7U9nP8ZNZmbkmUek760ZpxnCPWJIhaaLRuUSvpJ36fZKCGENxLwxClzwpOpnXNfChQ==",
+          "dev": true,
+          "requires": {
+            "abab": "^2.0.0",
+            "acorn": "^7.1.0",
+            "acorn-globals": "^4.3.2",
+            "array-equal": "^1.0.0",
+            "cssom": "^0.4.1",
+            "cssstyle": "^2.0.0",
+            "data-urls": "^1.1.0",
+            "domexception": "^1.0.1",
+            "escodegen": "^1.11.1",
+            "html-encoding-sniffer": "^1.0.2",
+            "nwsapi": "^2.1.4",
+            "parse5": "5.1.0",
+            "pn": "^1.1.0",
+            "request": "^2.88.0",
+            "request-promise-native": "^1.0.7",
+            "saxes": "^3.1.9",
+            "symbol-tree": "^3.2.2",
+            "tough-cookie": "^3.0.1",
+            "w3c-hr-time": "^1.0.1",
+            "w3c-xmlserializer": "^1.1.2",
+            "webidl-conversions": "^4.0.2",
+            "whatwg-encoding": "^1.0.5",
+            "whatwg-mimetype": "^2.3.0",
+            "whatwg-url": "^7.0.0",
+            "ws": "^7.0.0",
+            "xml-name-validator": "^3.0.0"
+          },
+          "dependencies": {
+            "acorn": {
+              "version": "7.1.1",
+              "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
+              "integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+              "dev": true
+            }
+          }
+        },
+        "load-json-file": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
+          "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.2",
+            "parse-json": "^2.2.0",
+            "pify": "^2.0.0",
+            "strip-bom": "^3.0.0"
+          }
+        },
+        "lodash": {
+          "version": "4.17.4",
+          "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.4.tgz",
+          "integrity": "sha1-eCA6TRwyiuHYbcpkYONptX9AVa4=",
+          "dev": true
         },
         "mini-css-extract-plugin": {
           "version": "0.7.0",
@@ -1031,6 +1669,21 @@
             "normalize-url": "1.9.1",
             "schema-utils": "^1.0.0",
             "webpack-sources": "^1.1.0"
+          }
+        },
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+          "dev": true
+        },
+        "mkdirp": {
+          "version": "0.5.1",
+          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+          "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+          "dev": true,
+          "requires": {
+            "minimist": "0.0.8"
           }
         },
         "normalize-url": {
@@ -1045,16 +1698,29 @@
             "sort-keys": "^1.0.0"
           }
         },
-        "postcss": {
-          "version": "6.0.23",
-          "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
-          "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+        "parse-json": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
+          "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
           "dev": true,
           "requires": {
-            "chalk": "^2.4.1",
-            "source-map": "^0.6.1",
-            "supports-color": "^5.4.0"
+            "error-ex": "^1.2.0"
           }
+        },
+        "path-type": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
+          "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
+          "dev": true,
+          "requires": {
+            "pify": "^2.0.0"
+          }
+        },
+        "pify": {
+          "version": "2.3.0",
+          "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+          "integrity": "sha1-7RQaasBDqEnqWISY59yosVMw6Qw=",
+          "dev": true
         },
         "postcss-attribute-case-insensitive": {
           "version": "3.0.1",
@@ -1064,6 +1730,34 @@
           "requires": {
             "postcss": "^6.0.23",
             "postcss-selector-parser": "^4.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-color-functional-notation": {
@@ -1074,6 +1768,34 @@
           "requires": {
             "postcss": "^6.0.23",
             "postcss-values-parser": "^1.5.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-color-hex-alpha": {
@@ -1085,6 +1807,34 @@
             "color": "^1.0.3",
             "postcss": "^6.0.1",
             "postcss-message-helpers": "^2.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-color-mod-function": {
@@ -1096,6 +1846,34 @@
             "@csstools/convert-colors": "^1.4.0",
             "postcss": "^6.0.23",
             "postcss-values-parser": "^1.5.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-color-rebeccapurple": {
@@ -1106,6 +1884,34 @@
           "requires": {
             "postcss": "^6.0.22",
             "postcss-values-parser": "^1.5.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-custom-media": {
@@ -1115,6 +1921,34 @@
           "dev": true,
           "requires": {
             "postcss": "^6.0.1"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-custom-properties": {
@@ -1125,6 +1959,34 @@
           "requires": {
             "balanced-match": "^1.0.0",
             "postcss": "^6.0.18"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-custom-selectors": {
@@ -1135,6 +1997,34 @@
           "requires": {
             "postcss": "^6.0.1",
             "postcss-selector-matches": "^3.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-dir-pseudo-class": {
@@ -1145,6 +2035,34 @@
           "requires": {
             "postcss": "^6.0.22",
             "postcss-selector-parser": "^4.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-env-function": {
@@ -1155,6 +2073,34 @@
           "requires": {
             "postcss": "^6.0.22",
             "postcss-values-parser": "^1.5.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-focus-visible": {
@@ -1164,6 +2110,34 @@
           "dev": true,
           "requires": {
             "postcss": "^6.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-focus-within": {
@@ -1173,6 +2147,34 @@
           "dev": true,
           "requires": {
             "postcss": "^6.0.21"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-font-variant": {
@@ -1182,6 +2184,34 @@
           "dev": true,
           "requires": {
             "postcss": "^6.0.1"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-gap-properties": {
@@ -1191,6 +2221,34 @@
           "dev": true,
           "requires": {
             "postcss": "^6.0.22"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-image-set-function": {
@@ -1201,6 +2259,34 @@
           "requires": {
             "postcss": "^6.0.22",
             "postcss-values-parser": "^1.5.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-initial": {
@@ -1211,6 +2297,34 @@
           "requires": {
             "lodash.template": "^4.2.4",
             "postcss": "^6.0.1"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-lab-function": {
@@ -1222,6 +2336,34 @@
             "@csstools/convert-colors": "^1.4.0",
             "postcss": "^6.0.23",
             "postcss-values-parser": "^1.5.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-logical": {
@@ -1231,6 +2373,34 @@
           "dev": true,
           "requires": {
             "postcss": "^6.0.20"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-media-minmax": {
@@ -1240,6 +2410,34 @@
           "dev": true,
           "requires": {
             "postcss": "^6.0.1"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-nesting": {
@@ -1249,6 +2447,34 @@
           "dev": true,
           "requires": {
             "postcss": "^6.0.22"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-overflow-shorthand": {
@@ -1258,6 +2484,34 @@
           "dev": true,
           "requires": {
             "postcss": "^6.0.22"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-page-break": {
@@ -1267,6 +2521,34 @@
           "dev": true,
           "requires": {
             "postcss": "^6.0.16"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-place": {
@@ -1277,6 +2559,34 @@
           "requires": {
             "postcss": "^6.0.22",
             "postcss-values-parser": "^1.5.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-preset-env": {
@@ -1318,6 +2628,34 @@
             "postcss-replace-overflow-wrap": "^2.0.0",
             "postcss-selector-matches": "^3.0.1",
             "postcss-selector-not": "^3.0.1"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-pseudo-class-any-link": {
@@ -1328,6 +2666,34 @@
           "requires": {
             "postcss": "^6.0.22",
             "postcss-selector-parser": "^4.0.0"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-replace-overflow-wrap": {
@@ -1337,6 +2703,34 @@
           "dev": true,
           "requires": {
             "postcss": "^6.0.1"
+          },
+          "dependencies": {
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
+            }
           }
         },
         "postcss-selector-matches": {
@@ -1354,6 +2748,32 @@
               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
               "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
               "dev": true
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
             }
           }
         },
@@ -1372,6 +2792,32 @@
               "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-0.4.2.tgz",
               "integrity": "sha1-yz8+PHMtwPAe5wtAPzAuYddwmDg=",
               "dev": true
+            },
+            "has-flag": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+              "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+              "dev": true
+            },
+            "postcss": {
+              "version": "6.0.23",
+              "resolved": "https://registry.npmjs.org/postcss/-/postcss-6.0.23.tgz",
+              "integrity": "sha512-soOk1h6J3VMTZtVeVpv15/Hpdl2cBLX3CAw4TAbkpTJiNPk9YP/zWcD1ND+xEtvyuuvKzbxliTOIyvkSeSJ6ag==",
+              "dev": true,
+              "requires": {
+                "chalk": "^2.4.1",
+                "source-map": "^0.6.1",
+                "supports-color": "^5.4.0"
+              }
+            },
+            "supports-color": {
+              "version": "5.5.0",
+              "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+              "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+              "dev": true,
+              "requires": {
+                "has-flag": "^3.0.0"
+              }
             }
           }
         },
@@ -1403,6 +2849,27 @@
             "uniq": "^1.0.1"
           }
         },
+        "read-pkg": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
+          "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
+          "dev": true,
+          "requires": {
+            "load-json-file": "^2.0.0",
+            "normalize-package-data": "^2.3.2",
+            "path-type": "^2.0.0"
+          }
+        },
+        "read-pkg-up": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
+          "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
+          "dev": true,
+          "requires": {
+            "find-up": "^2.0.0",
+            "read-pkg": "^2.0.0"
+          }
+        },
         "strip-ansi": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
@@ -1410,6 +2877,29 @@
           "dev": true,
           "requires": {
             "ansi-regex": "^3.0.0"
+          },
+          "dependencies": {
+            "ansi-regex": {
+              "version": "3.0.0",
+              "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+              "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+              "dev": true
+            }
+          }
+        },
+        "strip-bom": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-3.0.0.tgz",
+          "integrity": "sha1-IzTBjpx1n3vdVv3vfprj1YjmjtM=",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "4.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
+          "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
+          "dev": true,
+          "requires": {
+            "has-flag": "^2.0.0"
           }
         },
         "ts-loader": {
@@ -1423,6 +2913,63 @@
             "loader-utils": "^1.0.2",
             "micromatch": "^3.1.4",
             "semver": "^5.0.1"
+          }
+        },
+        "ts-node": {
+          "version": "8.9.1",
+          "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.9.1.tgz",
+          "integrity": "sha512-yrq6ODsxEFTLz0R3BX2myf0WBCSQh9A+py8PBo1dCzWIOcvisbyH6akNKqDHMgXePF2kir5mm5JXJTH3OUJYOQ==",
+          "dev": true,
+          "requires": {
+            "arg": "^4.1.0",
+            "diff": "^4.0.1",
+            "make-error": "^1.1.1",
+            "source-map-support": "^0.5.17",
+            "yn": "3.1.1"
+          },
+          "dependencies": {
+            "diff": {
+              "version": "4.0.2",
+              "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+              "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
+              "dev": true
+            }
+          }
+        },
+        "y18n": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/y18n/-/y18n-3.2.1.tgz",
+          "integrity": "sha1-bRX7qITAhnnA136I53WegR4H+kE=",
+          "dev": true
+        },
+        "yargs": {
+          "version": "8.0.2",
+          "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
+          "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0",
+            "cliui": "^3.2.0",
+            "decamelize": "^1.1.1",
+            "get-caller-file": "^1.0.1",
+            "os-locale": "^2.0.0",
+            "read-pkg-up": "^2.0.0",
+            "require-directory": "^2.1.1",
+            "require-main-filename": "^1.0.1",
+            "set-blocking": "^2.0.0",
+            "string-width": "^2.0.0",
+            "which-module": "^2.0.0",
+            "y18n": "^3.2.1",
+            "yargs-parser": "^7.0.0"
+          }
+        },
+        "yargs-parser": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
+          "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
+          "dev": true,
+          "requires": {
+            "camelcase": "^4.1.0"
           }
         }
       }
@@ -1657,9 +3204,9 @@
       }
     },
     "@dojo/framework": {
-      "version": "7.0.0-rc.2",
-      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-rc.2.tgz",
-      "integrity": "sha512-XH6/pLIAofEf+BiwgOyTRiZbmLvKJ2dJweArvVuE21LEbxdli3mf9lAMKki1oe7z3/ph2U0sujT9teGp2+weFA==",
+      "version": "7.0.0-rc.3",
+      "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-rc.3.tgz",
+      "integrity": "sha512-BQcOcwg5JVTRBe5f3dMBCJZvOkZTiujLYF+zw8oFvP5+efBUEJOJz0hjNeO7aftTuqkioxRvtxsUwqf1ieJtsw==",
       "dev": true,
       "requires": {
         "@types/cldrjs": "0.4.20",
@@ -1669,6 +3216,7 @@
         "cldrjs": "^0.5.0",
         "cross-fetch": "3.0.2",
         "css-select-umd": "1.3.0-rc0",
+        "css-vars-ponyfill": "2.3.0",
         "diff": "3.5.0",
         "globalize": "1.4.0",
         "immutable": "3.8.2",
@@ -1861,12 +3409,12 @@
       }
     },
     "@dojo/webpack-contrib": {
-      "version": "7.0.0-rc.1",
-      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-rc.1.tgz",
-      "integrity": "sha512-lr/hTGsqwbpV9iOB5Bge6aa1TLRAQdlkpIs3vUORjy1ywDwFBspWAF4PHdx6jVfb/s98VyIyoTEc/2UYIsbYTA==",
+      "version": "7.0.0-rc.2",
+      "resolved": "https://registry.npmjs.org/@dojo/webpack-contrib/-/webpack-contrib-7.0.0-rc.2.tgz",
+      "integrity": "sha512-HsU5DKbHoMQmF7uVWdrvGKZi+D7u0/Rg4q9UUJqJMjO6Aa/HAYRKHcSPO/+O6+eLzi8mSj72YS0jMZnSFp7MsA==",
       "dev": true,
       "requires": {
-        "@dojo/framework": "7.0.0-rc.1",
+        "@dojo/framework": "7.0.0-rc.3",
         "acorn": "6.1.1",
         "acorn-dynamic-import": "4.0.0",
         "acorn-walk": "6.1.1",
@@ -1908,31 +3456,6 @@
         "wrapper-webpack-plugin": "2.0.0"
       },
       "dependencies": {
-        "@dojo/framework": {
-          "version": "7.0.0-rc.1",
-          "resolved": "https://registry.npmjs.org/@dojo/framework/-/framework-7.0.0-rc.1.tgz",
-          "integrity": "sha512-R5XvxD6Dvpv3CgbiHHBbRJJvSrp1Z73xRwozAKRI2iH3HuG+5UyXJEVfnE6MhtENXJlNkVvkihxbKlyH88CUIg==",
-          "dev": true,
-          "requires": {
-            "@types/cldrjs": "0.4.20",
-            "@types/globalize": "0.0.34",
-            "@webcomponents/webcomponentsjs": "1.1.0",
-            "cldr-core": "36.0.0",
-            "cldrjs": "^0.5.0",
-            "cross-fetch": "3.0.2",
-            "css-select-umd": "1.3.0-rc0",
-            "diff": "3.5.0",
-            "globalize": "1.4.0",
-            "immutable": "3.8.2",
-            "intersection-observer": "0.4.2",
-            "pepjs": "0.4.2",
-            "requirejs-text": "2.0.15",
-            "resize-observer-polyfill": "1.5.0",
-            "tslib": "1.9.3",
-            "web-animations-js": "2.3.1",
-            "wicg-inert": "3.0.0"
-          }
-        },
         "ansi-regex": {
           "version": "2.1.1",
           "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
@@ -1978,6 +3501,12 @@
           "version": "1.6.0",
           "resolved": "https://registry.npmjs.org/connect-history-api-fallback/-/connect-history-api-fallback-1.6.0.tgz",
           "integrity": "sha512-e54B99q/OUoH64zYYRf3HBP5z24G38h5D3qXu23JGRoigpX5Ss4r9ZnDk3g0Z8uQC2x2lPaJ+UlWBc1ZWBWdLg==",
+          "dev": true
+        },
+        "diff": {
+          "version": "4.0.2",
+          "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+          "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
           "dev": true
         },
         "has-flag": {
@@ -2163,14 +3692,6 @@
             "make-error": "^1.1.1",
             "source-map-support": "^0.5.17",
             "yn": "3.1.1"
-          },
-          "dependencies": {
-            "diff": {
-              "version": "4.0.2",
-              "resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-              "integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==",
-              "dev": true
-            }
           }
         },
         "typed-css-modules": {
@@ -8286,6 +9807,12 @@
         "source-map": "^0.6.1"
       }
     },
+    "css-vars-ponyfill": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/css-vars-ponyfill/-/css-vars-ponyfill-2.3.0.tgz",
+      "integrity": "sha512-3f8nyk9tLbpQMaSSMIQKTPplBNF44E/uxmbqq9LC3TETK5Q0eX1FabpDi6QdztDBGEkW7qBamxi/F6qOV90brA==",
+      "dev": true
+    },
     "css-what": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/css-what/-/css-what-2.1.3.tgz",
@@ -9057,9 +10584,9 @@
       }
     },
     "electron-to-chromium": {
-      "version": "1.3.423",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.423.tgz",
-      "integrity": "sha512-jXdnLcawJ/EMdN+j77TC3YyeAWiIjo1U63DFCKrjtLv4cu8ToyoF4HYXtFvkVVHhEtIl7lU1uDd307Xj1/YDjw==",
+      "version": "1.3.425",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.425.tgz",
+      "integrity": "sha512-JTEOWiqCY4snuKuQAaFy0z6LK2Gdb8Lojkd/csQwpNHgMUF8I6QRjGVKk44IH46dHQhUFKzr4o6zxZrtDBjc2Q==",
       "dev": true
     },
     "elegant-spinner": {
@@ -12263,12 +13790,6 @@
       "requires": {
         "loader-utils": "^1.1.0"
       }
-    },
-    "ie11-custom-properties": {
-      "version": "3.0.6",
-      "resolved": "https://registry.npmjs.org/ie11-custom-properties/-/ie11-custom-properties-3.0.6.tgz",
-      "integrity": "sha512-IIyVr9NhUc1LNwxEO9hlfE2Tw7X/dKzuIAXMB+FyJaN18WXxN9yJ3uE+se60nFcjRSfNgntyGuosh4daxaXpsA==",
-      "dev": true
     },
     "ieee754": {
       "version": "1.1.13",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
   },
   "scripts": {
     "dev": "dojo build app -m dev -w -s",
+    "dev:legacy": "dojo build app -m dev -w -s -l",
     "prettier": "prettier --write \"src/**/*.{ts,tsx,css}\"",
     "dojo-package": "dojo-package",
     "dojo-release": "dojo-release",
@@ -28,7 +29,7 @@
     "test:watch": "dojo test --watch",
     "test:ci": "run-s clean build:test test:headless",
     "build:ce": "dojo build widget",
-    "build:docs": "dojo build app -f docs=true",
+    "build:docs": "dojo build app -f docs=true -l",
     "build:themes": "dojo build theme",
     "build:examples": "dojo build app -f docs=true && dojo build app -m dev",
     "build:docs:dev": "dojo build app -m dev -w -s",
@@ -51,15 +52,15 @@
     }
   },
   "peerDependencies": {
-    "@dojo/framework": "7.0.0-rc.2"
+    "@dojo/framework": "7.0.0-rc.3"
   },
   "devDependencies": {
     "@dojo/cli": "7.0.0-rc.1",
-    "@dojo/cli-build-app": "7.0.0-rc.1",
+    "@dojo/cli-build-app": "7.0.0-rc.2",
     "@dojo/cli-build-theme": "7.0.0-rc.1",
     "@dojo/cli-build-widget": "7.0.0-rc.1",
     "@dojo/cli-test-intern": "7.0.0-rc.1",
-    "@dojo/framework": "7.0.0-rc.2",
+    "@dojo/framework": "7.0.0-rc.3",
     "@dojo/parade": "1.0.0-rc.3",
     "@dojo/scripts": "^4.0.3",
     "@material/button": "3.0.0",

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -238,8 +238,11 @@ import * as dojoDarkVariant from '@dojo/widgets/theme/dojo/variants/dark.m.css';
 import * as materialDarkVariant from '@dojo/widgets/theme/material/variants/dark.m.css';
 
 `!has('docs')`;
-import testsContext from './tests';
-const tests = typeof testsContext !== 'undefined' ? testsContext : { keys: () => [] };
+import * as testsContext from './tests';
+const tests =
+	typeof testsContext !== 'undefined' && typeof testsContext.default !== 'undefined'
+		? testsContext.default
+		: { keys: () => [] };
 
 const dojoDarkTheme = {
 	theme: { ...dojoTheme.theme },


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Make the deployment ie11 compatible.