### PR TITLE
Fix mobile scrolling on lists

### DIFF
--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -58,7 +58,7 @@ export const MenuItem = menuItemFactory(function MenuItem({
 				active && themedCss.active,
 				disabled && themedCss.disabled
 			]}
-			onpointerdown={() => {
+			onclick={() => {
 				requestActive();
 				select();
 			}}
@@ -125,7 +125,7 @@ export const ListItem = listItemFactory(function ListItem({
 				active && classes.active,
 				disabled && classes.disabled
 			]}
-			onpointerdown={() => {
+			onclick={() => {
 				requestActive();
 				select();
 			}}

--- a/src/list/tests/ListItem.spec.tsx
+++ b/src/list/tests/ListItem.spec.tsx
@@ -15,7 +15,7 @@ describe('ListBoxItem', () => {
 			key="root"
 			onpointermove={noop}
 			classes={[undefined, css.root, false, false, false]}
-			onpointerdown={noop}
+			onclick={noop}
 			role="option"
 			aria-selected={false}
 			aria-disabled={false}
@@ -102,25 +102,25 @@ describe('ListBoxItem', () => {
 		assert.isTrue(onRequestActive.notCalled);
 	});
 
-	it('calls onSelect onpointerdown', () => {
+	it('calls onSelect onclick', () => {
 		const onSelect = sb.stub();
 		const h = harness(() => (
 			<ListItem widgetId="test" onRequestActive={noop} onSelect={onSelect}>
 				test
 			</ListItem>
 		));
-		h.trigger('@root', 'onpointerdown');
+		h.trigger('@root', 'onclick');
 		assert.isTrue(onSelect.calledOnce);
 	});
 
-	it('does not call onSelect onpointerdown when disabled', () => {
+	it('does not call onSelect onclick when disabled', () => {
 		const onSelect = sb.stub();
 		const h = harness(() => (
 			<ListItem widgetId="test" disabled onRequestActive={noop} onSelect={onSelect}>
 				test
 			</ListItem>
 		));
-		h.trigger('@root', 'onpointerdown');
+		h.trigger('@root', 'onclick');
 		assert.isTrue(onSelect.notCalled);
 	});
 });

--- a/src/list/tests/MenuItem.spec.tsx
+++ b/src/list/tests/MenuItem.spec.tsx
@@ -15,7 +15,7 @@ describe('MenuItem', () => {
 			key="root"
 			onpointermove={noop}
 			classes={[undefined, css.root, false, false]}
-			onpointerdown={noop}
+			onclick={noop}
 			role="menuitem"
 			aria-disabled={false}
 			id="test"
@@ -88,25 +88,25 @@ describe('MenuItem', () => {
 		assert.isTrue(onRequestActive.notCalled);
 	});
 
-	it('calls onSelect onpointerdown', () => {
+	it('calls onSelect onclick', () => {
 		const onSelect = sb.stub();
 		const h = harness(() => (
 			<MenuItem widgetId="test" onRequestActive={noop} onSelect={onSelect}>
 				test
 			</MenuItem>
 		));
-		h.trigger('@root', 'onpointerdown');
+		h.trigger('@root', 'onclick');
 		assert.isTrue(onSelect.calledOnce);
 	});
 
-	it('does not call onSelect onpointerdown when disabled', () => {
+	it('does not call onSelect onclick when disabled', () => {
 		const onSelect = sb.stub();
 		const h = harness(() => (
 			<MenuItem widgetId="test" disabled onRequestActive={noop} onSelect={onSelect}>
 				test
 			</MenuItem>
 		));
-		h.trigger('@root', 'onpointerdown');
+		h.trigger('@root', 'onclick');
 		assert.isTrue(onSelect.notCalled);
 	});
 });


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Changes the `pointerdown` handler to an `onclick` handler to allow pointer scroll events.

Resolves #1485 
