### PR TITLE
Fixed broken Material tab theme

### DIFF
--- a/src/tab-container/index.tsx
+++ b/src/tab-container/index.tsx
@@ -3,6 +3,7 @@ import i18n from '@dojo/framework/core/middleware/i18n';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import theme from '@dojo/framework/core/middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
+import Icon from '../icon';
 
 import commonBundle from '../common/nls/common';
 import { formatAriaProperties, Keys } from '../common/util';
@@ -153,7 +154,7 @@ export const TabContainer = factory(function TabContainer({
 								}
 							}}
 						>
-							{messages.close}
+							<Icon type="closeIcon" altText={messages.close} />
 						</button>
 					) : null}
 					<span classes={[themeCss.indicator, active && themeCss.indicatorActive]}>

--- a/src/tab-container/index.tsx
+++ b/src/tab-container/index.tsx
@@ -154,7 +154,7 @@ export const TabContainer = factory(function TabContainer({
 								}
 							}}
 						>
-							<Icon type="closeIcon" altText={messages.close} />
+							<Icon type="closeIcon" altText={messages.close} size="small" />
 						</button>
 					) : null}
 					<span classes={[themeCss.indicator, active && themeCss.indicatorActive]}>

--- a/src/tab-container/tests/TabContainer.spec.tsx
+++ b/src/tab-container/tests/TabContainer.spec.tsx
@@ -6,6 +6,7 @@ import * as sinon from 'sinon';
 import { tsx } from '@dojo/framework/core/vdom';
 
 import { Keys } from '../../common/util';
+import Icon from '../../icon';
 import TabContainer from '../index';
 import * as css from '../../theme/default/tab-container.m.css';
 import {
@@ -193,6 +194,56 @@ registerSuite('TabContainer', {
 					<div>tab1</div>
 				</TabContainer>
 			));
+
+			h.expect(
+				baseTemplate
+					.setChildren('@buttons', () => [
+						<div
+							{...tabButtonProperties}
+							classes={[css.tabButton, css.activeTabButton, null, null]}
+						>
+							<span key="tabButtonContent" classes={css.tabButtonContent}>
+								tab0
+								<span classes={[css.indicator, css.indicatorActive]}>
+									<span classes={css.indicatorContent} />
+								</span>
+							</span>
+						</div>,
+						<div
+							{...tabButtonProperties}
+							aria-controls="test-tab-1"
+							key="1-tabbutton"
+							aria-selected="false"
+							classes={[css.tabButton, null, css.closeable, null]}
+							tabIndex={-1}
+						>
+							<span key="tabButtonContent" classes={css.tabButtonContent}>
+								tab1
+								<button
+									disabled={undefined}
+									tabIndex={-1}
+									classes={css.close}
+									key="1-tabbutton-close"
+									type="button"
+									onclick={noop}
+								>
+									<Icon type="closeIcon" altText="close" size="small" />
+								</button>
+								<span classes={[css.indicator, false]}>
+									<span classes={css.indicatorContent} />
+								</span>
+							</span>
+						</div>
+					])
+					.setChildren('@tabs', () => [
+						<div classes={css.tab} hidden={false}>
+							<div>tab0</div>
+						</div>,
+						<div classes={undefined} hidden={true}>
+							<div>tab1</div>
+						</div>
+					])
+			);
 
 			h.trigger('@1-tabbutton-close', 'onclick', mockClickEvent);
 			assert.isTrue(onCloseStub.calledOnceWith(1));

--- a/src/theme/dojo/tab-container.m.css
+++ b/src/theme/dojo/tab-container.m.css
@@ -66,12 +66,6 @@
 	transform: translateY(-50%);
 }
 
-.close:after {
-	content: '✕';
-	display: block;
-	font-size: var(--font-size-small);
-}
-
 .closeable {
 	padding-right: calc(var(--font-size-small) + 6px);
 }

--- a/src/theme/material/tab-container.m.css
+++ b/src/theme/material/tab-container.m.css
@@ -33,7 +33,7 @@
 	composes: nativeResetRoot from './button.m.css';
 	position: absolute;
 	top: 50%;
-	transform: translateY(-50%) scale(0.7);
+	transform: translateY(-50%);
 	right: 5px;
 	cursor: pointer;
 	padding: 1px 3px;

--- a/src/theme/material/tab-container.m.css
+++ b/src/theme/material/tab-container.m.css
@@ -33,18 +33,11 @@
 	composes: nativeResetRoot from './button.m.css';
 	position: absolute;
 	top: 50%;
-	transform: translateY(-50%);
+	transform: translateY(-50%) scale(0.7);
 	right: 5px;
 	cursor: pointer;
 	padding: 1px 3px;
 	margin-top: -1px;
-}
-
-.close:after {
-	content: '✕';
-	display: block;
-	font-size: 14px;
-	line-height: 14px;
 }
 
 /* TAB INDICATOR */


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Replaced tab "close" with Icon:

Dojo Theme:
![image](https://user-images.githubusercontent.com/41762295/81967431-e67b1a00-95e8-11ea-92dc-3c108faf576a.png)

Material Theme:
![image](https://user-images.githubusercontent.com/41762295/81967442-ebd86480-95e8-11ea-96a5-5843318f02ad.png)



Resolves #1468 
