### PR TITLE
Resource wrapper widget

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -43,6 +43,7 @@
 			"src/radio-group",
 			"src/raised-button",
 			"src/range-slider",
+			"src/resource",
 			"src/result",
 			"src/select",
 			"src/slide-pane",

--- a/src/chip-typeahead/index.tsx
+++ b/src/chip-typeahead/index.tsx
@@ -99,8 +99,12 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 		name,
 		placement = 'inline',
 		strict,
-		resource: { template, options = createOptions(id) }
+		resource: resourceProp
 	} = properties();
+	if (!resourceProp) {
+		return null;
+	}
+	const { template, options = createOptions(id) } = resourceProp;
 	const [{ label, items, selected } = {} as ChipTypeaheadChildren] = children();
 	const themeCss = theme.classes(css);
 	const { value } = properties();

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -233,6 +233,7 @@ import FreeTextTypeahead from './widgets/typeahead/FreeText';
 import BasicTwoColumnLayout from './widgets/two-column-layout/Basic';
 import TrailingBiasTwoColumnLayout from './widgets/two-column-layout/TrailingBias';
 import CollapsingLayout from './widgets/two-column-layout/Collapsing';
+import BasicResource from './widgets/resource/Basic';
 import BasicResult from './widgets/result/Basic';
 import AlertResult from './widgets/result/Alert';
 import ErrorResult from './widgets/result/Error';
@@ -1313,6 +1314,14 @@ export const config = {
 					title: 'Controlled'
 				}
 			]
+		},
+		resource: {
+			overview: {
+				example: {
+					filename: 'Basic',
+					module: BasicResource
+				}
+			}
 		},
 		result: {
 			overview: {

--- a/src/examples/src/widgets/resource/Basic.tsx
+++ b/src/examples/src/widgets/resource/Basic.tsx
@@ -1,0 +1,27 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import List, { ListOption } from '@dojo/widgets/list';
+import Resource from '@dojo/widgets/resource';
+import icache from '@dojo/framework/core/middleware/icache';
+import Example from '../../Example';
+import { createMemoryResourceTemplate } from '@dojo/framework/core/middleware/resources';
+
+const factory = create({ icache });
+
+const animals = [{ value: 'cat' }, { value: 'dog' }, { value: 'mouse' }, { value: 'rat' }];
+const template = createMemoryResourceTemplate<ListOption>();
+
+export default factory(function Basic({ id, middleware: { icache } }) {
+	const ResourcelessList = List as any;
+	return (
+		<Example>
+			<Resource initOptions={{ id, data: animals }} template={template}>
+				<ResourcelessList
+					onValue={(value: string) => {
+						icache.set('value', value);
+					}}
+				/>
+			</Resource>
+			<p>{`Clicked on: ${icache.getOrSet('value', '')}`}</p>
+		</Example>
+	);
+});

--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -239,9 +239,13 @@ export const List = factory(function List({
 		onValue,
 		widgetId,
 		theme: themeProp,
-		resource: { template, options = createOptions(id) }
+		resource: resourceProp
 	} = properties();
 	const [itemRenderer] = children();
+	if (!resourceProp) {
+		return null;
+	}
+	const { template, options = createOptions(id) } = resourceProp;
 
 	function setActiveIndex(index: number) {
 		if (onActiveIndexChange) {

--- a/src/resource/README.md
+++ b/src/resource/README.md
@@ -1,0 +1,3 @@
+# @dojo/widgets/resource
+
+Dojo's `Resuorce` provides a wrapper for use as a custom element to support widgets that expect a resource property

--- a/src/resource/index.ts
+++ b/src/resource/index.ts
@@ -1,0 +1,41 @@
+import {
+	createMemoryResourceTemplate,
+	createResourceMiddleware
+} from '@dojo/framework/core/middleware/resources';
+import { create, isWNode } from '@dojo/framework/core/vdom';
+import icache from '@dojo/framework/core/middleware/icache';
+
+const resource = createResourceMiddleware();
+
+export interface ResourceProperties {
+	template?: any;
+	initOptions?: any;
+}
+
+const factory = create({ resource, icache }).properties<ResourceProperties>();
+
+export default factory(function Resource({
+	id,
+	properties,
+	children,
+	middleware: { resource, icache }
+}) {
+	let { template, initOptions } = properties();
+	if (template !== icache.get('template') || initOptions !== icache.get('initOptions')) {
+		template = icache.set('template', template || createMemoryResourceTemplate());
+		initOptions = icache.set('initOptions', initOptions || { id, data: [] });
+		const resourceProp = resource({
+			template,
+			initOptions,
+			options: resource.createOptions(id)
+		});
+		icache.set('resource', resourceProp);
+	}
+
+	return children().map((child) => {
+		if (child && isWNode(child) && child.properties.resource !== icache.get('resource')) {
+			child.properties = { ...child.properties, resource: icache.get('resource') };
+		}
+		return child;
+	});
+});

--- a/src/resource/index.tsx
+++ b/src/resource/index.tsx
@@ -8,13 +8,15 @@ import icache from '@dojo/framework/core/middleware/icache';
 const resource = createResourceMiddleware();
 
 export interface ResourceProperties {
+	/** The resource template for children of this widget */
 	template?: any;
+	/** The resource initOptions for children of this widget */
 	initOptions?: any;
 }
 
 const factory = create({ resource, icache }).properties<ResourceProperties>();
 
-export default factory(function Resource({
+export const Resource = factory(function Resource({
 	id,
 	properties,
 	children,
@@ -39,3 +41,5 @@ export default factory(function Resource({
 		return child;
 	});
 });
+
+export default Resource;

--- a/src/resource/tests/Resource.spec.tsx
+++ b/src/resource/tests/Resource.spec.tsx
@@ -1,0 +1,49 @@
+const { describe, it } = intern.getInterface('bdd');
+import { tsx } from '@dojo/framework/core/vdom';
+import { renderer, assertion, wrap, compare } from '@dojo/framework/testing/renderer';
+import { createMemoryResourceTemplate } from '@dojo/framework/core/middleware/resources';
+import { noop } from '../../common/tests/support/test-helpers';
+import Resource from '../index';
+import List from '../../list';
+
+describe('resource', () => {
+	const WrappedList = wrap(List as any);
+
+	it('passes an undefined resource prop to children if no props are provided', () => {
+		const ResourceLessList = List as any;
+		const r = renderer(() => (
+			<Resource>
+				<ResourceLessList onValue={noop} />
+			</Resource>
+		));
+
+		r.expect(assertion(() => <ResourceLessList onValue={noop} />));
+	});
+
+	it('passes a resource with the specified values if they are provided', () => {
+		const ResourceLessList = List as any;
+		const template = createMemoryResourceTemplate();
+		const initOptions = { id: 'foo', data: [] };
+		const r = renderer(() => (
+			<Resource template={template} initOptions={initOptions}>
+				<ResourceLessList onValue={noop} />
+			</Resource>
+		));
+
+		r.expect(
+			assertion(() => (
+				<WrappedList
+					onValue={noop}
+					resource={compare((actual: any) => {
+						return (
+							typeof actual.template.id === 'string' &&
+							actual.template.template === template
+						);
+						actual.template.initOptions === initOptions &&
+							typeof actual.options === 'function';
+					})}
+				/>
+			))
+		);
+	});
+});

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -104,8 +104,12 @@ export const Select = factory(function Select({
 		position,
 		required,
 		name,
-		resource: { template, options = createOptions(id) }
+		resource: resourceProp
 	} = properties();
+	if (!resourceProp) {
+		return null;
+	}
+	const { template, options = createOptions(id) } = resourceProp;
 	const [{ items, label } = { items: undefined, label: undefined }] = children();
 
 	let { value } = properties();

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -108,11 +108,14 @@ export const Typeahead = factory(function Typeahead({
 		strict = true,
 		value: controlledValue,
 		itemDisabled,
-		resource: { template, options = createOptions(id) }
+		resource: resourceProp
 	} = properties();
 	const themedCss = theme.classes(css);
 	const { messages } = i18n.localize(bundle);
-
+	if (!resourceProp) {
+		return null;
+	}
+	const { template, options = createOptions(id) } = resourceProp;
 	const [{ label, items, leading } = {} as TypeaheadChildren] = children();
 
 	if (


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds a `Resource` widget which is intended to be used only as a custom element to wrap widgets that expect a resource. It can be seen in action here wrapping a list component:
https://resource-widget.vercel.app/

The changes to other widgets were needed because when rendering as a custom element the child widget renders once before the parent can edit its properties, which was accessing an undefined object in widgets that use a resource.
Resolves #1481 
