### PR TITLE
fix: paginated grid row selection (#1439)

### DIFF
--- a/src/grid/index.ts
+++ b/src/grid/index.ts
@@ -1,30 +1,31 @@
-import WidgetBase from '@dojo/framework/core/WidgetBase';
-import { v, w } from '@dojo/framework/core/vdom';
-import ThemedMixin, { theme, ThemedProperties } from '@dojo/framework/core/mixins/Themed';
-import diffProperty from '@dojo/framework/core/decorators/diffProperty';
-import { DNode } from '@dojo/framework/core/interfaces';
-import { reference } from '@dojo/framework/core/diff';
-import { Store } from '@dojo/framework/stores/Store';
-import Dimensions from '@dojo/framework/core/meta/Dimensions';
-import Resize from '@dojo/framework/core/meta/Resize';
 import './utils';
 
-import { Fetcher, ColumnConfig, GridState, Updater } from './interfaces';
-import {
-	fetcherProcess,
-	pageChangeProcess,
-	sortProcess,
-	filterProcess,
-	updaterProcess,
-	selectionProcess
-} from './processes';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import diffProperty from '@dojo/framework/core/decorators/diffProperty';
+import { reference } from '@dojo/framework/core/diff';
+import { DNode } from '@dojo/framework/core/interfaces';
+import Dimensions from '@dojo/framework/core/meta/Dimensions';
+import Resize from '@dojo/framework/core/meta/Resize';
+import ThemedMixin, { ThemedProperties, theme } from '@dojo/framework/core/mixins/Themed';
+import { v, w } from '@dojo/framework/core/vdom';
+import { Store } from '@dojo/framework/stores/Store';
 
-import Header, { SortRenderer, FilterRenderer } from './Header';
+import * as css from '../theme/grid.m.css';
 import Body from './Body';
 import Footer from './Footer';
-import PaginatedFooter from './PaginatedFooter';
+import Header, { FilterRenderer, SortRenderer } from './Header';
 import PaginatedBody from './PaginatedBody';
-import * as css from '../theme/grid.m.css';
+import PaginatedFooter from './PaginatedFooter';
+import { ColumnConfig, Fetcher, GridState, Updater } from './interfaces';
+import {
+	clearSelectionProcess,
+	fetcherProcess,
+	filterProcess,
+	pageChangeProcess,
+	selectionProcess,
+	sortProcess,
+	updaterProcess
+} from './processes';
 import * as fixedCss from './styles/grid.m.css';
 
 const defaultGridMeta = {
@@ -158,7 +159,10 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 	}
 
 	private _pageChange(page: number) {
-		const { storeId } = this._getProperties();
+		const { pagination, storeId } = this._getProperties();
+		if (pagination) {
+			clearSelectionProcess(this._store)({ id: storeId });
+		}
 		pageChangeProcess(this._store)({ id: storeId, page });
 	}
 
@@ -169,10 +173,12 @@ export default class Grid<S> extends ThemedMixin(WidgetBase)<GridProperties<S>> 
 			this._store.get(this._store.path(storeId, 'meta', 'selection')) || [];
 		const items = [];
 		const data = this._store.get(this._store.path(storeId, 'data', 'pages'));
+		const pageNumber = this._store.get(this._store.path(storeId, 'meta', 'page'));
+
 		for (let i = 0; i < selectedIndexes.length; i++) {
 			const selectedIndex = selectedIndexes[i];
-			const pageNumber = Math.floor(selectedIndex / this._pageSize) + 1;
-			const itemIndex = selectedIndex - (pageNumber - 1) * this._pageSize;
+			const offset = Math.floor(selectedIndex / this._pageSize) + 1;
+			const itemIndex = selectedIndex - (offset - 1) * this._pageSize;
 			if (data[`page-${pageNumber}`]) {
 				items.push(data[`page-${pageNumber}`][itemIndex]);
 			}

--- a/src/grid/tests/unit/Grid.ts
+++ b/src/grid/tests/unit/Grid.ts
@@ -1,23 +1,26 @@
 const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 
-import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/core/vdom';
+import { spy, stub } from 'sinon';
+
 import Dimensions from '@dojo/framework/core/meta/Dimensions';
 import Resize from '@dojo/framework/core/meta/Resize';
+import { v, w } from '@dojo/framework/core/vdom';
 import { Store } from '@dojo/framework/stores/Store';
 import { OperationType } from '@dojo/framework/stores/state/Patch';
 import { Pointer } from '@dojo/framework/stores/state/Pointer';
+import harness from '@dojo/framework/testing/harness';
 
-import Grid from '../../index';
-import * as css from '../../../theme/grid.m.css';
-import * as fixedCss from '../../styles/grid.m.css';
-import { ColumnConfig } from '../../interfaces';
-import { stub, spy } from 'sinon';
 import { MockMetaMixin } from '../../../common/tests/support/test-helpers';
-import Header from '../../Header';
+import * as css from '../../../theme/grid.m.css';
 import Body from '../../Body';
 import Footer from '../../Footer';
+import Header from '../../Header';
+import PaginatedBody from '../../PaginatedBody';
+import PaginatedFooter from '../../PaginatedFooter';
+import Grid from '../../index';
+import { ColumnConfig } from '../../interfaces';
+import * as fixedCss from '../../styles/grid.m.css';
 
 const noop: any = () => {};
 
@@ -706,7 +709,8 @@ describe('Grid', () => {
 				updater: noop,
 				columnConfig,
 				height: 500,
-				onRowSelect: noop
+				onRowSelect: noop,
+				pagination: true
 			})
 		);
 
@@ -757,17 +761,15 @@ describe('Grid', () => {
 							)
 						]
 					),
-					w(Body, {
-						key: 'body',
+					w(PaginatedBody, {
+						key: 'paginated-body',
 						pages: {},
-						totalRows: undefined,
 						pageSize: 100,
 						columnConfig,
 						columnWidths: {
 							id: 500,
 							name: 500
 						},
-						pageChange: noop,
 						updater: noop,
 						fetcher: noop,
 						onScroll: noop,
@@ -776,11 +778,12 @@ describe('Grid', () => {
 						theme: undefined,
 						width: 1000,
 						onRowSelect: noop,
-						selectedRows: [1]
+						selectedRows: [1],
+						pageNumber: 1
 					}),
 					v('div', { key: 'footer' }, [
-						w(Footer, {
-							key: 'footer-row',
+						w(PaginatedFooter, {
+							onPageChange: noop,
 							total: undefined,
 							page: 1,
 							pageSize: 100,

--- a/src/grid/tests/unit/Row.ts
+++ b/src/grid/tests/unit/Row.ts
@@ -1,15 +1,16 @@
 const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 
-import harness from '@dojo/framework/testing/harness';
-import { v, w } from '@dojo/framework/core/vdom';
 import { stub } from 'sinon';
-import Row from '../../Row';
 
-import * as fixedCss from './../../styles/row.m.css';
+import { v, w } from '@dojo/framework/core/vdom';
+import harness from '@dojo/framework/testing/harness';
+
 import * as css from '../../../theme/grid-row.m.css';
-import { ColumnConfig } from '../../interfaces';
+import * as fixedCss from './../../styles/row.m.css';
 import Cell from '../../Cell';
+import Row from '../../Row';
+import { ColumnConfig } from '../../interfaces';
 
 const noop = () => {};
 


### PR DESCRIPTION
**Type:** bugfix

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request back-ports grid-related fixes from #1439 to `@dojo/widgets@^6.2.0`.

References #1461
