### PR TITLE
Pinned cli-build-app to version 7.0.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   },
   "devDependencies": {
     "@dojo/cli": "~7.0.0",
-    "@dojo/cli-build-app": "~7.0.0",
+    "@dojo/cli-build-app": "7.0.1",
     "@dojo/cli-build-theme": "~7.0.0",
     "@dojo/cli-build-widget": "7.0.0",
     "@dojo/cli-test-intern": "~7.0.0",


### PR DESCRIPTION
**Type:** Bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

Pins `cli-build-app` dependency to version `7.0.1` to resolve vercel deploy caching issue