### PR TITLE
Consolidate Slider & RangeSlider styles/interactions

### DIFF
--- a/src/range-slider/index.tsx
+++ b/src/range-slider/index.tsx
@@ -73,6 +73,7 @@ export interface RangeSliderChildren {
 export interface RangeSliderICache {
 	initialValue?: RangeValue;
 	value?: RangeValue;
+	focused: boolean;
 }
 
 const factory = create({
@@ -139,6 +140,7 @@ export const RangeSlider = factory(function RangeSlider({
 
 	const themeCss = theme.classes(css);
 	const size = dimensions.get('root');
+	const isFocused = icache.getOrSet('focused', false);
 
 	const maxLabelId = `max-label-${id}`;
 	const minLabelId = `min-label-${id}`;
@@ -162,9 +164,11 @@ export const RangeSlider = factory(function RangeSlider({
 		min: `${minRestraint}`,
 		name: isSlider1 ? minName : maxName,
 		onblur: () => {
+			icache.set('focused', false);
 			onBlur && onBlur();
 		},
 		onfocus: () => {
+			icache.set('focused', true);
 			onFocus && onFocus();
 		},
 		oninput: (event: Event) => {
@@ -218,7 +222,7 @@ export const RangeSlider = factory(function RangeSlider({
 				theme.variant(),
 				themeCss.root,
 				disabled ? themeCss.disabled : null,
-				focus.isFocused('root') ? themeCss.focused : null,
+				isFocused ? themeCss.focused : null,
 				valid === false ? themeCss.invalid : null,
 				valid === true ? themeCss.valid : null,
 				readOnly ? themeCss.readonly : null,
@@ -229,7 +233,7 @@ export const RangeSlider = factory(function RangeSlider({
 				<Label
 					classes={classes}
 					disabled={disabled}
-					focused={focus.isFocused('root')}
+					focused={isFocused}
 					hidden={labelHidden}
 					key="label"
 					readOnly={readOnly}

--- a/src/range-slider/tests/unit/RangeSlider.spec.tsx
+++ b/src/range-slider/tests/unit/RangeSlider.spec.tsx
@@ -229,6 +229,26 @@ describe('RangeSlider', () => {
 		h.expect(testTemplate);
 	});
 
+	it('renders focused when inputs focus', () => {
+		const focusedTemplate = template.setProperty('@root', 'classes', [
+			undefined,
+			themeCss.root,
+			null,
+			themeCss.focused,
+			null,
+			null,
+			null,
+			null
+		]);
+
+		const h = harness(() => <RangeSlider />);
+		h.trigger('@slider1', 'onfocus', stubEvent);
+		h.expect(focusedTemplate);
+
+		h.trigger('@slider1', 'onblur', stubEvent);
+		h.expect(template);
+	});
+
 	it('calls event callbacks', () => {
 		const onBlurStub = stub();
 		const onFocusStub = stub();

--- a/src/theme/dojo/range-slider.m.css
+++ b/src/theme/dojo/range-slider.m.css
@@ -26,7 +26,7 @@
 	border-radius: 50%;
 	height: calc(var(--grid-base) * 2);
 	left: 50%;
-	margin-left: 0;
+	margin-left: calc(var(--grid-base) * -1);
 	position: absolute;
 	top: -8px;
 	transition: border var(--transition-duration) var(--transition-easing),
@@ -34,7 +34,7 @@
 	width: calc(var(--grid-base) * 2);
 }
 
-.input {
+.root .input {
 	height: 15px;
 	outline: none;
 	top: -7px;

--- a/src/theme/dojo/slider.m.css
+++ b/src/theme/dojo/slider.m.css
@@ -37,7 +37,7 @@
 	width: calc(var(--grid-base) * 2);
 }
 
-.input {
+.root .input {
 	height: 15px;
 	outline: none;
 	top: -7px;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Tweaks to both Slider and RangeSlider to consolidate their styling and interaction.

1. CSS fixes to Slider to correctly position `input` for proper interaction
2. Fixed RangeSlider focus detection to properly apply focus styles

![image](https://user-images.githubusercontent.com/41762295/85296168-f9e29600-b46e-11ea-8c61-677fbfb6ee6b.png)

![image](https://user-images.githubusercontent.com/41762295/85296213-0cf56600-b46f-11ea-83f2-05e307e48d72.png)

Resolves #1491 
