### PR TITLE
Offscreen middleware

### DIFF
--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -1,7 +1,7 @@
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import { focus } from '@dojo/framework/core/middleware/focus';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-import { create, renderer, tsx } from '@dojo/framework/core/vdom';
+import { create, renderer, tsx, getRegistry } from '@dojo/framework/core/vdom';
 import global from '@dojo/framework/shim/global';
 import { Keys } from '../common/util';
 import theme from '../middleware/theme';
@@ -13,6 +13,7 @@ import { createResourceMiddleware } from '@dojo/framework/core/middleware/resour
 import LoadingIndicator from '../loading-indicator';
 import { throttle } from '@dojo/framework/core/util';
 import Icon from '../icon';
+import Registry from '@dojo/framework/core/Registry';
 
 export interface MenuItemProperties {
 	/** Callback used when the item is clicked */
@@ -251,12 +252,12 @@ interface ListICache {
 	requestedInputText: string;
 }
 
-const offscreenHeight = (dnode: RenderResult) => {
+const offscreenHeight = (dnode: RenderResult, registry?: Registry) => {
 	const r = renderer(() => dnode);
 	const div = global.document.createElement('div');
 	div.style.position = 'absolute';
 	global.document.body.appendChild(div);
-	r.mount({ domNode: div, sync: true });
+	r.mount({ domNode: div, sync: true, registry });
 	const dimensions = div.getBoundingClientRect();
 	global.document.body.removeChild(div);
 	return dimensions.height;
@@ -266,6 +267,7 @@ const factory = create({
 	icache: createICacheMiddleware<ListICache>(),
 	focus,
 	theme,
+	getRegistry,
 	resource: createResourceMiddleware<ListOption>()
 })
 	.properties<ListProperties>()
@@ -275,7 +277,7 @@ export const List = factory(function List({
 	children,
 	properties,
 	id,
-	middleware: { icache, focus, theme, resource }
+	middleware: { icache, focus, theme, resource, getRegistry }
 }) {
 	const { getOrRead, createOptions, find, meta, isLoading } = resource;
 	const {
@@ -636,7 +638,15 @@ export const List = factory(function List({
 			<ListItem {...offscreenItemProps}>offscreen</ListItem>
 		);
 
-		const itemHeight = icache.getOrSet('itemHeight', offscreenHeight(offscreenMenuItem));
+		const handler = getRegistry();
+		let registry: Registry | undefined;
+		if (handler) {
+			registry = handler.base;
+		}
+		const itemHeight = icache.getOrSet(
+			'itemHeight',
+			offscreenHeight(offscreenMenuItem, registry)
+		);
 
 		itemHeight && icache.set('menuHeight', itemsInView * itemHeight);
 	}

--- a/src/list/tests/List.spec.tsx
+++ b/src/list/tests/List.spec.tsx
@@ -2,7 +2,7 @@ const { describe, it, afterEach, beforeEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 import { sandbox } from 'sinon';
 import global from '@dojo/framework/shim/global';
-import { tsx } from '@dojo/framework/core/vdom';
+import { tsx, getRegistry, create } from '@dojo/framework/core/vdom';
 import { renderer, assertion, wrap } from '@dojo/framework/testing/renderer';
 import {
 	createMemoryResourceTemplate,
@@ -16,6 +16,15 @@ import * as css from '../../theme/default/list.m.css';
 import * as fixedCss from '../list.m.css';
 import * as listItemCss from '../../theme/default/list-item.m.css';
 import * as menuItemCss from '../../theme/default/menu-item.m.css';
+import Registry from '@dojo/framework/core/Registry';
+import RegistryHandler from '@dojo/framework/core/RegistryHandler';
+
+const mockGetRegistry = create()(function() {
+	const registry = new Registry();
+	const handler = new RegistryHandler();
+	handler.base = registry;
+	return () => handler;
+});
 
 let template = createMemoryResourceTemplate<{ value: string; label: string; disabled?: boolean }>();
 const data = [
@@ -296,14 +305,17 @@ describe('List', () => {
 	});
 
 	it('should not render with no data', () => {
-		const r = renderer(() => (
-			<List
-				resource={{
-					template: { template, id: 'test', initOptions: { data: [], id: 'test' } }
-				}}
-				onValue={onValueStub}
-			/>
-		));
+		const r = renderer(
+			() => (
+				<List
+					resource={{
+						template: { template, id: 'test', initOptions: { data: [], id: 'test' } }
+					}}
+					onValue={onValueStub}
+				/>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
 		r.expect(assertion(() => undefined));
 	});
 
@@ -389,9 +401,10 @@ describe('List', () => {
 			find: () => {}
 		});
 
-		const r = renderer(() => (
-			<List resource={{ template: { template, id: 'test' } }} onValue={onValueStub} />
-		));
+		const r = renderer(
+			() => <List resource={{ template: { template, id: 'test' } }} onValue={onValueStub} />,
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
 		r.expect(assertion(() => null));
 		pageOneResolver!({ data: data.slice(0, 30), total: data.length });
 		await pageOnePromise;
@@ -496,23 +509,33 @@ describe('List', () => {
 	});
 
 	it('should render list with list items data', () => {
-		const r = renderer(() => (
-			<List
-				resource={{ template: { template, id: 'test', initOptions: { data, id: 'test' } } }}
-				onValue={onValueStub}
-			/>
-		));
+		const r = renderer(
+			() => (
+				<List
+					resource={{
+						template: { template, id: 'test', initOptions: { data, id: 'test' } }
+					}}
+					onValue={onValueStub}
+				/>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
 		r.expect(listWithListItemsAssertion);
 	});
 
 	it('should render list with menu items data', () => {
-		const r = renderer(() => (
-			<List
-				menu
-				resource={{ template: { template, id: 'test', initOptions: { data, id: 'test' } } }}
-				onValue={onValueStub}
-			/>
-		));
+		const r = renderer(
+			() => (
+				<List
+					menu
+					resource={{
+						template: { template, id: 'test', initOptions: { data, id: 'test' } }
+					}}
+					onValue={onValueStub}
+				/>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
 		r.expect(listWithMenuItemsAssertion);
 	});
 
@@ -581,9 +604,16 @@ describe('List', () => {
 			find: () => {}
 		});
 
-		const r = renderer(() => (
-			<List menu resource={{ template: { template, id: 'test' } }} onValue={onValueStub} />
-		));
+		const r = renderer(
+			() => (
+				<List
+					menu
+					resource={{ template: { template, id: 'test' } }}
+					onValue={onValueStub}
+				/>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
 		r.expect(assertion(() => null));
 		pageOneResolver!({ data: data.slice(0, 30), total: data.length });
 		await pageOnePromise;
@@ -712,22 +742,25 @@ describe('List', () => {
 				}
 			]
 		];
-		const r = renderer(() => (
-			<List
-				resource={{
-					template: {
-						template,
-						id: 'test',
-						initOptions: { data: testData, id: 'test' }
-					}
-				}}
-				disabled={(item) => {
-					return item.value === '3';
-				}}
-				onValue={onValueStub}
-				onRequestClose={onRequestCloseStub}
-			/>
-		));
+		const r = renderer(
+			() => (
+				<List
+					resource={{
+						template: {
+							template,
+							id: 'test',
+							initOptions: { data: testData, id: 'test' }
+						}
+					}}
+					disabled={(item) => {
+						return item.value === '3';
+					}}
+					onValue={onValueStub}
+					onRequestClose={onRequestCloseStub}
+				/>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
 		r.expect(
 			baseAssertion
 				.setProperty(WrappedItemWrapper, 'styles', {
@@ -988,18 +1021,21 @@ describe('List', () => {
 				label: 'Bobby'
 			}
 		];
-		const r = renderer(() => (
-			<List
-				resource={{
-					template: {
-						template,
-						id: 'test',
-						initOptions: { data: testData, id: 'test' }
-					}
-				}}
-				onValue={onValueStub}
-			/>
-		));
+		const r = renderer(
+			() => (
+				<List
+					resource={{
+						template: {
+							template,
+							id: 'test',
+							initOptions: { data: testData, id: 'test' }
+						}
+					}}
+					onValue={onValueStub}
+				/>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
 		const listAssertion = baseAssertion
 			.setProperty(WrappedItemWrapper, 'styles', {
 				height: '225px'
@@ -1975,18 +2011,21 @@ describe('List', () => {
 				value: 'Bobby'
 			}
 		];
-		const r = renderer(() => (
-			<List
-				resource={{
-					template: {
-						template,
-						id: 'test',
-						initOptions: { data: testData, id: 'test' }
-					}
-				}}
-				onValue={onValueStub}
-			/>
-		));
+		const r = renderer(
+			() => (
+				<List
+					resource={{
+						template: {
+							template,
+							id: 'test',
+							initOptions: { data: testData, id: 'test' }
+						}
+					}}
+					onValue={onValueStub}
+				/>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
 		const listAssertion = baseAssertion
 			.setProperty(WrappedItemWrapper, 'styles', {
 				height: '225px'
@@ -2222,31 +2261,41 @@ describe('List', () => {
 					Fish
 				</ListItem>
 			]);
-		const r = renderer(() => (
-			<List
-				resource={{ template: { template, id: 'test', initOptions: { data, id: 'test' } } }}
-				onValue={onValueStub}
-			>
-				{(item, itemProps) => {
-					return (
-						<ListItem classes={undefined} {...itemProps}>
-							{item.label || item.value}
-						</ListItem>
-					);
-				}}
-			</List>
-		));
+		const r = renderer(
+			() => (
+				<List
+					resource={{
+						template: { template, id: 'test', initOptions: { data, id: 'test' } }
+					}}
+					onValue={onValueStub}
+				>
+					{(item, itemProps) => {
+						return (
+							<ListItem classes={undefined} {...itemProps}>
+								{item.label || item.value}
+							</ListItem>
+						);
+					}}
+				</List>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
 		r.expect(listWithListItemsAssertion);
 	});
 
 	it('should render with initial value', () => {
-		const r = renderer(() => (
-			<List
-				resource={{ template: { template, id: 'test', initOptions: { data, id: 'test' } } }}
-				onValue={onValueStub}
-				initialValue="2"
-			/>
-		));
+		const r = renderer(
+			() => (
+				<List
+					resource={{
+						template: { template, id: 'test', initOptions: { data, id: 'test' } }
+					}}
+					onValue={onValueStub}
+					initialValue="2"
+				/>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
 		const listAssertion = baseAssertion
 			.setProperty(WrappedItemWrapper, 'styles', {
 				height: '135px'
@@ -2368,13 +2417,18 @@ describe('List', () => {
 		const props = {
 			value: '2'
 		};
-		const r = renderer(() => (
-			<List
-				resource={{ template: { template, id: 'test', initOptions: { data, id: 'test' } } }}
-				onValue={onValueStub}
-				value={props.value}
-			/>
-		));
+		const r = renderer(
+			() => (
+				<List
+					resource={{
+						template: { template, id: 'test', initOptions: { data, id: 'test' } }
+					}}
+					onValue={onValueStub}
+					value={props.value}
+				/>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
 		let listAssertion = baseAssertion
 			.setProperty(WrappedItemWrapper, 'styles', {
 				height: '135px'
@@ -2626,14 +2680,21 @@ describe('List', () => {
 				disabled: true
 			}
 		];
-		const r = renderer(() => (
-			<List
-				resource={{
-					template: { template, id: 'test', initOptions: { data: testData, id: 'test' } }
-				}}
-				onValue={onValueStub}
-			/>
-		));
+		const r = renderer(
+			() => (
+				<List
+					resource={{
+						template: {
+							template,
+							id: 'test',
+							initOptions: { data: testData, id: 'test' }
+						}
+					}}
+					onValue={onValueStub}
+				/>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
 		const listAssertion = baseAssertion
 			.setProperty(WrappedItemWrapper, 'styles', {
 				height: '135px'

--- a/src/middleware/offscreen.ts
+++ b/src/middleware/offscreen.ts
@@ -1,0 +1,25 @@
+import { renderer, create, getRegistry } from '@dojo/framework/core/vdom';
+import global from '@dojo/framework/shim/global';
+import { RenderResult } from '@dojo/framework/core/interfaces';
+
+const factory = create({ getRegistry });
+
+export const offscreen = factory(function offscreen({ middleware: { getRegistry } }) {
+	return <RESULT>(
+		renderFunction: () => RenderResult,
+		predicate: (node: HTMLDivElement) => RESULT
+	): RESULT => {
+		const handler = getRegistry();
+		const registry = handler ? handler.base : undefined;
+		const domNode = global.document.createElement('div');
+		domNode.style.position = 'absolute';
+		global.document.body.appendChild(domNode);
+		const r = renderer(renderFunction);
+		r.mount({ domNode, sync: true, registry });
+		const result = predicate(domNode);
+		global.document.body.removeChild(domNode);
+		return result;
+	};
+});
+
+export default offscreen;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

A middleware that renders nodes offscreen and executes a function on the root node returning the result, using the applications base registry to ensure that theming and other global aspects are applied.