### PR TITLE
Make the form api typing more ergonomic

### DIFF
--- a/src/examples/src/widgets/form/ActionForm.tsx
+++ b/src/examples/src/widgets/form/ActionForm.tsx
@@ -1,7 +1,6 @@
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Form, { FormField, FormGroup } from '@dojo/widgets/form';
-import { FormMiddleware } from '@dojo/widgets/form/middleware';
 import TextInput from '@dojo/widgets/text-input';
 
 import Example from '../../Example';
@@ -29,7 +28,8 @@ const App = factory(function({ middleware: { icache } }) {
 				action="action-url"
 				onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}
 			>
-				{({ field }: FormMiddleware<Fields>) => {
+				{(form) => {
+					const { field } = form<Fields>();
 					const firstName = field('firstName');
 					const middleName = field('middleName');
 					const lastName = field('lastName');

--- a/src/examples/src/widgets/form/Basic.tsx
+++ b/src/examples/src/widgets/form/Basic.tsx
@@ -1,7 +1,6 @@
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Form, { FormField, FormGroup } from '@dojo/widgets/form';
-import { FormMiddleware } from '@dojo/widgets/form/middleware';
 import TextInput from '@dojo/widgets/text-input';
 
 import Example from '../../Example';
@@ -28,7 +27,8 @@ const App = factory(function({ middleware: { icache } }) {
 				name="basicForm"
 				onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}
 			>
-				{({ field }: FormMiddleware<Fields>) => {
+				{(form) => {
+					const { field } = form<Fields>();
 					const firstName = field('firstName');
 					const middleName = field('middleName');
 					const lastName = field('lastName');

--- a/src/examples/src/widgets/form/Controlled.tsx
+++ b/src/examples/src/widgets/form/Controlled.tsx
@@ -1,7 +1,6 @@
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Form, { FormField, FormGroup } from '@dojo/widgets/form';
-import { FormMiddleware } from '@dojo/widgets/form/middleware';
 import TextInput from '@dojo/widgets/text-input';
 
 import Example from '../../Example';
@@ -29,7 +28,8 @@ const App = factory(function({ middleware: { icache } }) {
 				onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}
 				value={results}
 			>
-				{({ field }: FormMiddleware<Fields>) => {
+				{(form) => {
+					const { field } = form<Fields>();
 					const firstName = field('firstName');
 					const middleName = field('middleName');
 					const lastName = field('lastName');

--- a/src/examples/src/widgets/form/DisabledFieldsForm.tsx
+++ b/src/examples/src/widgets/form/DisabledFieldsForm.tsx
@@ -2,7 +2,6 @@ import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
 import Form, { FormField, FormGroup } from '@dojo/widgets/form';
-import { FormMiddleware } from '@dojo/widgets/form/middleware';
 import TextInput from '@dojo/widgets/text-input';
 
 import Example from '../../Example';
@@ -26,7 +25,8 @@ const App = factory(function({ middleware: { icache } }) {
 	return (
 		<Example>
 			<Form onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}>
-				{({ field }: FormMiddleware<Fields>) => {
+				{(form) => {
+					const { field } = form<Fields>();
 					const firstName = field('firstName');
 					const middleName = field('middleName');
 					const lastName = field('lastName');

--- a/src/examples/src/widgets/form/DisabledForm.tsx
+++ b/src/examples/src/widgets/form/DisabledForm.tsx
@@ -2,7 +2,6 @@ import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
 import Form, { FormField, FormGroup } from '@dojo/widgets/form';
-import { FormMiddleware } from '@dojo/widgets/form/middleware';
 import TextInput from '@dojo/widgets/text-input';
 
 import Example from '../../Example';
@@ -26,7 +25,8 @@ const App = factory(function({ middleware: { icache } }) {
 	return (
 		<Example>
 			<Form onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}>
-				{({ disabled, field }: FormMiddleware<Fields>) => {
+				{(form) => {
+					const { field, disabled } = form<Fields>();
 					const firstName = field('firstName');
 					const middleName = field('middleName');
 					const lastName = field('lastName');

--- a/src/examples/src/widgets/form/FillingForm.tsx
+++ b/src/examples/src/widgets/form/FillingForm.tsx
@@ -2,7 +2,6 @@ import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
 import Form, { FormField, FormGroup } from '@dojo/widgets/form';
-import { FormMiddleware } from '@dojo/widgets/form/middleware';
 import TextInput from '@dojo/widgets/text-input';
 
 import Example from '../../Example';
@@ -26,7 +25,8 @@ const App = factory(function({ middleware: { icache } }) {
 	return (
 		<Example>
 			<Form onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}>
-				{({ value, field }: FormMiddleware<Fields>) => {
+				{(form) => {
+					const { field, value } = form<Fields>();
 					const firstName = field('firstName');
 					const middleName = field('middleName');
 					const lastName = field('lastName');

--- a/src/examples/src/widgets/form/InitialValueForm.tsx
+++ b/src/examples/src/widgets/form/InitialValueForm.tsx
@@ -1,7 +1,6 @@
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Form, { FormField, FormGroup } from '@dojo/widgets/form';
-import { FormMiddleware } from '@dojo/widgets/form/middleware';
 import TextInput from '@dojo/widgets/text-input';
 
 import Example from '../../Example';
@@ -31,7 +30,8 @@ const App = factory(function({ middleware: { icache } }) {
 				}}
 				onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}
 			>
-				{({ field }: FormMiddleware<Fields>) => {
+				{(form) => {
+					const { field } = form<Fields>();
 					const firstName = field('firstName');
 					const middleName = field('middleName');
 					const lastName = field('lastName');

--- a/src/examples/src/widgets/form/KitchenSinkForm.tsx
+++ b/src/examples/src/widgets/form/KitchenSinkForm.tsx
@@ -2,7 +2,6 @@ import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
 import Form, { FormField, FormGroup } from '@dojo/widgets/form';
-import { FormMiddleware } from '@dojo/widgets/form/middleware';
 import TextInput from '@dojo/widgets/text-input';
 
 import Example from '../../Example';
@@ -36,7 +35,8 @@ const App = factory(function({ middleware: { icache } }) {
 					icache.set('basicOnValue', { ...icache.get('basicOnValue'), ...values })
 				}
 			>
-				{({ value, valid, disabled, field, reset }: FormMiddleware<Fields>) => {
+				{(form) => {
+					const { value, valid, disabled, field, reset } = form<Fields>();
 					const firstName = field('firstName', true);
 					const middleName = field('middleName');
 					const lastName = field('lastName', true);

--- a/src/examples/src/widgets/form/RequiredFieldsForm.tsx
+++ b/src/examples/src/widgets/form/RequiredFieldsForm.tsx
@@ -2,7 +2,6 @@ import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
 import Form, { FormField, FormGroup } from '@dojo/widgets/form';
-import { FormMiddleware } from '@dojo/widgets/form/middleware';
 import TextInput from '@dojo/widgets/text-input';
 
 import Example from '../../Example';
@@ -26,7 +25,8 @@ const App = factory(function({ middleware: { icache } }) {
 	return (
 		<Example>
 			<Form onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}>
-				{({ field }: FormMiddleware<Fields>) => {
+				{(form) => {
+					const { field } = form<Fields>();
 					const firstName = field('firstName', true);
 					const middleName = field('middleName');
 					const lastName = field('lastName', true);

--- a/src/examples/src/widgets/form/ResettingForm.tsx
+++ b/src/examples/src/widgets/form/ResettingForm.tsx
@@ -2,7 +2,6 @@ import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
 import Form, { FormField, FormGroup } from '@dojo/widgets/form';
-import { FormMiddleware } from '@dojo/widgets/form/middleware';
 import TextInput from '@dojo/widgets/text-input';
 
 import Example from '../../Example';
@@ -26,7 +25,8 @@ const App = factory(function({ middleware: { icache } }) {
 	return (
 		<Example>
 			<Form onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}>
-				{({ field, reset }: FormMiddleware<Fields>) => {
+				{(form) => {
+					const { field, reset } = form<Fields>();
 					const firstName = field('firstName');
 					const middleName = field('middleName');
 					const lastName = field('lastName');

--- a/src/examples/src/widgets/form/SubmitForm.tsx
+++ b/src/examples/src/widgets/form/SubmitForm.tsx
@@ -2,7 +2,6 @@ import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
 import Form, { FormField, FormGroup } from '@dojo/widgets/form';
-import { FormMiddleware } from '@dojo/widgets/form/middleware';
 import TextInput from '@dojo/widgets/text-input';
 
 import Example from '../../Example';
@@ -26,7 +25,8 @@ const App = factory(function({ middleware: { icache } }) {
 	return (
 		<Example>
 			<Form onSubmit={(values) => icache.set('basic', values)}>
-				{({ valid, field }: FormMiddleware<Fields>) => {
+				{(form) => {
+					const { valid, field } = form<Fields>();
 					const firstName = field('firstName', true);
 					const middleName = field('middleName');
 					const lastName = field('lastName', true);

--- a/src/examples/src/widgets/form/Validation.tsx
+++ b/src/examples/src/widgets/form/Validation.tsx
@@ -1,7 +1,6 @@
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Form, { FormField, FormGroup } from '@dojo/widgets/form';
-import { FormMiddleware } from '@dojo/widgets/form/middleware';
 import TextInput from '@dojo/widgets/text-input';
 
 import Example from '../../Example';
@@ -25,7 +24,8 @@ const App = factory(function({ middleware: { icache } }) {
 	return (
 		<Example>
 			<Form onValue={(values) => icache.set('basic', { ...icache.get('basic'), ...values })}>
-				{({ field }: FormMiddleware<Fields>) => {
+				{(form) => {
+					const { field } = form<Fields>();
 					const firstName = field('firstName');
 					const middleName = field('middleName');
 					const lastName = field('lastName');

--- a/src/form/tests/unit/Form.spec.tsx
+++ b/src/form/tests/unit/Form.spec.tsx
@@ -237,6 +237,134 @@ describe('Form', () => {
 		h.expect(baseAssertion);
 	});
 
+	it('renders with form api function', () => {
+		const h = harness(() => (
+			<Form
+				initialValue={{
+					firstName: 'Billy'
+				}}
+				value={undefined}
+				onSubmit={onSubmit}
+				onValue={onValue}
+				name="formName"
+			>
+				{(form) => {
+					const { field, value, disabled, reset, valid } = form<Fields>();
+					const firstName = field('firstName', true);
+					const middleName = field('middleName');
+					const lastName = field('lastName', true);
+					const email = field('email');
+
+					return [
+						<TextInput
+							key="firstName"
+							placeholder="Enter first name (must be Billy)"
+							pattern="Billy"
+							required={true}
+							initialValue={firstName.value()}
+							valid={firstName.valid()}
+							onValue={firstName.value}
+							onValidate={firstName.valid}
+							disabled={firstName.disabled()}
+						>
+							{{ label: 'First Name' }}
+						</TextInput>,
+						<TextInput
+							key="middleName"
+							placeholder="Enter a middle name"
+							required={middleName.required()}
+							initialValue={middleName.value()}
+							valid={middleName.valid()}
+							onValue={middleName.value}
+							onValidate={middleName.valid}
+							maxLength={5}
+							disabled={middleName.disabled()}
+						>
+							{{ label: 'Middle Name' }}
+						</TextInput>,
+						<TextInput
+							key="lastName"
+							placeholder="Enter a last name"
+							required={true}
+							initialValue={lastName.value()}
+							valid={lastName.valid()}
+							onValue={lastName.value}
+							onValidate={lastName.valid}
+							minLength={2}
+							disabled={lastName.disabled()}
+						>
+							{{ label: 'Last Name' }}
+						</TextInput>,
+						<TextInput
+							key="email"
+							placeholder="Enter an email address"
+							required={false}
+							initialValue={email.value()}
+							valid={email.valid()}
+							onValue={email.value}
+							onValidate={email.valid}
+							type="email"
+							pattern="^[^\s@]+@[^\s@]+\.[^\s@]{2,}$"
+							disabled={email.disabled()}
+						>
+							{{ label: 'Email' }}
+						</TextInput>,
+						<Button
+							key="fill"
+							type="button"
+							disabled={disabled()}
+							onClick={() => {
+								value({
+									firstName: 'Billy',
+									middleName: '',
+									lastName: 'Bob'
+								});
+							}}
+						>
+							Fill
+						</Button>,
+						<Button
+							key="requireMiddleName"
+							type="button"
+							disabled={disabled()}
+							onClick={() => middleName.required(!middleName.required())}
+						>
+							{`Make middle name ${middleName.required() ? 'optional' : 'required'}`}
+						</Button>,
+						<Button
+							key="reset"
+							type="button"
+							disabled={disabled()}
+							onClick={() => reset()}
+						>
+							Reset
+						</Button>,
+						<Button
+							key="disableForm"
+							type="button"
+							onClick={() => disabled(!disabled())}
+						>
+							{`${disabled() ? 'Enable' : 'Disable'} Form`}
+						</Button>,
+						<Button
+							key="disableEmail"
+							type="button"
+							disabled={disabled()}
+							onClick={() => email.disabled(!email.disabled())}
+						>
+							{`${email.disabled() ? 'Enable' : 'Disable'} Email`}
+						</Button>,
+						<Button key="submit" type="submit" disabled={!valid() || disabled()}>
+							Submit
+						</Button>
+					];
+				}}
+			</Form>
+		));
+
+		h.expect(baseAssertion);
+	});
+
 	it('properly handles onValue and onValidate', () => {
 		const h = harness(form);
 


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Overload the form middleware children function API to be a function factory that returns the API - this means that consumers do not need to import the `FormMiddleware` interface to get the typings, instead use the factory function and pass the field interface.

```ts
const { field } = form<Fields>();
```

Resolves #1582
