### PR TITLE
Add example of Collapsible Header using toolbar using Header and SlidePane

### DIFF
--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -410,6 +410,72 @@ The `Header` no longer auto-collapses action items into a `SlidePane`. Instead, 
 </Header>
 ```
 
+#### Example of pevious responsive toolbar behaviour using `Header` and `SlidePane`
+
+```tsx
+import { create, tsx } from '@dojo/framework/core/vdom';
+import theme from '@dojo/framework/core/middleware/theme';
+import breakpoint from '@dojo/framework/core/middleware/breakpoint';
+import icache from '@dojo/framework/core/middleware/icache';
+import { Header } from '@dojo/widgets/header';
+import { SlidePane } from '@dojo/widgets/slide-pane';
+import { Icon } from '@dojo/widgets/icon';
+import * as css from './CollapsingHeader.m.css';
+
+const factory = create({ theme, breakpoint, icache });
+export default factory(function CollapsingHeader({ middleware: { theme, breakpoint, icache } }) {
+
+	const size = breakpoint.get('root');
+	const open = icache.getOrSet('open', false);
+	const collapse = size && (size.breakpoint === 'SM' || size.breakpoint === 'MD');
+
+	const appTitle = 'My App';
+	const actions = (
+		<virtual>
+			<a classes={css.action}>foo</a>
+			<a classes={css.action}>bar</a>
+			<a classes={css.action}>baz</a>
+		</virtual>
+	);
+
+	return (
+		<div key='root' classes={[css.root, theme.variant()]}>
+			<Header>{{
+				title: appTitle,
+				actions: !collapse && <div classes={css.headerActions}>{ actions }</div>,
+				leading: collapse && 
+					<button onclick={() => { icache.set('open', !open) }} type='button'>
+						<Icon size='large' type='barsIcon' />
+					</button>
+			}}</Header>
+			{collapse && 
+				<SlidePane title={appTitle} open={open} onRequestClose={() => { icache.set('open', false)}}>
+					<div classes={css.collapsedActions}>
+						{ actions }
+					</div>				
+				</SlidePane>
+			}
+		</div>
+	);
+});
+```
+
+```css
+.headerActions {
+	display: flex;
+	flex-direction: row;
+}
+
+.collapsedActions {
+	display: flex;
+	flex-direction: column;
+}
+
+.action {
+	padding: 10px;
+}
+```
+
 Latest example can be found at [widgets.dojo.io/#widget/header/overview](https://widgets.dojo.io/#widget/header/overview)
 
 ---

--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -410,7 +410,7 @@ The `Header` no longer auto-collapses action items into a `SlidePane`. Instead, 
 </Header>
 ```
 
-#### Example of pevious responsive toolbar behaviour using `Header` and `SlidePane`
+#### Example of responsive toolbar behaviour using `Header` and `SlidePane`
 
 ```tsx
 import { create, tsx } from '@dojo/framework/core/vdom';


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Add example of creating a collapsible header that repliates the previous `Toolbar` functionality using a header and a slide pane.
