### PR TITLE
Fix example imports in examples

### DIFF
--- a/src/examples/src/widgets/chip-typeahead/Basic.tsx
+++ b/src/examples/src/widgets/chip-typeahead/Basic.tsx
@@ -1,6 +1,6 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import ChipTypeahead from '@dojo/widgets/chip-typeahead';
-import states from '@dojo/widgets/examples/src/widgets/list/states';
+import states from '../list/states';
 import Example from '../../Example';
 import {
 	createMemoryResourceTemplate,

--- a/src/examples/src/widgets/chip-typeahead/BottomPlacement.tsx
+++ b/src/examples/src/widgets/chip-typeahead/BottomPlacement.tsx
@@ -1,6 +1,6 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import ChipTypeahead from '@dojo/widgets/chip-typeahead';
-import states from '@dojo/widgets/examples/src/widgets/list/states';
+import states from '../list/states';
 import Example from '../../Example';
 import {
 	createMemoryResourceTemplate,

--- a/src/examples/src/widgets/chip-typeahead/FreeText.tsx
+++ b/src/examples/src/widgets/chip-typeahead/FreeText.tsx
@@ -1,6 +1,6 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import ChipTypeahead from '@dojo/widgets/chip-typeahead';
-import states from '@dojo/widgets/examples/src/widgets/list/states';
+import states from '../list/states';
 import Example from '../../Example';
 import {
 	createMemoryResourceTemplate,

--- a/src/examples/src/widgets/date-input/Basic.tsx
+++ b/src/examples/src/widgets/date-input/Basic.tsx
@@ -1,6 +1,6 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import DateInput from '@dojo/widgets/date-input';
-import Example from '@dojo/widgets/examples/src/Example';
+import Example from '../../Example';
 
 const factory = create();
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Fixes import paths to other example files in examples
Resolves #1476 
