### PR TITLE
Updating slidepane css to not be dependent on theme import order (#1522)

### DIFF
--- a/src/slide-pane/styles/slide-pane.m.css
+++ b/src/slide-pane/styles/slide-pane.m.css
@@ -11,10 +11,10 @@
 .paneFixed {
 	position: fixed;
 	box-sizing: border-box;
-	display: flex;
+	display: flex !important;
 	flex-direction: column;
 	/* zindex-partial-overlay + 1*/
-	z-index: 201;
+	z-index: 201 !important;
 }
 
 .contentFixed {
@@ -39,7 +39,7 @@
 }
 
 .rightFixed {
-	right: 0;
+	right: 0 !important;
 }
 
 .topFixed {

--- a/src/theme/dojo/slide-pane.m.css
+++ b/src/theme/dojo/slide-pane.m.css
@@ -16,6 +16,10 @@
 	box-shadow: var(--box-shadow-dimensions-large) var(--color-box-shadow-strong);
 }
 
+.pane.open {
+	transform: translate(0, 0);
+}
+
 .content {
 	padding: calc(2 * var(--grid-base));
 }

--- a/src/theme/dojo/slide-pane.m.css.d.ts
+++ b/src/theme/dojo/slide-pane.m.css.d.ts
@@ -1,6 +1,7 @@
 export const root: string;
 export const underlayVisible: string;
 export const pane: string;
+export const open: string;
 export const content: string;
 export const title: string;
 export const close: string;

--- a/src/theme/material/slide-pane.m.css
+++ b/src/theme/material/slide-pane.m.css
@@ -46,3 +46,7 @@
 .underlayVisible {
 	background: var(--mdc-theme-elevation-1);
 }
+
+.root .open {
+	transform: translate(0, 0);
+}

--- a/src/theme/material/slide-pane.m.css.d.ts
+++ b/src/theme/material/slide-pane.m.css.d.ts
@@ -9,3 +9,4 @@ export const right: string;
 export const top: string;
 export const bottom: string;
 export const underlayVisible: string;
+export const open: string;


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixes an issue with SlidePane when the theme was imported _after_ the SlidePane. This will change the order of the CSS and things weren't being applied in the right order.

Resolves #1522 
