### PR TITLE
Removed trivial `onpointerleave` from examples

### DIFF
--- a/src/examples/src/widgets/trigger-popup/Basic.tsx
+++ b/src/examples/src/widgets/trigger-popup/Basic.tsx
@@ -14,11 +14,8 @@ export default factory(function Basic() {
 						trigger: (onToggleOpen) => (
 							<Button onClick={onToggleOpen}>Popup Below</Button>
 						),
-						content: (onClose) => (
-							<div
-								onpointerleave={onClose}
-								styles={{ background: 'red', height: '100px', fontSize: '32px' }}
-							>
+						content: () => (
+							<div styles={{ background: 'red', height: '100px', fontSize: '32px' }}>
 								Hello Below!
 							</div>
 						)
@@ -29,9 +26,8 @@ export default factory(function Basic() {
 						trigger: (onToggleOpen) => (
 							<Button onClick={onToggleOpen}>Popup Above</Button>
 						),
-						content: (onClose) => (
+						content: () => (
 							<div
-								onpointerleave={onClose}
 								styles={{ background: 'green', height: '100px', fontSize: '32px' }}
 							>
 								Hello Above!

--- a/src/examples/src/widgets/trigger-popup/SetWidth.tsx
+++ b/src/examples/src/widgets/trigger-popup/SetWidth.tsx
@@ -11,11 +11,8 @@ export default factory(function SetWidth() {
 			<TriggerPopup position="below" matchWidth={false}>
 				{{
 					trigger: (onToggleOpen) => <Button onClick={onToggleOpen}>Own Width</Button>,
-					content: (onClose) => (
-						<div
-							onpointerleave={onClose}
-							styles={{ background: 'orange', width: '350px', fontSize: '32px' }}
-						>
+					content: () => (
+						<div styles={{ background: 'orange', width: '350px', fontSize: '32px' }}>
 							My Width is 150px!
 						</div>
 					)

--- a/src/examples/src/widgets/trigger-popup/Underlay.tsx
+++ b/src/examples/src/widgets/trigger-popup/Underlay.tsx
@@ -11,11 +11,8 @@ export default factory(function Underlay() {
 			<TriggerPopup position="below" underlayVisible={true}>
 				{{
 					trigger: (onToggleOpen) => <Button onClick={onToggleOpen}>Underlay</Button>,
-					content: (onClose) => (
-						<div
-							onpointerleave={onClose}
-							styles={{ background: 'yellow', height: '150px', fontSize: '32px' }}
-						>
+					content: () => (
+						<div styles={{ background: 'yellow', height: '150px', fontSize: '32px' }}>
 							I'm on a visible underlay
 						</div>
 					)


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
The `onpointerleave` implementation was too trivial for it to work consistently enough in this case. The default behavior of TriggerPopup is sufficient for these examples, so I'm just removing them.

Resolves #1448 
