### PR TITLE
Remove height 100% from grid header

### DIFF
--- a/src/grid/styles/grid.m.css
+++ b/src/grid/styles/grid.m.css
@@ -7,5 +7,4 @@
 	overflow-y: scroll;
 	overflow-x: hidden;
 	box-sizing: border-box;
-	height: 100%;
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Removes `height: 100%` from the grid's fixed css for the header

Resolves #1517
