### PR TITLE
Add example of using resources within a class based widget to migration guide

### DIFF
--- a/docs/V7-Migration-Guide.md
+++ b/docs/V7-Migration-Guide.md
@@ -699,6 +699,78 @@ const resource = createResource(createMemoryTemplate());
 
 Latest example can be found at [widgets.dojo.io/#widget/select/overview](https://widgets.dojo.io/#widget/select/overview)
 
+#### Example using select and resource within a class-based widget
+
+To use a widget that requires a resource within a class-bassed widget, you must inject the resource middleware via a wrapping widget.
+An example of this approach can be seen below. (Example taken from [github.com/agubler/dojo-resource-wrapper](https://github.com/agubler/dojo-resource-wrapper))
+
+```tsx
+// Resource wrapper
+import { create } from '@dojo/framework/core/vdom';
+import { createResourceMiddleware } from '@dojo/framework/core/middleware/resources';
+import { RenderResult } from '@dojo/framework/core/interfaces';
+
+const resourceMiddleware = createResourceMiddleware();
+
+const factory = create({ resource: resourceMiddleware }).children<(resource: ReturnType<typeof resourceMiddleware>['api']) => RenderResult>();
+
+export default factory(function ResourceWrapper({ middleware: { resource }, children }) {
+    const [renderer] = children();
+    return renderer(resource);
+});
+```
+
+```tsx
+// Resource wrapper use within a class
+import renderer, { w, v } from '@dojo/framework/core/vdom';
+import { uuid } from '@dojo/framework/core/util';
+import WidgetBase from '@dojo/framework/core/WidgetBase';
+import watch from '@dojo/framework/core/decorators/watch';
+import Select from '@dojo/widgets/select';
+import theme from '@dojo/widgets/theme/dojo';
+import Registry from '@dojo/framework/core/Registry'
+import { registerThemeInjector } from '@dojo/framework/core/mixins/Themed';
+import { createMemoryResourceTemplate } from '@dojo/framework/core/middleware/resources';
+import ResourceWrapper from './ResourceWrapper';
+
+interface Animals {
+    value: string;
+}
+
+const template = createMemoryResourceTemplate<Animals>()
+
+class App extends WidgetBase {
+    @watch()
+    private _selectedValue = '';
+
+    private _id = uuid();
+
+    private _onValue = (value: string) => {
+        this._selectedValue = value;
+    }
+
+    render() {
+        return (
+            v('div', [
+                w(ResourceWrapper, {}, [(resource) => {
+                    return w(Select, {
+                        resource: resource({ template,  initOptions: { id: this._id, data: [{ value: 'panda'} ] }}),
+                        onValue: this._onValue
+                    })
+                }]),
+                v('div', [this._selectedValue])
+            ])
+        );
+    }
+}
+
+const registry = new Registry();
+registerThemeInjector(theme, registry)
+
+const r = renderer(() => w(App, {}));
+r.mount({ registry });
+```
+
 ---
 
 ### SlidePane


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adds an example of using a resource widget (Select) within a class-based widget parent.
This uses the resource-wrapper founds [here](https://github.com/agubler/dojo-resource-wrapper)
