### PR TITLE
Fix multichild types

### DIFF
--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -139,7 +139,7 @@ export const FormGroup = formGroupFactory(function FormRow({
 	);
 });
 
-const formFieldFactory = create({ theme }).children();
+const formFieldFactory = create({ theme });
 
 export const FormField = formFieldFactory(function FormField({ children, middleware: { theme } }) {
 	const themedCss = theme.classes(css);

--- a/src/form/tests/unit/Form.spec.tsx
+++ b/src/form/tests/unit/Form.spec.tsx
@@ -3,7 +3,7 @@ const { describe, it, beforeEach } = intern.getInterface('bdd');
 import { assert } from 'chai';
 import { stub } from 'sinon';
 
-import { tsx } from '@dojo/framework/core/vdom';
+import { tsx, w } from '@dojo/framework/core/vdom';
 import assertionTemplate from '@dojo/framework/testing/harness/assertionTemplate';
 import harness from '@dojo/framework/testing/harness/harness';
 
@@ -605,6 +605,19 @@ describe('FormField', () => {
 			assertionTemplate(() => (
 				<div key="root" classes={[undefined, css.fieldRoot]}>
 					foo
+				</div>
+			))
+		);
+	});
+
+	it('renders with multiple children', () => {
+		const h = harness(() => w(FormField, {}, [<div>foo</div>, <div>bar</div>]));
+
+		h.expect(
+			assertionTemplate(() => (
+				<div key="root" classes={[undefined, css.fieldRoot]}>
+					<div>foo</div>
+					<div>bar</div>
 				</div>
 			))
 		);

--- a/src/tab-container/index.tsx
+++ b/src/tab-container/index.tsx
@@ -41,9 +41,7 @@ const factory = create({
 	i18n,
 	icache: createICacheMiddleware<TabContainerICache>(),
 	theme
-})
-	.properties<TabContainerProperties>()
-	.children();
+}).properties<TabContainerProperties>();
 
 export const TabContainer = factory(function TabContainer({
 	children,

--- a/src/tab-container/tests/TabContainer.spec.tsx
+++ b/src/tab-container/tests/TabContainer.spec.tsx
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
 
-import { tsx } from '@dojo/framework/core/vdom';
+import { tsx, v, w } from '@dojo/framework/core/vdom';
 
 import { Keys } from '../../common/util';
 import Icon from '../../icon';
@@ -130,6 +130,57 @@ registerSuite('TabContainer', {
 				]);
 
 			h.expect(orientationTemplate);
+		},
+
+		'renders with two children'() {
+			const tabs = [{ name: 'tab0' }, { name: 'tab1' }];
+
+			const h = harness(() =>
+				w(
+					TabContainer,
+					{
+						tabs: tabs
+					},
+					[v('div', {}, ['tab0']), v('div', {}, ['tab1'])]
+				)
+			);
+
+			const twoChildTemplate = baseTemplate
+				.setChildren('@buttons', () => [
+					<div {...tabButtonProperties}>
+						<span key="tabButtonContent" classes={css.tabButtonContent}>
+							tab0
+							<span classes={[css.indicator, css.indicatorActive]}>
+								<span classes={css.indicatorContent} />
+							</span>
+						</span>
+					</div>,
+					<div
+						{...tabButtonProperties}
+						classes={[css.tabButton, null, null, null]}
+						aria-selected="false"
+						aria-controls="test-tab-1"
+						tabIndex={-1}
+						key="1-tabbutton"
+					>
+						<span key="tabButtonContent" classes={css.tabButtonContent}>
+							tab1
+							<span classes={[css.indicator, false]}>
+								<span classes={css.indicatorContent} />
+							</span>
+						</span>
+					</div>
+				])
+				.setChildren('@tabs', () => [
+					<div classes={css.tab} hidden={false}>
+						<div>tab0</div>
+					</div>,
+					<div classes={undefined} hidden={true}>
+						<div>tab1</div>
+					</div>
+				]);
+
+			h.expect(twoChildTemplate);
 		},
 
 		'Clicking tab should change the active tab'() {

--- a/src/text-input/index.tsx
+++ b/src/text-input/index.tsx
@@ -336,9 +336,7 @@ export interface AddonProperties {
 
 const addonFactory = create({
 	theme
-})
-	.properties<AddonProperties>()
-	.children();
+}).properties<AddonProperties>();
 
 export const Addon = addonFactory(function Addon({ middleware: { theme }, properties, children }) {
 	const themeCss = theme.classes(css);

--- a/src/text-input/tests/unit/TextInput.spec.tsx
+++ b/src/text-input/tests/unit/TextInput.spec.tsx
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
 
-import { tsx } from '@dojo/framework/core/vdom';
+import { tsx, w } from '@dojo/framework/core/vdom';
 import focus from '@dojo/framework/core/middleware/focus';
 import validity from '@dojo/framework/core/middleware/validity';
 import assertionTemplate from '@dojo/framework/testing/harness/assertionTemplate';
@@ -747,6 +747,15 @@ registerSuite('TextInput', {
 		});
 
 		const h = harness(() => <Addon filled>foo</Addon>);
+		h.expect(addonTemplate);
+	},
+
+	'addon with multiple children'() {
+		const addonTemplate = assertionTemplate(() => {
+			return <span classes={[css.addonRoot, null]}>foo</span>;
+		});
+
+		const h = harness(() => w(Addon, {}, ['foo', <div>bar</div>]));
 		h.expect(addonTemplate);
 	}
 });

--- a/src/text-input/tests/unit/TextInput.spec.tsx
+++ b/src/text-input/tests/unit/TextInput.spec.tsx
@@ -730,32 +730,38 @@ registerSuite('TextInput', {
 			const h = harness(() => <TextInput labelHidden={true}>{{ label: 'foo' }}</TextInput>);
 
 			h.expect(() => expected({ label: true, labelHidden: true }));
+		},
+
+		addon() {
+			const addonTemplate = assertionTemplate(() => {
+				return <span classes={[css.addonRoot, null]}>foo</span>;
+			});
+
+			const h = harness(() => <Addon>foo</Addon>);
+			h.expect(addonTemplate);
+		},
+
+		'addon filled'() {
+			const addonTemplate = assertionTemplate(() => {
+				return <span classes={[css.addonRoot, css.addonFilled]}>foo</span>;
+			});
+
+			const h = harness(() => <Addon filled>foo</Addon>);
+			h.expect(addonTemplate);
+		},
+
+		'addon with multiple children'() {
+			const addonTemplate = assertionTemplate(() => {
+				return (
+					<span classes={[css.addonRoot, null]}>
+						foo
+						<div>bar</div>
+					</span>
+				);
+			});
+
+			const h = harness(() => w(Addon, {}, ['foo', <div>bar</div>]));
+			h.expect(addonTemplate);
 		}
-	},
-	addon() {
-		const addonTemplate = assertionTemplate(() => {
-			return <span classes={[css.addonRoot, null]}>foo</span>;
-		});
-
-		const h = harness(() => <Addon>foo</Addon>);
-		h.expect(addonTemplate);
-	},
-
-	'addon filled'() {
-		const addonTemplate = assertionTemplate(() => {
-			return <span classes={[css.addonRoot, css.addonFilled]}>foo</span>;
-		});
-
-		const h = harness(() => <Addon filled>foo</Addon>);
-		h.expect(addonTemplate);
-	},
-
-	'addon with multiple children'() {
-		const addonTemplate = assertionTemplate(() => {
-			return <span classes={[css.addonRoot, null]}>foo</span>;
-		});
-
-		const h = harness(() => w(Addon, {}, ['foo', <div>bar</div>]));
-		h.expect(addonTemplate);
 	}
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Fixes types when using multiple children with `w` for `tab-container`, `Addon` from `TextInput`, and `FormField` from `Form` 
Resolves #1500 
