### PR TITLE
Fix Material Chip typeahead styles

### DIFF
--- a/src/theme/material/chip-typeahead.m.css
+++ b/src/theme/material/chip-typeahead.m.css
@@ -14,11 +14,14 @@
 }
 
 .value {
-	margin: 2px;
+	margin-bottom: 2px;
+	margin-right: 2px;
+	/* nasty !important needed to override the material 32px */
+	height: 28px !important;
 }
 
 .root.hasLabel .wrapper .inputWrapper .input {
-	padding: 20px 16px 6px;
+	padding: 0px 16px 6px;
 }
 
 .selectedIcon {
@@ -35,9 +38,10 @@
 	display: flex;
 	flex-wrap: wrap;
 	align-items: center;
+	padding-top: 20px;
 }
 
-.value {
+.values .value {
 	margin: 4px 4px 4px 0;
 }
 
@@ -54,16 +58,12 @@
 	padding-left: 16px;
 }
 
-.root.hasValue.hasLabel .inputWrapper {
-	padding-top: 24px;
-}
-
 .root .wrapper {
 	height: auto;
 }
 
 .root .input {
-	height: auto;
+	height: 36px;
 	padding-left: 16px;
 }
 
@@ -73,5 +73,4 @@
 
 .values {
 	padding-left: 16px;
-	padding-top: 4px;
 }

--- a/src/theme/material/chip-typeahead.m.css.d.ts
+++ b/src/theme/material/chip-typeahead.m.css.d.ts
@@ -7,6 +7,6 @@ export const wrapper: string;
 export const inputWrapper: string;
 export const input: string;
 export const selectedIcon: string;
+export const values: string;
 export const label: string;
 export const hasValue: string;
-export const values: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixes mis-aligned text input for chip-typeahead and ensures the height does not jump when chips are added.
