### PR TITLE
Add result widget to dojorc

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -43,6 +43,7 @@
 			"src/radio-group",
 			"src/raised-button",
 			"src/range-slider",
+			"src/result",
 			"src/select",
 			"src/slide-pane",
 			"src/slider",


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds the result widget to `.dojorc`
Resolves #1475 