### PR TITLE
Fix typo: rename Accordion function to Accordion

### DIFF
--- a/src/accordion/index.tsx
+++ b/src/accordion/index.tsx
@@ -25,7 +25,7 @@ const factory = create({
 	.properties<AccordionPaneProperties>()
 	.children<RenderResult>();
 
-export const Accordion = factory(function LoadingIndicator({
+export const Accordion = factory(function Accordion({
 	middleware: { icache, theme },
 	properties,
 	children


### PR DESCRIPTION
Rename Accordion function from LoadingIndicator to Accordion

Fixes #1537