### PR TITLE
fix: wrap list item result text

### DIFF
--- a/src/theme/dojo/list-item.m.css
+++ b/src/theme/dojo/list-item.m.css
@@ -4,6 +4,9 @@
 	color: var(--color-text-primary);
 	font-family: var(--font-family);
 	cursor: pointer;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .active {

--- a/src/theme/dojo/menu-item.m.css
+++ b/src/theme/dojo/menu-item.m.css
@@ -4,6 +4,9 @@
 	color: var(--color-text-primary);
 	font-family: var(--font-family);
 	cursor: pointer;
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .active {

--- a/src/theme/material/list-item.m.css
+++ b/src/theme/material/list-item.m.css
@@ -2,6 +2,9 @@
 	composes: mdc-list-item from '@material/list/dist/mdc.list.css';
 	background: var(--mdc-raised-surface-background);
 	color: var(--mdc-text-color);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .root:hover {

--- a/src/theme/material/menu-item.m.css
+++ b/src/theme/material/menu-item.m.css
@@ -2,6 +2,9 @@
 	composes: mdc-list-item from '@material/list/dist/mdc.list.css';
 	background: var(--mdc-raised-surface-background);
 	color: var(--mdc-text-color);
+	overflow: hidden;
+	text-overflow: ellipsis;
+	white-space: nowrap;
 }
 
 .root:hover {


### PR DESCRIPTION
**Type:** bugfix

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request adds list item text wrapping to the Dojo and Material themes.

Resolves #1457 

**Preview:**

<img width="659" alt="preview" src="https://user-images.githubusercontent.com/334586/81316825-1317ba80-905a-11ea-9222-9e39bdeeaf77.png">

