### PR TITLE
Better guard for dealing with classes

### DIFF
--- a/src/middleware/theme.tsx
+++ b/src/middleware/theme.tsx
@@ -69,16 +69,14 @@ export const theme = factory(function({ middleware: { coreTheme }, properties })
 					(prefixCss, key) => {
 						if (key.indexOf(prefix) === 0 && key !== prefix) {
 							const classKey = lowercaseFirstChar(key.replace(prefix, ''));
-							if (
-								!variantTheme[key] &&
-								virtualTheme[key] &&
-								virtualTheme[key].trim()
-							) {
-								prefixCss[classKey] = `${baseTheme[classKey]} ${virtualTheme[
-									key
-								].trim()}`;
+							const variantClass =
+								typeof variantTheme[key] === 'string' && variantTheme[key].trim();
+							const virtualClass =
+								typeof virtualTheme[key] === 'string' && virtualTheme[key].trim();
+							if (!variantClass && virtualClass) {
+								prefixCss[classKey] = `${baseTheme[classKey]} ${virtualClass}`;
 							}
-							if (variantTheme[key]) {
+							if (variantClass) {
 								prefixCss[classKey] = variantTheme[key];
 							}
 						}
@@ -112,11 +110,14 @@ export const theme = factory(function({ middleware: { coreTheme }, properties })
 					if (key === THEME_KEY) {
 						return theme;
 					}
-					const variantComposesClass = variantTheme[key] && variantTheme[key].trim();
-					if (variantTheme[key]) {
+					const variantComposesClass =
+						typeof variantTheme[key] === 'string' && variantTheme[key].trim();
+					const virtualClass =
+						typeof virtualTheme[key] === 'string' && virtualTheme[key].trim();
+					if (variantComposesClass) {
 						theme[key] = variantComposesClass;
-					} else if (virtualTheme[key] && virtualTheme[key].trim()) {
-						theme[key] = `${theme[key]} ${virtualTheme[key].trim()}`;
+					} else if (virtualClass) {
+						theme[key] = `${theme[key]} ${virtualClass}`;
 					}
 					return theme;
 				},


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

This deals correctly with classes when using the theme middleware.