### PR TITLE
Updated header widget title to be optional

### DIFF
--- a/src/header/index.tsx
+++ b/src/header/index.tsx
@@ -12,7 +12,7 @@ export type HeaderChildren = {
 	/** Renderer for leading elements like icons */
 	leading?: RenderResult;
 	/** Renderer for the header title */
-	title: RenderResult;
+	title?: RenderResult;
 	/** Renderer for header actions like links */
 	actions?: RenderResult;
 	/** Renderer for trailing elements like search inputs */


### PR DESCRIPTION
**Type:** Feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Makes header widget title optional
Resolves #1556
