### PR TITLE
Decouple the list rendered page size from the resource request size

### DIFF
--- a/src/examples/src/widgets/list/Basic.tsx
+++ b/src/examples/src/widgets/list/Basic.tsx
@@ -14,11 +14,15 @@ const factory = create({ icache, resource });
 const template = createMemoryResourceTemplate<Data>();
 
 export default factory(function Basic({ id, middleware: { icache, resource } }) {
+	const { createOptions } = resource;
+	const options = createOptions(id);
+	options({ size: 5 });
 	return (
 		<Example>
 			<List
 				resource={resource({
 					template,
+					options,
 					transform: { value: 'id', label: 'summary' },
 					initOptions: { id, data }
 				})}

--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -375,12 +375,13 @@ export const List = factory(function List({
 
 	function renderItems(start: number, count: number, startNode: number) {
 		const renderedItems = [];
+		const { size: resourceRequestSize } = options();
 		const metaInfo = meta(template, options(), true);
 		if (metaInfo && metaInfo.total) {
 			let pages: number[] = [];
 			for (let i = 0; i < Math.min(metaInfo.total - start, count); i++) {
 				const index = i + startNode;
-				const page = Math.floor(index / count) + 1;
+				const page = Math.floor(index / resourceRequestSize) + 1;
 				if (pages.indexOf(page) === -1) {
 					pages.push(page);
 				}
@@ -391,9 +392,9 @@ export const List = factory(function List({
 			const pageItems = getOrRead(template, options({ page: pages }));
 			for (let i = 0; i < Math.min(metaInfo.total - start, count); i++) {
 				const index = i + startNode;
-				const page = Math.floor(index / count) + 1;
+				const page = Math.floor(index / resourceRequestSize) + 1;
 				const pageIndex = pages.indexOf(page);
-				const indexWithinPage = index - (page - 1) * count;
+				const indexWithinPage = index - (page - 1) * resourceRequestSize;
 				const items = pageItems[pageIndex];
 				if (items && items[indexWithinPage]) {
 					const { value, label, disabled, divider } = items[indexWithinPage];
@@ -640,7 +641,6 @@ export const List = factory(function List({
 		itemHeight && icache.set('menuHeight', itemsInView * itemHeight);
 	}
 
-	const nodePadding = Math.min(itemsInView, 20);
 	const menuHeight = icache.get('menuHeight');
 	const idBase = widgetId || `menu-${id}`;
 	const rootStyles = menuHeight ? { maxHeight: `${menuHeight}px` } : {};
@@ -648,9 +648,8 @@ export const List = factory(function List({
 	const themedCss = theme.classes(css);
 	const itemHeight = icache.getOrSet('itemHeight', 0);
 	let scrollTop = icache.getOrSet('scrollTop', 0);
-
+	const nodePadding = Math.min(itemsInView, 20);
 	const renderedItemsCount = itemsInView + 2 * nodePadding;
-	options({ size: renderedItemsCount });
 	let computedActiveIndex =
 		activeIndex === undefined ? icache.getOrSet('activeIndex', 0) : activeIndex;
 	const inputText = icache.get('inputText');

--- a/src/list/tests/List.spec.tsx
+++ b/src/list/tests/List.spec.tsx
@@ -308,6 +308,10 @@ describe('List', () => {
 	});
 
 	it('should render with list item placeholders', async () => {
+		const data: any[] = [];
+		for (let i = 0; i < 60; i++) {
+			data.push({ value: `${i}`, label: `Item ${i}` });
+		}
 		let pageOneResolver: (options: { data: any[]; total: number }) => void;
 		const pageOnePromise = new Promise<{ data: any[]; total: number }>((resolve) => {
 			pageOneResolver = resolve;
@@ -318,10 +322,54 @@ describe('List', () => {
 		});
 		const listAssertion = listWithListItemsAssertion
 			.setProperty(WrappedItemWrapper, 'styles', {
-				height: '270px'
+				height: '2700px'
 			})
 			.setProperty(WrappedRoot, 'styles', {
-				maxHeight: '45px'
+				maxHeight: '450px'
+			})
+			.replaceChildren(WrappedItemContainer, () => {
+				const children: any[] = [];
+				for (let i = 0; i < 30; i++) {
+					children.push(
+						<ListItem
+							classes={undefined}
+							active={i === 0}
+							disabled={false}
+							key={`item-${i}`}
+							onRequestActive={noop}
+							onSelect={noop}
+							selected={false}
+							theme={{
+								'@dojo/widgets/list-item': {
+									active: listItemCss.active,
+									disabled: listItemCss.disabled,
+									root: listItemCss.root,
+									s: css.items,
+									selected: listItemCss.selected,
+									collapsed: listItemCss.collapsed,
+									dragged: listItemCss.dragged,
+									dragIcon: listItemCss.dragIcon,
+									draggable: listItemCss.draggable,
+									movedUp: listItemCss.movedUp,
+									movedDown: listItemCss.movedDown
+								}
+							}}
+							widgetId={`menu-test-item-${i}`}
+							collapsed={false}
+							draggable={undefined}
+							dragged={false}
+							movedDown={false}
+							movedUp={false}
+							onDragEnd={noop}
+							onDragOver={noop}
+							onDragStart={noop}
+							onDrop={noop}
+						>
+							{`Item ${i}`}
+						</ListItem>
+					);
+				}
+				return children;
 			});
 		const template = createResourceTemplate<{
 			value: string;
@@ -342,172 +390,108 @@ describe('List', () => {
 		});
 
 		const r = renderer(() => (
-			<List
-				itemsInView={1}
-				resource={{ template: { template, id: 'test' } }}
-				onValue={onValueStub}
-			/>
+			<List resource={{ template: { template, id: 'test' } }} onValue={onValueStub} />
 		));
 		r.expect(assertion(() => null));
-		pageOneResolver!({ data, total: 6 });
+		pageOneResolver!({ data: data.slice(0, 30), total: data.length });
 		await pageOnePromise;
 		r.expect(listAssertion);
 		r.property(WrappedRoot, 'onkeydown', createMockEvent({ which: Keys.End }));
 		const endAssertion = listAssertion
-			.setProperty(WrappedRoot, 'aria-activedescendant', 'menu-test-item-5')
-			.setProperty(WrappedRoot, 'scrollTop', 225)
-			.setProperty(WrappedItemContainer, 'styles', { transform: 'translateY(180px)' });
-		const placeHolderAssertion = endAssertion.replaceChildren(WrappedItemContainer, () => [
-			<ListItem
-				classes={undefined}
-				active={false}
-				disabled={true}
-				key={'item-4'}
-				onRequestActive={noop}
-				onSelect={noop}
-				selected={false}
-				theme={{
-					'@dojo/widgets/list-item': {
-						active: listItemCss.active,
-						disabled: listItemCss.disabled,
-						root: listItemCss.root,
-						s: css.items,
-						selected: listItemCss.selected,
-						collapsed: listItemCss.collapsed,
-						dragged: listItemCss.dragged,
-						dragIcon: listItemCss.dragIcon,
-						draggable: listItemCss.draggable,
-						movedUp: listItemCss.movedUp,
-						movedDown: listItemCss.movedDown
-					}
-				}}
-				widgetId={'menu-test-item-4'}
-				collapsed={false}
-				draggable={undefined}
-				dragged={false}
-				movedDown={false}
-				movedUp={false}
-				onDragEnd={noop}
-				onDragOver={noop}
-				onDragStart={noop}
-				onDrop={noop}
-			>
-				<LoadingIndicator />
-			</ListItem>,
-			<ListItem
-				classes={undefined}
-				active={false}
-				disabled={true}
-				key={'item-5'}
-				onRequestActive={noop}
-				onSelect={noop}
-				selected={false}
-				theme={{
-					'@dojo/widgets/list-item': {
-						active: listItemCss.active,
-						disabled: listItemCss.disabled,
-						root: listItemCss.root,
-						s: css.items,
-						selected: listItemCss.selected,
-						collapsed: listItemCss.collapsed,
-						dragged: listItemCss.dragged,
-						dragIcon: listItemCss.dragIcon,
-						draggable: listItemCss.draggable,
-						movedUp: listItemCss.movedUp,
-						movedDown: listItemCss.movedDown
-					}
-				}}
-				widgetId={'menu-test-item-5'}
-				collapsed={false}
-				draggable={undefined}
-				dragged={false}
-				movedDown={false}
-				movedUp={false}
-				onDragEnd={noop}
-				onDragOver={noop}
-				onDragStart={noop}
-				onDrop={noop}
-			>
-				<LoadingIndicator />
-			</ListItem>
-		]);
+			.setProperty(WrappedRoot, 'aria-activedescendant', 'menu-test-item-59')
+			.setProperty(WrappedRoot, 'scrollTop', 2250)
+			.setProperty(WrappedItemContainer, 'styles', { transform: 'translateY(1800px)' });
+		const placeHolderAssertion = endAssertion.replaceChildren(WrappedItemContainer, () => {
+			const children: any[] = [];
+			for (let i = 40; i < 60; i++) {
+				children.push(
+					<ListItem
+						classes={undefined}
+						active={false}
+						disabled={true}
+						key={`item-${i}`}
+						onRequestActive={noop}
+						onSelect={noop}
+						selected={false}
+						theme={{
+							'@dojo/widgets/list-item': {
+								active: listItemCss.active,
+								disabled: listItemCss.disabled,
+								root: listItemCss.root,
+								s: css.items,
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
+							}
+						}}
+						widgetId={`menu-test-item-${i}`}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
+					>
+						<LoadingIndicator />
+					</ListItem>
+				);
+			}
+			return children;
+		});
 		r.expect(placeHolderAssertion);
-		pageTwoResolver!({ data, total: 6 });
+		pageTwoResolver!({ data: data.slice(30), total: data.length });
 		await pageTwoPromise;
-		const lastPageItemsAssertion = endAssertion.replaceChildren(WrappedItemContainer, () => [
-			<ListItem
-				classes={undefined}
-				active={false}
-				disabled={false}
-				key={'item-4'}
-				onRequestActive={noop}
-				onSelect={noop}
-				selected={false}
-				theme={{
-					'@dojo/widgets/list-item': {
-						active: listItemCss.active,
-						disabled: listItemCss.disabled,
-						root: listItemCss.root,
-						s: css.items,
-						selected: listItemCss.selected,
-						collapsed: listItemCss.collapsed,
-						dragged: listItemCss.dragged,
-						dragIcon: listItemCss.dragIcon,
-						draggable: listItemCss.draggable,
-						movedUp: listItemCss.movedUp,
-						movedDown: listItemCss.movedDown
-					}
-				}}
-				widgetId={'menu-test-item-4'}
-				collapsed={false}
-				draggable={undefined}
-				dragged={false}
-				movedDown={false}
-				movedUp={false}
-				onDragEnd={noop}
-				onDragOver={noop}
-				onDragStart={noop}
-				onDrop={noop}
-			>
-				Cat
-			</ListItem>,
-			<ListItem
-				classes={undefined}
-				active={true}
-				disabled={true}
-				key={'item-5'}
-				onRequestActive={noop}
-				onSelect={noop}
-				selected={false}
-				theme={{
-					'@dojo/widgets/list-item': {
-						active: listItemCss.active,
-						disabled: listItemCss.disabled,
-						root: listItemCss.root,
-						s: css.items,
-						selected: listItemCss.selected,
-						collapsed: listItemCss.collapsed,
-						dragged: listItemCss.dragged,
-						dragIcon: listItemCss.dragIcon,
-						draggable: listItemCss.draggable,
-						movedUp: listItemCss.movedUp,
-						movedDown: listItemCss.movedDown
-					}
-				}}
-				widgetId={'menu-test-item-5'}
-				collapsed={false}
-				draggable={undefined}
-				dragged={false}
-				movedDown={false}
-				movedUp={false}
-				onDragEnd={noop}
-				onDragOver={noop}
-				onDragStart={noop}
-				onDrop={noop}
-			>
-				Fish
-			</ListItem>
-		]);
+		const lastPageItemsAssertion = endAssertion.replaceChildren(WrappedItemContainer, () => {
+			const children: any[] = [];
+			for (let i = 40; i < 60; i++) {
+				children.push(
+					<ListItem
+						classes={undefined}
+						active={i === 59}
+						disabled={false}
+						key={`item-${i}`}
+						onRequestActive={noop}
+						onSelect={noop}
+						selected={false}
+						theme={{
+							'@dojo/widgets/list-item': {
+								active: listItemCss.active,
+								disabled: listItemCss.disabled,
+								root: listItemCss.root,
+								s: css.items,
+								selected: listItemCss.selected,
+								collapsed: listItemCss.collapsed,
+								dragged: listItemCss.dragged,
+								dragIcon: listItemCss.dragIcon,
+								draggable: listItemCss.draggable,
+								movedUp: listItemCss.movedUp,
+								movedDown: listItemCss.movedDown
+							}
+						}}
+						widgetId={`menu-test-item-${i}`}
+						collapsed={false}
+						draggable={undefined}
+						dragged={false}
+						movedDown={false}
+						movedUp={false}
+						onDragEnd={noop}
+						onDragOver={noop}
+						onDragStart={noop}
+						onDrop={noop}
+					>
+						{`Item ${i}`}
+					</ListItem>
+				);
+			}
+			return children;
+		});
 		r.expect(lastPageItemsAssertion);
 	});
 
@@ -533,6 +517,10 @@ describe('List', () => {
 	});
 
 	it('should render with menu item placeholders', async () => {
+		const data: any[] = [];
+		for (let i = 0; i < 60; i++) {
+			data.push({ value: `${i}`, label: `Item ${i}` });
+		}
 		let pageOneResolver: (options: { data: any[]; total: number }) => void;
 		const pageOnePromise = new Promise<{ data: any[]; total: number }>((resolve) => {
 			pageOneResolver = resolve;
@@ -543,10 +531,37 @@ describe('List', () => {
 		});
 		const menuAssertion = listWithMenuItemsAssertion
 			.setProperty(WrappedItemWrapper, 'styles', {
-				height: '270px'
+				height: '2700px'
 			})
 			.setProperty(WrappedRoot, 'styles', {
-				maxHeight: '45px'
+				maxHeight: '450px'
+			})
+			.replaceChildren(WrappedItemContainer, () => {
+				const children: any[] = [];
+				for (let i = 0; i < 30; i++) {
+					children.push(
+						<MenuItem
+							classes={undefined}
+							active={i === 0}
+							disabled={false}
+							key={`item-${i}`}
+							onRequestActive={noop}
+							onSelect={noop}
+							theme={{
+								'@dojo/widgets/menu-item': {
+									active: menuItemCss.active,
+									disabled: menuItemCss.disabled,
+									root: menuItemCss.root,
+									s: css.items
+								}
+							}}
+							widgetId={`menu-test-item-${i}`}
+						>
+							{`Item ${i}`}
+						</MenuItem>
+					);
+				}
+				return children;
 			});
 		const template = createResourceTemplate<{
 			value: string;
@@ -567,105 +582,74 @@ describe('List', () => {
 		});
 
 		const r = renderer(() => (
-			<List
-				menu
-				itemsInView={1}
-				resource={{ template: { template, id: 'test' } }}
-				onValue={onValueStub}
-			/>
+			<List menu resource={{ template: { template, id: 'test' } }} onValue={onValueStub} />
 		));
 		r.expect(assertion(() => null));
-		pageOneResolver!({ data, total: 6 });
+		pageOneResolver!({ data: data.slice(0, 30), total: data.length });
 		await pageOnePromise;
 		r.expect(menuAssertion);
 		r.property(WrappedRoot, 'onkeydown', createMockEvent({ which: Keys.End }));
 		const endAssertion = menuAssertion
-			.setProperty(WrappedRoot, 'aria-activedescendant', 'menu-test-item-5')
-			.setProperty(WrappedRoot, 'scrollTop', 225)
-			.setProperty(WrappedItemContainer, 'styles', { transform: 'translateY(180px)' });
-		const placeHolderAssertion = endAssertion.replaceChildren(WrappedItemContainer, () => [
-			<MenuItem
-				classes={undefined}
-				active={false}
-				disabled={true}
-				key={'item-4'}
-				onRequestActive={noop}
-				onSelect={noop}
-				theme={{
-					'@dojo/widgets/menu-item': {
-						active: menuItemCss.active,
-						disabled: menuItemCss.disabled,
-						root: menuItemCss.root,
-						s: css.items
-					}
-				}}
-				widgetId={'menu-test-item-4'}
-			>
-				<LoadingIndicator />
-			</MenuItem>,
-			<MenuItem
-				classes={undefined}
-				active={false}
-				disabled={true}
-				key={'item-5'}
-				onRequestActive={noop}
-				onSelect={noop}
-				theme={{
-					'@dojo/widgets/menu-item': {
-						active: menuItemCss.active,
-						disabled: menuItemCss.disabled,
-						root: menuItemCss.root,
-						s: css.items
-					}
-				}}
-				widgetId={'menu-test-item-5'}
-			>
-				<LoadingIndicator />
-			</MenuItem>
-		]);
+			.setProperty(WrappedRoot, 'aria-activedescendant', 'menu-test-item-59')
+			.setProperty(WrappedRoot, 'scrollTop', 2250)
+			.setProperty(WrappedItemContainer, 'styles', { transform: 'translateY(1800px)' });
+		const placeHolderAssertion = endAssertion.replaceChildren(WrappedItemContainer, () => {
+			const children: any[] = [];
+			for (let i = 40; i < 60; i++) {
+				children.push(
+					<MenuItem
+						classes={undefined}
+						active={false}
+						disabled={true}
+						key={`item-${i}`}
+						onRequestActive={noop}
+						onSelect={noop}
+						theme={{
+							'@dojo/widgets/menu-item': {
+								active: menuItemCss.active,
+								disabled: menuItemCss.disabled,
+								root: menuItemCss.root,
+								s: css.items
+							}
+						}}
+						widgetId={`menu-test-item-${i}`}
+					>
+						<LoadingIndicator />
+					</MenuItem>
+				);
+			}
+			return children;
+		});
 		r.expect(placeHolderAssertion);
-		pageTwoResolver!({ data, total: 6 });
+		pageTwoResolver!({ data: data.slice(30), total: data.length });
 		await pageTwoPromise;
-		const lastPageItemsAssertion = endAssertion.replaceChildren(WrappedItemContainer, () => [
-			<MenuItem
-				classes={undefined}
-				active={false}
-				disabled={false}
-				key={'item-4'}
-				onRequestActive={noop}
-				onSelect={noop}
-				theme={{
-					'@dojo/widgets/menu-item': {
-						active: menuItemCss.active,
-						disabled: menuItemCss.disabled,
-						root: menuItemCss.root,
-						s: css.items
-					}
-				}}
-				widgetId={'menu-test-item-4'}
-			>
-				Cat
-			</MenuItem>,
-			<MenuItem
-				classes={undefined}
-				active={true}
-				disabled={true}
-				key={'item-5'}
-				onRequestActive={noop}
-				onSelect={noop}
-				theme={{
-					'@dojo/widgets/menu-item': {
-						active: menuItemCss.active,
-						disabled: menuItemCss.disabled,
-						root: menuItemCss.root,
-						s: css.items
-					}
-				}}
-				widgetId={'menu-test-item-5'}
-			>
-				Fish
-			</MenuItem>
-		]);
+		const lastPageItemsAssertion = endAssertion.replaceChildren(WrappedItemContainer, () => {
+			const children: any[] = [];
+			for (let i = 40; i < 60; i++) {
+				children.push(
+					<MenuItem
+						classes={undefined}
+						active={59 === i}
+						disabled={false}
+						key={`item-${i}`}
+						onRequestActive={noop}
+						onSelect={noop}
+						theme={{
+							'@dojo/widgets/menu-item': {
+								active: menuItemCss.active,
+								disabled: menuItemCss.disabled,
+								root: menuItemCss.root,
+								s: css.items
+							}
+						}}
+						widgetId={`menu-test-item-${i}`}
+					>
+						{`Item ${i}`}
+					</MenuItem>
+				);
+			}
+			return children;
+		});
 		r.expect(lastPageItemsAssertion);
 	});
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

At the moment the list "controls" the size of the resource page based on the number of items that need to be rendered. This is bad when options are passed to the list with a custom page size set, it overrides the page size requested by the user. Instead this change calculates the number of items required for rendering and then uses the existing page size to determine how many pages need to be requested to fulfil each page.
