### PR TITLE
Snap List Scroll via calculated scroll top attribute

### DIFF
--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -602,8 +602,14 @@ export const List = factory(function List({
 			scrollTop={scrollTop}
 			onscroll={(e) => {
 				const newScrollTop = (e.target as HTMLElement).scrollTop;
-				if (scrollTop !== newScrollTop) {
-					icache.set('scrollTop', newScrollTop);
+				const remainder = newScrollTop % itemHeight;
+				let targetTop = newScrollTop - remainder;
+				if (remainder >= itemHeight / 2) {
+					targetTop = newScrollTop - remainder + itemHeight;
+				}
+
+				if (scrollTop !== targetTop) {
+					icache.set('scrollTop', targetTop);
 				}
 			}}
 			styles={rootStyles}

--- a/src/list/list.m.css
+++ b/src/list/list.m.css
@@ -10,4 +10,5 @@
 
 .root {
 	overflow: auto;
+	scroll-behavior: smooth;
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Implements scroll snap via calculated scroll top height. 
The intention was to accomplish this via css `scroll-snap` but this does not appear to work as we are manually setting both `scrollTop` and `translate-y` to facilitate our virtual scrolling window.
Raising this mainly to get feedback on how this feels / performs, it may be that it's too 'janky' and we simply remove it.

Feedback appreciated.

Resolves #1450 
