### PR TITLE
Support capability to indicate widgets should inherit css vars for the variant from a parent

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -11,6 +11,7 @@
 		"prefix": "dojo",
 		"widgets": [
 			"src/accordion",
+			"src/action-button",
 			"src/avatar",
 			"src/breadcrumb-group",
 			"src/button",

--- a/src/action-button/README.md
+++ b/src/action-button/README.md
@@ -1,0 +1,3 @@
+# @dojo/widgets/action-button
+
+Dojo's `ActionButton` widget provides a button that inherits the themes variant (css variables) from it's parent instead of from the theme directly.

--- a/src/action-button/index.tsx
+++ b/src/action-button/index.tsx
@@ -1,0 +1,17 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Button, { ButtonProperties } from '../button/index';
+import theme from '../middleware/theme';
+
+export interface ActionButtonProperties extends ButtonProperties {}
+
+const factory = create({ theme }).properties<ActionButtonProperties>();
+
+export const ActionButton = factory(function ActionButton({ properties, children }) {
+	return (
+		<Button {...properties()} variant="inherit">
+			{children()}
+		</Button>
+	);
+});
+
+export default ActionButton;

--- a/src/action-button/tests/unit/ActionButton.spec.tsx
+++ b/src/action-button/tests/unit/ActionButton.spec.tsx
@@ -1,0 +1,31 @@
+const { describe, it } = intern.getInterface('bdd');
+
+import { tsx } from '@dojo/framework/core/vdom';
+import { renderer, assertion, wrap } from '@dojo/framework/testing/renderer';
+
+import ActionButton from '../../index';
+import Button from '../../../button/index';
+
+const WrappedButton = wrap(Button);
+
+const baseTemplate = assertion(() => {
+	return <WrappedButton variant="inherit" />;
+});
+
+describe('ActionButton', () => {
+	it('render', () => {
+		const r = renderer(() => <ActionButton />);
+		r.expect(baseTemplate);
+	});
+
+	it('passes all properties through', () => {
+		const r = renderer(() => <ActionButton onClick={() => {}} type="submit" />);
+		r.expect(
+			baseTemplate.setProperties(WrappedButton, {
+				onClick: () => {},
+				type: 'submit',
+				variant: 'inherit'
+			})
+		);
+	});
+});

--- a/src/avatar/index.tsx
+++ b/src/avatar/index.tsx
@@ -3,8 +3,8 @@ import theme from '../middleware/theme';
 import * as css from '../theme/default/avatar.m.css';
 
 export interface AvatarProperties {
-	/* defines the avatar variant, defaults to circle */
-	variant?: 'square' | 'rounded' | 'circle';
+	/* defines the avatar type, defaults to circle */
+	type?: 'square' | 'rounded' | 'circle';
 	/* determines if secondary color scheme should be used */
 	secondary?: boolean;
 	/* Determines if avatar should be rendered as an outline */
@@ -21,7 +21,7 @@ const factory = create({ theme }).properties<AvatarProperties>();
 
 export const Avatar = factory(function Avatar({ middleware: { theme }, properties, children }) {
 	const themeCss = theme.classes(css);
-	const { secondary, outline, src, alt, variant = 'circle', size = 'medium' } = properties();
+	const { secondary, outline, src, alt, type = 'circle', size = 'medium' } = properties();
 	return (
 		<div
 			key="root"
@@ -33,7 +33,7 @@ export const Avatar = factory(function Avatar({ middleware: { theme }, propertie
 				secondary ? themeCss.avatarColorSecondary : themeCss.avatarColor,
 				outline && themeCss.avatarOutline,
 				themeCss[size],
-				themeCss[variant]
+				themeCss[type]
 			]}
 			styles={
 				src

--- a/src/avatar/tests/unit/Avatar.spec.tsx
+++ b/src/avatar/tests/unit/Avatar.spec.tsx
@@ -52,9 +52,9 @@ describe('Avatar', () => {
 		);
 	});
 
-	describe('variants', () => {
+	describe('types', () => {
 		it('renders circle', () => {
-			const h = harness(() => <Avatar variant="circle">D</Avatar>);
+			const h = harness(() => <Avatar type="circle">D</Avatar>);
 			h.expect(
 				template.setProperty('@root', 'classes', [
 					undefined,
@@ -68,7 +68,7 @@ describe('Avatar', () => {
 		});
 
 		it('renders square', () => {
-			const h = harness(() => <Avatar variant="square">D</Avatar>);
+			const h = harness(() => <Avatar type="square">D</Avatar>);
 			h.expect(
 				template.setProperty('@root', 'classes', [
 					undefined,
@@ -82,7 +82,7 @@ describe('Avatar', () => {
 		});
 
 		it('renders rounded', () => {
-			const h = harness(() => <Avatar variant="rounded">D</Avatar>);
+			const h = harness(() => <Avatar type="rounded">D</Avatar>);
 			h.expect(
 				template.setProperty('@root', 'classes', [
 					undefined,

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -10,6 +10,7 @@ import AvatarIcon from './widgets/avatar/Icon';
 import AvatarSecondary from './widgets/avatar/Secondary';
 import AvatarOutlines from './widgets/avatar/Outline';
 import Exclusive from './widgets/accordion/Exclusive';
+import BasicActionButton from './widgets/action-button/Basic';
 import BasicBreadcrumbGroup from './widgets/breadcrumb-group/Basic';
 import CustomRendererBreadcrumbGroup from './widgets/breadcrumb-group/CustomRenderer';
 import BasicButton from './widgets/button/Basic';
@@ -317,6 +318,15 @@ export const config = {
 				example: {
 					filename: 'Basic',
 					module: BasicAccordionPane
+				}
+			}
+		},
+		'action-button': {
+			filename: 'index',
+			overview: {
+				example: {
+					filename: 'Basic',
+					module: BasicActionButton
 				}
 			}
 		},

--- a/src/examples/src/widgets/action-button/Basic.tsx
+++ b/src/examples/src/widgets/action-button/Basic.tsx
@@ -1,0 +1,17 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import ActionButton from '@dojo/widgets/action-button';
+import * as css from './example.m.css';
+import Example from '../../Example';
+
+const factory = create();
+
+export default factory(function Basic() {
+	return (
+		<Example>
+			<div classes={css.root}>
+				<div>Action Button that inherits theme CSS variables from it's parent</div>
+				<ActionButton>Action Button</ActionButton>
+			</div>
+		</Example>
+	);
+});

--- a/src/examples/src/widgets/action-button/example.m.css
+++ b/src/examples/src/widgets/action-button/example.m.css
@@ -1,0 +1,4 @@
+.root {
+	--mdc-theme-primary: red;
+	--color-highlight: red;
+}

--- a/src/examples/src/widgets/action-button/example.m.css.d.ts
+++ b/src/examples/src/widgets/action-button/example.m.css.d.ts
@@ -1,0 +1,1 @@
+export const root: string;

--- a/src/examples/src/widgets/avatar/Icon.tsx
+++ b/src/examples/src/widgets/avatar/Icon.tsx
@@ -9,13 +9,13 @@ export default factory(function Basic() {
 	return (
 		<Example>
 			<div styles={{ maxWidth: '400px', display: 'flex', justifyContent: 'space-around' }}>
-				<Avatar variant="circle">
+				<Avatar type="circle">
 					<Icon type="secureIcon" />
 				</Avatar>
-				<Avatar variant="rounded">
+				<Avatar type="rounded">
 					<Icon type="secureIcon" />
 				</Avatar>
-				<Avatar variant="square">
+				<Avatar type="square">
 					<Icon type="secureIcon" />
 				</Avatar>
 			</div>

--- a/src/examples/src/widgets/avatar/Image.tsx
+++ b/src/examples/src/widgets/avatar/Image.tsx
@@ -10,8 +10,8 @@ export default factory(function Basic() {
 		<Example>
 			<div styles={{ maxWidth: '400px', display: 'flex', justifyContent: 'space-around' }}>
 				<Avatar src={avatar} alt="Dojo" />
-				<Avatar variant="rounded" src={avatar} alt="Dojo" />
-				<Avatar variant="square" src={avatar} alt="Dojo" />
+				<Avatar type="rounded" src={avatar} alt="Dojo" />
+				<Avatar type="square" src={avatar} alt="Dojo" />
 			</div>
 		</Example>
 	);

--- a/src/examples/src/widgets/avatar/Secondary.tsx
+++ b/src/examples/src/widgets/avatar/Secondary.tsx
@@ -8,13 +8,13 @@ export default factory(function Basic() {
 	return (
 		<Example>
 			<div styles={{ maxWidth: '400px', display: 'flex', justifyContent: 'space-around' }}>
-				<Avatar secondary variant="circle">
+				<Avatar secondary type="circle">
 					A
 				</Avatar>
-				<Avatar secondary variant="rounded">
+				<Avatar secondary type="rounded">
 					A
 				</Avatar>
-				<Avatar secondary variant="square">
+				<Avatar secondary type="square">
 					A
 				</Avatar>
 			</div>

--- a/src/examples/src/widgets/avatar/Variant.tsx
+++ b/src/examples/src/widgets/avatar/Variant.tsx
@@ -8,9 +8,9 @@ export default factory(function Basic() {
 	return (
 		<Example>
 			<div styles={{ maxWidth: '400px', display: 'flex', justifyContent: 'space-around' }}>
-				<Avatar variant="circle">A</Avatar>
-				<Avatar variant="rounded">A</Avatar>
-				<Avatar variant="square">A</Avatar>
+				<Avatar type="circle">A</Avatar>
+				<Avatar type="rounded">A</Avatar>
+				<Avatar type="square">A</Avatar>
 			</div>
 		</Example>
 	);

--- a/src/examples/src/widgets/snackbar/Stacked.tsx
+++ b/src/examples/src/widgets/snackbar/Stacked.tsx
@@ -1,7 +1,7 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Snackbar from '@dojo/widgets/snackbar';
 import Example from '../../Example';
-import Button from '@dojo/widgets/button';
+import ActionButton from '@dojo/widgets/action-button';
 
 const factory = create();
 
@@ -11,7 +11,7 @@ export default factory(function Stacked() {
 			<Snackbar stacked open={true}>
 				{{
 					message: 'Stacked Snackbar',
-					actions: <Button>Some Action</Button>
+					actions: <ActionButton>Some Action</ActionButton>
 				}}
 			</Snackbar>
 		</Example>

--- a/src/middleware/tests/theme.spec.tsx
+++ b/src/middleware/tests/theme.spec.tsx
@@ -699,4 +699,34 @@ describe('theme middleware', () => {
 			}
 		});
 	});
+
+	it('should not apply variant if set to inherit', () => {
+		properties.theme = {
+			theme: {
+				theme: {
+					'@dojo/widgets/Base': {
+						active: 'base_theme_active'
+					},
+					'@dojo/widgets/Variant': {
+						baseActive: 'variant_theme_active'
+					}
+				},
+				variants: {
+					default: {
+						root: 'default root variant'
+					}
+				}
+			},
+			variant: {
+				name: 'default',
+				value: {
+					root: 'default root variant'
+				}
+			}
+		};
+
+		assert.strictEqual(composesInstance.variant(), 'default root variant');
+		properties.variant = 'inherit';
+		assert.isUndefined(composesInstance.variant());
+	});
 });

--- a/src/middleware/theme.tsx
+++ b/src/middleware/theme.tsx
@@ -5,7 +5,7 @@ import coreTheme, {
 import { ThemeWithVariant, ClassNames, Theme } from '@dojo/framework/core/interfaces';
 import { isThemeInjectorPayloadWithVariant } from '@dojo/framework/core/ThemeInjector';
 
-const factory = create({ coreTheme });
+const factory = create({ coreTheme }).properties<{ variant?: 'default' | 'inherit' }>();
 export const THEME_KEY = ' _key';
 
 function uppercaseFirstChar(value: string) {
@@ -23,6 +23,7 @@ function isThemeWithVariant(theme: any): theme is ThemeWithVariant {
 export interface ThemeProperties extends CoreThemeProperties {}
 
 export const theme = factory(function({ middleware: { coreTheme }, properties }) {
+	const { variant: coreVariant, get, set, classes } = coreTheme;
 	function getTheme() {
 		const { theme } = properties();
 		if (theme) {
@@ -141,7 +142,12 @@ export const theme = factory(function({ middleware: { coreTheme }, properties })
 				[baseKey]: constructedTheme
 			};
 		},
-		...coreTheme
+		variant: () => {
+			return properties().variant === 'inherit' ? undefined : coreVariant();
+		},
+		get,
+		set,
+		classes
 	};
 });
 

--- a/src/theme/material/snackbar.m.css
+++ b/src/theme/material/snackbar.m.css
@@ -15,7 +15,7 @@
 }
 
 .actions {
-	--mdc-theme-primary: var(--mdc-theme-dark-primary);
+	--mdc-theme-primary: var(--mdc-theme-primary-on-dark);
 	composes: mdc-snackbar__actions from '@material/snackbar/dist/mdc.snackbar.css';
 }
 

--- a/src/theme/material/snackbar.m.css
+++ b/src/theme/material/snackbar.m.css
@@ -15,6 +15,7 @@
 }
 
 .actions {
+	--mdc-theme-primary: var(--mdc-theme-dark-primary);
 	composes: mdc-snackbar__actions from '@material/snackbar/dist/mdc.snackbar.css';
 }
 

--- a/src/theme/material/variants/default.m.css
+++ b/src/theme/material/variants/default.m.css
@@ -3,7 +3,7 @@
 
 	/* variables taken from @material/theme/dist/mdc.theme.css */
 	--mdc-theme-primary: #6200ee;
-	--mdc-theme-dark-primary: #bb86fc;
+	--mdc-theme-primary-on-dark: #bb86fc;
 	--mdc-theme-secondary: #018786;
 	--mdc-theme-background: #fff;
 	--mdc-theme-surface: #fff;

--- a/src/theme/material/variants/default.m.css
+++ b/src/theme/material/variants/default.m.css
@@ -3,6 +3,7 @@
 
 	/* variables taken from @material/theme/dist/mdc.theme.css */
 	--mdc-theme-primary: #6200ee;
+	--mdc-theme-dark-primary: #bb86fc;
 	--mdc-theme-secondary: #018786;
 	--mdc-theme-background: #fff;
 	--mdc-theme-surface: #fff;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

Proof of concept that introduces a property from the widget `theme` middleware to prevent applying the `theme.variant` class to the root meaning that widgets will instead inherit the variable properties from a parent. This allows variables to be partially overridden falling back to the standard set that are applied either at the root of the composite widget or the root of the application.

Unfortunately there was a clash of the property name with the `Avatar` widget that also used `variant` for a different purpose, this property has been renamed `type` and therefore makes this a breaking changes.

Also introduces a new widget `ActionButton` that sets the `variant` property to inherit that should be used for actions throughout the application, allowing parent widgets such as the `SnackBar` to control certain variables as required.

Resolves #1586 (when using the new `ActionButton`)
