### PR TITLE
Fixed styling issues with range-slider interaction

### DIFF
--- a/src/theme/dojo/range-slider.m.css
+++ b/src/theme/dojo/range-slider.m.css
@@ -26,7 +26,7 @@
 	border-radius: 50%;
 	height: calc(var(--grid-base) * 2);
 	left: 50%;
-	margin-left: 0;
+	margin-left: calc(var(--grid-base) * -1);
 	position: absolute;
 	top: -8px;
 	transition: border var(--transition-duration) var(--transition-easing),
@@ -34,7 +34,7 @@
 	width: calc(var(--grid-base) * 2);
 }
 
-.input {
+.root .input {
 	height: 15px;
 	outline: none;
 	top: -7px;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adjusted input height & thumb positioning. Material theme is working correctly, so ported some styles from there to Dojo.

![image](https://user-images.githubusercontent.com/41762295/84808469-b7d0d480-afd6-11ea-918a-9cc0d27e4d30.png)

![image](https://user-images.githubusercontent.com/41762295/84808476-bacbc500-afd6-11ea-9248-e234e84cd20a.png)

Resolves #1477 
