### PR TITLE
Removes zh-TW from supported locales

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -5,7 +5,7 @@
 	},
 	"build-app": {
 		"locale": "en",
-		"supportedLocales": ["zh", "zh-CN", "zh-TW"]
+		"supportedLocales": ["zh", "zh-CN"]
 	},
 	"build-widget": {
 		"prefix": "dojo",


### PR DESCRIPTION
**Type:** Bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

Removes zh-TW from supported locales to resolve issues with vercel deployment
