### PR TITLE
feat: DraggableList v2

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -24,6 +24,7 @@
 			"src/context-popup",
 			"src/date-input",
 			"src/dialog",
+			"src/draggable-list",
 			"src/email-input",
 			"src/floating-action-button",
 			"src/form",

--- a/.dojorc
+++ b/.dojorc
@@ -24,7 +24,6 @@
 			"src/context-popup",
 			"src/date-input",
 			"src/dialog",
-			"src/draggable-list",
 			"src/email-input",
 			"src/floating-action-button",
 			"src/form",

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -102,6 +102,7 @@ import ControlledList from './widgets/list/Controlled';
 import ItemRenderer from './widgets/list/ItemRenderer';
 import FetchedResource from './widgets/list/FetchedResource';
 import DisabledList from './widgets/list/Disabled';
+import DraggableList from './widgets/list/Draggable';
 import Menu from './widgets/list/Menu';
 import CustomTransformer from './widgets/list/CustomTransformer';
 import BasicChipTypeahead from './widgets/chip-typeahead/Basic';
@@ -1023,6 +1024,13 @@ export const config = {
 					filename: 'Disabled',
 					module: DisabledList,
 					title: 'Disabled'
+				},
+				{
+					description:
+						'This example shows how items within a list can be reordered via drag-and-drop.',
+					filename: 'Draggable',
+					module: DraggableList,
+					title: 'Draggable'
 				}
 			],
 			overview: {

--- a/src/examples/src/widgets/list/Draggable.tsx
+++ b/src/examples/src/widgets/list/Draggable.tsx
@@ -1,45 +1,33 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
-import List, { ListOption } from '@dojo/widgets/list';
 import icache from '@dojo/framework/core/middleware/icache';
-import Example from '../../Example';
 import {
 	createMemoryResourceTemplate,
 	createResourceMiddleware
 } from '@dojo/framework/core/middleware/resources';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import List, { ListOption } from '@dojo/widgets/list';
+
+import Example from '../../Example';
 
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
 
-const animals = [
-	{ value: 'cat' },
-	{ value: 'dog' },
-	{ value: 'mouse' },
-	{ value: 'rat' },
-	{ value: 'cat' },
-	{ value: 'dog' },
-	{ value: 'mouse' },
-	{ value: 'rat' },
-	{ value: 'cat' },
-	{ value: 'dog' },
-	{ value: 'mouse' },
-	{ value: 'rat' }
-];
+const items = Array.from(Array(100).keys()).map((value) => ({ value: `${value}` }));
 const template = createMemoryResourceTemplate<ListOption>();
 
 export default factory(function Draggable({ id, middleware: { icache, resource } }) {
-	const animalData = icache.getOrSet('animalData', animals);
-	const data = resource({ template, initOptions: { id, data: animalData } });
+	const rawData = icache.getOrSet('rawData', items);
+	const data = resource({ template, initOptions: { id, data: rawData } });
 
 	return (
 		<Example>
 			<List
 				draggable
 				onMove={(from, to) => {
-					const sortable = [...animalData];
+					const sortable = [...rawData];
 					const item = sortable[from];
 					sortable.splice(from, 1);
 					sortable.splice(to, 0, item);
-					icache.set('animalData', sortable);
+					icache.set('rawData', sortable);
 				}}
 				resource={data}
 				onValue={(value: string) => {

--- a/src/examples/src/widgets/list/Draggable.tsx
+++ b/src/examples/src/widgets/list/Draggable.tsx
@@ -1,0 +1,52 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import List, { ListOption } from '@dojo/widgets/list';
+import icache from '@dojo/framework/core/middleware/icache';
+import Example from '../../Example';
+import {
+	createMemoryResourceTemplate,
+	createResourceMiddleware
+} from '@dojo/framework/core/middleware/resources';
+
+const resource = createResourceMiddleware();
+const factory = create({ icache, resource });
+
+const animals = [
+	{ value: 'cat' },
+	{ value: 'dog' },
+	{ value: 'mouse' },
+	{ value: 'rat' },
+	{ value: 'cat' },
+	{ value: 'dog' },
+	{ value: 'mouse' },
+	{ value: 'rat' },
+	{ value: 'cat' },
+	{ value: 'dog' },
+	{ value: 'mouse' },
+	{ value: 'rat' }
+];
+const template = createMemoryResourceTemplate<ListOption>();
+
+export default factory(function Draggable({ id, middleware: { icache, resource } }) {
+	const animalData = icache.getOrSet('animalData', animals);
+	const data = resource({ template, initOptions: { id, data: animalData } });
+
+	return (
+		<Example>
+			<List
+				draggable
+				onMove={(from, to) => {
+					const sortable = [...animalData];
+					const item = sortable[from];
+					sortable.splice(from, 1);
+					sortable.splice(to, 0, item);
+					icache.set('animalData', sortable);
+				}}
+				resource={data}
+				onValue={(value: string) => {
+					icache.set('value', value);
+				}}
+			/>
+			<p>{`Clicked on: ${icache.getOrSet('value', '')}`}</p>
+		</Example>
+	);
+});

--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -12,7 +12,6 @@ import * as fixedCss from './list.m.css';
 import { createResourceMiddleware } from '@dojo/framework/core/middleware/resources';
 import LoadingIndicator from '../loading-indicator';
 import { throttle } from '@dojo/framework/core/util';
-import drag from '@dojo/framework/core/middleware/drag';
 import Icon from '../icon';
 
 export interface MenuItemProperties {

--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -454,17 +454,16 @@ export const List = factory(function List({
 			return;
 		}
 		icache.set('dragIndex', index);
-		setActiveIndex(-1);
 		event.dataTransfer!.setData('text/plain', `${index}`);
 	}
 
 	function onDragOver(event: DragEvent, index: number) {
-		if (!draggable) {
+		const dragIndex = icache.get('dragIndex')!;
+		if (!draggable || dragIndex === undefined) {
 			return;
 		}
 		event.preventDefault();
 		event.dataTransfer!.dropEffect = 'move';
-		const dragIndex = icache.get('dragIndex')!;
 		let targetIndex: number | undefined = index;
 		if (event.offsetY < 10 && index === dragIndex + 1) {
 			targetIndex = undefined;
@@ -520,7 +519,6 @@ export const List = factory(function List({
 			disabled: itemDisabled,
 			classes
 		};
-
 		let item: RenderResult;
 
 		if (itemRenderer) {

--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -12,6 +12,8 @@ import * as fixedCss from './list.m.css';
 import { createResourceMiddleware } from '@dojo/framework/core/middleware/resources';
 import LoadingIndicator from '../loading-indicator';
 import { throttle } from '@dojo/framework/core/util';
+import drag from '@dojo/framework/core/middleware/drag';
+import Icon from '../icon';
 
 export interface MenuItemProperties {
 	/** Callback used when the item is clicked */
@@ -154,7 +156,8 @@ export const ListItem = listItemFactory(function ListItem({
 				movedUp && classes.movedUp,
 				movedDown && classes.movedDown,
 				collapsed && classes.collapsed,
-				dragged && classes.dragged
+				dragged && classes.dragged,
+				draggable && classes.draggable
 			]}
 			onclick={() => {
 				requestActive();
@@ -172,6 +175,12 @@ export const ListItem = listItemFactory(function ListItem({
 			styles={{ visibility: dragged ? 'hidden' : undefined }}
 		>
 			{children()}
+			{draggable && (
+				<Icon
+					type="barsIcon"
+					classes={{ '@dojo/widgets/icon': { icon: [classes.dragIcon] } }}
+				/>
+			)}
 		</div>
 	);
 });

--- a/src/list/tests/List.spec.tsx
+++ b/src/list/tests/List.spec.tsx
@@ -116,10 +116,23 @@ const listWithListItemsAssertion = baseAssertion
 					disabled: listItemCss.disabled,
 					root: listItemCss.root,
 					s: css.items,
-					selected: listItemCss.selected
+					selected: listItemCss.selected,
+					collapsed: listItemCss.collapsed,
+					dragged: listItemCss.dragged,
+					movedUp: listItemCss.movedUp,
+					movedDown: listItemCss.movedDown
 				}
 			}}
 			widgetId={'menu-test-item-0'}
+			collapsed={false}
+			draggable={undefined}
+			dragged={false}
+			movedDown={false}
+			movedUp={false}
+			onDragEnd={noop}
+			onDragOver={noop}
+			onDragStart={noop}
+			onDrop={noop}
 		>
 			dog
 		</ListItem>,
@@ -137,10 +150,23 @@ const listWithListItemsAssertion = baseAssertion
 					disabled: listItemCss.disabled,
 					root: listItemCss.root,
 					s: css.items,
-					selected: listItemCss.selected
+					selected: listItemCss.selected,
+					collapsed: listItemCss.collapsed,
+					dragged: listItemCss.dragged,
+					movedUp: listItemCss.movedUp,
+					movedDown: listItemCss.movedDown
 				}
 			}}
 			widgetId={'menu-test-item-1'}
+			collapsed={false}
+			draggable={undefined}
+			dragged={false}
+			movedDown={false}
+			movedUp={false}
+			onDragEnd={noop}
+			onDragOver={noop}
+			onDragStart={noop}
+			onDrop={noop}
 		>
 			Cat
 		</ListItem>,
@@ -158,10 +184,23 @@ const listWithListItemsAssertion = baseAssertion
 					disabled: listItemCss.disabled,
 					root: listItemCss.root,
 					s: css.items,
-					selected: listItemCss.selected
+					selected: listItemCss.selected,
+					collapsed: listItemCss.collapsed,
+					dragged: listItemCss.dragged,
+					movedUp: listItemCss.movedUp,
+					movedDown: listItemCss.movedDown
 				}
 			}}
 			widgetId={'menu-test-item-2'}
+			collapsed={false}
+			draggable={undefined}
+			dragged={false}
+			movedDown={false}
+			movedUp={false}
+			onDragEnd={noop}
+			onDragOver={noop}
+			onDragStart={noop}
+			onDrop={noop}
 		>
 			fish
 		</ListItem>
@@ -317,10 +356,23 @@ describe('List', () => {
 						disabled: listItemCss.disabled,
 						root: listItemCss.root,
 						s: css.items,
-						selected: listItemCss.selected
+						selected: listItemCss.selected,
+						collapsed: listItemCss.collapsed,
+						dragged: listItemCss.dragged,
+						movedUp: listItemCss.movedUp,
+						movedDown: listItemCss.movedDown
 					}
 				}}
 				widgetId={'menu-test-item-4'}
+				collapsed={false}
+				draggable={undefined}
+				dragged={false}
+				movedDown={false}
+				movedUp={false}
+				onDragEnd={noop}
+				onDragOver={noop}
+				onDragStart={noop}
+				onDrop={noop}
 			>
 				<LoadingIndicator />
 			</ListItem>,
@@ -338,10 +390,23 @@ describe('List', () => {
 						disabled: listItemCss.disabled,
 						root: listItemCss.root,
 						s: css.items,
-						selected: listItemCss.selected
+						selected: listItemCss.selected,
+						collapsed: listItemCss.collapsed,
+						dragged: listItemCss.dragged,
+						movedUp: listItemCss.movedUp,
+						movedDown: listItemCss.movedDown
 					}
 				}}
 				widgetId={'menu-test-item-5'}
+				collapsed={false}
+				draggable={undefined}
+				dragged={false}
+				movedDown={false}
+				movedUp={false}
+				onDragEnd={noop}
+				onDragOver={noop}
+				onDragStart={noop}
+				onDrop={noop}
 			>
 				<LoadingIndicator />
 			</ListItem>
@@ -364,10 +429,23 @@ describe('List', () => {
 						disabled: listItemCss.disabled,
 						root: listItemCss.root,
 						s: css.items,
-						selected: listItemCss.selected
+						selected: listItemCss.selected,
+						collapsed: listItemCss.collapsed,
+						dragged: listItemCss.dragged,
+						movedUp: listItemCss.movedUp,
+						movedDown: listItemCss.movedDown
 					}
 				}}
 				widgetId={'menu-test-item-4'}
+				collapsed={false}
+				draggable={undefined}
+				dragged={false}
+				movedDown={false}
+				movedUp={false}
+				onDragEnd={noop}
+				onDragOver={noop}
+				onDragStart={noop}
+				onDrop={noop}
 			>
 				Cat
 			</ListItem>,
@@ -385,10 +463,23 @@ describe('List', () => {
 						disabled: listItemCss.disabled,
 						root: listItemCss.root,
 						s: css.items,
-						selected: listItemCss.selected
+						selected: listItemCss.selected,
+						collapsed: listItemCss.collapsed,
+						dragged: listItemCss.dragged,
+						movedUp: listItemCss.movedUp,
+						movedDown: listItemCss.movedDown
 					}
 				}}
 				widgetId={'menu-test-item-5'}
+				collapsed={false}
+				draggable={undefined}
+				dragged={false}
+				movedDown={false}
+				movedUp={false}
+				onDragEnd={noop}
+				onDragOver={noop}
+				onDragStart={noop}
+				onDrop={noop}
 			>
 				fish
 			</ListItem>
@@ -567,10 +658,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={`menu-test-item-${index}`}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					{testData[index].label || testData[index].value}
 				</ListItem>
@@ -894,10 +998,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-0'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					Bob
 				</ListItem>,
@@ -915,10 +1032,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-1'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					Adam
 				</ListItem>,
@@ -936,10 +1066,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-2'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					Ant
 				</ListItem>,
@@ -957,10 +1100,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-3'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					Anthony
 				</ListItem>,
@@ -978,10 +1134,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-4'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					Bobby
 				</ListItem>
@@ -1020,10 +1189,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-0'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Bob
 					</ListItem>,
@@ -1041,10 +1223,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-1'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Adam
 					</ListItem>,
@@ -1062,10 +1257,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-2'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Ant
 					</ListItem>,
@@ -1083,10 +1291,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-3'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Anthony
 					</ListItem>,
@@ -1104,10 +1325,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-4'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Bobby
 					</ListItem>
@@ -1136,10 +1370,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-0'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Bob
 					</ListItem>,
@@ -1157,10 +1404,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-1'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Adam
 					</ListItem>,
@@ -1178,10 +1438,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-2'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Ant
 					</ListItem>,
@@ -1199,10 +1472,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-3'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Anthony
 					</ListItem>,
@@ -1220,10 +1506,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-4'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Bobby
 					</ListItem>
@@ -1249,10 +1548,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-0'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Bob
 					</ListItem>,
@@ -1270,10 +1582,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-1'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Adam
 					</ListItem>,
@@ -1291,10 +1616,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-2'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Ant
 					</ListItem>,
@@ -1312,10 +1650,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-3'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Anthony
 					</ListItem>,
@@ -1333,10 +1684,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-4'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Bobby
 					</ListItem>
@@ -1362,10 +1726,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-0'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Bob
 					</ListItem>,
@@ -1383,10 +1760,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-1'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Adam
 					</ListItem>,
@@ -1404,10 +1794,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-2'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Ant
 					</ListItem>,
@@ -1425,10 +1828,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-3'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Anthony
 					</ListItem>,
@@ -1446,10 +1862,23 @@ describe('List', () => {
 								disabled: listItemCss.disabled,
 								root: listItemCss.root,
 								s: css.items,
-								selected: listItemCss.selected
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
 							}
 						}}
 						widgetId={'menu-test-item-4'}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
 					>
 						Bobby
 					</ListItem>
@@ -1506,10 +1935,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-0'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					Bob
 				</ListItem>,
@@ -1527,10 +1969,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-1'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					Adam
 				</ListItem>,
@@ -1548,10 +2003,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-2'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					Ant
 				</ListItem>,
@@ -1569,10 +2037,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-3'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					Anthony
 				</ListItem>,
@@ -1590,10 +2071,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-4'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					Bobby
 				</ListItem>
@@ -1691,10 +2185,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-0'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					dog
 				</ListItem>,
@@ -1712,10 +2219,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-1'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					Cat
 				</ListItem>,
@@ -1733,10 +2253,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-2'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					fish
 				</ListItem>
@@ -1774,10 +2307,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-0'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					dog
 				</ListItem>,
@@ -1795,10 +2341,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-1'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					Cat
 				</ListItem>,
@@ -1816,10 +2375,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-2'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					fish
 				</ListItem>
@@ -1845,10 +2417,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-0'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					dog
 				</ListItem>,
@@ -1866,10 +2451,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-1'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					Cat
 				</ListItem>,
@@ -1887,10 +2485,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-2'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					fish
 				</ListItem>
@@ -1941,10 +2552,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-0'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					dog
 				</ListItem>,
@@ -1963,10 +2587,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-1'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					Cat
 				</ListItem>,
@@ -1985,10 +2622,23 @@ describe('List', () => {
 							disabled: listItemCss.disabled,
 							root: listItemCss.root,
 							s: css.items,
-							selected: listItemCss.selected
+							selected: listItemCss.selected,
+							collapsed: listItemCss.collapsed,
+							dragged: listItemCss.dragged,
+							movedUp: listItemCss.movedUp,
+							movedDown: listItemCss.movedDown
 						}
 					}}
 					widgetId={'menu-test-item-2'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
 				>
 					fish
 				</ListItem>

--- a/src/list/tests/List.spec.tsx
+++ b/src/list/tests/List.spec.tsx
@@ -119,6 +119,8 @@ const listWithListItemsAssertion = baseAssertion
 					selected: listItemCss.selected,
 					collapsed: listItemCss.collapsed,
 					dragged: listItemCss.dragged,
+					dragIcon: listItemCss.dragIcon,
+					draggable: listItemCss.draggable,
 					movedUp: listItemCss.movedUp,
 					movedDown: listItemCss.movedDown
 				}
@@ -153,6 +155,8 @@ const listWithListItemsAssertion = baseAssertion
 					selected: listItemCss.selected,
 					collapsed: listItemCss.collapsed,
 					dragged: listItemCss.dragged,
+					dragIcon: listItemCss.dragIcon,
+					draggable: listItemCss.draggable,
 					movedUp: listItemCss.movedUp,
 					movedDown: listItemCss.movedDown
 				}
@@ -187,6 +191,8 @@ const listWithListItemsAssertion = baseAssertion
 					selected: listItemCss.selected,
 					collapsed: listItemCss.collapsed,
 					dragged: listItemCss.dragged,
+					dragIcon: listItemCss.dragIcon,
+					draggable: listItemCss.draggable,
 					movedUp: listItemCss.movedUp,
 					movedDown: listItemCss.movedDown
 				}
@@ -359,6 +365,8 @@ describe('List', () => {
 						selected: listItemCss.selected,
 						collapsed: listItemCss.collapsed,
 						dragged: listItemCss.dragged,
+						dragIcon: listItemCss.dragIcon,
+						draggable: listItemCss.draggable,
 						movedUp: listItemCss.movedUp,
 						movedDown: listItemCss.movedDown
 					}
@@ -393,6 +401,8 @@ describe('List', () => {
 						selected: listItemCss.selected,
 						collapsed: listItemCss.collapsed,
 						dragged: listItemCss.dragged,
+						dragIcon: listItemCss.dragIcon,
+						draggable: listItemCss.draggable,
 						movedUp: listItemCss.movedUp,
 						movedDown: listItemCss.movedDown
 					}
@@ -432,6 +442,8 @@ describe('List', () => {
 						selected: listItemCss.selected,
 						collapsed: listItemCss.collapsed,
 						dragged: listItemCss.dragged,
+						dragIcon: listItemCss.dragIcon,
+						draggable: listItemCss.draggable,
 						movedUp: listItemCss.movedUp,
 						movedDown: listItemCss.movedDown
 					}
@@ -466,6 +478,8 @@ describe('List', () => {
 						selected: listItemCss.selected,
 						collapsed: listItemCss.collapsed,
 						dragged: listItemCss.dragged,
+						dragIcon: listItemCss.dragIcon,
+						draggable: listItemCss.draggable,
 						movedUp: listItemCss.movedUp,
 						movedDown: listItemCss.movedDown
 					}
@@ -661,6 +675,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -1001,6 +1017,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -1035,6 +1053,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -1069,6 +1089,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -1103,6 +1125,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -1137,6 +1161,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -1192,6 +1218,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1226,6 +1254,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1260,6 +1290,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1294,6 +1326,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1328,6 +1362,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1373,6 +1409,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1407,6 +1445,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1441,6 +1481,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1475,6 +1517,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1509,6 +1553,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1551,6 +1597,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1585,6 +1633,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1619,6 +1669,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1653,6 +1705,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1687,6 +1741,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1729,6 +1785,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1763,6 +1821,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1797,6 +1857,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1831,6 +1893,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1865,6 +1929,8 @@ describe('List', () => {
 								selected: listItemCss.selected,
 								collapsed: listItemCss.collapsed,
 								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
 								movedUp: listItemCss.movedUp,
 								movedDown: listItemCss.movedDown
 							}
@@ -1938,6 +2004,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -1972,6 +2040,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -2006,6 +2076,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -2040,6 +2112,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -2074,6 +2148,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -2188,6 +2264,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -2222,6 +2300,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -2256,6 +2336,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -2310,6 +2392,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -2344,6 +2428,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -2378,6 +2464,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -2420,6 +2508,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -2454,6 +2544,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -2488,6 +2580,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -2555,6 +2649,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -2590,6 +2686,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}
@@ -2625,6 +2723,8 @@ describe('List', () => {
 							selected: listItemCss.selected,
 							collapsed: listItemCss.collapsed,
 							dragged: listItemCss.dragged,
+							dragIcon: listItemCss.dragIcon,
+							draggable: listItemCss.draggable,
 							movedUp: listItemCss.movedUp,
 							movedDown: listItemCss.movedDown
 						}

--- a/src/list/tests/ListItem.spec.tsx
+++ b/src/list/tests/ListItem.spec.tsx
@@ -23,6 +23,7 @@ describe('ListBoxItem', () => {
 				undefined,
 				undefined,
 				undefined,
+				undefined,
 				undefined
 			]}
 			draggable={undefined}
@@ -75,6 +76,7 @@ describe('ListBoxItem', () => {
 				undefined,
 				undefined,
 				undefined,
+				undefined,
 				undefined
 			])
 			.setProperty('@root', 'aria-selected', true);
@@ -94,6 +96,7 @@ describe('ListBoxItem', () => {
 				false,
 				false,
 				css.disabled,
+				undefined,
 				undefined,
 				undefined,
 				undefined,
@@ -118,6 +121,7 @@ describe('ListBoxItem', () => {
 			undefined,
 			undefined,
 			undefined,
+			undefined,
 			undefined
 		]);
 		h.expect(activeTemplate);
@@ -136,6 +140,7 @@ describe('ListBoxItem', () => {
 			false,
 			false,
 			css.movedUp,
+			undefined,
 			undefined,
 			undefined,
 			undefined
@@ -158,6 +163,7 @@ describe('ListBoxItem', () => {
 			undefined,
 			css.movedDown,
 			undefined,
+			undefined,
 			undefined
 		]);
 		h.expect(selectedTemplate);
@@ -178,6 +184,7 @@ describe('ListBoxItem', () => {
 			undefined,
 			undefined,
 			css.collapsed,
+			undefined,
 			undefined
 		]);
 		h.expect(selectedTemplate);
@@ -199,7 +206,8 @@ describe('ListBoxItem', () => {
 				undefined,
 				undefined,
 				undefined,
-				css.dragged
+				css.dragged,
+				undefined
 			])
 			.setProperty('@root', 'styles', { visibility: 'hidden' });
 		h.expect(selectedTemplate);

--- a/src/list/tests/ListItem.spec.tsx
+++ b/src/list/tests/ListItem.spec.tsx
@@ -14,12 +14,31 @@ describe('ListBoxItem', () => {
 		<div
 			key="root"
 			onpointermove={noop}
-			classes={[undefined, css.root, false, false, false]}
+			classes={[
+				undefined,
+				css.root,
+				false,
+				false,
+				false,
+				undefined,
+				undefined,
+				undefined,
+				undefined
+			]}
+			draggable={undefined}
 			onclick={noop}
 			role="option"
 			aria-selected={false}
 			aria-disabled={false}
 			id="test"
+			ondragend={undefined}
+			ondragenter={noop}
+			ondragover={undefined}
+			ondragstart={undefined}
+			ondrop={undefined}
+			styles={{
+				visibility: undefined
+			}}
 		>
 			test
 		</div>
@@ -47,7 +66,17 @@ describe('ListBoxItem', () => {
 			</ListItem>
 		));
 		const selectedTemplate = template
-			.setProperty('@root', 'classes', [undefined, css.root, css.selected, false, false])
+			.setProperty('@root', 'classes', [
+				undefined,
+				css.root,
+				css.selected,
+				false,
+				false,
+				undefined,
+				undefined,
+				undefined,
+				undefined
+			])
 			.setProperty('@root', 'aria-selected', true);
 		h.expect(selectedTemplate);
 	});
@@ -59,7 +88,17 @@ describe('ListBoxItem', () => {
 			</ListItem>
 		));
 		const disabledTemplate = template
-			.setProperty('@root', 'classes', [undefined, css.root, false, false, css.disabled])
+			.setProperty('@root', 'classes', [
+				undefined,
+				css.root,
+				false,
+				false,
+				css.disabled,
+				undefined,
+				undefined,
+				undefined,
+				undefined
+			])
 			.setProperty('@root', 'aria-disabled', true);
 		h.expect(disabledTemplate);
 	});
@@ -75,9 +114,95 @@ describe('ListBoxItem', () => {
 			css.root,
 			false,
 			css.active,
-			false
+			false,
+			undefined,
+			undefined,
+			undefined,
+			undefined
 		]);
 		h.expect(activeTemplate);
+	});
+
+	it('renders moved up', () => {
+		const h = harness(() => (
+			<ListItem widgetId="test" onRequestActive={noop} onSelect={noop} movedUp>
+				test
+			</ListItem>
+		));
+		const selectedTemplate = template.setProperty('@root', 'classes', [
+			undefined,
+			css.root,
+			false,
+			false,
+			false,
+			css.movedUp,
+			undefined,
+			undefined,
+			undefined
+		]);
+		h.expect(selectedTemplate);
+	});
+
+	it('renders moved down', () => {
+		const h = harness(() => (
+			<ListItem widgetId="test" onRequestActive={noop} onSelect={noop} movedDown>
+				test
+			</ListItem>
+		));
+		const selectedTemplate = template.setProperty('@root', 'classes', [
+			undefined,
+			css.root,
+			false,
+			false,
+			false,
+			undefined,
+			css.movedDown,
+			undefined,
+			undefined
+		]);
+		h.expect(selectedTemplate);
+	});
+
+	it('renders collapsed', () => {
+		const h = harness(() => (
+			<ListItem widgetId="test" onRequestActive={noop} onSelect={noop} collapsed>
+				test
+			</ListItem>
+		));
+		const selectedTemplate = template.setProperty('@root', 'classes', [
+			undefined,
+			css.root,
+			false,
+			false,
+			false,
+			undefined,
+			undefined,
+			css.collapsed,
+			undefined
+		]);
+		h.expect(selectedTemplate);
+	});
+
+	it('renders dragged', () => {
+		const h = harness(() => (
+			<ListItem widgetId="test" onRequestActive={noop} onSelect={noop} dragged>
+				test
+			</ListItem>
+		));
+		const selectedTemplate = template
+			.setProperty('@root', 'classes', [
+				undefined,
+				css.root,
+				false,
+				false,
+				false,
+				undefined,
+				undefined,
+				undefined,
+				css.dragged
+			])
+			.setProperty('@root', 'styles', { visibility: 'hidden' });
+		h.expect(selectedTemplate);
 	});
 
 	it('requests active onpointermove', () => {

--- a/src/theme/default/list-item.m.css
+++ b/src/theme/default/list-item.m.css
@@ -33,6 +33,10 @@
 	padding: 0;
 }
 
+/* Applied to a draggable item */
+.draggable {
+}
+
 /* Added to an item shifted up due to DnD */
 .root.movedUp {
 	padding-bottom: 58px;
@@ -45,4 +49,8 @@
 
 /* Added to an item currently being dragged */
 .dragged {
+}
+
+/* Added to a draggable item's handle icon */
+.dragIcon {
 }

--- a/src/theme/default/list-item.m.css
+++ b/src/theme/default/list-item.m.css
@@ -34,13 +34,13 @@
 }
 
 /* Added to an item shifted up due to DnD */
-.movedUp {
-	padding-bottom: 58px !important;
+.root.movedUp {
+	padding-bottom: 58px;
 }
 
 /* Added to an item shifted down due to DnD */
-.movedDown {
-	padding-top: 58px !important;
+.root.movedDown {
+	padding-top: 58px;
 }
 
 /* Added to an item currently being dragged */

--- a/src/theme/default/list-item.m.css
+++ b/src/theme/default/list-item.m.css
@@ -4,8 +4,9 @@
 	padding: 10px;
 	border: 1px solid transparent;
 	box-sizing: border-box;
-	height: 45px;
+	min-height: 45px;
 	cursor: pointer;
+	position: relative;
 }
 
 /* Added to selected items */
@@ -22,4 +23,26 @@
 .disabled {
 	color: grey;
 	font-style: italic;
+}
+
+/* Added to an item that's collapsed dur to DnD */
+.collapsed {
+	border-width: 0;
+	height: 0;
+	min-height: 0;
+	padding: 0;
+}
+
+/* Added to an item shifted up due to DnD */
+.movedUp {
+	padding-bottom: 58px !important;
+}
+
+/* Added to an item shifted down due to DnD */
+.movedDown {
+	padding-top: 58px !important;
+}
+
+/* Added to an item currently being dragged */
+.dragged {
 }

--- a/src/theme/default/list-item.m.css.d.ts
+++ b/src/theme/default/list-item.m.css.d.ts
@@ -3,6 +3,8 @@ export const selected: string;
 export const active: string;
 export const disabled: string;
 export const collapsed: string;
+export const draggable: string;
 export const movedUp: string;
 export const movedDown: string;
 export const dragged: string;
+export const dragIcon: string;

--- a/src/theme/default/list-item.m.css.d.ts
+++ b/src/theme/default/list-item.m.css.d.ts
@@ -2,3 +2,7 @@ export const root: string;
 export const selected: string;
 export const active: string;
 export const disabled: string;
+export const collapsed: string;
+export const movedUp: string;
+export const movedDown: string;
+export const dragged: string;

--- a/src/theme/dojo/list-item.m.css
+++ b/src/theme/dojo/list-item.m.css
@@ -13,9 +13,9 @@
 	display: flex;
 }
 
-.active {
+.root.active {
 	border: 1px solid var(--color-highlight-border);
-	transition: none !important;
+	transition: none;
 }
 
 .selected {
@@ -27,10 +27,18 @@
 	font-style: italic;
 }
 
-.collapsed {
-	border-width: 0 !important;
-	height: 0 !important;
-	min-height: 0 !important;
+.root.movedUp {
+	padding-bottom: calc(var(--grid-base) * 6.5);
+}
+
+.root.movedDown {
+	padding-top: calc(var(--grid-base) * 6.5);
+}
+
+.root.collapsed {
+	border-width: 0;
+	height: 0;
+	min-height: 0;
 	overflow: hidden;
 	padding-bottom: 0;
 	padding-top: 0;

--- a/src/theme/dojo/list-item.m.css
+++ b/src/theme/dojo/list-item.m.css
@@ -43,3 +43,10 @@
 	padding-bottom: 0;
 	padding-top: 0;
 }
+
+.dragIcon {
+	cursor: move;
+	opacity: 0.5;
+	position: absolute;
+	right: var(--grid-base);
+}

--- a/src/theme/dojo/list-item.m.css
+++ b/src/theme/dojo/list-item.m.css
@@ -9,12 +9,13 @@
 	white-space: nowrap;
 	align-items: center;
 	justify-content: flex-start;
-	height: calc(var(--grid-base) * 5.5);
+	min-height: calc(var(--grid-base) * 5.5);
 	display: flex;
 }
 
 .active {
 	border: 1px solid var(--color-highlight-border);
+	transition: none !important;
 }
 
 .selected {
@@ -24,4 +25,13 @@
 .disabled {
 	color: var(--color-text-faded);
 	font-style: italic;
+}
+
+.collapsed {
+	border-width: 0 !important;
+	height: 0 !important;
+	min-height: 0 !important;
+	overflow: hidden;
+	padding-bottom: 0;
+	padding-top: 0;
 }

--- a/src/theme/dojo/list-item.m.css.d.ts
+++ b/src/theme/dojo/list-item.m.css.d.ts
@@ -5,3 +5,4 @@ export const disabled: string;
 export const movedUp: string;
 export const movedDown: string;
 export const collapsed: string;
+export const draggable: string;

--- a/src/theme/dojo/list-item.m.css.d.ts
+++ b/src/theme/dojo/list-item.m.css.d.ts
@@ -2,4 +2,6 @@ export const root: string;
 export const active: string;
 export const selected: string;
 export const disabled: string;
+export const movedUp: string;
+export const movedDown: string;
 export const collapsed: string;

--- a/src/theme/dojo/list-item.m.css.d.ts
+++ b/src/theme/dojo/list-item.m.css.d.ts
@@ -2,3 +2,4 @@ export const root: string;
 export const active: string;
 export const selected: string;
 export const disabled: string;
+export const collapsed: string;

--- a/src/theme/material/list-item.m.css
+++ b/src/theme/material/list-item.m.css
@@ -4,6 +4,7 @@
 	overflow: hidden;
 	text-overflow: ellipsis;
 	white-space: nowrap;
+	height: 48px;
 }
 
 .root:hover {
@@ -17,4 +18,30 @@
 .active {
 	border: none;
 	background: var(--mdc-theme-on-surface);
+	height: 48px;
+	box-shadow: none;
+}
+
+.collapsed {
+	height: 0 !important;
+	padding: 0 !important;
+	border: 0 !important;
+	min-height: 0 !important;
+}
+
+.movedUp {
+	padding-bottom: 62px;
+	height: auto;
+	padding-top: 10px;
+}
+
+.movedDown {
+	padding-top: 62px;
+	height: auto;
+	padding-bottom: 10px;
+}
+
+.root:before,
+.root:after {
+	display: none !important;
 }

--- a/src/theme/material/list-item.m.css
+++ b/src/theme/material/list-item.m.css
@@ -45,3 +45,10 @@
 .root:after {
 	display: none !important;
 }
+
+.dragIcon {
+	cursor: move;
+	opacity: 0.5;
+	position: absolute;
+	right: 16px;
+}

--- a/src/theme/material/list-item.m.css.d.ts
+++ b/src/theme/material/list-item.m.css.d.ts
@@ -1,3 +1,6 @@
 export const root: string;
 export const selected: string;
 export const active: string;
+export const collapsed: string;
+export const movedUp: string;
+export const movedDown: string;


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request augments the existing resource-powered `List` widget by adding the ability to drag-and-drop reorder items. This work implements a completely different approach to that in #1547, the latter of which did not build upon `List` or use resources.

Resolves #1429

**Preview:**

![preview](https://i.gyazo.com/976075781da9242d3e3aba9d7c97a1dc.gif)
