### PR TITLE
v7 Backport: remove height 100% from grid header (#1518)

### DIFF
--- a/src/grid/styles/grid.m.css
+++ b/src/grid/styles/grid.m.css
@@ -7,5 +7,4 @@
 	overflow-y: scroll;
 	overflow-x: hidden;
 	box-sizing: border-box;
-	height: 100%;
 }


### PR DESCRIPTION
Backport of #1518 