### PR TITLE
Fix codesandbox for parade examples

### DIFF
--- a/.dojorc
+++ b/.dojorc
@@ -5,7 +5,10 @@
 	},
 	"build-app": {
 		"locale": "en",
-		"supportedLocales": ["zh", "zh-CN", "zh-TW"]
+		"supportedLocales": ["zh", "zh-CN", "zh-TW"],
+		"features": {
+			"tests": true
+		}
 	},
 	"build-widget": {
 		"prefix": "dojo",

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -1,6 +1,5 @@
 import dojoTheme from '@dojo/widgets/theme/dojo';
 import materialTheme from '@dojo/widgets/theme/material';
-import defaultTheme from '@dojo/widgets/theme/default';
 import BasicAccordionPane from './widgets/accordion/Basic';
 import BasicAvatar from './widgets/avatar/Basic';
 import ImageAvatar from './widgets/avatar/Image';
@@ -294,7 +293,7 @@ export const config = {
 		{ label: 'material', theme: materialTheme },
 		{ label: 'dojo-dark', theme: dojoDarkTheme },
 		{ label: 'material-dark', theme: materialDarkTheme },
-		{ label: 'default', theme: defaultTheme }
+		{ label: 'default', theme: { theme: {}, variants: {} } }
 	],
 	tests,
 	readmePath: (widget: string) => `src/${widget}/README.md`,

--- a/src/examples/src/tests.tsx
+++ b/src/examples/src/tests.tsx
@@ -1,2 +1,11 @@
+import has from '@dojo/framework/core/has';
+
+if (!has('tests')) {
+	if (typeof (require as any).context === 'undefined') {
+		(require as any).context = () => {
+			return { keys: () => [] };
+		};
+	}
+}
 const tests = (require as any).context('../../', true, /\.spec\.ts(x)?$/);
 export default tests;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Codesandbox fails for the require.context usage and the import of the default theme (it's not published). These changes should fix codesandbox and also work as expected for parade builds.