### PR TITLE
Initial Readme updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,9 +9,8 @@ These widgets are built using Dojo's widget authoring system [(@dojo/framework/c
 
 - [Usage](#usage)
 - [Features](#features)
+- [Examples](#examples)
 - [Conventions](#conventions)
-  - [Icons](#icons)
-  - [Coding conventions](#coding-conventions)
 - [How Do I Contribute?](#how-do-i-contribute)
     - [Installation](#installation)
     - [Testing](#testing)
@@ -50,86 +49,15 @@ This allows our [`dojo cli`](https://github.com/dojo/cli) build tooling to make 
 
 - All widgets are designed to be accessible. If custom ARIA semantics are required, widgets have an `aria` property that may be passed an object with custom `aria-*` attributes.
 
-- All widgets are fully themeable. Example themes are available in the [@dojo/themes](https://github.com/dojo/themes) repository.
+- All widgets are fully themeable. Example themes are available in the [/theme](https://github.com/dojo/widgets/tree/master/src/theme) folder.
 
 - All widgets support internationalization (`i18n`)
 
-## Widgets
+## Examples
 
-Live examples of current widgets are available in the [widget showcase](https://dojo.github.io/examples/widget-showcase/).
-
-### Form widgets
-[Button](src/button/README.md)
-
-[Calendar](src/calendar/README.md)
-
-[Checkbox/Toggle](src/checkbox/README.md)
-
-[ComboBox](src/combobox/README.md)
-
-[Label](src/label/README.md)
-
-[Listbox](src/listbox/README.md)
-
-[Radio](src/radio/README.md)
-
-[RangeSlider](src/range-slider/README.md)
-
-[Select](src/select/README.md)
-
-[NativeSelect](src/native-select/README.md)
-
-[Slider](src/slider/README.md)
-
-[TextArea](src/text-area/README.md)
-
-[TextInput](src/text-input/README.md)
-
-[TimePicker](src/time-picker/README.md)
-
-### Layout widgets
-[Accordion](src/accordion/README.md)
-
-[SlidePane](src/slide-pane/README.md)
-
-[SplitPane](src/split-pane/README.md)
-
-[TabController](src/tab-controller/README.md)
-
-[TitlePane](src/title-pane/README.md)
-
-### Misc widgets
-[Grid](src/grid/README.md)
-
-[Dialog](src/dialog/README.md)
-
-[GlobalEvent](src/global-event/README.md)
-
-[Icon](src/icon/README.md)
-
-[Progress](src/progress/README.md)
-
-[Toolbar](src/toolbar/README.md)
-
-[Tooltip](src/tooltip/README.md)
+Live examples of current widgets are available at [widgets.dojo.io](https://widgets.dojo.io ).
 
 ## Conventions
-
-### EventHandlers
-
-You can register event handlers that get called when the corresponding events occur by passing the handlers into a widget's `properties`.
-The naming convention for event handlers is as follows:
-
-- if the parent of the widget has the power to decide *if* an event is successful, i.e. can cancel the event, then the child widget will call an event handler in the following format:
-
- `onRequest[X]`, e.g. for a `close` event, the event handler called by the child widget must be called `onRequestClose`
-
- Here the child widget is requesting that the `close` event take place.
-
-- for events that will occur regardless of child/parent interaction, then the `Request` naming convention is dropped:
-
-`on[X]`, e.g. for a `dismiss` event, the event handler called by the child widget must be called `onDismiss`
-
 
 ### Icons
 
@@ -140,7 +68,7 @@ Icon fonts are generated using [IcoMoon](https://icomoon.io/app). If a new icon 
 
 To make use of the new icons it is necessary to update the `icon.m.css` file in the theme folder with the new unicode icon like so:
 
-```
+```css
 .newIcon:before {
 	content: "\f123";
 }
@@ -169,30 +97,6 @@ The range definitions are as follows:
 - **500 +***: Alerts and special cases. Toast notifications could potentially be in this range, or any component important enough to interrupt all other interaction.
 
 
-## How to customize a widget
-
-There are many ways in which you can customize the behavior and appearance of Dojo widgets.
-See the [`core`](https://github.com/dojo/framework/blob/master/src/core/README.md) README for examples of how to customize the theme or a specific CSS class of a widget.
-
-Or can you write your own widget that extends an official widget.
-
-### Extending widgets
-
-Because all Dojo widgets are Classes, you can simply extend the Class to add or change its behavior.
-
-```ts
-export class MyWidget extends Button {
-...
-}
-```
-
-Dojo widgets provide standard extension points to allow you to customize their behavior. For more details, please refer to the [widget authoring system](https://github.com/dojo/framework/blob/master/src/core/README.md#decorator-lifecycle-hooks).
-
-Individual widgets also provide certain types of extension points where applicable:
-- `render*`: Large render functions are split up into multiple smaller pieces that can be more easily overridden to create custom vdom.
-- `getModifierClasses`: Modify the array of conditionally applied classes like `css.selected` or `css.disabled`.
-Not all widgets include these extension points, and some have additional overridable methods.
-
 ## Widget Variants
 
 When writing a widget variant, ie. `RaisedButton`, you should ensure that you use `theme.compose` from the widget [theme middleware](https://github.com/dojo/widgets/blob/master/src/middleware/theme.ts). This allows your variant to interit css from it's base widget whilst allowing it to be themed separately.
@@ -201,8 +105,6 @@ When writing a widget variant, ie. `RaisedButton`, you should ensure that you us
 
 We appreciate your interest!  Please see the [Dojo Meta Repository](https://github.com/dojo/meta#readme) for the
 Contributing Guidelines and Style Guide.
-
-Note that all changes to widgets should work with the [dojo theme](https://github.com/dojo/themes/). To test this start the example page (instructions at [Installation](#installation) section) and select the dojo option at the top of the page.
 
 ### Installation
 
@@ -220,9 +122,9 @@ To test locally in node run:
 
 `npm run test`
 
-### Widget Examples
+### Adding Examples
 
-The Dojo widget examples application is located in `src/examples`.
+We use [Parade](https://github.com/dojo/parade) to showcase our widget examples. The latest deployment of this can be found at [widgets.dojo.io](https://widgets.dojo.io ).
 
 To add a new example, create a directory that matches the directory name of the widget e.g. `src/examples/src/widgets/text-input`. Each widget _must_ have an example called `Basic.tsx` and an entry in the `src/examples/src/config.ts` keyed by the name of the widget directory. The widget example should import widgets from `@dojo/widgets` and not via a relative import. It is very important that the config entry name (ie. `text-input`) matches the folder name / css file name of the widget otherwise the doc build will fail.
 
@@ -271,6 +173,7 @@ interface ExampleProperties {
     /** This is the description for bar */
     bar: string;
 }
+```
 
 To build the documentation run `npm run build:docs` and to build and serve the documentation in watch mode run `npm run build:docs:dev`
 
@@ -280,4 +183,4 @@ The examples also run on Codesanbox, to run the examples on the master branch go
 
 ## Licensing information
 
-© 2018 [JS Foundation](https://js.foundation/). [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.
+© 2020 [JS Foundation](https://js.foundation/). [New BSD](http://opensource.org/licenses/BSD-3-Clause) license.

--- a/README.md
+++ b/README.md
@@ -57,33 +57,77 @@ This allows our [`dojo cli`](https://github.com/dojo/cli) build tooling to make 
 
 Live examples of current widgets are available at [widgets.dojo.io](https://widgets.dojo.io ).
 
-## Conventions
+## Writing widgets
 
-### Icons
+### Properties
+TBD
 
-We use [font awesome](http://fontawesome.io/) for icons.
-Where a theme requires specific icons that are not part of the Font Awesome set, then those themes will ship their own icons.
+### Event callbacks
+TBD
 
-Icon fonts are generated using [IcoMoon](https://icomoon.io/app). If a new icon is required, it is possible to upload the current `dojoSelect.json` from `src/theme/fonts` and then add new icons by selecting from the Font Awesome library. After selecting the new icons from the library, merge them down into the current icon set, then delete the rest of the Font Awesome icons that were added by IcoMoon. After this you can export and download them as a zip. Once downloaded you will also need to unzip them and replace the font files (svg, woff, ttf) in `src/theme/fonts`. Now download the new selection JSON file from the `projects` page of IcoMoon and replace the current `dojoSelection.json` file.
+### Control patterns
+TBD
 
-To make use of the new icons it is necessary to update the `icon.m.css` file in the theme folder with the new unicode icon like so:
+#### Partial control
+TBD
 
-```css
-.newIcon:before {
-	content: "\f123";
-}
-```
+#### Fully controlled
+TBD
 
-Where `\f123` is the unicode character for the new icon. To check the new icon works you can render it in the `src/widgets/examples/icon/Basic.tsx` to make sure everything renders correctly.
+### Children
+TBD
 
-There is an [icon widget](src/icon/README.md) that aids in creating in proper semantics and provides type-checking for the type of icon.
+#### Normal children
+TBD
 
-### Coding conventions
+#### Named children
+TBD
+
+#### Child render functions
+TBD
+
+### Types of widgets
+TBD
+
+#### Form Inputs
+TBD
+
+- name / value
+- native form submissions
+#### Containers
+TBD
+
+- child renders
+- avoiding functions where possible
+#### Grouping
+TBD
+
+- radio / checkbox groups
+- middleware
+- custom child renderers
+### Custom Elements
+TBD
+
+#### Simple children / named children over child renderers
+TBD
+
+- usage differences
+- slots
+#### Attributes over properties
+TBD
+
+### Styling
+TBD
+
+#### CSS modules
+TBD
+
+#### CSS unit conventions
 
 `px vs. em` - we specify font sizes in `px`.
 When creating a widget, spacing (margin, padding) should be specified using `px` unless the design calls for proportional spacing, in which case `em` can be used.
 
-### Z-index layering
+#### Z-index layering
 
 Widgets adhere to a basic convention for using specific ranges of z-index values based on function and visual context. This convention is followed in both individual widget CSS and in the Dojo theme styles. These values can be overridden in a custom theme if necessary since no `z-index` values are set in fixed styles.
 
@@ -96,31 +140,39 @@ The range definitions are as follows:
 - **400 - 500**: Dialogs and other full-page overlays. Slide panes are another good example of a common UI pattern in this range. It includes any widget that is intended to cover all page content, or that often is used with an underlay.
 - **500 +***: Alerts and special cases. Toast notifications could potentially be in this range, or any component important enough to interrupt all other interaction.
 
+### Theming
+TBD
 
-## Widget Variants
+#### Theme classes
+TBD
 
+#### Theme variants
+TBD
+
+#### Theme composition
+TBD
+
+### Pointer events
+TBD
+
+### Widget state
+TBD
+
+### Widget variants
+TBD
 When writing a widget variant, ie. `RaisedButton`, you should ensure that you use `theme.compose` from the widget [theme middleware](https://github.com/dojo/widgets/blob/master/src/middleware/theme.ts). This allows your variant to interit css from it's base widget whilst allowing it to be themed separately.
 
-## How do I contribute?
-
-We appreciate your interest!  Please see the [Dojo Meta Repository](https://github.com/dojo/meta#readme) for the
-Contributing Guidelines and Style Guide.
-
-### Installation
-
-To start working with this package, clone the repository and run `npm install`.
-
-In order to build the project run `npm run build`.
-
 ### Testing
+TBD
 
-Test cases MUST be written using [Intern](https://theintern.github.io) using the Object test interface and Assert assertion interface.
+#### Unit Tests
+TBD
 
-90% branch coverage MUST be provided for all code submitted to this repository, as reported by istanbul’s combined coverage results for all supported platforms.
+#### Harness
+TBD
 
-To test locally in node run:
-
-`npm run test`
+#### Assertion templates
+TBD
 
 ### Adding Examples
 
@@ -156,9 +208,30 @@ To add a new example, create a directory that matches the directory name of the 
 
  To view the examples locally run `npm run dev` in the root directory and navigate to http://localhost:9999, this starts the examples in watch mode and should update widget module are changed. Note that you do not have to install dependencies in the `src/examples` project, this will result in an error.
 
+## How do I contribute?
+
+We appreciate your interest!  Please see the [Dojo Meta Repository](https://github.com/dojo/meta#readme) for the
+Contributing Guidelines and Style Guide.
+
+### Installation
+
+To start working with this package, clone the repository and run `npm install`.
+
+In order to build the project run `npm run build`.
+
+### Testing
+
+Test cases MUST be written using [Intern](https://theintern.github.io) using the Object test interface and Assert assertion interface.
+
+90% branch coverage MUST be provided for all code submitted to this repository, as reported by istanbul’s combined coverage results for all supported platforms.
+
+To test locally in node run:
+
+`npm run test`
+
 ### Widget Documentation
 
-The widget examples and documentation is automatically generated by the `examples` application when built with the `docs` feature flag set to `true`. The site relies on a few conventions in order to be able do this:
+The widget examples and documentation is automatically generated by the `parade` application when built with the `docs` feature flag set to `true`. The site relies on a few conventions in order to be able do this:
 
 1. A widgets properties interface must be the name of the widget with a suffix of `Properties`, e.g. for `text-input` the properties interface would be `TextInputProperties`
 2. The widget properties must be exported to ensure they are visible in the generated widget documentation.

--- a/README.md
+++ b/README.md
@@ -59,6 +59,8 @@ Live examples of current widgets are available at [widgets.dojo.io](https://widg
 
 ## Writing widgets
 
+When writing a widget there are multiple thing to consider. From accessibility to usability. This section covers
+
 ### Properties
 - defining properties
 - passing properties
@@ -128,15 +130,6 @@ If the widget doesn’t need to determine where the children are rendered, or wh
 </ParentWidget>
 ```
 
-#### Child render functions
-When a widget needs to inject functions or properties into the child widgets, a child function should be used:
-
-```tsx
-<ParentWidget>
-	{ (foo) => <ChildWidget foo={foo('a')} /> }
-</ParentWidget>
-```
-
 #### Named children
 When multiple children are accepted and are to be placed in different locations by the parent widget, a child object should be used. This approach is use for example in our Card widget as it accepts content for different sections of the card and renders them in the appropriate locations with wrapping styles / classes. The child object can contain a mix of both RenderResult and functions that return a RenderResult.
 
@@ -147,6 +140,19 @@ When multiple children are accepted and are to be placed in different locations 
 	baz: 'hello, world'
 }}</ParentWidget>
 ```
+
+#### Child render functions
+When a widget needs to inject functions or properties into the child widgets, a child function should be used:
+
+```tsx
+<ParentWidget>
+	{ (foo) => <ChildWidget foo={foo('a')} /> }
+</ParentWidget>
+```
+
+#### Named child render functions
+
+
 
 ### Types of widgets
 

--- a/README.md
+++ b/README.md
@@ -60,67 +60,140 @@ Live examples of current widgets are available at [widgets.dojo.io](https://widg
 ## Writing widgets
 
 ### Properties
-TBD
+- defining properties
+- passing properties
+- reading properties
 
 ### Event callbacks
-TBD
+- defining callbacks
+- passing callbacks
+- using event callbacks
 
 ### Control patterns
-TBD
+
+Widgets should work out of the box wherever possible and be easy to use without needing to be fully controlled. What we mean by this is that a widget should be able to manage it's own state and perform as would a native input component when placed on a page. As a result, we have re-written most of our widgets to use the icache middleware and maintain their own state.
+
+```tsx
+// place uncontrolled text-input on a page
+<TextInput />
+```
+
+Most widgets offer both partial and fully controlled properties and callbacks as covered below.
 
 #### Partial control
-TBD
+
+Partially controlled widgets accept properties prefixed with `initial`, the most common of which is `initialValue`. This will allow you to pass an initial value to a widget without needing to write a feedback function that constantly re-set's the value each time it's changed. If the `initialValue` changes from it's previous value, then the widget should react to this change and display the new value.
+
+```tsx
+// text-input with initial value of foo
+<TextInput initialValue='foo' />
+```
 
 #### Fully controlled
-TBD
+
+Fully controlled widget properties are those which are **not** prefixed with `initial`. For example, if you were to set a `value` property on the above `TextInput` example without keeping it upto date each time it's accompanying `onValue` callback is called.
+The lower level inputs, text-input, radio and checkbox are the exceptions to the "uncontrolled" approach as they are generally used as building blocks for more specialised widgets. For example, text-input allows you to control validation whereas the email-input, which utilises a text-input internally, is uncontrolled and manages its own validation state.
+In the same fashion, checkboxes and radio buttons are fully controlled but we anticipate them to be used most frequently via checkbox-group and radio-group, both of which are partially controlled and follow the same initialValue pattern as other input widgets.
+
+```tsx
+// controlled input
+let value = 'foo';
+<TextInput value={value} onValue={(newValue) => { value = newValue; invalidator(); }} />
+
+// uncontrolled input
+<TextInput initialValue={'foo'} />
+```
 
 ### Children
 TBD
 
 #### Normal children
-TBD
+If a node is rendered inside a widget, it should be passed as a child rather than via a child renderer. This child could be any RenderResult.
 
-#### Named children
-TBD
+If the widget doesn’t need to determine where the children are rendered, or when they are rendered in a single location, then normal children are fine.
+
+```tsx
+<ParentWidget>
+	<ChildWidget />
+</ParentWidget>
+
+<ParentWidget>
+	<ChildWidget />
+	<ChildWidget />
+	<ChildWidget />
+</ParentWidget>
+
+<ParentWidget>
+	Hello, World
+</ParentWidget>
+```
 
 #### Child render functions
-TBD
+When a widget needs to inject functions or properties into the child widgets, a child function should be used:
+
+```tsx
+<ParentWidget>
+	{ (foo) => <ChildWidget foo={foo('a')} /> }
+</ParentWidget>
+```
+
+#### Named children
+When multiple children are accepted and are to be placed in different locations by the parent widget, a child object should be used. This approach is use for example in our Card widget as it accepts content for different sections of the card and renders them in the appropriate locations with wrapping styles / classes. The child object can contain a mix of both RenderResult and functions that return a RenderResult.
+
+```tsx
+<ParentWidget>{{
+	foo: (foo) => <ChildWidget foo={foo('a')} />,
+	bar: <span>bar</span>,
+	baz: 'hello, world'
+}}</ParentWidget>
+```
 
 ### Types of widgets
-TBD
 
 #### Form Inputs
-TBD
 
+- intro
 - name / value
 - native form submissions
-#### Containers
-TBD
+- render result label
+- example
 
-- child renders
+#### Containers
+
+- intro
+- child renders / slots
 - avoiding functions where possible
+- example
+
 #### Grouping
-TBD
 
 - radio / checkbox groups
+- name / value / native forms
 - middleware
 - custom child renderers
+- example
+
 ### Custom Elements
-TBD
+
+- intro - widgets are released as custom elements as well
+- designed for ease of use
+- add to dojorc
 
 #### Simple children / named children over child renderers
-TBD
-
 - usage differences
 - slots
+
 #### Attributes over properties
-TBD
+- attributes directly on the widget
+- props have to be set
 
 ### Styling
-TBD
 
 #### CSS modules
-TBD
+- simple class names
+- avoid bem
+- variables can be used but not imported
+- don't use tag selectors
 
 #### CSS unit conventions
 
@@ -141,38 +214,69 @@ The range definitions are as follows:
 - **500 +***: Alerts and special cases. Toast notifications could potentially be in this range, or any component important enough to interrupt all other interaction.
 
 ### Theming
-TBD
+
+- intro
+- theme structure
+- variants (link to section)
 
 #### Theme classes
-TBD
+
+- intro
+- theme middleware
+- theme.classes
+- fixed classes reference
+- example
 
 #### Theme variants
-TBD
+
+- structure
+- usage
+- example
 
 #### Theme composition
-TBD
+
+- intro
+- variant use
+- prefix use
+- example
 
 ### Pointer events
-TBD
+
+- intro
+- example
 
 ### Widget state
-TBD
+
+- intro
+- icache
+- example
 
 ### Widget variants
-TBD
+
+- link back to theme-variants
+
 When writing a widget variant, ie. `RaisedButton`, you should ensure that you use `theme.compose` from the widget [theme middleware](https://github.com/dojo/widgets/blob/master/src/middleware/theme.ts). This allows your variant to interit css from it's base widget whilst allowing it to be themed separately.
 
 ### Testing
-TBD
+
+- intern
+- coverage
 
 #### Unit Tests
-TBD
+
+- sinon
+- assert chai
+- example
 
 #### Harness
-TBD
+
+- link to harness docs
+- example
 
 #### Assertion templates
-TBD
+
+- intro
+- example
 
 ### Adding Examples
 
@@ -209,6 +313,8 @@ To add a new example, create a directory that matches the directory name of the 
  To view the examples locally run `npm run dev` in the root directory and navigate to http://localhost:9999, this starts the examples in watch mode and should update widget module are changed. Note that you do not have to install dependencies in the `src/examples` project, this will result in an error.
 
 ## How do I contribute?
+
+TODO: Where does this live now?
 
 We appreciate your interest! Please see the [Dojo Meta Repository](https://github.com/dojo/meta#readme) for the
 Contributing Guidelines and Style Guide.

--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ To add a new example, create a directory that matches the directory name of the 
 
 ## How do I contribute?
 
-We appreciate your interest!  Please see the [Dojo Meta Repository](https://github.com/dojo/meta#readme) for the
+We appreciate your interest! Please see the [Dojo Meta Repository](https://github.com/dojo/meta#readme) for the
 Contributing Guidelines and Style Guide.
 
 ### Installation

--- a/src/icon/README.md
+++ b/src/icon/README.md
@@ -1,3 +1,18 @@
 # @dojo/widgets/icon
 
 Dojo's `Icon` widget renders one of Dojo's predefined font icons.
+
+We use [font awesome](http://fontawesome.io/) for icons.
+Where a theme requires specific icons that are not part of the Font Awesome set, then those themes will ship their own icons.
+
+Icon fonts are generated using [IcoMoon](https://icomoon.io/app). If a new icon is required, it is possible to upload the current `dojoSelect.json` from `src/theme/fonts` and then add new icons by selecting from the Font Awesome library. After selecting the new icons from the library, merge them down into the current icon set, then delete the rest of the Font Awesome icons that were added by IcoMoon. After this you can export and download them as a zip. Once downloaded you will also need to unzip them and replace the font files (svg, woff, ttf) in `src/theme/fonts`. Now download the new selection JSON file from the `projects` page of IcoMoon and replace the current `dojoSelection.json` file.
+
+To make use of the new icons it is necessary to update the `icon.m.css` file in the theme folder with the new unicode icon like so:
+
+```css
+.newIcon:before {
+	content: "\f123";
+}
+```
+
+Where `\f123` is the unicode character for the new icon. To check the new icon works you can render it in the `src/widgets/examples/icon/Basic.tsx` to make sure everything renders correctly.


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Initial work on the widgets readme.
- Adds outline for upcoming sections
- Removes deprecated info re. class extension
- Changes examples refs to parade
- Change themes repo refs 
- Moves icon info to icon readme
- Removes list of widget readme
- Updates licence year to 2020

Work towards https://github.com/dojo/widgets/issues/1223