### PR TITLE
Fix format time in IE 11

### DIFF
--- a/src/time-picker/index.tsx
+++ b/src/time-picker/index.tsx
@@ -235,8 +235,8 @@ export const TimePicker = factory(function TimePicker({
 					minute: 'numeric',
 					second: hideSeconds ? undefined : 'numeric'
 				})
-				.replace(/[^a-zA-Z\d:.]/g, '');
-		} else if (format === '12') {
+				.replace(/[^a-zA-Z\d\s:.]/g, '');
+		} else {
 			return time
 				.toLocaleTimeString(undefined, {
 					hour12: true,
@@ -244,15 +244,7 @@ export const TimePicker = factory(function TimePicker({
 					minute: 'numeric',
 					second: hideSeconds ? undefined : 'numeric'
 				})
-				.replace(/[^a-zA-Z\d:.]/g, '');
-		} else {
-			return time
-				.toLocaleTimeString(undefined, {
-					hour: 'numeric',
-					minute: 'numeric',
-					second: hideSeconds ? undefined : 'numeric'
-				})
-				.replace(/[^a-zA-Z\d:.]/g, '');
+				.replace(/[^a-zA-Z\d\s:.]/g, '');
 		}
 	};
 

--- a/src/time-picker/index.tsx
+++ b/src/time-picker/index.tsx
@@ -228,25 +228,31 @@ export const TimePicker = factory(function TimePicker({
 		const hideSeconds = step >= 60 && time.getSeconds() === 0;
 
 		if (format === '24') {
-			return time.toLocaleTimeString(undefined, {
-				hour12: false,
-				hour: 'numeric',
-				minute: 'numeric',
-				second: hideSeconds ? undefined : 'numeric'
-			});
+			return time
+				.toLocaleTimeString(undefined, {
+					hour12: false,
+					hour: 'numeric',
+					minute: 'numeric',
+					second: hideSeconds ? undefined : 'numeric'
+				})
+				.replace(/[^a-zA-Z\d:.]/g, '');
 		} else if (format === '12') {
-			return time.toLocaleTimeString(undefined, {
-				hour12: true,
-				hour: 'numeric',
-				minute: 'numeric',
-				second: hideSeconds ? undefined : 'numeric'
-			});
+			return time
+				.toLocaleTimeString(undefined, {
+					hour12: true,
+					hour: 'numeric',
+					minute: 'numeric',
+					second: hideSeconds ? undefined : 'numeric'
+				})
+				.replace(/[^a-zA-Z\d:.]/g, '');
 		} else {
-			return time.toLocaleTimeString(undefined, {
-				hour: 'numeric',
-				minute: 'numeric',
-				second: hideSeconds ? undefined : 'numeric'
-			});
+			return time
+				.toLocaleTimeString(undefined, {
+					hour: 'numeric',
+					minute: 'numeric',
+					second: hideSeconds ? undefined : 'numeric'
+				})
+				.replace(/[^a-zA-Z\d:.]/g, '');
 		}
 	};
 

--- a/src/time-picker/tests/unit/TimePicker.spec.tsx
+++ b/src/time-picker/tests/unit/TimePicker.spec.tsx
@@ -15,7 +15,6 @@ import { createHarness, compareTheme, stubEvent } from '../../../common/tests/su
 import { Keys } from '../../../common/util';
 import focus from '@dojo/framework/core/middleware/focus';
 import { createResource } from '@dojo/framework/core/resource';
-import TimePicker, { format24HourTime } from '@dojo/widgets/time-picker';
 
 const { describe, it, afterEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
IE injects invisible unicode characters into the output of `toLocaleTimeString`, which breaks the regex.
