### PR TITLE
Unfocusable list no longer focuses on scroll

### DIFF
--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -597,6 +597,7 @@ export const List = factory(function List({
 			}}
 			focus={() => shouldFocus}
 			onfocus={onFocus}
+			onpointerdown={focusable ? undefined : (event) => event.preventDefault()}
 			onblur={onBlur}
 			scrollTop={scrollTop}
 			onscroll={(e) => {

--- a/src/list/tests/List.spec.tsx
+++ b/src/list/tests/List.spec.tsx
@@ -37,6 +37,7 @@ describe('List', () => {
 			tabIndex={0}
 			onkeydown={noop}
 			focus={noop}
+			onpointerdown={undefined}
 			onfocus={undefined}
 			onblur={undefined}
 			styles={{ maxHeight: '450px' }}
@@ -349,6 +350,22 @@ describe('List', () => {
 		);
 		h.expect(itemRendererTemplate);
 	});
+
+	it('renders not focusable', () => {
+		const h = harness(() => (
+			<List
+				onValue={noop}
+				resource={resource(animalOptions)}
+				transform={defaultTransform}
+				focusable={false}
+			/>
+		));
+		h.expect(
+			template
+				.setProperty('@root', 'tabIndex', -1)
+				.setProperty('@root', 'onpointerdown', noop)
+		);
+	});
 });
 
 describe('List - Menu', () => {
@@ -367,6 +384,7 @@ describe('List - Menu', () => {
 			tabIndex={0}
 			onkeydown={noop}
 			focus={noop}
+			onpointerdown={undefined}
 			onfocus={undefined}
 			onblur={undefined}
 			styles={{ maxHeight: '450px' }}


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

If the list is marked as `focusable` false, ignore pointer down events so the list does not become focusable when scrolling.

Resolves #1449 
