### PR TITLE
Update Restful Grid Example

### DIFF
--- a/src/examples/src/widgets/grid/Restful.tsx
+++ b/src/examples/src/widgets/grid/Restful.tsx
@@ -1,7 +1,7 @@
 import { tsx, create } from '@dojo/framework/core/vdom';
 
 import Grid from '@dojo/widgets/grid';
-import { FetcherOptions } from '@dojo/widgets/grid/interfaces';
+import { FetcherOptions, FetcherResult } from '@dojo/widgets/grid/interfaces';
 import Example from '../../Example';
 
 const columnConfig = [
@@ -19,26 +19,34 @@ const columnConfig = [
 	}
 ];
 
-const fetcher = async (page: number, pageSize: number, options: FetcherOptions = {}) => {
-	const offset = (page - 1) * pageSize;
-	const response = await fetch(
-		`https://mock-json-server.now.sh/data?offset=${offset}&size=${pageSize}`,
-		{
-			method: 'POST',
-			body: JSON.stringify({
-				sort: options.sort,
-				filter: options.filter,
-				offset,
-				size: pageSize
-			}),
-			headers: {
-				'Content-Type': 'application/json'
-			}
+async function fetcher(
+	page: number,
+	size: number,
+	options: FetcherOptions = {}
+): Promise<FetcherResult<any>> {
+	let url = `https://mixolydian-appendix.glitch.me/user?page=${page}&size=${size}`;
+	const { filter, sort } = options;
+	if (filter) {
+		Object.keys(filter).forEach((key) => {
+			url = `${url}&${key}=${filter[key]}`;
+		});
+	}
+	if (sort) {
+		url = `${url}&sort=${sort.columnId}&direction=${sort.direction}`;
+	}
+	const response = await fetch(url, {
+		headers: {
+			'Content-Type': 'application/json'
 		}
-	);
-	const json = await response.json();
-	return { data: json.data, meta: { total: json.total } };
-};
+	});
+	const data = await response.json();
+	return {
+		data: data.data,
+		meta: {
+			total: data.total
+		}
+	};
+}
 
 const factory = create();
 export default factory(() => {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

The old mock server used no longer worked, updated to the same server as the advanced examples.