### PR TITLE
Fix the filtering behaviour of resource widgets to use visible label

### DIFF
--- a/src/chip-typeahead/index.tsx
+++ b/src/chip-typeahead/index.tsx
@@ -268,7 +268,7 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 						return (
 							<ListItem {...props} selected={selected}>
 								<div classes={[themeCss.item, selected ? themeCss.selected : null]}>
-									{item.label || item.value}
+									{item.label}
 								</div>
 							</ListItem>
 						);

--- a/src/chip-typeahead/index.tsx
+++ b/src/chip-typeahead/index.tsx
@@ -153,7 +153,7 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 
 								options.splice(index, 1);
 								icache.set('value', options.map((option) => option.value));
-
+								icache.set('options', options);
 								onValue && onValue(options);
 
 								focus.focus();

--- a/src/chip-typeahead/index.tsx
+++ b/src/chip-typeahead/index.tsx
@@ -162,8 +162,10 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 			>
 				{{
 					label: selected
-						? selected(value, option && option.label)
-						: (option && option.label) || value
+						? selected(value, option ? option.label : value)
+						: option
+						? option.label
+						: value
 				}}
 			</Chip>
 		);

--- a/src/chip-typeahead/index.tsx
+++ b/src/chip-typeahead/index.tsx
@@ -116,12 +116,15 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 		icache.set('initialValue', initialValue);
 	}
 
-	const chips = icache.getOrSet('value', []).map((value, index) => {
+	const storedValues = icache.getOrSet('value', []);
+	const findOptions = createOptions(`${id}-find`);
+	findOptions({ size: options().size, page: options().page });
+	const chips = storedValues.map((value, index) => {
 		let option: any;
 		if (value) {
 			option = (
 				find(template, {
-					options: options(),
+					options: findOptions(),
 					start: 0,
 					query: { value },
 					type: 'exact'

--- a/src/chip-typeahead/index.tsx
+++ b/src/chip-typeahead/index.tsx
@@ -24,7 +24,7 @@ export interface ChipTypeaheadProperties {
 	/** The initial selected value */
 	initialValue?: string[];
 	/** Callback called when user selects an option from the typeahead */
-	onValue?: (value: string[]) => void;
+	onValue?: (value: ListOption[]) => void;
 	/** Optional controlled value */
 	value?: string[];
 	/** Property to determine if the input is disabled */
@@ -52,11 +52,12 @@ export interface ChipTypeaheadChildren {
 		props: ListItemProperties & MenuItemProperties
 	) => RenderResult;
 	/** Custom renderer for selected items */
-	selected?: (value: string, label?: string) => RenderResult;
+	selected?: (value: string, label: string) => RenderResult;
 }
 
 export interface ChipTypeaheadIcache {
 	initialValue: string[];
+	options: ListOption[];
 	value: string[];
 	focused: boolean;
 }
@@ -148,12 +149,12 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 						? undefined
 						: () => {
 								const { onValue } = properties();
-								const values = [...icache.getOrSet('value', [])];
+								const options = [...icache.getOrSet('options', [])];
 
-								values.splice(index, 1);
-								icache.set('value', values);
+								options.splice(index, 1);
+								icache.set('value', options.map((option) => option.value));
 
-								onValue && onValue(values);
+								onValue && onValue(options);
 
 								focus.focus();
 						  }
@@ -217,9 +218,15 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 				onValue={(value) => {
 					const { onValue } = properties();
 
-					const values = [...icache.getOrSet('value', []), value];
+					const options = icache.set('options', (values = []) => {
+						return [...values, value];
+					});
+					const values = icache.set('value', (values = []) => {
+						return [...values, value.value];
+					});
 					icache.set('value', values);
-					onValue && onValue(values);
+					icache.set('options', options);
+					onValue && onValue(options);
 
 					focus.focus();
 				}}

--- a/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
+++ b/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
@@ -87,7 +87,7 @@ const bottomAssertion = hasValueAssertion.insertAfter('@typeahead', () => [
 	<div classes={themeCss.values}>
 		<Chip
 			theme={{ '@dojo/widgets/chip': chipCss }}
-			key="value-cat"
+			key="value-2"
 			classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 			onClose={stub}
 		>
@@ -130,7 +130,7 @@ registerSuite('ChipTypeahead', {
 				<ChipTypeahead
 					resource={createTestResource(animalOptions)}
 					onValue={noop}
-					initialValue={['cat']}
+					initialValue={['2']}
 				>
 					{}
 				</ChipTypeahead>
@@ -143,7 +143,7 @@ registerSuite('ChipTypeahead', {
 				() => [
 					<Chip
 						theme={{ '@dojo/widgets/chip': chipCss }}
-						key="value-cat"
+						key="value-2"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={stub}
 					>
@@ -158,7 +158,7 @@ registerSuite('ChipTypeahead', {
 
 		'renders with controlled values'() {
 			const properties = {
-				value: ['cat']
+				value: ['2']
 			};
 
 			const h = harness(() => (
@@ -178,7 +178,7 @@ registerSuite('ChipTypeahead', {
 				() => [
 					<Chip
 						theme={{ '@dojo/widgets/chip': chipCss }}
-						key="value-cat"
+						key="value-2"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={stub}
 					>
@@ -190,7 +190,7 @@ registerSuite('ChipTypeahead', {
 
 			assert.isTrue(chips[0].children[0].label === 'Cat');
 
-			properties.value = ['dog'];
+			properties.value = ['1'];
 
 			h.expect(hasValueAssertion);
 
@@ -199,11 +199,11 @@ registerSuite('ChipTypeahead', {
 				() => [
 					<Chip
 						theme={{ '@dojo/widgets/chip': chipCss }}
-						key="value-dog"
+						key="value-1"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={stub}
 					>
-						{{ label: 'dog' }}
+						{{ label: 'Dog' }}
 					</Chip>
 				],
 				() => chips
@@ -215,10 +215,10 @@ registerSuite('ChipTypeahead', {
 				<ChipTypeahead
 					resource={createTestResource(animalOptions)}
 					onValue={noop}
-					initialValue={['cat']}
+					initialValue={['2']}
 				>
 					{{
-						selected: (value) => value.toUpperCase()
+						selected: (_, label) => label.toUpperCase()
 					}}
 				</ChipTypeahead>
 			));
@@ -230,7 +230,7 @@ registerSuite('ChipTypeahead', {
 				() => [
 					<Chip
 						theme={{ '@dojo/widgets/chip': chipCss }}
-						key="value-cat"
+						key="value-2"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={stub}
 					>
@@ -240,7 +240,7 @@ registerSuite('ChipTypeahead', {
 				() => chips
 			);
 
-			assert.isTrue(chips[0].children[0].label === 'CAT');
+			assert.strictEqual(chips[0].children[0].label, 'CAT');
 		},
 
 		'closing a chip removes the selection'() {
@@ -276,14 +276,14 @@ registerSuite('ChipTypeahead', {
 			const h = harness(() => (
 				<ChipTypeahead resource={createTestResource(animalOptions)} onValue={valueStub}>
 					{{
-						selected: (value) => value.toUpperCase()
+						selected: (value) => value && value.toUpperCase()
 					}}
 				</ChipTypeahead>
 			));
 
-			h.trigger('@typeahead', 'onValue', 'cat');
+			h.trigger('@typeahead', 'onValue', { value: '2', label: 'Cat' });
 
-			assert.isTrue(valueStub.calledWith(['cat']));
+			assert.isTrue(valueStub.calledWith([{ value: '2', label: 'Cat' }]));
 
 			h.expect(hasValueAssertion);
 
@@ -292,7 +292,7 @@ registerSuite('ChipTypeahead', {
 				() => [
 					<Chip
 						theme={{ '@dojo/widgets/chip': chipCss }}
-						key="value-cat"
+						key="value-2"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={stub}
 					>
@@ -317,7 +317,7 @@ registerSuite('ChipTypeahead', {
 
 		'the default item renderer shows selected items'() {
 			const h = harness(() => (
-				<ChipTypeahead resource={createTestResource(animalOptions)} initialValue={['cat']}>
+				<ChipTypeahead resource={createTestResource(animalOptions)} initialValue={['2']}>
 					{}
 				</ChipTypeahead>
 			));
@@ -339,7 +339,7 @@ registerSuite('ChipTypeahead', {
 				),
 				() =>
 					itemRenderer(
-						{ value: 'cat', label: 'Cat' },
+						{ value: '2', label: 'Cat' },
 						{ onSelect: stub(), onRequestActive: stub(), widgetId: '' }
 					)
 			);
@@ -352,12 +352,12 @@ registerSuite('ChipTypeahead', {
 						widgetId=""
 						selected={false}
 					>
-						<div classes={[themeCss.item, null]}>dog</div>
+						<div classes={[themeCss.item, null]}>Dog</div>
 					</ListItem>
 				),
 				() =>
 					itemRenderer(
-						{ value: 'dog' },
+						{ value: '1', label: 'Dog' },
 						{ onSelect: stub(), onRequestActive: stub(), widgetId: '' }
 					)
 			);
@@ -365,10 +365,10 @@ registerSuite('ChipTypeahead', {
 
 		'uses a custom item renderer'() {
 			const h = harness(() => (
-				<ChipTypeahead resource={createTestResource(animalOptions)} initialValue={['cat']}>
+				<ChipTypeahead resource={createTestResource(animalOptions)} initialValue={['2']}>
 					{{
 						items: (item: any) =>
-							`Item ${item.value}, selected = ${item.selected ? 'true' : 'false'}`
+							`Item ${item.label}, selected = ${item.selected ? 'true' : 'false'}`
 					}}
 				</ChipTypeahead>
 			));
@@ -377,14 +377,17 @@ registerSuite('ChipTypeahead', {
 				node.children[0].items
 			);
 
-			assert.isTrue(itemRenderer({ value: 'cat' }) === 'Item cat, selected = true');
+			assert.strictEqual(
+				itemRenderer({ value: '2', label: 'Cat' }),
+				'Item Cat, selected = true'
+			);
 		},
 
 		'can place chips on the bottom instead of inline'() {
 			const h = harness(() => (
 				<ChipTypeahead
 					resource={createTestResource(animalOptions)}
-					initialValue={['cat']}
+					initialValue={['2']}
 					placement="bottom"
 				>
 					{}
@@ -401,7 +404,7 @@ registerSuite('ChipTypeahead', {
 			const h = harness(() => (
 				<ChipTypeahead
 					resource={createTestResource(animalOptions)}
-					initialValue={['cat']}
+					initialValue={['2']}
 					disabled
 				>
 					{}
@@ -415,7 +418,7 @@ registerSuite('ChipTypeahead', {
 				() => [
 					<Chip
 						theme={{ '@dojo/widgets/chip': chipCss }}
-						key="value-cat"
+						key="value-2"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={undefined}
 					>
@@ -440,7 +443,7 @@ registerSuite('ChipTypeahead', {
 
 		'disables items that are selected'() {
 			const h = harness(() => (
-				<ChipTypeahead resource={createTestResource(animalOptions)} initialValue={['cat']}>
+				<ChipTypeahead resource={createTestResource(animalOptions)} initialValue={['2']}>
 					{}
 				</ChipTypeahead>
 			));
@@ -449,8 +452,8 @@ registerSuite('ChipTypeahead', {
 				node.properties.itemDisabled
 			);
 
-			assert.isTrue(disabled({ value: 'cat' }));
-			assert.isFalse(disabled({ value: 'dog' }));
+			assert.isTrue(disabled({ value: '2', label: 'Cat' }));
+			assert.isFalse(disabled({ value: '1', label: 'Dog' }));
 		},
 
 		'allows duplicate values if duplicates are allowed'() {
@@ -468,8 +471,8 @@ registerSuite('ChipTypeahead', {
 				node.properties.itemDisabled
 			);
 
-			assert.isFalse(disabled({ value: 'cat' }));
-			assert.isFalse(disabled({ value: 'dog' }));
+			assert.isFalse(disabled({ value: '2', label: 'Cat' }));
+			assert.isFalse(disabled({ value: '1', label: 'Dog' }));
 		},
 
 		'allows duplicate values if not strict'() {
@@ -488,8 +491,8 @@ registerSuite('ChipTypeahead', {
 				node.properties.itemDisabled
 			);
 
-			assert.isFalse(disabled({ value: 'cat' }));
-			assert.isFalse(disabled({ value: 'dog' }));
+			assert.isFalse(disabled({ value: '2', label: 'Cat' }));
+			assert.isFalse(disabled({ value: '1', label: 'Dog' }));
 		},
 
 		'allows free text values if strict is set to false'() {

--- a/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
+++ b/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
@@ -25,9 +25,9 @@ const { registerSuite } = intern.getInterface('object');
 const noop = stub();
 
 const animalOptions: ListOption[] = [
-	{ value: 'dog' },
-	{ value: 'cat', label: 'Cat' },
-	{ value: 'fish', disabled: true }
+	{ value: '1', label: 'Dog' },
+	{ value: '2', label: 'Cat' },
+	{ value: '3', label: 'Fish', disabled: true }
 ];
 
 const baseAssertion = assertionTemplate(() => (

--- a/src/context-menu/index.tsx
+++ b/src/context-menu/index.tsx
@@ -8,7 +8,7 @@ import { createResourceMiddleware } from '@dojo/framework/core/middleware/resour
 
 export interface ContextMenuProperties {
 	/* A callback that will be called with the value of whatever item is selected */
-	onSelect(value: string): void;
+	onSelect(value: ListOption): void;
 }
 
 const factory = create({ theme, resource: createResourceMiddleware<ListOption>() }).properties<

--- a/src/date-input/tests/unit/DateInput.spec.tsx
+++ b/src/date-input/tests/unit/DateInput.spec.tsx
@@ -1,4 +1,4 @@
-import { RenderResult, WNode } from '@dojo/framework/core/interfaces';
+import { RenderResult, WNode, DefaultMiddlewareResult } from '@dojo/framework/core/interfaces';
 
 const { describe, it, afterEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
@@ -32,7 +32,7 @@ function createFocusMock({
 	focused = false,
 	isFocused = false,
 	focus = () => {}
-} = {}) {
+} = {}): () => DefaultMiddlewareResult {
 	const factory = create();
 	return () =>
 		factory(() => ({

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -262,6 +262,8 @@ import PopupConfirmationUnderlay from './widgets/popup-confirmation/Underlay';
 import * as dojoDarkVariant from '@dojo/widgets/theme/dojo/variants/dark.m.css';
 import * as materialDarkVariant from '@dojo/widgets/theme/material/variants/dark.m.css';
 
+import './data';
+
 `!has('docs')`;
 import * as testsContext from './tests';
 
@@ -1414,7 +1416,7 @@ export const config = {
 				example: {
 					filename: 'Basic',
 					module: BasicSelect,
-					sandbox: true,
+					sandbox: false,
 					size: 'medium'
 				}
 			},

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -1416,7 +1416,7 @@ export const config = {
 				example: {
 					filename: 'Basic',
 					module: BasicSelect,
-					sandbox: false,
+					sandbox: true,
 					size: 'medium'
 				}
 			},

--- a/src/examples/src/data.tsx
+++ b/src/examples/src/data.tsx
@@ -1,0 +1,998 @@
+import { ListOption } from '@dojo/widgets/list';
+
+export interface Data {
+	id: string;
+	product: string;
+	category: string;
+	department: string;
+	price: string;
+	description: string;
+	summary: string;
+}
+
+export const data: Data[] = [
+	{
+		id: '09e90971-9e34-4450-8af5-df33371d11af',
+		product: 'Awesome Granite Bacon',
+		category: 'Cheese',
+		department: 'Baby',
+		price: '625.00',
+		description:
+			'The Apollotech B340 is an affordable wireless mouse with reliable connectivity, 12 months battery life and modern design',
+		summary: 'Awesome Granite Bacon / Cheese / Baby / $625.00'
+	},
+	{
+		id: 'f106a6ce-d514-4cf3-bb74-41e08d541dcb',
+		product: 'Handcrafted Plastic Sausages',
+		category: 'Computer',
+		department: 'Grocery',
+		price: '706.00',
+		description:
+			'The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive',
+		summary: 'Handcrafted Plastic Sausages / Computer / Grocery / $706.00'
+	},
+	{
+		id: '5f814c11-615b-4ec9-9b93-67dbb2d66823',
+		product: 'Generic Rubber Chicken',
+		category: 'Towels',
+		department: 'Sports',
+		price: '705.00',
+		description:
+			'The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients',
+		summary: 'Generic Rubber Chicken / Towels / Sports / $705.00'
+	},
+	{
+		id: '2be4af15-0973-48b5-a034-2495f511f2ba',
+		product: 'Small Plastic Chicken',
+		category: 'Ball',
+		department: 'Beauty',
+		price: '43.00',
+		description: 'The Football Is Good For Training And Recreational Purposes',
+		summary: 'Small Plastic Chicken / Ball / Beauty / $43.00'
+	},
+	{
+		id: 'a1835fcd-a723-47f5-9f83-d116a936512c',
+		product: 'Handmade Granite Car',
+		category: 'Gloves',
+		department: 'Tools',
+		price: '439.00',
+		description:
+			'The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J',
+		summary: 'Handmade Granite Car / Gloves / Tools / $439.00'
+	},
+	{
+		id: 'd8766593-e49b-4726-86a1-c038a2778c88',
+		product: 'Fantastic Soft Sausages',
+		category: 'Keyboard',
+		department: 'Electronics',
+		price: '816.00',
+		description:
+			'The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients',
+		summary: 'Fantastic Soft Sausages / Keyboard / Electronics / $816.00'
+	},
+	{
+		id: '13dd0c79-f0ff-44dc-a598-14c8b2535a7e',
+		product: 'Handcrafted Soft Soap',
+		category: 'Tuna',
+		department: 'Health',
+		price: '140.00',
+		description:
+			'The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality',
+		summary: 'Handcrafted Soft Soap / Tuna / Health / $140.00'
+	},
+	{
+		id: 'a2d7ecd4-4a3a-4508-b7f5-99a274321877',
+		product: 'Ergonomic Concrete Table',
+		category: 'Shirt',
+		department: 'Health',
+		price: '803.00',
+		description:
+			'The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients',
+		summary: 'Ergonomic Concrete Table / Shirt / Health / $803.00'
+	},
+	{
+		id: 'c2226fd7-47f0-4031-b6d3-d0f5f6ca51c9',
+		product: 'Gorgeous Soft Chips',
+		category: 'Bacon',
+		department: 'Music',
+		price: '283.00',
+		description:
+			'New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart',
+		summary: 'Gorgeous Soft Chips / Bacon / Music / $283.00'
+	},
+	{
+		id: '811efad9-cee2-4649-bdac-2caa5626580b',
+		product: 'Awesome Metal Table',
+		category: 'Sausages',
+		department: 'Toys',
+		price: '832.00',
+		description:
+			'New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart',
+		summary: 'Awesome Metal Table / Sausages / Toys / $832.00'
+	},
+	{
+		id: '707ea70a-5d09-46f9-ace3-29acaf3f11e1',
+		product: 'Fantastic Rubber Chair',
+		category: 'Keyboard',
+		department: 'Games',
+		price: '788.00',
+		description: 'The Football Is Good For Training And Recreational Purposes',
+		summary: 'Fantastic Rubber Chair / Keyboard / Games / $788.00'
+	},
+	{
+		id: '9d5085e5-be3f-4be7-ba3b-3f157e142757',
+		product: 'Sleek Granite Bike',
+		category: 'Towels',
+		department: 'Health',
+		price: '163.00',
+		description: 'The Football Is Good For Training And Recreational Purposes',
+		summary: 'Sleek Granite Bike / Towels / Health / $163.00'
+	},
+	{
+		id: 'a4f281bb-6b1f-4ea4-9556-a06ed68ee93c',
+		product: 'Small Concrete Mouse',
+		category: 'Gloves',
+		department: 'Music',
+		price: '138.00',
+		description: 'The Football Is Good For Training And Recreational Purposes',
+		summary: 'Small Concrete Mouse / Gloves / Music / $138.00'
+	},
+	{
+		id: '3a77f516-b56e-4eae-8751-8d4b684e3b81',
+		product: 'Handcrafted Metal Computer',
+		category: 'Pants',
+		department: 'Automotive',
+		price: '275.00',
+		description:
+			'The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive',
+		summary: 'Handcrafted Metal Computer / Pants / Automotive / $275.00'
+	},
+	{
+		id: '2b12ae49-7645-4022-b5bd-c7ee55fbd8dd',
+		product: 'Sleek Steel Mouse',
+		category: 'Pants',
+		department: 'Industrial',
+		price: '434.00',
+		description:
+			"Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+		summary: 'Sleek Steel Mouse / Pants / Industrial / $434.00'
+	},
+	{
+		id: '9fe14881-05a1-40ca-99e2-8f19927626a9',
+		product: 'Generic Cotton Shoes',
+		category: 'Mouse',
+		department: 'Baby',
+		price: '922.00',
+		description:
+			'The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J',
+		summary: 'Generic Cotton Shoes / Mouse / Baby / $922.00'
+	},
+	{
+		id: 'a73b5894-86ca-446f-843d-60891d69b41a',
+		product: 'Awesome Metal Pizza',
+		category: 'Pants',
+		department: 'Health',
+		price: '666.00',
+		description:
+			'The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality',
+		summary: 'Awesome Metal Pizza / Pants / Health / $666.00'
+	},
+	{
+		id: '5fed813c-2788-497d-b477-e65ef4f9e5c5',
+		product: 'Generic Metal Towels',
+		category: 'Table',
+		department: 'Outdoors',
+		price: '966.00',
+		description:
+			'Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals',
+		summary: 'Generic Metal Towels / Table / Outdoors / $966.00'
+	},
+	{
+		id: 'bfae9901-4c4a-4dc1-8f0b-ac7c60c5976a',
+		product: 'Refined Soft Pants',
+		category: 'Car',
+		department: 'Games',
+		price: '30.00',
+		description:
+			'The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive',
+		summary: 'Refined Soft Pants / Car / Games / $30.00'
+	},
+	{
+		id: '916b1f87-6966-4074-8379-d3d3598126ee',
+		product: 'Licensed Wooden Computer',
+		category: 'Bike',
+		department: 'Movies',
+		price: '130.00',
+		description:
+			'New ABC 13 9370, 13.3, 5th Gen CoreA5-8250U, 8GB RAM, 256GB SSD, power UHD Graphics, OS 10 Home, OS Office A & J 2016',
+		summary: 'Licensed Wooden Computer / Bike / Movies / $130.00'
+	},
+	{
+		id: '345805c0-0967-45b1-8827-340c6bfb0252',
+		product: 'Incredible Cotton Soap',
+		category: 'Cheese',
+		department: 'Automotive',
+		price: '202.00',
+		description:
+			'Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals',
+		summary: 'Incredible Cotton Soap / Cheese / Automotive / $202.00'
+	},
+	{
+		id: '096ea07c-b0b7-4242-9030-6a03ee822b43',
+		product: 'Intelligent Concrete Pants',
+		category: 'Shirt',
+		department: 'Shoes',
+		price: '733.00',
+		description:
+			'The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients',
+		summary: 'Intelligent Concrete Pants / Shirt / Shoes / $733.00'
+	},
+	{
+		id: 'b9a344d4-601d-4c71-90d6-09c8d2b0c462',
+		product: 'Awesome Fresh Pizza',
+		category: 'Cheese',
+		department: 'Games',
+		price: '213.00',
+		description: 'The Football Is Good For Training And Recreational Purposes',
+		summary: 'Awesome Fresh Pizza / Cheese / Games / $213.00'
+	},
+	{
+		id: 'c8500f1d-806c-4475-a9df-e9da4f7ac315',
+		product: 'Handcrafted Fresh Salad',
+		category: 'Hat',
+		department: 'Movies',
+		price: '190.00',
+		description:
+			'The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J',
+		summary: 'Handcrafted Fresh Salad / Hat / Movies / $190.00'
+	},
+	{
+		id: 'f794b1fd-4890-4f49-92e3-51bd5b1b076d',
+		product: 'Awesome Fresh Bacon',
+		category: 'Bike',
+		department: 'Jewelery',
+		price: '137.00',
+		description:
+			'The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J',
+		summary: 'Awesome Fresh Bacon / Bike / Jewelery / $137.00'
+	},
+	{
+		id: '38ec3edd-c54e-42d1-a289-edca0b38939b',
+		product: 'Handmade Plastic Mouse',
+		category: 'Chips',
+		department: 'Movies',
+		price: '992.00',
+		description:
+			'New ABC 13 9370, 13.3, 5th Gen CoreA5-8250U, 8GB RAM, 256GB SSD, power UHD Graphics, OS 10 Home, OS Office A & J 2016',
+		summary: 'Handmade Plastic Mouse / Chips / Movies / $992.00'
+	},
+	{
+		id: '0d6e836f-c29b-4d91-9c63-57fa2529963c',
+		product: 'Small Frozen Ball',
+		category: 'Shirt',
+		department: 'Industrial',
+		price: '386.00',
+		description:
+			'New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart',
+		summary: 'Small Frozen Ball / Shirt / Industrial / $386.00'
+	},
+	{
+		id: '6c8dabf7-69d2-4c8b-b2b4-53e6235d0cbb',
+		product: 'Ergonomic Soft Gloves',
+		category: 'Cheese',
+		department: 'Kids',
+		price: '670.00',
+		description:
+			'Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support',
+		summary: 'Ergonomic Soft Gloves / Cheese / Kids / $670.00'
+	},
+	{
+		id: '80fa58fb-882b-4749-ac12-72f5bc1fa1f1',
+		product: 'Practical Rubber Table',
+		category: 'Salad',
+		department: 'Computers',
+		price: '963.00',
+		description:
+			'Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support',
+		summary: 'Practical Rubber Table / Salad / Computers / $963.00'
+	},
+	{
+		id: 'f0adec85-6701-4f9b-a30a-f491e62b3186',
+		product: 'Intelligent Plastic Chips',
+		category: 'Sausages',
+		department: 'Jewelery',
+		price: '957.00',
+		description:
+			'New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart',
+		summary: 'Intelligent Plastic Chips / Sausages / Jewelery / $957.00'
+	},
+	{
+		id: '4c956494-b643-491b-86ac-e5889b061d5a',
+		product: 'Ergonomic Cotton Bike',
+		category: 'Chair',
+		department: 'Music',
+		price: '555.00',
+		description: 'Carbonite web goalkeeper gloves are ergonomically designed to give easy fit',
+		summary: 'Ergonomic Cotton Bike / Chair / Music / $555.00'
+	},
+	{
+		id: '3a689e19-816a-479d-a331-a21a595cf1fd',
+		product: 'Unbranded Fresh Bike',
+		category: 'Pants',
+		department: 'Grocery',
+		price: '922.00',
+		description:
+			'Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals',
+		summary: 'Unbranded Fresh Bike / Pants / Grocery / $922.00'
+	},
+	{
+		id: '3f64cc97-1722-4ad0-a1d6-7d63b2758b07',
+		product: 'Practical Wooden Shoes',
+		category: 'Table',
+		department: 'Jewelery',
+		price: '447.00',
+		description:
+			'The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality',
+		summary: 'Practical Wooden Shoes / Table / Jewelery / $447.00'
+	},
+	{
+		id: '083795f8-8a8d-4c3a-8469-2dad705417e7',
+		product: 'Handmade Rubber Table',
+		category: 'Ball',
+		department: 'Computers',
+		price: '179.00',
+		description:
+			'New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart',
+		summary: 'Handmade Rubber Table / Ball / Computers / $179.00'
+	},
+	{
+		id: '5d547ec5-3dd8-45d0-83f7-d6902f1e959c',
+		product: 'Generic Metal Chair',
+		category: 'Chair',
+		department: 'Health',
+		price: '265.00',
+		description:
+			'The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients',
+		summary: 'Generic Metal Chair / Chair / Health / $265.00'
+	},
+	{
+		id: '20169baa-79f2-4ba5-9ac0-edd81b069368',
+		product: 'Generic Soft Tuna',
+		category: 'Fish',
+		department: 'Movies',
+		price: '32.00',
+		description: 'The Football Is Good For Training And Recreational Purposes',
+		summary: 'Generic Soft Tuna / Fish / Movies / $32.00'
+	},
+	{
+		id: '865be68b-11d4-4ea1-9451-5152ef0cc356',
+		product: 'Ergonomic Cotton Bike',
+		category: 'Pizza',
+		department: 'Music',
+		price: '277.00',
+		description:
+			'Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support',
+		summary: 'Ergonomic Cotton Bike / Pizza / Music / $277.00'
+	},
+	{
+		id: '97bbb876-a411-4e6a-928d-7747589056e0',
+		product: 'Handcrafted Frozen Salad',
+		category: 'Table',
+		department: 'Kids',
+		price: '904.00',
+		description:
+			'New ABC 13 9370, 13.3, 5th Gen CoreA5-8250U, 8GB RAM, 256GB SSD, power UHD Graphics, OS 10 Home, OS Office A & J 2016',
+		summary: 'Handcrafted Frozen Salad / Table / Kids / $904.00'
+	},
+	{
+		id: 'd0fb3af6-c465-45a7-8bd6-f9c3a3d8122a',
+		product: 'Refined Soft Tuna',
+		category: 'Chicken',
+		department: 'Tools',
+		price: '524.00',
+		description:
+			'The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients',
+		summary: 'Refined Soft Tuna / Chicken / Tools / $524.00'
+	},
+	{
+		id: '9d8d04dc-a793-47e6-a1eb-c175b99e4b65',
+		product: 'Awesome Plastic Fish',
+		category: 'Bacon',
+		department: 'Jewelery',
+		price: '570.00',
+		description:
+			'The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive',
+		summary: 'Awesome Plastic Fish / Bacon / Jewelery / $570.00'
+	},
+	{
+		id: '4543142e-7a93-4231-b01e-63b21c585367',
+		product: 'Gorgeous Cotton Chicken',
+		category: 'Keyboard',
+		department: 'Grocery',
+		price: '925.00',
+		description: 'Carbonite web goalkeeper gloves are ergonomically designed to give easy fit',
+		summary: 'Gorgeous Cotton Chicken / Keyboard / Grocery / $925.00'
+	},
+	{
+		id: 'be8ea310-ab77-475a-ad5b-600b8e45411e',
+		product: 'Practical Frozen Pizza',
+		category: 'Pizza',
+		department: 'Industrial',
+		price: '815.00',
+		description: 'The Football Is Good For Training And Recreational Purposes',
+		summary: 'Practical Frozen Pizza / Pizza / Industrial / $815.00'
+	},
+	{
+		id: '4151cdb5-53f1-4278-98c7-9e50f25aa4b2',
+		product: 'Sleek Frozen Chicken',
+		category: 'Chair',
+		department: 'Home',
+		price: '416.00',
+		description:
+			'New ABC 13 9370, 13.3, 5th Gen CoreA5-8250U, 8GB RAM, 256GB SSD, power UHD Graphics, OS 10 Home, OS Office A & J 2016',
+		summary: 'Sleek Frozen Chicken / Chair / Home / $416.00'
+	},
+	{
+		id: 'def84018-5dda-4b3d-9d17-3bd6b02683b4',
+		product: 'Rustic Fresh Chicken',
+		category: 'Ball',
+		department: 'Health',
+		price: '857.00',
+		description:
+			'The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients',
+		summary: 'Rustic Fresh Chicken / Ball / Health / $857.00'
+	},
+	{
+		id: 'f7011bbe-379f-4bb2-b4f3-d68bbb170b02',
+		product: 'Handcrafted Steel Keyboard',
+		category: 'Shirt',
+		department: 'Books',
+		price: '517.00',
+		description:
+			'The Apollotech B340 is an affordable wireless mouse with reliable connectivity, 12 months battery life and modern design',
+		summary: 'Handcrafted Steel Keyboard / Shirt / Books / $517.00'
+	},
+	{
+		id: '1da802b8-f12d-4687-9d72-92a54b1da4e4',
+		product: 'Licensed Frozen Hat',
+		category: 'Tuna',
+		department: 'Home',
+		price: '711.00',
+		description:
+			'The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients',
+		summary: 'Licensed Frozen Hat / Tuna / Home / $711.00'
+	},
+	{
+		id: 'b4a3d8e0-fb22-49a8-a2b3-592540b4a240',
+		product: 'Handcrafted Soft Hat',
+		category: 'Fish',
+		department: 'Clothing',
+		price: '892.00',
+		description:
+			'The Apollotech B340 is an affordable wireless mouse with reliable connectivity, 12 months battery life and modern design',
+		summary: 'Handcrafted Soft Hat / Fish / Clothing / $892.00'
+	},
+	{
+		id: 'b3587a6f-9773-4879-ba01-ab695d4046a8',
+		product: 'Practical Frozen Tuna',
+		category: 'Shoes',
+		department: 'Toys',
+		price: '684.00',
+		description:
+			"Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+		summary: 'Practical Frozen Tuna / Shoes / Toys / $684.00'
+	},
+	{
+		id: 'abc40c70-3753-48d0-8eaa-dc8cbabb8192',
+		product: 'Tasty Metal Chips',
+		category: 'Fish',
+		department: 'Toys',
+		price: '339.00',
+		description:
+			'The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients',
+		summary: 'Tasty Metal Chips / Fish / Toys / $339.00'
+	},
+	{
+		id: 'f4874ba8-22a9-4329-afeb-ab9bb5781323',
+		product: 'Refined Granite Bike',
+		category: 'Pants',
+		department: 'Baby',
+		price: '521.00',
+		description:
+			"Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+		summary: 'Refined Granite Bike / Pants / Baby / $521.00'
+	},
+	{
+		id: '89bb3dac-dce7-4914-93d4-5ead460d7bab',
+		product: 'Small Rubber Keyboard',
+		category: 'Soap',
+		department: 'Shoes',
+		price: '394.00',
+		description: 'The Football Is Good For Training And Recreational Purposes',
+		summary: 'Small Rubber Keyboard / Soap / Shoes / $394.00'
+	},
+	{
+		id: 'e23f03f2-be54-43ff-b5e3-7e79a0961fef',
+		product: 'Gorgeous Metal Keyboard',
+		category: 'Shoes',
+		department: 'Electronics',
+		price: '795.00',
+		description:
+			'Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals',
+		summary: 'Gorgeous Metal Keyboard / Shoes / Electronics / $795.00'
+	},
+	{
+		id: '46263091-daff-4ab2-a33f-65a835828743',
+		product: 'Small Granite Car',
+		category: 'Tuna',
+		department: 'Clothing',
+		price: '554.00',
+		description:
+			'The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J',
+		summary: 'Small Granite Car / Tuna / Clothing / $554.00'
+	},
+	{
+		id: '0f76a975-bd97-48d9-814d-55a7fa19096d',
+		product: 'Refined Soft Soap',
+		category: 'Sausages',
+		department: 'Games',
+		price: '179.00',
+		description: 'The Football Is Good For Training And Recreational Purposes',
+		summary: 'Refined Soft Soap / Sausages / Games / $179.00'
+	},
+	{
+		id: '0d4c5b50-b2f6-41cb-a3da-ba9074ef6198',
+		product: 'Practical Granite Bacon',
+		category: 'Shirt',
+		department: 'Garden',
+		price: '128.00',
+		description:
+			'The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality',
+		summary: 'Practical Granite Bacon / Shirt / Garden / $128.00'
+	},
+	{
+		id: 'de8a9dc3-6e7e-4150-b6f9-d4aee2bfe7d2',
+		product: 'Unbranded Cotton Computer',
+		category: 'Towels',
+		department: 'Books',
+		price: '877.00',
+		description:
+			'The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality',
+		summary: 'Unbranded Cotton Computer / Towels / Books / $877.00'
+	},
+	{
+		id: 'dca170e6-b75b-4535-8339-8c9812c1f885',
+		product: 'Awesome Fresh Keyboard',
+		category: 'Salad',
+		department: 'Toys',
+		price: '716.00',
+		description:
+			'New ABC 13 9370, 13.3, 5th Gen CoreA5-8250U, 8GB RAM, 256GB SSD, power UHD Graphics, OS 10 Home, OS Office A & J 2016',
+		summary: 'Awesome Fresh Keyboard / Salad / Toys / $716.00'
+	},
+	{
+		id: 'da453419-54b2-4607-a733-2211d3ccd668',
+		product: 'Handcrafted Soft Keyboard',
+		category: 'Bacon',
+		department: 'Baby',
+		price: '287.00',
+		description:
+			'The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients',
+		summary: 'Handcrafted Soft Keyboard / Bacon / Baby / $287.00'
+	},
+	{
+		id: '975928af-3192-473d-bcc2-45db5859facf',
+		product: 'Rustic Plastic Shirt',
+		category: 'Pizza',
+		department: 'Home',
+		price: '439.00',
+		description:
+			'The Apollotech B340 is an affordable wireless mouse with reliable connectivity, 12 months battery life and modern design',
+		summary: 'Rustic Plastic Shirt / Pizza / Home / $439.00'
+	},
+	{
+		id: '33de4d99-6ca7-4e4d-be31-862b0eaed206',
+		product: 'Refined Cotton Pizza',
+		category: 'Fish',
+		department: 'Sports',
+		price: '322.00',
+		description:
+			'The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J',
+		summary: 'Refined Cotton Pizza / Fish / Sports / $322.00'
+	},
+	{
+		id: '68398931-02e4-4502-a542-6b3b48595416',
+		product: 'Refined Fresh Keyboard',
+		category: 'Pizza',
+		department: 'Sports',
+		price: '991.00',
+		description:
+			'The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients',
+		summary: 'Refined Fresh Keyboard / Pizza / Sports / $991.00'
+	},
+	{
+		id: '4aff9404-8f16-48b6-8297-806fb83fd320',
+		product: 'Tasty Granite Bacon',
+		category: 'Mouse',
+		department: 'Computers',
+		price: '322.00',
+		description:
+			'New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart',
+		summary: 'Tasty Granite Bacon / Mouse / Computers / $322.00'
+	},
+	{
+		id: 'ad62f282-d9ce-4f86-be50-aba328f004b7',
+		product: 'Tasty Fresh Shoes',
+		category: 'Keyboard',
+		department: 'Clothing',
+		price: '825.00',
+		description:
+			"Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+		summary: 'Tasty Fresh Shoes / Keyboard / Clothing / $825.00'
+	},
+	{
+		id: '0b528df6-03f1-4b89-ac27-ca5fb8da4227',
+		product: 'Practical Plastic Chips',
+		category: 'Shirt',
+		department: 'Computers',
+		price: '260.00',
+		description:
+			"Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+		summary: 'Practical Plastic Chips / Shirt / Computers / $260.00'
+	},
+	{
+		id: '4743e0f8-e8a8-4a54-bece-ce1598ed7d32',
+		product: 'Rustic Soft Ball',
+		category: 'Chicken',
+		department: 'Sports',
+		price: '919.00',
+		description: 'The Football Is Good For Training And Recreational Purposes',
+		summary: 'Rustic Soft Ball / Chicken / Sports / $919.00'
+	},
+	{
+		id: 'e3d05e3c-17c4-4afb-bbbc-d93be6e945b1',
+		product: 'Handmade Plastic Car',
+		category: 'Sausages',
+		department: 'Electronics',
+		price: '29.00',
+		description:
+			"Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+		summary: 'Handmade Plastic Car / Sausages / Electronics / $29.00'
+	},
+	{
+		id: '66958cbe-672d-403b-a0bc-e2ebb7636c67',
+		product: 'Generic Cotton Mouse',
+		category: 'Mouse',
+		department: 'Automotive',
+		price: '370.00',
+		description: 'The Football Is Good For Training And Recreational Purposes',
+		summary: 'Generic Cotton Mouse / Mouse / Automotive / $370.00'
+	},
+	{
+		id: 'c7e59045-84ba-400b-92db-cb40cab1c3ef',
+		product: 'Intelligent Concrete Bike',
+		category: 'Pants',
+		department: 'Games',
+		price: '521.00',
+		description:
+			'New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart',
+		summary: 'Intelligent Concrete Bike / Pants / Games / $521.00'
+	},
+	{
+		id: '01842f1e-95ae-4bfe-8c60-210dd578c108',
+		product: 'Awesome Frozen Soap',
+		category: 'Chips',
+		department: 'Baby',
+		price: '783.00',
+		description:
+			'Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support',
+		summary: 'Awesome Frozen Soap / Chips / Baby / $783.00'
+	},
+	{
+		id: '35ef42e6-3468-42f3-8e0c-fc979af761ab',
+		product: 'Refined Soft Shoes',
+		category: 'Car',
+		department: 'Sports',
+		price: '558.00',
+		description:
+			"Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+		summary: 'Refined Soft Shoes / Car / Sports / $558.00'
+	},
+	{
+		id: '1f29a11d-8b38-4cd4-9c87-66a9f2d6f378',
+		product: 'Incredible Soft Computer',
+		category: 'Bacon',
+		department: 'Books',
+		price: '957.00',
+		description:
+			'The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J',
+		summary: 'Incredible Soft Computer / Bacon / Books / $957.00'
+	},
+	{
+		id: '267683af-9f68-4a4c-8b08-6fe1f5903b49',
+		product: 'Generic Soft Towels',
+		category: 'Shirt',
+		department: 'Beauty',
+		price: '656.00',
+		description:
+			"Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+		summary: 'Generic Soft Towels / Shirt / Beauty / $656.00'
+	},
+	{
+		id: '770b614e-ce44-4dca-81f8-80aec0628172',
+		product: 'Refined Cotton Computer',
+		category: 'Towels',
+		department: 'Music',
+		price: '671.00',
+		description: 'Carbonite web goalkeeper gloves are ergonomically designed to give easy fit',
+		summary: 'Refined Cotton Computer / Towels / Music / $671.00'
+	},
+	{
+		id: '9acad2bf-9240-4f7c-ab1c-8188a1698cb9',
+		product: 'Sleek Soft Chicken',
+		category: 'Sausages',
+		department: 'Garden',
+		price: '778.00',
+		description: 'The Football Is Good For Training And Recreational Purposes',
+		summary: 'Sleek Soft Chicken / Sausages / Garden / $778.00'
+	},
+	{
+		id: '2aaab651-9fb8-4505-aa7c-8e856960785d',
+		product: 'Refined Cotton Shirt',
+		category: 'Bike',
+		department: 'Outdoors',
+		price: '222.00',
+		description: 'Carbonite web goalkeeper gloves are ergonomically designed to give easy fit',
+		summary: 'Refined Cotton Shirt / Bike / Outdoors / $222.00'
+	},
+	{
+		id: '00ae56d0-b268-4b3f-99f6-e0565fb3b48b',
+		product: 'Small Cotton Cheese',
+		category: 'Cheese',
+		department: 'Clothing',
+		price: '293.00',
+		description:
+			"Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+		summary: 'Small Cotton Cheese / Cheese / Clothing / $293.00'
+	},
+	{
+		id: '25b99703-339d-4b9a-a502-5d0bae77aa9e',
+		product: 'Small Granite Mouse',
+		category: 'Hat',
+		department: 'Beauty',
+		price: '454.00',
+		description:
+			'New ABC 13 9370, 13.3, 5th Gen CoreA5-8250U, 8GB RAM, 256GB SSD, power UHD Graphics, OS 10 Home, OS Office A & J 2016',
+		summary: 'Small Granite Mouse / Hat / Beauty / $454.00'
+	},
+	{
+		id: '662f83c8-f3ad-481a-8502-a7395b7b1d4a',
+		product: 'Licensed Fresh Chair',
+		category: 'Bacon',
+		department: 'Outdoors',
+		price: '4.00',
+		description:
+			'The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive',
+		summary: 'Licensed Fresh Chair / Bacon / Outdoors / $4.00'
+	},
+	{
+		id: 'cff23cb8-47bb-401c-b2a5-8ea5a35cd2cf',
+		product: 'Unbranded Concrete Computer',
+		category: 'Ball',
+		department: 'Tools',
+		price: '940.00',
+		description:
+			'New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart',
+		summary: 'Unbranded Concrete Computer / Ball / Tools / $940.00'
+	},
+	{
+		id: '9f726027-30f0-4d4d-ba33-ee474e490023',
+		product: 'Handmade Granite Chips',
+		category: 'Pizza',
+		department: 'Baby',
+		price: '516.00',
+		description: 'Carbonite web goalkeeper gloves are ergonomically designed to give easy fit',
+		summary: 'Handmade Granite Chips / Pizza / Baby / $516.00'
+	},
+	{
+		id: '479af14c-6851-47ea-ad29-3850b3cac55b',
+		product: 'Incredible Fresh Hat',
+		category: 'Pizza',
+		department: 'Computers',
+		price: '490.00',
+		description:
+			'The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J',
+		summary: 'Incredible Fresh Hat / Pizza / Computers / $490.00'
+	},
+	{
+		id: '02e1cca4-3229-47d9-b53c-1d6252db6c47',
+		product: 'Sleek Wooden Computer',
+		category: 'Hat',
+		department: 'Beauty',
+		price: '220.00',
+		description:
+			'The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive',
+		summary: 'Sleek Wooden Computer / Hat / Beauty / $220.00'
+	},
+	{
+		id: '91e4513b-3cf3-45cc-80da-534d2e774e16',
+		product: 'Small Cotton Gloves',
+		category: 'Fish',
+		department: 'Jewelery',
+		price: '879.00',
+		description: 'Carbonite web goalkeeper gloves are ergonomically designed to give easy fit',
+		summary: 'Small Cotton Gloves / Fish / Jewelery / $879.00'
+	},
+	{
+		id: 'ae6b1484-8ab1-4e43-8097-bceaff0c8423',
+		product: 'Small Plastic Towels',
+		category: 'Gloves',
+		department: 'Kids',
+		price: '382.00',
+		description: 'The Football Is Good For Training And Recreational Purposes',
+		summary: 'Small Plastic Towels / Gloves / Kids / $382.00'
+	},
+	{
+		id: 'be1b4053-7a0b-4dd4-9fc3-ffa8ffa8f8ac',
+		product: 'Fantastic Wooden Pants',
+		category: 'Bike',
+		department: 'Computers',
+		price: '432.00',
+		description:
+			'The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J',
+		summary: 'Fantastic Wooden Pants / Bike / Computers / $432.00'
+	},
+	{
+		id: 'f891a0e3-b129-4a01-81f8-329ebd994f9c',
+		product: 'Generic Frozen Table',
+		category: 'Towels',
+		department: 'Garden',
+		price: '539.00',
+		description:
+			"Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+		summary: 'Generic Frozen Table / Towels / Garden / $539.00'
+	},
+	{
+		id: '5cf23dec-9597-4d91-a62e-41c327ed91c7',
+		product: 'Licensed Cotton Computer',
+		category: 'Pizza',
+		department: 'Toys',
+		price: '164.00',
+		description:
+			'The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality',
+		summary: 'Licensed Cotton Computer / Pizza / Toys / $164.00'
+	},
+	{
+		id: 'e49615d9-aa06-4911-a1ca-61bcf71a412a',
+		product: 'Rustic Steel Table',
+		category: 'Mouse',
+		department: 'Industrial',
+		price: '977.00',
+		description:
+			'The automobile layout consists of a front-engine design, with transaxle-type transmissions mounted at the rear of the engine and four wheel drive',
+		summary: 'Rustic Steel Table / Mouse / Industrial / $977.00'
+	},
+	{
+		id: '13c31ab3-7680-4746-9326-cd8968530b4d',
+		product: 'Intelligent Metal Salad',
+		category: 'Computer',
+		department: 'Baby',
+		price: '79.00',
+		description:
+			'New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart',
+		summary: 'Intelligent Metal Salad / Computer / Baby / $79.00'
+	},
+	{
+		id: 'a85d3006-3311-4719-917d-1d1cec82cf69',
+		product: 'Ergonomic Plastic Chips',
+		category: 'Tuna',
+		department: 'Health',
+		price: '261.00',
+		description:
+			'The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients',
+		summary: 'Ergonomic Plastic Chips / Tuna / Health / $261.00'
+	},
+	{
+		id: 'bfdd88e4-8e55-4dea-a6a9-0d12e7bc183a',
+		product: 'Ergonomic Granite Salad',
+		category: 'Sausages',
+		department: 'Outdoors',
+		price: '405.00',
+		description:
+			'Ergonomic executive chair upholstered in bonded black leather and PVC padded seat and back for all-day comfort and support',
+		summary: 'Ergonomic Granite Salad / Sausages / Outdoors / $405.00'
+	},
+	{
+		id: '3d506f5e-522f-4152-83ad-0636542d182b',
+		product: 'Fantastic Cotton Pizza',
+		category: 'Gloves',
+		department: 'Beauty',
+		price: '383.00',
+		description:
+			'New range of formal shirts are designed keeping you in mind. With fits and styling that will make you stand apart',
+		summary: 'Fantastic Cotton Pizza / Gloves / Beauty / $383.00'
+	},
+	{
+		id: '9dd54a7b-c76a-4292-a361-d9f4315007e3',
+		product: 'Rustic Concrete Mouse',
+		category: 'Tuna',
+		department: 'Books',
+		price: '274.00',
+		description:
+			'The beautiful range of Apple Naturalé that has an exciting mix of natural ingredients. With the Goodness of 100% Natural Ingredients',
+		summary: 'Rustic Concrete Mouse / Tuna / Books / $274.00'
+	},
+	{
+		id: '1e5d4d7f-509f-40d3-9ab2-caed1831dc1f',
+		product: 'Practical Metal Pizza',
+		category: 'Chair',
+		department: 'Beauty',
+		price: '83.00',
+		description:
+			'The Apollotech B340 is an affordable wireless mouse with reliable connectivity, 12 months battery life and modern design',
+		summary: 'Practical Metal Pizza / Chair / Beauty / $83.00'
+	},
+	{
+		id: '4fe6c6e5-b569-435c-be1a-01768ff260eb',
+		product: 'Ergonomic Cotton Computer',
+		category: 'Gloves',
+		department: 'Jewelery',
+		price: '44.00',
+		description: 'The Football Is Good For Training And Recreational Purposes',
+		summary: 'Ergonomic Cotton Computer / Gloves / Jewelery / $44.00'
+	},
+	{
+		id: '321a32af-b494-4ae3-85b8-ca016b42fb3a',
+		product: 'Awesome Plastic Fish',
+		category: 'Keyboard',
+		department: 'Health',
+		price: '327.00',
+		description:
+			'The Nagasaki Lander is the trademarked name of several series of Nagasaki sport bikes, that started with the 1984 ABC800J',
+		summary: 'Awesome Plastic Fish / Keyboard / Health / $327.00'
+	},
+	{
+		id: '680badd3-ff8b-47c1-8c82-4b0642dcb6ea',
+		product: 'Refined Frozen Gloves',
+		category: 'Bacon',
+		department: 'Music',
+		price: '926.00',
+		description:
+			'The slim & simple Maple Gaming Keyboard from Dev Byte comes with a sleek body and 7- Color RGB LED Back-lighting for smart functionality',
+		summary: 'Refined Frozen Gloves / Bacon / Music / $926.00'
+	},
+	{
+		id: '2b1a15d4-7b28-4d1d-96cb-aeb98a545507',
+		product: 'Unbranded Concrete Tuna',
+		category: 'Shirt',
+		department: 'Outdoors',
+		price: '275.00',
+		description:
+			'Andy shoes are designed to keeping in mind durability as well as trends, the most stylish range of shoes & sandals',
+		summary: 'Unbranded Concrete Tuna / Shirt / Outdoors / $275.00'
+	},
+	{
+		id: '2a9ea674-abbb-40fd-a0a9-5dd8d2f2a1f3',
+		product: 'Rustic Fresh Pants',
+		category: 'Chips',
+		department: 'Beauty',
+		price: '197.00',
+		description:
+			"Boston's most advanced compression wear technology increases muscle oxygenation, stabilizes active muscles",
+		summary: 'Rustic Fresh Pants / Chips / Beauty / $197.00'
+	},
+	{
+		id: 'bac4f2a9-15ad-4e90-a08e-691ab24c2cfa',
+		product: 'Gorgeous Concrete Shoes',
+		category: 'Fish',
+		department: 'Home',
+		price: '592.00',
+		description: 'Carbonite web goalkeeper gloves are ergonomically designed to give easy fit',
+		summary: 'Gorgeous Concrete Shoes / Fish / Home / $592.00'
+	}
+];
+
+export const listOptions: ListOption[] = data.map((item) => ({
+	value: item.id,
+	label: item.summary
+}));

--- a/src/examples/src/widgets/chip-typeahead/Basic.tsx
+++ b/src/examples/src/widgets/chip-typeahead/Basic.tsx
@@ -1,6 +1,6 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import ChipTypeahead from '@dojo/widgets/chip-typeahead';
-import states from '../list/states';
+import { data, Data } from '../../data';
 import Example from '../../Example';
 import {
 	createMemoryResourceTemplate,
@@ -10,7 +10,7 @@ import {
 const resource = createResourceMiddleware();
 const factory = create({ resource });
 
-const template = createMemoryResourceTemplate<{ value: string; disabled?: boolean }>();
+const template = createMemoryResourceTemplate<Data>();
 
 export default factory(function Basic({ id, middleware: { resource } }) {
 	return (
@@ -18,12 +18,12 @@ export default factory(function Basic({ id, middleware: { resource } }) {
 			<ChipTypeahead
 				resource={resource({
 					template,
-					transform: { value: 'value', label: 'value' },
-					initOptions: { id, data: states }
+					transform: { value: 'id', label: 'product' },
+					initOptions: { id, data }
 				})}
 			>
 				{{
-					label: 'Select All States That Apply'
+					label: 'Select Products'
 				}}
 			</ChipTypeahead>
 		</Example>

--- a/src/examples/src/widgets/chip-typeahead/Basic.tsx
+++ b/src/examples/src/widgets/chip-typeahead/Basic.tsx
@@ -6,17 +6,22 @@ import {
 	createMemoryResourceTemplate,
 	createResourceMiddleware
 } from '@dojo/framework/core/middleware/resources';
-import { ListOption } from '@dojo/widgets/list';
 
 const resource = createResourceMiddleware();
 const factory = create({ resource });
 
-const template = createMemoryResourceTemplate<ListOption>();
+const template = createMemoryResourceTemplate<{ value: string; disabled?: boolean }>();
 
 export default factory(function Basic({ id, middleware: { resource } }) {
 	return (
 		<Example>
-			<ChipTypeahead resource={resource({ template, initOptions: { id, data: states } })}>
+			<ChipTypeahead
+				resource={resource({
+					template,
+					transform: { value: 'value', label: 'value' },
+					initOptions: { id, data: states }
+				})}
+			>
 				{{
 					label: 'Select All States That Apply'
 				}}

--- a/src/examples/src/widgets/chip-typeahead/BottomPlacement.tsx
+++ b/src/examples/src/widgets/chip-typeahead/BottomPlacement.tsx
@@ -6,18 +6,21 @@ import {
 	createMemoryResourceTemplate,
 	createResourceMiddleware
 } from '@dojo/framework/core/middleware/resources';
-import { ListOption } from '@dojo/widgets/list';
 
 const resource = createResourceMiddleware();
 const factory = create({ resource });
 
-const template = createMemoryResourceTemplate<ListOption>();
+const template = createMemoryResourceTemplate<typeof states[0]>();
 
 export default factory(function Bottom({ id, middleware: { resource } }) {
 	return (
 		<Example>
 			<ChipTypeahead
-				resource={resource({ template, initOptions: { id, data: states } })}
+				resource={resource({
+					template,
+					transform: { value: 'value', label: 'value' },
+					initOptions: { id, data: states }
+				})}
 				placement="bottom"
 			>
 				{{

--- a/src/examples/src/widgets/chip-typeahead/BottomPlacement.tsx
+++ b/src/examples/src/widgets/chip-typeahead/BottomPlacement.tsx
@@ -1,6 +1,6 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import ChipTypeahead from '@dojo/widgets/chip-typeahead';
-import states from '../list/states';
+import { data, Data } from '../../data';
 import Example from '../../Example';
 import {
 	createMemoryResourceTemplate,
@@ -10,7 +10,7 @@ import {
 const resource = createResourceMiddleware();
 const factory = create({ resource });
 
-const template = createMemoryResourceTemplate<typeof states[0]>();
+const template = createMemoryResourceTemplate<Data>();
 
 export default factory(function Bottom({ id, middleware: { resource } }) {
 	return (
@@ -18,13 +18,13 @@ export default factory(function Bottom({ id, middleware: { resource } }) {
 			<ChipTypeahead
 				resource={resource({
 					template,
-					transform: { value: 'value', label: 'value' },
-					initOptions: { id, data: states }
+					transform: { value: 'id', label: 'summary' },
+					initOptions: { id, data }
 				})}
 				placement="bottom"
 			>
 				{{
-					label: 'Select Applicable States'
+					label: 'Select Products'
 				}}
 			</ChipTypeahead>
 		</Example>

--- a/src/examples/src/widgets/chip-typeahead/Controlled.tsx
+++ b/src/examples/src/widgets/chip-typeahead/Controlled.tsx
@@ -12,9 +12,9 @@ import { ListOption } from '@dojo/widgets/list';
 const resource = createResourceMiddleware();
 const factory = create({ resource, icache });
 const options = [
-	{ value: 'cat', label: 'Cat' },
-	{ value: 'dog', label: 'Dog' },
-	{ value: 'fish', label: 'Fish' }
+	{ value: '1', label: 'Cat' },
+	{ value: '2', label: 'Dog' },
+	{ value: '3', label: 'Fish' }
 ];
 
 const template = createMemoryResourceTemplate<ListOption>();

--- a/src/examples/src/widgets/chip-typeahead/Controlled.tsx
+++ b/src/examples/src/widgets/chip-typeahead/Controlled.tsx
@@ -1,5 +1,5 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import icache from '@dojo/framework/core/middleware/icache';
+import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import ChipTypeahead from '@dojo/widgets/chip-typeahead';
 import Icon from '@dojo/widgets/icon';
 import Example from '../../Example';
@@ -7,24 +7,25 @@ import {
 	createMemoryResourceTemplate,
 	createResourceMiddleware
 } from '@dojo/framework/core/middleware/resources';
+import { data, Data } from '../../data';
 import { ListOption } from '@dojo/widgets/list';
 
+const icache = createICacheMiddleware<{ value: ListOption[] }>();
 const resource = createResourceMiddleware();
 const factory = create({ resource, icache });
-const options = [
-	{ value: '1', label: 'Cat' },
-	{ value: '2', label: 'Dog' },
-	{ value: '3', label: 'Fish' }
-];
 
-const template = createMemoryResourceTemplate<ListOption>();
+const template = createMemoryResourceTemplate<Data>();
 
 export default factory(function Controlled({ id, middleware: { icache, resource } }) {
 	return (
 		<Example>
 			<ChipTypeahead
-				resource={resource({ template, initOptions: { id, data: options } })}
-				value={icache.getOrSet('value', [])}
+				resource={resource({
+					template,
+					transform: { value: 'id', label: 'product' },
+					initOptions: { id, data }
+				})}
+				value={icache.getOrSet('value', []).map((value) => value.value)}
 				onValue={(value) => icache.set('value', value)}
 			>
 				{{
@@ -36,7 +37,7 @@ export default factory(function Controlled({ id, middleware: { icache, resource 
 				The selected values are:
 				<ul>
 					{icache.getOrSet('value', []).map((value, index) => (
-						<li key={value}>
+						<li key={value.value}>
 							<a
 								href="#"
 								onclick={(event) => {
@@ -46,7 +47,7 @@ export default factory(function Controlled({ id, middleware: { icache, resource 
 									icache.set('value', value);
 								}}
 							>
-								{value} <Icon type="closeIcon" />
+								{value.label} <Icon type="closeIcon" />
 							</a>
 						</li>
 					))}

--- a/src/examples/src/widgets/chip-typeahead/CustomRenderer.tsx
+++ b/src/examples/src/widgets/chip-typeahead/CustomRenderer.tsx
@@ -30,11 +30,11 @@ export default factory(function CustomRenderer({ id, middleware: { resource } })
 					),
 					selected: (value) => {
 						switch (value) {
-							case 'apples':
+							case '1':
 								return '🍎';
-							case 'tacos':
+							case '2':
 								return '🌮';
-							case 'pizza':
+							case '3':
 								return '🍕';
 						}
 					}

--- a/src/examples/src/widgets/chip-typeahead/CustomRenderer.tsx
+++ b/src/examples/src/widgets/chip-typeahead/CustomRenderer.tsx
@@ -10,9 +10,9 @@ import {
 const resource = createResourceMiddleware();
 const factory = create({ resource });
 const options = [
-	{ value: 'apples', label: 'Apples' },
-	{ value: 'tacos', label: 'Tacos' },
-	{ value: 'pizza', label: 'Pizza' }
+	{ value: '1', label: 'Apples' },
+	{ value: '2', label: 'Tacos' },
+	{ value: '3', label: 'Pizza' }
 ];
 
 const template = createMemoryResourceTemplate<ListOption>();

--- a/src/examples/src/widgets/chip-typeahead/Disabled.tsx
+++ b/src/examples/src/widgets/chip-typeahead/Disabled.tsx
@@ -10,9 +10,9 @@ import { ListOption } from '@dojo/widgets/list';
 const resource = createResourceMiddleware();
 const factory = create({ resource });
 const options = [
-	{ value: 'cat', label: 'Cat' },
-	{ value: 'dog', label: 'Dog' },
-	{ value: 'fish', label: 'Fish' }
+	{ value: '1', label: 'Cat' },
+	{ value: '2', label: 'Dog' },
+	{ value: '3', label: 'Fish' }
 ];
 
 const template = createMemoryResourceTemplate<ListOption>();

--- a/src/examples/src/widgets/chip-typeahead/FreeText.tsx
+++ b/src/examples/src/widgets/chip-typeahead/FreeText.tsx
@@ -6,19 +6,22 @@ import {
 	createMemoryResourceTemplate,
 	createResourceMiddleware
 } from '@dojo/framework/core/middleware/resources';
-import { ListOption } from '@dojo/widgets/list';
 
 const resource = createResourceMiddleware();
 const factory = create({ resource });
 
-const template = createMemoryResourceTemplate<ListOption>();
+const template = createMemoryResourceTemplate<typeof states[0]>();
 
 export default factory(function FreeText({ id, middleware: { resource } }) {
 	return (
 		<Example>
 			<ChipTypeahead
 				strict={false}
-				resource={resource({ template, initOptions: { id, data: states } })}
+				resource={resource({
+					template,
+					transform: { value: 'value', label: 'value' },
+					initOptions: { id, data: states }
+				})}
 			>
 				{{
 					label: 'Select All States That Apply, or make up your own'

--- a/src/examples/src/widgets/context-menu/Basic.tsx
+++ b/src/examples/src/widgets/context-menu/Basic.tsx
@@ -25,10 +25,10 @@ export default factory(function Basic({ id, middleware: { icache, resource } }) 
 				resource={resource({ template, initOptions: { id, data: options } })}
 				onSelect={(value) => {
 					const selection = window.getSelection() || '';
-					if (value === 'print') {
+					if (value.value === 'print') {
 						icache.set('printedText', selection ? selection.toString() : '');
 					} else if (
-						value === 'delete' &&
+						value.value === 'delete' &&
 						selection &&
 						selection.anchorOffset !== selection.focusOffset
 					) {

--- a/src/examples/src/widgets/list/Basic.tsx
+++ b/src/examples/src/widgets/list/Basic.tsx
@@ -6,12 +6,12 @@ import {
 	createMemoryResourceTemplate,
 	createResourceMiddleware
 } from '@dojo/framework/core/middleware/resources';
+import { data, Data } from '../../data';
 
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
 
-const animals = [{ value: 'cat' }, { value: 'dog' }, { value: 'mouse' }, { value: 'rat' }];
-const template = createMemoryResourceTemplate<{ value: string }>();
+const template = createMemoryResourceTemplate<Data>();
 
 export default factory(function Basic({ id, middleware: { icache, resource } }) {
 	return (
@@ -19,8 +19,8 @@ export default factory(function Basic({ id, middleware: { icache, resource } }) 
 			<List
 				resource={resource({
 					template,
-					transform: { value: 'value', label: 'value' },
-					initOptions: { id, data: animals }
+					transform: { value: 'id', label: 'summary' },
+					initOptions: { id, data }
 				})}
 				onValue={(value) => {
 					icache.set('value', value);

--- a/src/examples/src/widgets/list/Basic.tsx
+++ b/src/examples/src/widgets/list/Basic.tsx
@@ -1,5 +1,5 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import List, { ListOption } from '@dojo/widgets/list';
+import List from '@dojo/widgets/list';
 import icache from '@dojo/framework/core/middleware/icache';
 import Example from '../../Example';
 import {
@@ -11,18 +11,22 @@ const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
 
 const animals = [{ value: 'cat' }, { value: 'dog' }, { value: 'mouse' }, { value: 'rat' }];
-const template = createMemoryResourceTemplate<ListOption>();
+const template = createMemoryResourceTemplate<{ value: string }>();
 
 export default factory(function Basic({ id, middleware: { icache, resource } }) {
 	return (
 		<Example>
 			<List
-				resource={resource({ template, initOptions: { id, data: animals } })}
-				onValue={(value: string) => {
+				resource={resource({
+					template,
+					transform: { value: 'value', label: 'value' },
+					initOptions: { id, data: animals }
+				})}
+				onValue={(value) => {
 					icache.set('value', value);
 				}}
 			/>
-			<p>{`Clicked on: ${icache.getOrSet('value', '')}`}</p>
+			<p>{`Clicked on: ${JSON.stringify(icache.getOrSet('value', ''))}`}</p>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/list/Controlled.tsx
+++ b/src/examples/src/widgets/list/Controlled.tsx
@@ -1,7 +1,7 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import List from '@dojo/widgets/list';
 import icache from '@dojo/framework/core/middleware/icache';
-import states from './states';
+import { listOptions } from '../../data';
 import Example from '../../Example';
 import {
 	createMemoryResourceTemplate,
@@ -23,7 +23,7 @@ export default factory(function Controlled({ id, middleware: { icache, resource 
 					onclick={() => {
 						icache.set(
 							'activeIndex',
-							(activeIndex - 1 + states.length) % states.length
+							(activeIndex - 1 + listOptions.length) % listOptions.length
 						);
 					}}
 				>
@@ -32,7 +32,7 @@ export default factory(function Controlled({ id, middleware: { icache, resource 
 				<button
 					type="button"
 					onclick={() => {
-						icache.set('activeIndex', (activeIndex + 1) % states.length);
+						icache.set('activeIndex', (activeIndex + 1) % listOptions.length);
 					}}
 				>
 					DOWN
@@ -42,8 +42,8 @@ export default factory(function Controlled({ id, middleware: { icache, resource 
 					onclick={() => {
 						const activeIndex = icache.get<number>('activeIndex');
 						if (activeIndex) {
-							const item = states[activeIndex];
-							!item.disabled && icache.set('value', states[activeIndex]);
+							const item = listOptions[activeIndex];
+							!item.disabled && icache.set('value', listOptions[activeIndex]);
 						}
 					}}
 				>
@@ -55,7 +55,7 @@ export default factory(function Controlled({ id, middleware: { icache, resource 
 					resource={resource({
 						template,
 						transform: { value: 'value', label: 'value' },
-						initOptions: { id, data: states }
+						initOptions: { id, data: listOptions }
 					})}
 					onActiveIndexChange={(index: number) => {
 						icache.set('activeIndex', index);

--- a/src/examples/src/widgets/list/Controlled.tsx
+++ b/src/examples/src/widgets/list/Controlled.tsx
@@ -1,5 +1,5 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import List, { ListOption } from '@dojo/widgets/list';
+import List from '@dojo/widgets/list';
 import icache from '@dojo/framework/core/middleware/icache';
 import states from './states';
 import Example from '../../Example';
@@ -10,7 +10,7 @@ import {
 
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
-const template = createMemoryResourceTemplate<ListOption>();
+const template = createMemoryResourceTemplate<{ value: string; disabled?: boolean }>();
 
 export default factory(function Controlled({ id, middleware: { icache, resource } }) {
 	const activeIndex = icache.getOrSet('activeIndex', 0);
@@ -43,7 +43,7 @@ export default factory(function Controlled({ id, middleware: { icache, resource 
 						const activeIndex = icache.get<number>('activeIndex');
 						if (activeIndex) {
 							const item = states[activeIndex];
-							!item.disabled && icache.set('value', states[activeIndex].value);
+							!item.disabled && icache.set('value', states[activeIndex]);
 						}
 					}}
 				>
@@ -52,7 +52,11 @@ export default factory(function Controlled({ id, middleware: { icache, resource 
 				<List
 					focusable={false}
 					itemsInView={4}
-					resource={resource({ template, initOptions: { id, data: states } })}
+					resource={resource({
+						template,
+						transform: { value: 'value', label: 'value' },
+						initOptions: { id, data: states }
+					})}
 					onActiveIndexChange={(index: number) => {
 						icache.set('activeIndex', index);
 					}}
@@ -63,7 +67,7 @@ export default factory(function Controlled({ id, middleware: { icache, resource 
 					}}
 				/>
 			</div>
-			<p>{`Clicked on: ${icache.getOrSet('value', '')}`}</p>
+			<p>{`Clicked on: ${JSON.stringify(icache.getOrSet('value', ''))}`}</p>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/list/CustomTransformer.tsx
+++ b/src/examples/src/widgets/list/CustomTransformer.tsx
@@ -32,11 +32,11 @@ export default factory(function CustomTransformer({ id, middleware: { icache, re
 					transform: { value: 'type', label: 'name' },
 					initOptions: { id, data: animals }
 				})}
-				onValue={(value: string) => {
+				onValue={(value) => {
 					icache.set('value', value);
 				}}
 			/>
-			<p>{`Clicked on: ${icache.getOrSet('value', '')}`}</p>
+			<p>{`Clicked on: ${JSON.stringify(icache.getOrSet('value', ''))}`}</p>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/list/Disabled.tsx
+++ b/src/examples/src/widgets/list/Disabled.tsx
@@ -21,8 +21,12 @@ export default factory(function Disabled({ id, middleware: { icache, resource } 
 	return (
 		<Example>
 			<List
-				resource={resource({ template, initOptions: { id, data: animals } })}
-				onValue={(value: string) => {
+				resource={resource({
+					template,
+					transform: { value: 'value', label: 'value' },
+					initOptions: { id, data: animals }
+				})}
+				onValue={(value) => {
 					icache.set('value', value);
 				}}
 				disabled={(item) => item.value === 'mouse'}

--- a/src/examples/src/widgets/list/Dividers.tsx
+++ b/src/examples/src/widgets/list/Dividers.tsx
@@ -10,11 +10,12 @@ import {
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
 const options = [
-	{ value: 'Save' },
-	{ value: 'Delete', divider: true },
-	{ value: 'copy', label: 'Copy' },
-	{ value: 'Paste', disabled: true, divider: true },
-	{ value: 'Edit' }
+	{ value: '1', label: 'Save' },
+	{ value: '2', label: 'Copy' },
+	{ value: '3', label: 'Paste', disabled: true },
+	{ value: '4', label: 'Print' },
+	{ value: '5', label: 'Export' },
+	{ value: '6', label: 'Share' }
 ];
 
 const template = createMemoryResourceTemplate<ListOption>();

--- a/src/examples/src/widgets/list/Dividers.tsx
+++ b/src/examples/src/widgets/list/Dividers.tsx
@@ -28,7 +28,7 @@ export default factory(function Dividers({ id, middleware: { icache, resource } 
 					icache.set('value', value);
 				}}
 			/>
-			<p>{`Clicked on: ${icache.getOrSet('value', '')}`}</p>
+			<p>{`Clicked on: ${JSON.stringify(icache.getOrSet('value', ''))}`}</p>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/list/Dividers.tsx
+++ b/src/examples/src/widgets/list/Dividers.tsx
@@ -11,11 +11,10 @@ const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
 const options = [
 	{ value: '1', label: 'Save' },
-	{ value: '2', label: 'Copy' },
-	{ value: '3', label: 'Paste', disabled: true },
-	{ value: '4', label: 'Print' },
-	{ value: '5', label: 'Export' },
-	{ value: '6', label: 'Share' }
+	{ value: '2', label: 'Delete', divider: true },
+	{ value: '3', label: 'Copy' },
+	{ value: '4', label: 'Paste', disabled: true, divider: true },
+	{ value: '5', label: 'Edit' }
 ];
 
 const template = createMemoryResourceTemplate<ListOption>();

--- a/src/examples/src/widgets/list/Draggable.tsx
+++ b/src/examples/src/widgets/list/Draggable.tsx
@@ -11,7 +11,10 @@ import Example from '../../Example';
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
 
-const items = Array.from(Array(100).keys()).map((value) => ({ value: `${value}` }));
+const items = Array.from(Array(100).keys()).map((value, i) => ({
+	value: `${i}`,
+	label: `${value}`
+}));
 const template = createMemoryResourceTemplate<ListOption>();
 
 export default factory(function Draggable({ id, middleware: { icache, resource } }) {
@@ -30,11 +33,11 @@ export default factory(function Draggable({ id, middleware: { icache, resource }
 					icache.set('rawData', sortable);
 				}}
 				resource={data}
-				onValue={(value: string) => {
+				onValue={(value) => {
 					icache.set('value', value);
 				}}
 			/>
-			<p>{`Clicked on: ${icache.getOrSet('value', '')}`}</p>
+			<p>{`Clicked on: ${JSON.stringify(icache.getOrSet('value', ''))}`}</p>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/list/FetchedResource.tsx
+++ b/src/examples/src/widgets/list/FetchedResource.tsx
@@ -61,12 +61,12 @@ export default factory(function FetchedResource({ middleware: { icache, resource
 					template,
 					transform: { value: 'firstName', label: 'firstName' }
 				})}
-				onValue={(value: string) => {
+				onValue={(value) => {
 					icache.set('value', value);
 				}}
 				itemsInView={10}
 			/>
-			<p>{`Clicked on: ${icache.getOrSet('value', '')}`}</p>
+			<p>{`Clicked on: ${JSON.stringify(icache.getOrSet('value', ''))}`}</p>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/list/FetchedResource.tsx
+++ b/src/examples/src/widgets/list/FetchedResource.tsx
@@ -9,6 +9,7 @@ import {
 } from '@dojo/framework/core/middleware/resources';
 
 interface User {
+	id: string;
 	firstName: string;
 	lastName: string;
 }
@@ -59,7 +60,7 @@ export default factory(function FetchedResource({ middleware: { icache, resource
 			<List
 				resource={resource({
 					template,
-					transform: { value: 'firstName', label: 'firstName' }
+					transform: { value: 'id', label: 'firstName' }
 				})}
 				onValue={(value) => {
 					icache.set('value', value);

--- a/src/examples/src/widgets/list/ItemRenderer.tsx
+++ b/src/examples/src/widgets/list/ItemRenderer.tsx
@@ -1,5 +1,5 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import List, { ListItem, ListOption } from '@dojo/widgets/list';
+import List, { ListItem } from '@dojo/widgets/list';
 import states from './states';
 import icache from '@dojo/framework/core/middleware/icache';
 import Example from '../../Example';
@@ -10,13 +10,17 @@ import {
 
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
-const template = createMemoryResourceTemplate<ListOption>();
+const template = createMemoryResourceTemplate<typeof states[0]>();
 
 export default factory(function ItemRenderer({ id, middleware: { icache, resource } }) {
 	return (
 		<Example>
 			<List
-				resource={resource({ template, initOptions: { id, data: states } })}
+				resource={resource({
+					template,
+					transform: { value: 'value', label: 'value' },
+					initOptions: { id, data: states }
+				})}
 				onValue={(value) => {
 					icache.set('value', value);
 				}}

--- a/src/examples/src/widgets/list/ItemRenderer.tsx
+++ b/src/examples/src/widgets/list/ItemRenderer.tsx
@@ -35,7 +35,7 @@ export default factory(function ItemRenderer({ id, middleware: { icache, resourc
 					);
 				}}
 			</List>
-			<p>{`Clicked On: ${icache.getOrSet('value', '')}`}</p>
+			<p>{`Clicked On: ${JSON.stringify(icache.getOrSet('value', ''))}`}</p>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/list/Menu.tsx
+++ b/src/examples/src/widgets/list/Menu.tsx
@@ -11,12 +11,12 @@ const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
 
 const options = [
-	{ value: 'Save' },
-	{ value: 'copy', label: 'Copy' },
-	{ value: 'Paste', disabled: true },
-	{ value: 'Print' },
-	{ value: 'Export' },
-	{ value: 'Share' }
+	{ value: '1', label: 'Save' },
+	{ value: '2', label: 'Copy' },
+	{ value: '3', label: 'Paste', disabled: true },
+	{ value: '4', label: 'Print' },
+	{ value: '5', label: 'Export' },
+	{ value: '6', label: 'Share' }
 ];
 
 const template = createMemoryResourceTemplate<ListOption>();

--- a/src/examples/src/widgets/list/Menu.tsx
+++ b/src/examples/src/widgets/list/Menu.tsx
@@ -32,7 +32,7 @@ export default factory(function Menu({ id, middleware: { icache, resource } }) {
 				}}
 				itemsInView={8}
 			/>
-			<p>{`Selected: ${icache.getOrSet('value', '')}`}</p>
+			<p>{`Selected: ${JSON.stringify(icache.getOrSet('value', ''))}`}</p>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/native-select/Basic.tsx
+++ b/src/examples/src/widgets/native-select/Basic.tsx
@@ -23,7 +23,7 @@ export default factory(function Basic({ middleware: { icache } }) {
 			>
 				Basic Select
 			</NativeSelect>
-			<pre>{icache.getOrSet('value', '')}</pre>
+			<pre>{JSON.stringify(icache.getOrSet('value', ''))}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/select/AdditionalText.tsx
+++ b/src/examples/src/widgets/select/AdditionalText.tsx
@@ -10,7 +10,11 @@ import { ListOption } from '@dojo/widgets/list';
 
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
-const options = [{ value: 'cat' }, { value: 'dog' }, { value: 'fish' }];
+const options = [
+	{ value: '1', label: 'cat' },
+	{ value: '2', label: 'dog' },
+	{ value: '3', label: 'fish' }
+];
 
 const template = createMemoryResourceTemplate<ListOption>();
 

--- a/src/examples/src/widgets/select/AdditionalText.tsx
+++ b/src/examples/src/widgets/select/AdditionalText.tsx
@@ -33,7 +33,7 @@ export default factory(function AdditionalText({ id, middleware: { icache, resou
 					label: 'Additional Text'
 				}}
 			</Select>
-			<pre>{`Value: ${icache.getOrSet('value', '')}`}</pre>
+			<pre>{JSON.stringify(icache.getOrSet('value', ''))}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/select/Basic.tsx
+++ b/src/examples/src/widgets/select/Basic.tsx
@@ -11,9 +11,9 @@ import { ListOption } from '@dojo/widgets/list';
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
 const options = [
-	{ value: 'cat', label: 'Cat' },
-	{ value: 'dog', label: 'Dog' },
-	{ value: 'fish', label: 'Fish' }
+	{ value: '1', label: 'Cat' },
+	{ value: '2', label: 'Dog' },
+	{ value: '3', label: 'Fish' }
 ];
 
 const template = createMemoryResourceTemplate<ListOption>();

--- a/src/examples/src/widgets/select/Basic.tsx
+++ b/src/examples/src/widgets/select/Basic.tsx
@@ -6,23 +6,22 @@ import {
 	createMemoryResourceTemplate,
 	createResourceMiddleware
 } from '@dojo/framework/core/middleware/resources';
-import { ListOption } from '@dojo/widgets/list';
+import { data, Data } from '../../data';
 
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
-const options = [
-	{ value: '1', label: 'Cat' },
-	{ value: '2', label: 'Dog' },
-	{ value: '3', label: 'Fish' }
-];
 
-const template = createMemoryResourceTemplate<ListOption>();
+const template = createMemoryResourceTemplate<Data>();
 
 export default factory(function Basic({ id, middleware: { icache, resource } }) {
 	return (
 		<Example>
 			<Select
-				resource={resource({ template, initOptions: { id, data: options } })}
+				resource={resource({
+					template,
+					transform: { value: 'id', label: 'summary' },
+					initOptions: { id, data }
+				})}
 				onValue={(value) => {
 					icache.set('value', value);
 				}}

--- a/src/examples/src/widgets/select/Basic.tsx
+++ b/src/examples/src/widgets/select/Basic.tsx
@@ -31,7 +31,7 @@ export default factory(function Basic({ id, middleware: { icache, resource } }) 
 					label: 'Basic Select'
 				}}
 			</Select>
-			<pre>{icache.getOrSet('value', '')}</pre>
+			<pre>{JSON.stringify(icache.getOrSet('value', ''))}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/select/Controlled.tsx
+++ b/src/examples/src/widgets/select/Controlled.tsx
@@ -11,9 +11,9 @@ import { ListOption } from '@dojo/widgets/list';
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
 const options = [
-	{ value: 'cat', label: 'Cat' },
-	{ value: 'dog', label: 'Dog' },
-	{ value: 'fish', label: 'Fish' }
+	{ value: '1', label: 'Cat' },
+	{ value: '2', label: 'Dog' },
+	{ value: '3', label: 'Fish' }
 ];
 
 const template = createMemoryResourceTemplate<ListOption>();

--- a/src/examples/src/widgets/select/Controlled.tsx
+++ b/src/examples/src/widgets/select/Controlled.tsx
@@ -19,6 +19,7 @@ const options = [
 const template = createMemoryResourceTemplate<ListOption>();
 
 export default factory(function Controlled({ id, middleware: { icache, resource } }) {
+	const currentValue = icache.get<ListOption>('value');
 	return (
 		<Example>
 			<Select
@@ -26,13 +27,13 @@ export default factory(function Controlled({ id, middleware: { icache, resource 
 				onValue={(value) => {
 					icache.set('value', value);
 				}}
-				value={icache.get('value')}
+				value={currentValue ? currentValue.value : '1'}
 			>
 				{{
 					label: 'Controlled Select'
 				}}
 			</Select>
-			<pre>{icache.getOrSet('value', '')}</pre>
+			<pre>{JSON.stringify(icache.getOrSet('value', ''))}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/select/CustomRenderer.tsx
+++ b/src/examples/src/widgets/select/CustomRenderer.tsx
@@ -39,7 +39,7 @@ export default factory(function CustomRenderer({ id, middleware: { icache, resou
 					}
 				}}
 			</Select>
-			<pre>{icache.getOrSet('value', '')}</pre>
+			<pre>{JSON.stringify(icache.getOrSet('value', ''))}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/select/CustomRenderer.tsx
+++ b/src/examples/src/widgets/select/CustomRenderer.tsx
@@ -1,7 +1,7 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Select from '@dojo/widgets/select';
 import icache from '@dojo/framework/core/middleware/icache';
-import { ListItem, ListOption } from '@dojo/widgets/list';
+import { ListItem } from '@dojo/widgets/list';
 import Example from '../../Example';
 import {
 	createMemoryResourceTemplate,
@@ -12,13 +12,17 @@ const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
 const options = [{ value: 'cat' }, { value: 'dog' }, { value: 'fish' }];
 
-const template = createMemoryResourceTemplate<ListOption>();
+const template = createMemoryResourceTemplate<{ value: string }>();
 
 export default factory(function CustomRenderer({ id, middleware: { icache, resource } }) {
 	return (
 		<Example>
 			<Select
-				resource={resource({ template, initOptions: { id, data: options } })}
+				resource={resource({
+					template,
+					transform: { value: 'value', label: 'value' },
+					initOptions: { id, data: options }
+				})}
 				onValue={(value) => {
 					icache.set('value', value);
 				}}

--- a/src/examples/src/widgets/select/DisabledSelect.tsx
+++ b/src/examples/src/widgets/select/DisabledSelect.tsx
@@ -10,7 +10,11 @@ import {
 
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
-const options = [{ value: 'cat' }, { value: 'dog' }, { value: 'fish' }];
+const options = [
+	{ value: '1', label: 'cat' },
+	{ value: '2', label: 'dog' },
+	{ value: '3', label: 'fish' }
+];
 
 const template = createMemoryResourceTemplate<ListOption>();
 

--- a/src/examples/src/widgets/select/RequiredSelect.tsx
+++ b/src/examples/src/widgets/select/RequiredSelect.tsx
@@ -2,7 +2,6 @@ import { create, tsx } from '@dojo/framework/core/vdom';
 import Select from '@dojo/widgets/select';
 import icache from '@dojo/framework/core/middleware/icache';
 import Example from '../../Example';
-import { ListOption } from '@dojo/widgets/list';
 import {
 	createMemoryResourceTemplate,
 	createResourceMiddleware
@@ -12,13 +11,17 @@ const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
 const options = [{ value: 'cat' }, { value: 'dog' }, { value: 'fish' }];
 
-const template = createMemoryResourceTemplate<ListOption>();
+const template = createMemoryResourceTemplate<{ value: string }>();
 
 export default factory(function RequiredSelect({ id, middleware: { icache, resource } }) {
 	return (
 		<Example>
 			<Select
-				resource={resource({ template, initOptions: { id, data: options } })}
+				resource={resource({
+					template,
+					transform: { value: 'value', label: 'value' },
+					initOptions: { id, data: options }
+				})}
 				onValue={(value) => {
 					icache.set('value', value);
 				}}

--- a/src/examples/src/widgets/select/RequiredSelect.tsx
+++ b/src/examples/src/widgets/select/RequiredSelect.tsx
@@ -34,7 +34,9 @@ export default factory(function RequiredSelect({ id, middleware: { icache, resou
 					label: 'Required Select'
 				}}
 			</Select>
-			<pre>{`Value: ${icache.getOrSet('value', '')}, Valid: ${icache.get('valid')}`}</pre>
+			<pre>{`Value: ${JSON.stringify(icache.getOrSet('value', ''))}, Valid: ${icache.get(
+				'valid'
+			)}`}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/trigger-popup/MenuPopup.tsx
+++ b/src/examples/src/widgets/trigger-popup/MenuPopup.tsx
@@ -11,9 +11,9 @@ import {
 const resource = createResourceMiddleware();
 const factory = create({ resource });
 const options = [
-	{ value: 'Save' },
-	{ value: 'copy', label: 'Copy' },
-	{ value: 'Paste', disabled: true }
+	{ value: '1', label: 'Save' },
+	{ value: '2', label: 'Copy' },
+	{ value: '3', label: 'Paste', disabled: true }
 ];
 const template = createMemoryResourceTemplate<ListOption>();
 

--- a/src/examples/src/widgets/typeahead/Basic.tsx
+++ b/src/examples/src/widgets/typeahead/Basic.tsx
@@ -31,7 +31,7 @@ export default factory(function Basic({ id, middleware: { icache, resource } }) 
 					label: 'Basic Typeahead'
 				}}
 			</Typeahead>
-			<pre>{icache.getOrSet('value', '')}</pre>
+			<pre>{JSON.stringify(icache.getOrSet('value', ''))}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/typeahead/Basic.tsx
+++ b/src/examples/src/widgets/typeahead/Basic.tsx
@@ -11,9 +11,9 @@ import { ListOption } from '@dojo/widgets/list';
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
 const options = [
-	{ value: 'cat', label: 'Cat' },
-	{ value: 'dog', label: 'Dog', disabled: true },
-	{ value: 'fish', label: 'Fish' }
+	{ value: '1', label: 'Cat' },
+	{ value: '2', label: 'Dog', disabled: true },
+	{ value: '3', label: 'Fish' }
 ];
 
 const template = createMemoryResourceTemplate<ListOption>();

--- a/src/examples/src/widgets/typeahead/Basic.tsx
+++ b/src/examples/src/widgets/typeahead/Basic.tsx
@@ -6,23 +6,24 @@ import {
 	createMemoryResourceTemplate,
 	createResourceMiddleware
 } from '@dojo/framework/core/middleware/resources';
-import { ListOption } from '@dojo/widgets/list';
+import { data, Data } from '../../data';
 
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
-const options = [
-	{ value: '1', label: 'Cat' },
-	{ value: '2', label: 'Dog', disabled: true },
-	{ value: '3', label: 'Fish' }
-];
 
-const template = createMemoryResourceTemplate<ListOption>();
+const template = createMemoryResourceTemplate<Data>();
+
+const dataWithDisabled = data.map((item) => ({ ...item, disabled: Math.random() < 0.1 }));
 
 export default factory(function Basic({ id, middleware: { icache, resource } }) {
 	return (
 		<Example>
 			<Typeahead
-				resource={resource({ template, initOptions: { data: options, id } })}
+				resource={resource({
+					template,
+					transform: { value: 'id', label: 'summary' },
+					initOptions: { data: dataWithDisabled, id }
+				})}
 				onValue={(value) => {
 					icache.set('value', value);
 				}}

--- a/src/examples/src/widgets/typeahead/FreeText.tsx
+++ b/src/examples/src/widgets/typeahead/FreeText.tsx
@@ -32,7 +32,7 @@ export default factory(function FreeText({ id, middleware: { icache, resource } 
 					label: 'Basic Typeahead'
 				}}
 			</Typeahead>
-			<pre>{icache.getOrSet('value', '')}</pre>
+			<pre>{JSON.stringify(icache.getOrSet('value', ''))}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/typeahead/FreeText.tsx
+++ b/src/examples/src/widgets/typeahead/FreeText.tsx
@@ -11,9 +11,9 @@ import { ListOption } from '@dojo/widgets/list';
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
 const options = [
-	{ value: 'cat', label: 'Cat' },
-	{ value: 'dog', label: 'Dog' },
-	{ value: 'fish', label: 'Fish' }
+	{ value: '1', label: 'Cat' },
+	{ value: '2', label: 'Dog' },
+	{ value: '3', label: 'Fish' }
 ];
 
 const template = createMemoryResourceTemplate<ListOption>();

--- a/src/examples/src/widgets/typeahead/RemoteSource.tsx
+++ b/src/examples/src/widgets/typeahead/RemoteSource.tsx
@@ -10,6 +10,7 @@ import {
 } from '@dojo/framework/core/middleware/resources';
 
 interface User {
+	id: string;
 	firstName: string;
 	lastName: string;
 }
@@ -61,7 +62,7 @@ export default factory(function Remote({ middleware: { icache, resource } }) {
 				helperText="Type to filter by last name"
 				resource={resource({
 					template,
-					transform: { value: 'firstName', label: 'firstName' }
+					transform: { value: 'id', label: 'firstName' }
 				})}
 				onValue={(value) => {
 					icache.set('value', value);
@@ -71,7 +72,7 @@ export default factory(function Remote({ middleware: { icache, resource } }) {
 					label: 'Remote Source Typeahead'
 				}}
 			</Typeahead>
-			<pre>{JSON.stringify(icache.getOrSet('value', ''))}</pre>
+			<pre>{JSON.stringify(icache.getOrSet('value', ''), null, 4)}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/typeahead/RemoteSource.tsx
+++ b/src/examples/src/widgets/typeahead/RemoteSource.tsx
@@ -71,7 +71,7 @@ export default factory(function Remote({ middleware: { icache, resource } }) {
 					label: 'Remote Source Typeahead'
 				}}
 			</Typeahead>
-			<pre>{icache.getOrSet('value', '')}</pre>
+			<pre>{JSON.stringify(icache.getOrSet('value', ''))}</pre>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/typeahead/Validation.tsx
+++ b/src/examples/src/widgets/typeahead/Validation.tsx
@@ -11,9 +11,9 @@ import { ListOption } from '@dojo/widgets/list';
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
 const options = [
-	{ value: 'cat', label: 'Cat' },
-	{ value: 'dog', label: 'Dog' },
-	{ value: 'fish', label: 'Fish' }
+	{ value: '1', label: 'Cat' },
+	{ value: '2', label: 'Dog' },
+	{ value: '3', label: 'Fish' }
 ];
 
 const template = createMemoryResourceTemplate<ListOption>();

--- a/src/examples/src/widgets/typeahead/Validation.tsx
+++ b/src/examples/src/widgets/typeahead/Validation.tsx
@@ -32,7 +32,7 @@ export default factory(function Validation({ id, middleware: { icache, resource 
 					label: 'Validation'
 				}}
 			</Typeahead>
-			<pre>{icache.getOrSet('value', '')}</pre>
+			<pre>{JSON.stringify(icache.getOrSet('value', ''))}</pre>
 		</Example>
 	);
 });

--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -393,7 +393,8 @@ export const List = factory(function List({
 				const indexWithinPage = index - (page - 1) * count;
 				const items = pageItems[pageIndex];
 				if (items && items[indexWithinPage]) {
-					renderedItems[i] = renderItem(items[indexWithinPage], index);
+					const { value, label, disabled, divider } = items[indexWithinPage];
+					renderedItems[i] = renderItem({ value, label, disabled, divider }, index);
 				} else if (!items) {
 					renderedItems[i] = renderPlaceholder(index);
 				}

--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -230,7 +230,7 @@ export interface ListChildren {
 export interface ItemRendererProperties {
 	active: boolean;
 	disabled: boolean;
-	label?: string;
+	label: string;
 	selected: boolean;
 	value: string;
 }
@@ -621,6 +621,7 @@ export const List = factory(function List({
 					selected: false,
 					active: false,
 					value: 'offscreen',
+					label: 'offscreen',
 					disabled: false
 				},
 				offscreenItemProps

--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -184,7 +184,7 @@ export const ListItem = listItemFactory(function ListItem({
 	);
 });
 
-export type ListOption = { value: string; label?: string; disabled?: boolean; divider?: boolean };
+export type ListOption = { value: string; label: string; disabled?: boolean; divider?: boolean };
 
 export interface ListProperties {
 	/** Determines if this list can be reordered */
@@ -196,7 +196,7 @@ export interface ListProperties {
 	/** Controlled value property */
 	value?: string;
 	/** Callback called when user selects a value */
-	onValue(value: string): void;
+	onValue(value: ListOption): void;
 	/** Called to request that the menu be closed */
 	onRequestClose?(): void;
 	/** Optional callback, when passed, the widget will no longer control it's own active index / keyboard navigation */
@@ -246,6 +246,7 @@ interface ListICache {
 	menuHeight: number;
 	resetInputTextTimer: any;
 	value: string;
+	listOption: ListOption;
 	scrollTop: number;
 	previousActiveIndex: number;
 	requestedInputText: string;
@@ -304,8 +305,8 @@ export const List = factory(function List({
 		}
 	}
 
-	function setValue(value: string) {
-		icache.set('value', value);
+	function setValue(value: ListOption) {
+		icache.set('value', value.value);
 		onValue(value);
 	}
 
@@ -323,7 +324,7 @@ export const List = factory(function List({
 					const itemDisabled = disabled ? disabled(activeItem) : activeItem.disabled;
 
 					if (!itemDisabled) {
-						setValue(activeItem.value);
+						setValue(activeItem);
 					}
 				}
 				break;
@@ -518,7 +519,7 @@ export const List = factory(function List({
 			widgetId: `${idBase}-item-${index}`,
 			key: `item-${index}`,
 			onSelect: () => {
-				setValue(value);
+				setValue(data);
 			},
 			active,
 			onRequestActive: () => {
@@ -655,7 +656,7 @@ export const List = factory(function List({
 			options: options(),
 			start: computedActiveIndex + 1,
 			type: 'start' as const,
-			query: { value: inputText || requestedInputText }
+			query: { label: inputText || requestedInputText }
 		};
 		if (!isLoading(template, findOptions)) {
 			const foundItem = find(template, findOptions);

--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -246,7 +246,6 @@ interface ListICache {
 	menuHeight: number;
 	resetInputTextTimer: any;
 	value: string;
-	listOption: ListOption;
 	scrollTop: number;
 	previousActiveIndex: number;
 	requestedInputText: string;

--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -377,13 +377,16 @@ export const List = factory(function List({
 		const renderedItems = [];
 		const metaInfo = meta(template, options(), true);
 		if (metaInfo && metaInfo.total) {
-			const pages: number[] = [];
+			let pages: number[] = [];
 			for (let i = 0; i < Math.min(metaInfo.total - start, count); i++) {
 				const index = i + startNode;
 				const page = Math.floor(index / count) + 1;
 				if (pages.indexOf(page) === -1) {
 					pages.push(page);
 				}
+			}
+			if (!pages.length) {
+				pages.push(1);
 			}
 			const pageItems = getOrRead(template, options({ page: pages }));
 			for (let i = 0; i < Math.min(metaInfo.total - start, count); i++) {

--- a/src/list/tests/List.spec.tsx
+++ b/src/list/tests/List.spec.tsx
@@ -138,7 +138,7 @@ const listWithListItemsAssertion = baseAssertion
 			onDragStart={noop}
 			onDrop={noop}
 		>
-			dog
+			Dog
 		</ListItem>,
 		<ListItem
 			classes={undefined}
@@ -210,7 +210,7 @@ const listWithListItemsAssertion = baseAssertion
 			onDragStart={noop}
 			onDrop={noop}
 		>
-			fish
+			Fish
 		</ListItem>
 	]);
 
@@ -237,7 +237,7 @@ const listWithMenuItemsAssertion = baseAssertion
 			}}
 			widgetId={'menu-test-item-0'}
 		>
-			dog
+			Dog
 		</MenuItem>,
 		<MenuItem
 			classes={undefined}
@@ -275,7 +275,7 @@ const listWithMenuItemsAssertion = baseAssertion
 			}}
 			widgetId={'menu-test-item-2'}
 		>
-			fish
+			Fish
 		</MenuItem>
 	]);
 
@@ -505,7 +505,7 @@ describe('List', () => {
 				onDragStart={noop}
 				onDrop={noop}
 			>
-				fish
+				Fish
 			</ListItem>
 		]);
 		r.expect(lastPageItemsAssertion);
@@ -663,7 +663,7 @@ describe('List', () => {
 				}}
 				widgetId={'menu-test-item-5'}
 			>
-				fish
+				Fish
 			</MenuItem>
 		]);
 		r.expect(lastPageItemsAssertion);
@@ -675,7 +675,7 @@ describe('List', () => {
 				<ListItem
 					classes={undefined}
 					active={index === activeIndex}
-					disabled={testData[index].value === 'fish'}
+					disabled={testData[index].value === '3'}
 					key={`item-${index}`}
 					onRequestActive={noop}
 					onSelect={noop}
@@ -715,15 +715,15 @@ describe('List', () => {
 			...data,
 			...[
 				{
-					value: '3',
+					value: '4',
 					label: 'Panda'
 				},
 				{
-					value: '2',
+					value: '5',
 					label: 'Crow'
 				},
 				{
-					value: '1',
+					value: '6',
 					label: 'Fire-Bellied Toad'
 				}
 			]
@@ -738,7 +738,7 @@ describe('List', () => {
 					}
 				}}
 				disabled={(item) => {
-					return item.value === 'fish';
+					return item.value === '3';
 				}}
 				onValue={onValueStub}
 				onRequestClose={onRequestCloseStub}
@@ -984,19 +984,24 @@ describe('List', () => {
 	it('should set active item based on keyboard input', async () => {
 		const testData = [
 			{
-				value: 'Bob'
+				value: '1',
+				label: 'Bob'
 			},
 			{
-				value: 'Adam'
+				value: '2',
+				label: 'Adam'
 			},
 			{
-				value: 'Ant'
+				value: '3',
+				label: 'Ant'
 			},
 			{
-				value: 'Anthony'
+				value: '4',
+				label: 'Anthony'
 			},
 			{
-				value: 'Bobby'
+				value: '5',
+				label: 'Bobby'
 			}
 		];
 		const r = renderer(() => (
@@ -2208,7 +2213,7 @@ describe('List', () => {
 					onSelect={noop}
 					widgetId={'menu-test-item-0'}
 				>
-					dog
+					Dog
 				</ListItem>,
 				<ListItem
 					classes={undefined}
@@ -2230,7 +2235,7 @@ describe('List', () => {
 					onSelect={noop}
 					widgetId={'menu-test-item-2'}
 				>
-					fish
+					Fish
 				</ListItem>
 			]);
 		const r = renderer(() => (
@@ -2255,7 +2260,7 @@ describe('List', () => {
 			<List
 				resource={{ template: { template, id: 'test', initOptions: { data, id: 'test' } } }}
 				onValue={onValueStub}
-				initialValue="cat"
+				initialValue="2"
 			/>
 		));
 		const listAssertion = baseAssertion
@@ -2297,7 +2302,7 @@ describe('List', () => {
 					onDragStart={noop}
 					onDrop={noop}
 				>
-					dog
+					Dog
 				</ListItem>,
 				<ListItem
 					classes={undefined}
@@ -2369,7 +2374,7 @@ describe('List', () => {
 					onDragStart={noop}
 					onDrop={noop}
 				>
-					fish
+					Fish
 				</ListItem>
 			]);
 		r.expect(listAssertion);
@@ -2377,7 +2382,7 @@ describe('List', () => {
 
 	it('should render with value', () => {
 		const props = {
-			value: 'cat'
+			value: '2'
 		};
 		const r = renderer(() => (
 			<List
@@ -2425,7 +2430,7 @@ describe('List', () => {
 					onDragStart={noop}
 					onDrop={noop}
 				>
-					dog
+					Dog
 				</ListItem>,
 				<ListItem
 					classes={undefined}
@@ -2497,11 +2502,11 @@ describe('List', () => {
 					onDragStart={noop}
 					onDrop={noop}
 				>
-					fish
+					Fish
 				</ListItem>
 			]);
 		r.expect(listAssertion);
-		props.value = 'dog';
+		props.value = '1';
 		listAssertion = baseAssertion
 			.setProperty(WrappedItemWrapper, 'styles', {
 				height: '135px'
@@ -2541,7 +2546,7 @@ describe('List', () => {
 					onDragStart={noop}
 					onDrop={noop}
 				>
-					dog
+					Dog
 				</ListItem>,
 				<ListItem
 					classes={undefined}
@@ -2613,7 +2618,7 @@ describe('List', () => {
 					onDragStart={noop}
 					onDrop={noop}
 				>
-					fish
+					Fish
 				</ListItem>
 			]);
 		r.expect(listAssertion);
@@ -2622,16 +2627,18 @@ describe('List', () => {
 	it('should render a divider based on the data', () => {
 		const testData = [
 			{
-				value: 'dog',
+				value: '1',
+				label: 'Dog',
 				divider: true
 			},
 			{
-				value: 'cat',
+				value: '2',
 				label: 'Cat',
 				divider: true
 			},
 			{
-				value: 'fish',
+				value: '3',
+				label: 'Fish',
 				disabled: true
 			}
 		];
@@ -2682,7 +2689,7 @@ describe('List', () => {
 					onDragStart={noop}
 					onDrop={noop}
 				>
-					dog
+					Dog
 				</ListItem>,
 				<hr classes={css.divider} />,
 				<ListItem
@@ -2756,7 +2763,7 @@ describe('List', () => {
 					onDragStart={noop}
 					onDrop={noop}
 				>
-					fish
+					Fish
 				</ListItem>
 			]);
 		r.expect(listAssertion);

--- a/src/list/tests/List.spec.tsx
+++ b/src/list/tests/List.spec.tsx
@@ -17,17 +17,19 @@ import * as fixedCss from '../list.m.css';
 import * as listItemCss from '../../theme/default/list-item.m.css';
 import * as menuItemCss from '../../theme/default/menu-item.m.css';
 
-let template = createMemoryResourceTemplate<{ value: string }>();
+let template = createMemoryResourceTemplate<{ value: string; label: string; disabled?: boolean }>();
 const data = [
 	{
-		value: 'dog'
+		value: '1',
+		label: 'Dog'
 	},
 	{
-		value: 'cat',
+		value: '2',
 		label: 'Cat'
 	},
 	{
-		value: 'fish',
+		value: '3',
+		label: 'Fish',
 		disabled: true
 	}
 ];
@@ -282,7 +284,11 @@ describe('List', () => {
 		sb.stub(global.window.HTMLDivElement.prototype, 'getBoundingClientRect').callsFake(() => ({
 			height: 45
 		}));
-		template = createMemoryResourceTemplate<{ value: string }>();
+		template = createMemoryResourceTemplate<{
+			value: string;
+			label: string;
+			disabled?: boolean;
+		}>();
 	});
 
 	afterEach(() => {
@@ -317,7 +323,11 @@ describe('List', () => {
 			.setProperty(WrappedRoot, 'styles', {
 				maxHeight: '45px'
 			});
-		const template = createResourceTemplate<{ value: string }>({
+		const template = createResourceTemplate<{
+			value: string;
+			label: string;
+			disabled?: boolean;
+		}>({
 			read: (request, { put }) => {
 				if (request.offset === 0) {
 					return pageOnePromise.then((res) => {
@@ -538,7 +548,11 @@ describe('List', () => {
 			.setProperty(WrappedRoot, 'styles', {
 				maxHeight: '45px'
 			});
-		const template = createResourceTemplate<{ value: string }>({
+		const template = createResourceTemplate<{
+			value: string;
+			label: string;
+			disabled?: boolean;
+		}>({
 			read: (request, { put }) => {
 				if (request.offset === 0) {
 					return pageOnePromise.then((res) => {
@@ -701,14 +715,16 @@ describe('List', () => {
 			...data,
 			...[
 				{
-					value: 'panda'
+					value: '3',
+					label: 'Panda'
 				},
 				{
-					value: 'crow',
+					value: '2',
 					label: 'Crow'
 				},
 				{
-					value: 'fire-bellied toad'
+					value: '1',
+					label: 'Fire-Bellied Toad'
 				}
 			]
 		];

--- a/src/pagination/index.tsx
+++ b/src/pagination/index.tsx
@@ -292,11 +292,14 @@ export default factory(function Pagination({
 								template: pageSizesTemplate,
 								initOptions: {
 									id,
-									data: pageSizes.map((ps) => ({ value: ps.toString() }))
+									data: pageSizes.map((ps) => ({
+										value: `${ps}`,
+										label: `${ps}`
+									}))
 								}
 							})}
 							onValue={(value) => {
-								onPageSize && onPageSize(parseInt(value, 10));
+								onPageSize && onPageSize(parseInt(value.value, 10));
 							}}
 						/>
 					</div>

--- a/src/pagination/tests/Pagination.spec.tsx
+++ b/src/pagination/tests/Pagination.spec.tsx
@@ -316,7 +316,7 @@ describe('Pagination', () => {
 			);
 			h.expect(sizeSelectorAssertion);
 
-			h.trigger('@page-size-select', 'onValue', '10');
+			h.trigger('@page-size-select', 'onValue', { value: '10', label: '10' });
 			sinon.assert.calledWith(onPageSizeChange, 10);
 		});
 
@@ -342,7 +342,7 @@ describe('Pagination', () => {
 					.setProperty('@page-size-select', 'initialValue', undefined)
 			);
 
-			h.trigger('@page-size-select', 'onValue', '10');
+			h.trigger('@page-size-select', 'onValue', { value: '10', label: '10' });
 			sinon.assert.calledWith(onPageSizeChange, 10);
 		});
 	});

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -28,7 +28,7 @@ import LoadingIndicator from '../loading-indicator';
 
 export interface SelectProperties {
 	/** Callback called when user selects a value */
-	onValue(value: string): void;
+	onValue(value: ListOption): void;
 	/** The initial selected value */
 	initialValue?: string;
 	/** Controlled value property */
@@ -201,7 +201,7 @@ export const Select = factory(function Select({
 								find(template, {
 									options: options(),
 									start: 0,
-									query: { value },
+									query: { label: value },
 									type: 'exact'
 								}) || {
 									item: undefined
@@ -269,10 +269,11 @@ export const Select = factory(function Select({
 									key="menu"
 									focus={() => focusNode === 'menu' && shouldFocus}
 									resource={resource({ template, options })}
-									onValue={(value: string) => {
+									onValue={(value) => {
 										focus.focus();
 										closeMenu();
-										value !== icache.get('value') && icache.set('value', value);
+										value.value !== icache.get('value') &&
+											icache.set('value', value.value);
 										onValue(value);
 									}}
 									onRequestClose={closeMenu}

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -197,7 +197,6 @@ export const Select = factory(function Select({
 
 						let valueOption: ListOption | undefined;
 						if (value) {
-							console.log(value);
 							valueOption = (
 								find(template, {
 									options: options(),

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -197,11 +197,12 @@ export const Select = factory(function Select({
 
 						let valueOption: ListOption | undefined;
 						if (value) {
+							console.log(value);
 							valueOption = (
 								find(template, {
 									options: options(),
 									start: 0,
-									query: { label: value },
+									query: { value },
 									type: 'exact'
 								}) || {
 									item: undefined

--- a/src/theme/dojo/list-item.m.css.d.ts
+++ b/src/theme/dojo/list-item.m.css.d.ts
@@ -5,4 +5,4 @@ export const disabled: string;
 export const movedUp: string;
 export const movedDown: string;
 export const collapsed: string;
-export const draggable: string;
+export const dragIcon: string;

--- a/src/theme/material/list-item.m.css.d.ts
+++ b/src/theme/material/list-item.m.css.d.ts
@@ -4,3 +4,4 @@ export const active: string;
 export const collapsed: string;
 export const movedUp: string;
 export const movedDown: string;
+export const dragIcon: string;

--- a/src/time-picker/index.tsx
+++ b/src/time-picker/index.tsx
@@ -342,11 +342,11 @@ export const TimePicker = factory(function TimePicker({
 		const end = parseTime(max, false) || new Date(1970, 0, 1, 23, 59, 59, 99);
 
 		while (dt.getDate() === 1 && dt <= end) {
-			const value = format24HourTime(dt);
+			const value = formatTime(dt);
 
 			options.push({
-				label: formatTime(dt),
-				value,
+				label: value,
+				value: value,
 				disabled: timeDisabled ? timeDisabled(dt) : false
 			});
 

--- a/src/time-picker/index.tsx
+++ b/src/time-picker/index.tsx
@@ -453,11 +453,11 @@ export const TimePicker = factory(function TimePicker({
 										template,
 										initOptions: { id, data: options }
 									})}
-									onValue={(value: string) => {
+									onValue={(value) => {
 										if (controlledValue === undefined) {
-											icache.set('inputValue', value);
+											icache.set('inputValue', value.value);
 										} else {
-											icache.set('nextValue', value);
+											icache.set('nextValue', value.value);
 										}
 										icache.set('shouldValidate', true);
 										closeMenu();

--- a/src/time-picker/tests/unit/TimePicker.spec.tsx
+++ b/src/time-picker/tests/unit/TimePicker.spec.tsx
@@ -349,17 +349,17 @@ describe('TimePicker', () => {
 
 		// Find the input; it should contain the new value
 		h.expect(baseTemplate(expected));
-		// const [input] = select(
-		// 	'@input',
-		// 	h.trigger('@popup', (node) => (node.children as any)[0].trigger)
-		// );
-		// assert(input.properties.initialValue, format24HourTime(expected));
+		const [input] = select(
+			'@input',
+			h.trigger('@popup', (node) => (node.children as any)[0].trigger)
+		);
+		assert(input.properties.initialValue, format24HourTime(expected));
 
-		// // If `onValue` is called, the input was accepted & validated
-		// sinon.assert.calledWith(onValue, format24HourTime(expected));
+		// If `onValue` is called, the input was accepted & validated
+		sinon.assert.calledWith(onValue, format24HourTime(expected));
 
-		// // The calendar popup should be closed after a selection
-		// sinon.assert.calledOnce(onClose);
+		// The calendar popup should be closed after a selection
+		sinon.assert.calledOnce(onClose);
 	});
 
 	it('allows time picker selection with 12 hour format', () => {

--- a/src/time-picker/tests/unit/TimePicker.spec.tsx
+++ b/src/time-picker/tests/unit/TimePicker.spec.tsx
@@ -344,21 +344,22 @@ describe('TimePicker', () => {
 		// Find the calendar widget and trigger a date selected
 		const [menu] = select('@menu', contentResult);
 		onValue.resetHistory();
-		menu.properties.onValue(format24HourTime(expected));
+		const formattedDate = format24HourTime(expected);
+		menu.properties.onValue({ value: formattedDate, label: formattedDate });
 
 		// Find the input; it should contain the new value
 		h.expect(baseTemplate(expected));
-		const [input] = select(
-			'@input',
-			h.trigger('@popup', (node) => (node.children as any)[0].trigger)
-		);
-		assert(input.properties.initialValue, format24HourTime(expected));
+		// const [input] = select(
+		// 	'@input',
+		// 	h.trigger('@popup', (node) => (node.children as any)[0].trigger)
+		// );
+		// assert(input.properties.initialValue, format24HourTime(expected));
 
-		// If `onValue` is called, the input was accepted & validated
-		sinon.assert.calledWith(onValue, format24HourTime(expected));
+		// // If `onValue` is called, the input was accepted & validated
+		// sinon.assert.calledWith(onValue, format24HourTime(expected));
 
-		// The calendar popup should be closed after a selection
-		sinon.assert.calledOnce(onClose);
+		// // The calendar popup should be closed after a selection
+		// sinon.assert.calledOnce(onClose);
 	});
 
 	it('allows time picker selection with 12 hour format', () => {
@@ -380,7 +381,8 @@ describe('TimePicker', () => {
 		// Find the calendar widget and trigger a date selected
 		const [menu] = select('@menu', contentResult);
 		onValue.resetHistory();
-		menu.properties.onValue(format24HourTime(expected));
+		const formattedDate = format24HourTime(expected);
+		menu.properties.onValue({ value: formattedDate, label: formattedDate });
 
 		// Find the input; it should contain the new value
 		h.expect(baseTemplate(expected));

--- a/src/tree/index.tsx
+++ b/src/tree/index.tsx
@@ -124,9 +124,9 @@ export default factory(function Tree({
 
 	function checkNode(id: string, checked: boolean) {
 		if (checked) {
-			icache.set('checkedIds', (currentChecked) => [...currentChecked, id]);
+			icache.set('checkedIds', (currentChecked = []) => [...currentChecked, id]);
 		} else {
-			icache.set('checkedIds', (currentChecked) =>
+			icache.set('checkedIds', (currentChecked = []) =>
 				currentChecked ? currentChecked.filter((n) => n !== id) : []
 			);
 		}
@@ -134,12 +134,12 @@ export default factory(function Tree({
 	}
 
 	function expandNode(id: string) {
-		icache.set('expandedIds', (currentExpanded) => [...currentExpanded, id]);
+		icache.set('expandedIds', (currentExpanded = []) => [...currentExpanded, id]);
 		onExpand && onExpand(icache.get('expandedIds') || []);
 	}
 
 	function collapseNode(id: string) {
-		icache.set('expandedIds', (currentExpanded) =>
+		icache.set('expandedIds', (currentExpanded = []) =>
 			currentExpanded ? currentExpanded.filter((n) => n !== id) : []
 		);
 		onExpand && onExpand(icache.get('expandedIds') || []);

--- a/src/tree/tests/unit/Tree.spec.tsx
+++ b/src/tree/tests/unit/Tree.spec.tsx
@@ -93,8 +93,8 @@ describe('Tree', () => {
 				}}
 			/>
 		));
-		r.child(WrappedNode1, {});
-		r.child(WrappedNode2, {});
+		r.child(WrappedNode1, { value: 'node-1' });
+		r.child(WrappedNode2, { value: 'node-2' });
 
 		r.expect(simpleTreeAssertion);
 	});

--- a/src/tree/tests/unit/Tree.spec.tsx
+++ b/src/tree/tests/unit/Tree.spec.tsx
@@ -93,6 +93,9 @@ describe('Tree', () => {
 				}}
 			/>
 		));
+		r.child(WrappedNode1, {});
+		r.child(WrappedNode2, {});
+
 		r.expect(simpleTreeAssertion);
 	});
 
@@ -197,7 +200,7 @@ describe('Tree', () => {
 									expanded={false}
 									node={simpleTree[1]}
 								>
-									{noop as any}
+									{() => ''}
 								</WrappedNode3>
 							</li>
 						</ol>
@@ -240,7 +243,7 @@ describe('Tree', () => {
 								>
 									<li role={'treeitem'} classes={[css.node, false, false, false]}>
 										<TreeNode {...nodeProps} node={simpleTree[1]}>
-											{noop as any}
+											{() => ''}
 										</TreeNode>
 									</li>
 								</ol>
@@ -286,7 +289,7 @@ describe('Tree', () => {
 								>
 									<li role={'treeitem'} classes={[css.node, false, false, false]}>
 										<TreeNode {...nodeProps} node={simpleTree[1]}>
-											{noop as any}
+											{() => ''}
 										</TreeNode>
 									</li>
 								</ol>
@@ -410,7 +413,8 @@ describe('Tree', () => {
 			r.child(WrappedNode1, { value: 'node-1' });
 			r.child(WrappedNode2, { value: 'node-2' });
 			r.expect(expandedAssertion);
-
+			r.child(WrappedNode1, {});
+			r.child(WrappedNode2, {});
 			r.property(WrappedNode1, 'onActive');
 			r.child(WrappedNode1, { value: 'node-1' });
 			r.child(WrappedNode2, { value: 'node-2' });

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -57,6 +57,7 @@ export interface TypeaheadProperties {
 
 export interface TypeaheadICache {
 	value: string;
+	labelValue: string;
 	lastValue: string | undefined;
 	activeIndex: number;
 	dirty: boolean;
@@ -133,6 +134,7 @@ export const Typeahead = factory(function Typeahead({
 
 	let valid = icache.get('valid');
 	let value = icache.get('value');
+	let labelValue = icache.get('labelValue');
 	const listId = `typeahead-list-${id}`;
 	const triggerId = `typeahead-trigger-${id}`;
 	const dirty = icache.get('dirty');
@@ -274,18 +276,32 @@ export const Typeahead = factory(function Typeahead({
 						}
 
 						let valueOption: any;
-						if (value) {
+						if (labelValue) {
+							console.log('label', labelValue);
 							valueOption = (
 								find(template, {
 									options: options(),
 									start: 0,
-									query: { label: value },
+									query: { label: labelValue },
+									type: 'exact'
+								}) || {
+									item: undefined
+								}
+							).item;
+						} else if (value) {
+							console.log('value', value);
+							valueOption = (
+								find(template, {
+									options: options(),
+									start: 0,
+									query: { value },
 									type: 'exact'
 								}) || {
 									item: undefined
 								}
 							).item;
 						}
+						console.log('valueOption', valueOption);
 
 						return (
 							<TextInput
@@ -294,7 +310,8 @@ export const Typeahead = factory(function Typeahead({
 									if (value !== icache.get('value')) {
 										openMenu();
 										options({ query: { label: value } });
-										icache.set('value', value || '');
+										icache.set('labelValue', value || '');
+										icache.delete('value');
 									}
 								}}
 								theme={theme.compose(
@@ -319,7 +336,9 @@ export const Typeahead = factory(function Typeahead({
 								}}
 								name={name}
 								initialValue={
-									valueOption ? valueOption.label || valueOption.value : value
+									valueOption
+										? valueOption.label || valueOption.value
+										: labelValue
 								}
 								focus={() =>
 									icache.get('focusNode') === 'trigger' && focus.shouldFocus()

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -217,8 +217,8 @@ export const Typeahead = factory(function Typeahead({
 					onValidate && onValidate(false);
 				}
 			} else {
-				const value = icache.getOrSet('value', '');
-				callOnValue({ value, label: value });
+				const labelValue = icache.getOrSet('labelValue', '');
+				callOnValue({ value: labelValue, label: labelValue });
 			}
 			icache.set('selected', false);
 		} else if (activeItem) {
@@ -276,20 +276,7 @@ export const Typeahead = factory(function Typeahead({
 						}
 
 						let valueOption: any;
-						if (labelValue) {
-							console.log('label', labelValue);
-							valueOption = (
-								find(template, {
-									options: options(),
-									start: 0,
-									query: { label: labelValue },
-									type: 'exact'
-								}) || {
-									item: undefined
-								}
-							).item;
-						} else if (value) {
-							console.log('value', value);
+						if (value) {
 							valueOption = (
 								find(template, {
 									options: options(),
@@ -301,7 +288,6 @@ export const Typeahead = factory(function Typeahead({
 								}
 							).item;
 						}
-						console.log('valueOption', valueOption);
 
 						return (
 							<TextInput
@@ -335,11 +321,7 @@ export const Typeahead = factory(function Typeahead({
 									onBlur && onBlur();
 								}}
 								name={name}
-								initialValue={
-									valueOption
-										? valueOption.label || valueOption.value
-										: labelValue
-								}
+								initialValue={valueOption ? valueOption.label : labelValue}
 								focus={() =>
 									icache.get('focusNode') === 'trigger' && focus.shouldFocus()
 								}

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -124,11 +124,13 @@ export const Typeahead = factory(function Typeahead({
 	) {
 		icache.set('initial', initialValue);
 		icache.set('value', initialValue);
+		icache.delete('labelValue');
 	}
 
 	if (controlledValue !== undefined && icache.get('lastValue') !== controlledValue) {
 		icache.set('value', controlledValue);
 		icache.set('lastValue', controlledValue);
+		icache.delete('labelValue');
 		options({ query: { value: controlledValue } });
 	}
 
@@ -226,8 +228,9 @@ export const Typeahead = factory(function Typeahead({
 		} else if (activeItem) {
 			let disabled = itemDisabled ? itemDisabled(activeItem) : !!activeItem.disabled;
 			if (!disabled) {
+				const { value: itemValue, label, disabled, divider } = activeItem;
 				value = icache.set('value', activeItem.value);
-				callOnValue(currentItems[activeIndex]);
+				callOnValue({ value: itemValue, label, disabled, divider });
 			}
 		}
 		icache.set('selected', false);
@@ -279,9 +282,13 @@ export const Typeahead = factory(function Typeahead({
 
 						let valueOption: ListOption | undefined;
 						if (value) {
+							const findOptions = createOptions(`${id}-find`);
 							valueOption = (
 								find(template, {
-									options: options(),
+									options: findOptions({
+										page: options().page,
+										size: options().size
+									}),
 									start: 0,
 									query: { value },
 									type: 'exact'
@@ -321,7 +328,14 @@ export const Typeahead = factory(function Typeahead({
 										const value = icache.getOrSet('labelValue', '');
 										icache.set('value', value);
 										callOnValue(
-											valueOption ? valueOption : { value, label: value }
+											valueOption
+												? {
+														value: valueOption.value,
+														label: valueOption.label,
+														divider: valueOption.divider,
+														disabled: valueOption.disabled
+												  }
+												: { value, label: value }
 										);
 									}
 

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -26,7 +26,7 @@ import { flat } from '@dojo/framework/shim/array';
 
 export interface TypeaheadProperties {
 	/** Callback called when user selects a value */
-	onValue(value: string): void;
+	onValue(value: ListOption): void;
 	/** The initial selected value */
 	initialValue?: string;
 	/** Property to determine how many items to render. Defaults to 6 */
@@ -128,7 +128,7 @@ export const Typeahead = factory(function Typeahead({
 	if (controlledValue !== undefined && icache.get('lastValue') !== controlledValue) {
 		icache.set('value', controlledValue);
 		icache.set('lastValue', controlledValue);
-		options({ query: { value: controlledValue } });
+		options({ query: { label: controlledValue } });
 	}
 
 	let valid = icache.get('valid');
@@ -146,11 +146,11 @@ export const Typeahead = factory(function Typeahead({
 		}
 	}
 
-	function callOnValue(value: string) {
+	function callOnValue(value: ListOption) {
 		const { onValidate, onValue, required } = properties();
 		const lastValue = icache.get('lastValue');
 
-		if (lastValue === value) {
+		if (lastValue === value.value) {
 			return;
 		}
 
@@ -159,7 +159,7 @@ export const Typeahead = factory(function Typeahead({
 			valid = false;
 		}
 
-		icache.set('lastValue', value);
+		icache.set('lastValue', value.value);
 		icache.set('valid', valid);
 		value && onValue && onValue(value);
 		onValidate && onValidate(valid);
@@ -216,14 +216,14 @@ export const Typeahead = factory(function Typeahead({
 				}
 			} else {
 				const value = icache.getOrSet('value', '');
-				callOnValue(value);
+				callOnValue({ value, label: value });
 			}
 			icache.set('selected', false);
 		} else if (activeItem) {
 			let disabled = itemDisabled ? itemDisabled(activeItem) : !!activeItem.disabled;
 			if (!disabled) {
 				value = icache.set('value', activeItem.value);
-				callOnValue(currentItems[activeIndex].value);
+				callOnValue(currentItems[activeIndex]);
 			}
 		}
 		icache.set('selected', false);
@@ -279,7 +279,7 @@ export const Typeahead = factory(function Typeahead({
 								find(template, {
 									options: options(),
 									start: 0,
-									query: { value },
+									query: { label: value },
 									type: 'exact'
 								}) || {
 									item: undefined
@@ -293,7 +293,7 @@ export const Typeahead = factory(function Typeahead({
 								onValue={(value) => {
 									if (value !== icache.get('value')) {
 										openMenu();
-										options({ query: { value } });
+										options({ query: { label: value } });
 										icache.set('value', value || '');
 									}
 								}}
@@ -311,7 +311,7 @@ export const Typeahead = factory(function Typeahead({
 
 									if (!strict) {
 										const value = icache.getOrSet('value', '');
-										callOnValue(value);
+										callOnValue({ value, label: value });
 									}
 
 									closeMenu();
@@ -369,7 +369,8 @@ export const Typeahead = factory(function Typeahead({
 									onValue={(value) => {
 										focus.focus();
 										closeMenu();
-										value !== icache.get('value') && icache.set('value', value);
+										value.value !== icache.get('value') &&
+											icache.set('value', value.value);
 										callOnValue(value);
 									}}
 									onRequestClose={closeMenu}

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -129,7 +129,7 @@ export const Typeahead = factory(function Typeahead({
 	if (controlledValue !== undefined && icache.get('lastValue') !== controlledValue) {
 		icache.set('value', controlledValue);
 		icache.set('lastValue', controlledValue);
-		options({ query: { label: controlledValue } });
+		options({ query: { value: controlledValue } });
 	}
 
 	let valid = icache.get('valid');
@@ -218,6 +218,8 @@ export const Typeahead = factory(function Typeahead({
 				}
 			} else {
 				const labelValue = icache.getOrSet('labelValue', '');
+				icache.set('value', labelValue);
+				value = labelValue;
 				callOnValue({ value: labelValue, label: labelValue });
 			}
 			icache.set('selected', false);
@@ -275,7 +277,7 @@ export const Typeahead = factory(function Typeahead({
 							}
 						}
 
-						let valueOption: any;
+						let valueOption: ListOption | undefined;
 						if (value) {
 							valueOption = (
 								find(template, {
@@ -287,13 +289,16 @@ export const Typeahead = factory(function Typeahead({
 									item: undefined
 								}
 							).item;
+							if (valueOption && icache.get('labelValue') !== valueOption.label) {
+								options({ query: { label: valueOption.label } });
+							}
 						}
 
 						return (
 							<TextInput
 								autocomplete={false}
 								onValue={(value) => {
-									if (value !== icache.get('value')) {
+									if (value !== icache.get('labelValue')) {
 										openMenu();
 										options({ query: { label: value } });
 										icache.set('labelValue', value || '');
@@ -313,8 +318,11 @@ export const Typeahead = factory(function Typeahead({
 									const { onBlur } = properties();
 
 									if (!strict) {
-										const value = icache.getOrSet('value', '');
-										callOnValue({ value, label: value });
+										const value = icache.getOrSet('labelValue', '');
+										icache.set('value', value);
+										callOnValue(
+											valueOption ? valueOption : { value, label: value }
+										);
 									}
 
 									closeMenu();
@@ -370,8 +378,9 @@ export const Typeahead = factory(function Typeahead({
 									onValue={(value) => {
 										focus.focus();
 										closeMenu();
-										value.value !== icache.get('value') &&
+										if (value.value !== icache.get('value')) {
 											icache.set('value', value.value);
+										}
 										callOnValue(value);
 									}}
 									onRequestClose={closeMenu}

--- a/src/typeahead/tests/unit/Typeahead.spec.tsx
+++ b/src/typeahead/tests/unit/Typeahead.spec.tsx
@@ -22,19 +22,25 @@ const { ' _key': listKey, ...listTheme } = listCss as any;
 
 const data = [
 	{
-		value: 'dog'
+		value: '1',
+		label: 'Dog'
 	},
 	{
-		value: 'cat',
+		value: '2',
 		label: 'Cat'
 	},
 	{
-		value: 'fish',
+		value: '3',
+		label: 'Fish',
 		disabled: true
 	}
 ];
 
-const template = createMemoryResourceTemplate<{ value: string }>();
+const template = createMemoryResourceTemplate<{
+	value: string;
+	label: string;
+	disabled?: boolean;
+}>();
 const WrappedRoot = wrap('div');
 const WrappedTrigger = wrap(TextInput);
 const WrappedPopup = wrap(TriggerPopup);
@@ -224,7 +230,7 @@ describe('Typeahead', () => {
 		// select second item from the drop down, `cat`
 		r.property(WrappedTrigger, 'onKeyDown', Keys.Enter, () => {});
 		// simulate `cat` value being selected on the list
-		r.property(WrappedList, 'onValue', 'cat');
+		r.property(WrappedList, 'onValue', { value: 'cat', label: 'Cat' });
 		// call `onClose` on the popup to simulate the dropdown closing
 		r.property(WrappedPopup, 'onClose');
 		r.expect(
@@ -273,7 +279,7 @@ describe('Typeahead', () => {
 		r.expect(baseAssertion);
 		// open the drop down
 		r.property(WrappedTrigger, 'onValue', 'unknown');
-		r.property(WrappedList, 'onValue', 'unknown');
+		r.property(WrappedList, 'onValue', { value: 'unknown', label: 'unknown' });
 		// focus second item from the drop down, `cat`
 		r.property(WrappedTrigger, 'onKeyDown', Keys.Enter, () => {});
 		r.expect(

--- a/src/typeahead/tests/unit/Typeahead.spec.tsx
+++ b/src/typeahead/tests/unit/Typeahead.spec.tsx
@@ -159,7 +159,7 @@ describe('Typeahead', () => {
 			<Typeahead
 				resource={{ template: { template, id: 'test', initOptions: { data, id: 'test' } } }}
 				onValue={onValueStub}
-				initialValue="cat"
+				initialValue="2"
 			/>
 		));
 		r.child(WrappedPopup, {
@@ -168,14 +168,14 @@ describe('Typeahead', () => {
 		r.expect(
 			baseAssertion.replaceChildren(WrappedPopup, () => ({
 				trigger: triggerAssertion.setProperty(WrappedTrigger, 'initialValue', 'Cat'),
-				content: contentAssertion.setProperty(WrappedList, 'initialValue', 'cat')
+				content: contentAssertion.setProperty(WrappedList, 'initialValue', '2')
 			}))
 		);
 	});
 
 	it('Should render the typeahead with a controlled value', () => {
 		const properties: any = {
-			value: 'cat'
+			value: '2'
 		};
 		const r = renderer(() => (
 			<Typeahead
@@ -190,14 +190,14 @@ describe('Typeahead', () => {
 		r.expect(
 			baseAssertion.replaceChildren(WrappedPopup, () => ({
 				trigger: triggerAssertion.setProperty(WrappedTrigger, 'initialValue', 'Cat'),
-				content: contentAssertion.setProperty(WrappedList, 'initialValue', 'cat')
+				content: contentAssertion.setProperty(WrappedList, 'initialValue', '2')
 			}))
 		);
-		properties.value = 'dog';
+		properties.value = '1';
 		r.expect(
 			baseAssertion.replaceChildren(WrappedPopup, () => ({
-				trigger: triggerAssertion.setProperty(WrappedTrigger, 'initialValue', 'dog'),
-				content: contentAssertion.setProperty(WrappedList, 'initialValue', 'dog')
+				trigger: triggerAssertion.setProperty(WrappedTrigger, 'initialValue', 'Dog'),
+				content: contentAssertion.setProperty(WrappedList, 'initialValue', '1')
 			}))
 		);
 	});
@@ -242,7 +242,7 @@ describe('Typeahead', () => {
 						.setProperty(WrappedTrigger, 'initialValue', 'Cat')
 						.setProperty(WrappedTrigger, 'valid', true),
 					content: contentAssertion
-						.setProperty(WrappedList, 'initialValue', 'cat')
+						.setProperty(WrappedList, 'initialValue', '2')
 						.setProperty(WrappedList, 'activeIndex', 1)
 				}))
 		);
@@ -256,7 +256,7 @@ describe('Typeahead', () => {
 					trigger: expandedTriggerAssertion
 						.setProperty(WrappedTrigger, 'valid', false)
 						.setProperty(WrappedTrigger, 'initialValue', ''),
-					content: contentAssertion.setProperty(WrappedList, 'initialValue', '')
+					content: contentAssertion.setProperty(WrappedList, 'initialValue', undefined)
 				}))
 		);
 	});
@@ -405,7 +405,7 @@ describe('Typeahead', () => {
 			baseAssertion.replaceChildren(WrappedPopup, () => ({
 				trigger: triggerAssertion.setProperty(WrappedTrigger, 'initialValue', 'Cat'),
 				content: contentAssertion
-					.setProperty(WrappedList, 'initialValue', 'cat')
+					.setProperty(WrappedList, 'initialValue', '2')
 					.setProperty(WrappedList, 'activeIndex', 1)
 			}))
 		);
@@ -439,7 +439,7 @@ describe('Typeahead', () => {
 			}))
 		);
 		assert.strictEqual(onValueStub.callCount, 1);
-		assert.deepEqual(onValueStub.firstCall.args, ['c']);
+		assert.deepEqual(onValueStub.firstCall.args, [{ value: 'c', label: 'c' }]);
 	});
 
 	it('Should not be able to select a disabled item', () => {
@@ -474,7 +474,7 @@ describe('Typeahead', () => {
 		const r = renderer(() => (
 			<Typeahead
 				resource={{ template: { template, id: 'test', initOptions: { data, id: 'test' } } }}
-				itemDisabled={(item) => item.value === 'cat'}
+				itemDisabled={(item) => item.value === '2'}
 				onValue={onValueStub}
 			/>
 		));
@@ -521,9 +521,7 @@ describe('Typeahead', () => {
 		r.expect(
 			baseAssertion.replaceChildren(WrappedPopup, () => ({
 				trigger: triggerAssertion.setProperty(WrappedTrigger, 'initialValue', 'Unknown'),
-				content: contentAssertion
-					.setProperty(WrappedList, 'initialValue', 'Unknown')
-					.setProperty(WrappedList, 'activeIndex', 0)
+				content: contentAssertion.setProperty(WrappedList, 'activeIndex', 0)
 			}))
 		);
 		assert.strictEqual(onValueStub.callCount, 0);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

All resource based list widgets should filter/search by the label not the "hidden" value of the item. Updates examples to be more realistic, i.e. have different values for `value` and `label` so incorrect behaviour is not masked.

Resolves #1562 