### PR TITLE
Consistently pass theme related props to widgets

### DIFF
--- a/src/accordion/index.tsx
+++ b/src/accordion/index.tsx
@@ -30,8 +30,8 @@ export const Accordion = factory(function Accordion({
 	properties,
 	children
 }) {
-	const classes = theme.classes(css);
-	const { exclusive, panes } = properties();
+	const themedCss = theme.classes(css);
+	const { exclusive, panes, variant, classes } = properties();
 
 	const openIndexes = icache.getOrSet('openIndexes', new Set());
 
@@ -52,7 +52,7 @@ export const Accordion = factory(function Accordion({
 	};
 
 	return (
-		<div classes={[theme.variant(), classes.root]}>
+		<div classes={[theme.variant(), themedCss.root]}>
 			{panes.map((paneName, index) => {
 				return (
 					<TitlePane
@@ -69,6 +69,8 @@ export const Accordion = factory(function Accordion({
 							css,
 							'pane'
 						)}
+						classes={classes}
+						variant={variant}
 						name={paneName}
 					>
 						{children()[index]}

--- a/src/accordion/tests/unit/Accordion.spec.tsx
+++ b/src/accordion/tests/unit/Accordion.spec.tsx
@@ -20,6 +20,8 @@ describe('Accordion', () => {
 					theme={{}}
 					open={false}
 					name="foo title"
+					classes={undefined}
+					variant={undefined}
 				>
 					foo content
 				</TitlePane>
@@ -30,6 +32,8 @@ describe('Accordion', () => {
 					theme={{}}
 					open={false}
 					name="bar title"
+					classes={undefined}
+					variant={undefined}
 				>
 					bar content
 				</TitlePane>

--- a/src/breadcrumb-group/index.tsx
+++ b/src/breadcrumb-group/index.tsx
@@ -1,5 +1,5 @@
 import { RenderResult } from '@dojo/framework/core/interfaces';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
 
 import * as css from '../theme/default/breadcrumb-group.m.css';
@@ -84,7 +84,7 @@ export const BreadcrumbGroup = factory(function BreadcrumbGroup({
 	properties,
 	middleware: { theme }
 }) {
-	const { items, label } = properties();
+	const { items, label, classes, theme: themeProp, variant } = properties();
 	const themeCss = theme.classes(css);
 
 	const defaultRenderer: BreadcrumbGroupChildren = (items: BreadcrumbItem[]) => {
@@ -98,6 +98,9 @@ export const BreadcrumbGroup = factory(function BreadcrumbGroup({
 					current={index === lastIndex ? 'page' : undefined}
 					href={item.href}
 					title={item.title}
+					classes={classes}
+					theme={themeProp}
+					variant={variant}
 				>
 					{item.label}
 				</Breadcrumb>

--- a/src/breadcrumb-group/tests/BreadcrumbGroup.spec.tsx
+++ b/src/breadcrumb-group/tests/BreadcrumbGroup.spec.tsx
@@ -74,6 +74,9 @@ describe('BreadcrumbGroup', () => {
 						current={undefined}
 						href={undefined}
 						title={undefined}
+						theme={undefined}
+						classes={undefined}
+						variant={undefined}
 					>
 						Home
 					</Breadcrumb>
@@ -85,6 +88,9 @@ describe('BreadcrumbGroup', () => {
 						current={undefined}
 						href={undefined}
 						title={undefined}
+						theme={undefined}
+						classes={undefined}
+						variant={undefined}
 					>
 						Overview
 					</Breadcrumb>
@@ -96,6 +102,9 @@ describe('BreadcrumbGroup', () => {
 						current="page"
 						href={undefined}
 						title={undefined}
+						theme={undefined}
+						classes={undefined}
+						variant={undefined}
 					>
 						Tests
 					</Breadcrumb>

--- a/src/calendar/index.tsx
+++ b/src/calendar/index.tsx
@@ -463,7 +463,7 @@ export const DatePicker = create({ theme, focus, icache }).properties<DatePicker
 		}
 
 		function renderPagingButtonContent(type: Paging) {
-			const { labels, classes } = properties();
+			const { labels, classes, variant } = properties();
 			const iconType = type === Paging.next ? 'rightIcon' : 'leftIcon';
 			const labelText = type === Paging.next ? labels.nextYears : labels.previousYears;
 
@@ -476,6 +476,7 @@ export const DatePicker = create({ theme, focus, icache }).properties<DatePicker
 						'datePickerPaging'
 					)}
 					classes={classes}
+					variant={variant}
 				/>,
 				<span classes={baseCss.visuallyHidden}>{labelText}</span>
 			];
@@ -913,7 +914,7 @@ export const Calendar = factory(function Calendar({
 		currentMonth: boolean,
 		today: boolean
 	) {
-		const { minDate, maxDate, theme, classes } = properties();
+		const { minDate, maxDate, theme, classes, variant } = properties();
 
 		const date = dateObj.getDate();
 		const outOfRange = isOutOfDateRange(dateObj, minDate, maxDate);
@@ -922,6 +923,7 @@ export const Calendar = factory(function Calendar({
 		return (
 			<CalendarCell
 				classes={classes}
+				variant={variant}
 				key={`date-${index}`}
 				callFocus={(callDateFocus || shouldFocus) && focusable}
 				date={date}
@@ -943,6 +945,7 @@ export const Calendar = factory(function Calendar({
 			monthNames = getMonths(commonMessages),
 			theme,
 			classes,
+			variant,
 			minDate,
 			maxDate
 		} = properties();
@@ -952,6 +955,7 @@ export const Calendar = factory(function Calendar({
 			<DatePicker
 				key="date-picker"
 				classes={classes}
+				variant={variant}
 				labelId={monthLabelId}
 				labels={labels}
 				month={month}
@@ -975,7 +979,7 @@ export const Calendar = factory(function Calendar({
 	}
 
 	function renderPagingButtonContent(type: Paging, labels: CalendarMessages) {
-		const { classes } = properties();
+		const { classes, variant } = properties();
 		const iconType = type === Paging.next ? 'rightIcon' : 'leftIcon';
 		const labelText = type === Paging.next ? labels.nextMonth : labels.previousMonth;
 
@@ -988,6 +992,7 @@ export const Calendar = factory(function Calendar({
 					'calendarPaging'
 				)}
 				classes={classes}
+				variant={variant}
 			/>,
 			<span classes={[baseCss.visuallyHidden]}>{labelText}</span>
 		];

--- a/src/calendar/tests/unit/Calendar.spec.tsx
+++ b/src/calendar/tests/unit/Calendar.spec.tsx
@@ -46,6 +46,7 @@ const expectedDateCell = function(
 			selected={dateIndex === selectedIndex}
 			theme={undefined}
 			classes={undefined}
+			variant={undefined}
 			today={false}
 			onClick={outOfRange ? undefined : noop}
 			onFocusCalled={noop}
@@ -194,6 +195,7 @@ const expected = function(
 				renderMonthLabel={customMonthLabel ? noop : undefined}
 				theme={undefined}
 				classes={undefined}
+				variant={undefined}
 				year={2017}
 				minDate={undefined}
 				maxDate={undefined}
@@ -288,7 +290,7 @@ const expected = function(
 					type="button"
 					onclick={noop}
 				>
-					<Icon type="leftIcon" theme={{}} classes={undefined} />
+					<Icon type="leftIcon" theme={{}} classes={undefined} variant={undefined} />
 					<span classes={[baseCss.visuallyHidden]}>Previous Month</span>
 				</button>
 				<button
@@ -298,7 +300,7 @@ const expected = function(
 					type="button"
 					onclick={noop}
 				>
-					<Icon type="rightIcon" theme={{}} classes={undefined} />
+					<Icon type="rightIcon" theme={{}} classes={undefined} variant={undefined} />
 					<span classes={[baseCss.visuallyHidden]}>Next Month</span>
 				</button>
 			</div>
@@ -318,6 +320,7 @@ const baseTemplate = assertionTemplate(() => {
 				renderMonthLabel={undefined}
 				theme={undefined}
 				classes={undefined}
+				variant={undefined}
 				year={2017}
 				minDate={undefined}
 				maxDate={undefined}
@@ -409,7 +412,7 @@ const baseTemplate = assertionTemplate(() => {
 					type="button"
 					onclick={noop}
 				>
-					<Icon type="leftIcon" theme={{}} classes={undefined} />
+					<Icon type="leftIcon" theme={{}} classes={undefined} variant={undefined} />
 					<span classes={[baseCss.visuallyHidden]}>Previous Month</span>
 				</button>
 				<button
@@ -420,7 +423,7 @@ const baseTemplate = assertionTemplate(() => {
 					type="button"
 					onclick={noop}
 				>
-					<Icon type="rightIcon" theme={{}} classes={undefined} />
+					<Icon type="rightIcon" theme={{}} classes={undefined} variant={undefined} />
 					<span classes={[baseCss.visuallyHidden]}>Next Month</span>
 				</button>
 			</div>
@@ -1018,6 +1021,7 @@ registerSuite('Calendar with min-max', {
 					selected={false}
 					theme={undefined}
 					classes={undefined}
+					variant={undefined}
 					today={false}
 					onClick={noop}
 					onFocusCalled={noop}

--- a/src/calendar/tests/unit/DatePicker.spec.tsx
+++ b/src/calendar/tests/unit/DatePicker.spec.tsx
@@ -163,7 +163,7 @@ const expectedControls = function(open: boolean) {
 				disabled={false}
 				onclick={noop}
 			>
-				<Icon type="leftIcon" theme={{}} classes={undefined} />
+				<Icon type="leftIcon" theme={{}} classes={undefined} variant={undefined} />
 				<span classes={baseCss.visuallyHidden}>{bundle.messages.previousYears}</span>
 			</button>
 			<button
@@ -173,7 +173,7 @@ const expectedControls = function(open: boolean) {
 				disabled={false}
 				onclick={noop}
 			>
-				<Icon type="rightIcon" theme={{}} classes={undefined} />
+				<Icon type="rightIcon" theme={{}} classes={undefined} variant={undefined} />
 				<span classes={baseCss.visuallyHidden}>{bundle.messages.nextYears}</span>
 			</button>
 		</div>
@@ -436,7 +436,12 @@ registerSuite('Calendar DatePicker', {
 							type="button"
 							onclick={noop}
 						>
-							<Icon type="leftIcon" theme={{}} classes={undefined} />
+							<Icon
+								type="leftIcon"
+								theme={{}}
+								classes={undefined}
+								variant={undefined}
+							/>
 							<span classes={baseCss.visuallyHidden}>
 								{bundle.messages.previousYears}
 							</span>
@@ -448,7 +453,12 @@ registerSuite('Calendar DatePicker', {
 							type="button"
 							onclick={noop}
 						>
-							<Icon type="rightIcon" theme={{}} classes={undefined} />
+							<Icon
+								type="rightIcon"
+								theme={{}}
+								classes={undefined}
+								variant={undefined}
+							/>
 							<span classes={baseCss.visuallyHidden}>
 								{bundle.messages.nextYears}
 							</span>

--- a/src/checkbox-group/index.tsx
+++ b/src/checkbox-group/index.tsx
@@ -2,7 +2,7 @@ import { create, tsx } from '@dojo/framework/core/vdom';
 import { checkboxGroup } from './middleware';
 import { Checkbox } from '../checkbox/index';
 import { RenderResult } from '@dojo/framework/core/interfaces';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import * as css from '../theme/default/checkbox-group.m.css';
 
 type CheckboxOptions = { value: string; label?: string }[];
@@ -40,7 +40,16 @@ export const CheckboxGroup = factory(function({
 	properties,
 	middleware: { checkboxGroup, theme }
 }) {
-	const { name, options, onValue, initialValue, value } = properties();
+	const {
+		name,
+		options,
+		onValue,
+		initialValue,
+		value,
+		classes,
+		theme: themeProp,
+		variant
+	} = properties();
 	const [{ checkboxes, label } = { checkboxes: undefined, label: undefined }] = children();
 
 	const checkbox = checkboxGroup(onValue, initialValue, value);
@@ -53,7 +62,15 @@ export const CheckboxGroup = factory(function({
 		return options.map(({ value, label }) => {
 			const { checked } = checkbox(value);
 			return (
-				<Checkbox name={name} value={value} checked={checked()} onValue={checked}>
+				<Checkbox
+					name={name}
+					value={value}
+					checked={checked()}
+					onValue={checked}
+					classes={classes}
+					theme={themeProp}
+					variant={variant}
+				>
 					{label || value}
 				</Checkbox>
 			);

--- a/src/checkbox-group/tests/CheckboxGroup.spec.tsx
+++ b/src/checkbox-group/tests/CheckboxGroup.spec.tsx
@@ -22,13 +22,37 @@ describe('CheckboxGroup', () => {
 			/>
 		));
 		const optionTemplate = template.setChildren('@root', () => [
-			<Checkbox name="test" value="cat" checked={false} onValue={noop}>
+			<Checkbox
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+			>
 				cat
 			</Checkbox>,
-			<Checkbox name="test" value="fish" checked={false} onValue={noop}>
+			<Checkbox
+				name="test"
+				value="fish"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+			>
 				fish
 			</Checkbox>,
-			<Checkbox name="test" value="dog" checked={false} onValue={noop}>
+			<Checkbox
+				name="test"
+				value="dog"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+			>
 				dog
 			</Checkbox>
 		]);
@@ -45,7 +69,15 @@ describe('CheckboxGroup', () => {
 		));
 		const labelTemplate = template.setChildren('@root', () => [
 			<legend classes={css.legend}>test label</legend>,
-			<Checkbox name="test" value="cat" checked={false} onValue={noop}>
+			<Checkbox
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+			>
 				cat
 			</Checkbox>
 		]);
@@ -62,13 +94,37 @@ describe('CheckboxGroup', () => {
 			/>
 		));
 		const optionTemplate = template.setChildren('@root', () => [
-			<Checkbox name="test" value="cat" checked={false} onValue={noop}>
+			<Checkbox
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+			>
 				cat
 			</Checkbox>,
-			<Checkbox name="test" value="fish" checked={true} onValue={noop}>
+			<Checkbox
+				name="test"
+				value="fish"
+				checked={true}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+			>
 				fish
 			</Checkbox>,
-			<Checkbox name="test" value="dog" checked={false} onValue={noop}>
+			<Checkbox
+				name="test"
+				value="dog"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+			>
 				dog
 			</Checkbox>
 		]);
@@ -85,13 +141,37 @@ describe('CheckboxGroup', () => {
 			/>
 		));
 		const optionTemplate = template.setChildren('@root', () => [
-			<Checkbox name="test" value="cat" checked={false} onValue={noop}>
+			<Checkbox
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+			>
 				cat
 			</Checkbox>,
-			<Checkbox name="test" value="fish" checked={true} onValue={noop}>
+			<Checkbox
+				name="test"
+				value="fish"
+				checked={true}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+			>
 				fish
 			</Checkbox>,
-			<Checkbox name="test" value="dog" checked={false} onValue={noop}>
+			<Checkbox
+				name="test"
+				value="dog"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+			>
 				dog
 			</Checkbox>
 		]);
@@ -106,7 +186,15 @@ describe('CheckboxGroup', () => {
 					checkboxes: () => {
 						return [
 							<span>custom label</span>,
-							<Checkbox name="test" value="cat" checked={false} onValue={noop}>
+							<Checkbox
+								name="test"
+								value="cat"
+								checked={false}
+								onValue={noop}
+								theme={undefined}
+								classes={undefined}
+								variant={undefined}
+							>
 								cat
 							</Checkbox>,
 							<hr />
@@ -118,7 +206,15 @@ describe('CheckboxGroup', () => {
 		const customTemplate = template.setChildren('@root', () => [
 			<legend classes={css.legend}>custom render label</legend>,
 			<span>custom label</span>,
-			<Checkbox name="test" value="cat" checked={false} onValue={noop}>
+			<Checkbox
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+			>
 				cat
 			</Checkbox>,
 			<hr />

--- a/src/checkbox/index.tsx
+++ b/src/checkbox/index.tsx
@@ -1,6 +1,6 @@
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import focus from '@dojo/framework/core/middleware/focus';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import { uuid } from '@dojo/framework/core/util';
 import { tsx, create } from '@dojo/framework/core/vdom';
 
@@ -66,6 +66,7 @@ export const Checkbox = factory(function Checkbox({
 		readOnly,
 		required,
 		theme: themeProp,
+		variant,
 		valid,
 		value,
 		widgetId = _uuid
@@ -121,6 +122,7 @@ export const Checkbox = factory(function Checkbox({
 					key="label"
 					classes={classes}
 					theme={themeProp}
+					variant={variant}
 					disabled={disabled}
 					focused={focus.isFocused('root')}
 					valid={valid}

--- a/src/checkbox/tests/unit/Checkbox.spec.tsx
+++ b/src/checkbox/tests/unit/Checkbox.spec.tsx
@@ -79,6 +79,7 @@ const expected = ({
 					key="label"
 					theme={undefined}
 					classes={undefined}
+					variant={undefined}
 					disabled={disabled}
 					focused={false}
 					hidden={undefined}

--- a/src/chip-typeahead/index.tsx
+++ b/src/chip-typeahead/index.tsx
@@ -104,7 +104,7 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 	} = properties();
 	const [{ label, items, selected } = {} as ChipTypeaheadChildren] = children();
 	const themeCss = theme.classes(css);
-	const { value } = properties();
+	const { value, classes = {}, variant } = properties();
 	const focused = icache.getOrSet('focused', false);
 
 	if (value !== undefined && arraysDifferent(value || [], icache.get('value') || [])) {
@@ -143,10 +143,13 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 				)}
 				key={`value-${value}`}
 				classes={{
+					...classes,
 					'@dojo/widgets/chip': {
+						...classes['@dojo/widgets/chip'],
 						root: [themeCss.value]
 					}
 				}}
+				variant={variant}
 				onClose={
 					disabled
 						? undefined
@@ -202,6 +205,7 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 							root: [themeCss.label]
 						}
 					}}
+					variant={variant}
 				>
 					{label}
 				</Label>
@@ -213,6 +217,7 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 					css,
 					'input'
 				)}
+				variant={variant}
 				strict={strict}
 				itemsInView={itemsInView}
 				position={position}

--- a/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
+++ b/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
@@ -49,6 +49,7 @@ const baseAssertion = assertionTemplate(() => (
 			value=""
 			onFocus={stub}
 			onBlur={stub}
+			variant={undefined}
 			classes={{
 				'@dojo/widgets/text-input': {
 					inputWrapper: [themeCss.inputWrapper],
@@ -90,6 +91,7 @@ const bottomAssertion = hasValueAssertion.insertAfter('@typeahead', () => [
 			key="value-2"
 			classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 			onClose={stub}
+			variant={undefined}
 		>
 			{{ label: 'Cat' }}
 		</Chip>
@@ -108,6 +110,7 @@ const labeledAssertion = baseAssertion
 					root: [themeCss.label]
 				}
 			}}
+			variant={undefined}
 		>
 			Label
 		</Label>
@@ -146,6 +149,7 @@ registerSuite('ChipTypeahead', {
 						key="value-2"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={stub}
+						variant={undefined}
 					>
 						{{ label: 'Cat' }}
 					</Chip>
@@ -181,6 +185,7 @@ registerSuite('ChipTypeahead', {
 						key="value-2"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={stub}
+						variant={undefined}
 					>
 						{{ label: 'Cat' }}
 					</Chip>
@@ -202,6 +207,7 @@ registerSuite('ChipTypeahead', {
 						key="value-1"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={stub}
+						variant={undefined}
 					>
 						{{ label: 'Dog' }}
 					</Chip>
@@ -233,6 +239,7 @@ registerSuite('ChipTypeahead', {
 						key="value-2"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={stub}
+						variant={undefined}
 					>
 						{{ label: 'Cat' }}
 					</Chip>
@@ -295,6 +302,7 @@ registerSuite('ChipTypeahead', {
 						key="value-2"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={stub}
+						variant={undefined}
 					>
 						{{ label: 'Cat' }}
 					</Chip>
@@ -421,6 +429,7 @@ registerSuite('ChipTypeahead', {
 						key="value-2"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={undefined}
+						variant={undefined}
 					>
 						{{ label: 'Cat' }}
 					</Chip>

--- a/src/chip/index.tsx
+++ b/src/chip/index.tsx
@@ -1,6 +1,6 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import { RenderResult } from '@dojo/framework/core/interfaces';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import * as css from '../theme/default/chip.m.css';
 import Icon from '../icon/index';
 import { Keys } from '../common/util';
@@ -30,7 +30,15 @@ const factory = create({ theme })
 	.children<ChipChildren>();
 
 export default factory(function Chip({ properties, children, middleware: { theme } }) {
-	const { onClose, onClick, disabled, checked } = properties();
+	const {
+		onClose,
+		onClick,
+		disabled,
+		checked,
+		theme: themeProp,
+		variant,
+		classes = {}
+	} = properties();
 	const themedCss = theme.classes(css);
 	const [{ icon, label, closeIcon }] = children();
 	const clickable = !disabled && onClick;
@@ -84,7 +92,15 @@ export default factory(function Chip({ properties, children, middleware: { theme
 					{closeIcon || (
 						<Icon
 							type="closeIcon"
-							classes={{ '@dojo/widgets/icon': { icon: [themedCss.icon] } }}
+							classes={{
+								...classes,
+								'@dojo/widgets/icon': {
+									...classes['@dojo/widgets/icon'],
+									icon: [themedCss.icon]
+								}
+							}}
+							theme={themeProp}
+							variant={variant}
 						/>
 					)}
 				</span>

--- a/src/chip/tests/Chip.spec.tsx
+++ b/src/chip/tests/Chip.spec.tsx
@@ -78,7 +78,12 @@ describe('Chip', () => {
 					onclick={noop}
 					onkeydown={noop}
 				>
-					<Icon type="closeIcon" classes={iconClasses} />
+					<Icon
+						type="closeIcon"
+						classes={iconClasses}
+						variant={undefined}
+						theme={undefined}
+					/>
 				</span>
 			])
 		);
@@ -126,7 +131,12 @@ describe('Chip', () => {
 						onclick={noop}
 						onkeydown={noop}
 					>
-						<Icon type="closeIcon" classes={iconClasses} />
+						<Icon
+							type="closeIcon"
+							classes={iconClasses}
+							variant={undefined}
+							theme={undefined}
+						/>
 					</span>
 				])
 				.prepend(':root', () => [
@@ -186,7 +196,12 @@ describe('Chip', () => {
 						onclick={noop}
 						onkeydown={noop}
 					>
-						<Icon type="closeIcon" classes={iconClasses} />
+						<Icon
+							type="closeIcon"
+							classes={iconClasses}
+							variant={undefined}
+							theme={undefined}
+						/>
 					</span>
 				])
 				.prepend(':root', () => [
@@ -254,7 +269,12 @@ describe('Chip', () => {
 						onclick={noop}
 						onkeydown={noop}
 					>
-						<Icon type="closeIcon" classes={iconClasses} />
+						<Icon
+							type="closeIcon"
+							classes={iconClasses}
+							variant={undefined}
+							theme={undefined}
+						/>
 					</span>
 				])
 				.prepend(':root', () => [

--- a/src/context-menu/index.tsx
+++ b/src/context-menu/index.tsx
@@ -16,7 +16,7 @@ const factory = create({ theme, resource: createResourceMiddleware<ListOption>()
 >();
 
 export const ContextMenu = factory(function({ properties, children, middleware: { theme } }) {
-	const { resource, onSelect } = properties();
+	const { resource, onSelect, classes, variant } = properties();
 	return (
 		<ContextPopup>
 			{{
@@ -30,6 +30,8 @@ export const ContextMenu = factory(function({ properties, children, middleware: 
 							css,
 							'menu'
 						)}
+						classes={classes}
+						variant={variant}
 						menu
 						resource={resource}
 						onBlur={close}

--- a/src/context-menu/tests/ContextMenu.spec.tsx
+++ b/src/context-menu/tests/ContextMenu.spec.tsx
@@ -85,6 +85,8 @@ describe('ContextMenu', () => {
 					onBlur={() => {}}
 					onRequestClose={() => {}}
 					onValue={() => {}}
+					variant={undefined}
+					classes={undefined}
 				/>
 			),
 			() =>

--- a/src/context-popup/index.tsx
+++ b/src/context-popup/index.tsx
@@ -2,6 +2,7 @@ import { create, tsx } from '@dojo/framework/core/vdom';
 import focus from '@dojo/framework/core/middleware/focus';
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import Popup from '../popup';
+import theme from '../middleware/theme';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 
 import * as css from '../theme/default/context-popup.m.css';
@@ -26,18 +27,19 @@ interface ContextIcache {
 
 const icache = createICacheMiddleware<ContextIcache>();
 
-const factory = create({ icache, focus })
+const factory = create({ icache, focus, theme })
 	.properties<ContextPopupProperties>()
 	.children<ContextPopupChildren>();
 
 const CursorWidth = 2;
 const CursorHeight = 4;
 
-export const ContextPopup = factory(function({
+export const ContextPopup = factory(function ContextPopup({
 	properties,
 	children,
 	middleware: { icache, focus }
 }) {
+	const { variant, theme, classes } = properties();
 	const x = icache.getOrSet('x', 0);
 	const y = icache.getOrSet('y', 0);
 
@@ -67,6 +69,9 @@ export const ContextPopup = factory(function({
 			</div>
 			<Popup
 				key="popup"
+				theme={theme}
+				variant={variant}
+				classes={classes}
 				yTop={y}
 				yBottom={document.documentElement.scrollTop + document.documentElement.clientHeight}
 				xLeft={x}

--- a/src/context-popup/tests/ContextPopup.spec.tsx
+++ b/src/context-popup/tests/ContextPopup.spec.tsx
@@ -12,6 +12,9 @@ const baseTemplate = assertionTemplate(() => (
 	<virtual>
 		<div classes={css.trigger} key="trigger" oncontextmenu={() => {}} />
 		<Popup
+			theme={undefined}
+			variant={undefined}
+			classes={undefined}
 			key="popup"
 			yTop={0}
 			yBottom={1100}

--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -68,9 +68,18 @@ export default factory(function({
 	children,
 	middleware: { theme, icache, i18n, focus }
 }) {
-	const { initialValue, name, onValue, onValidate, value: controlledValue } = properties();
+	const {
+		initialValue,
+		name,
+		onValue,
+		onValidate,
+		value: controlledValue,
+		theme: themeProp,
+		variant,
+		classes
+	} = properties();
 	const { messages } = i18n.localize(bundle);
-	const classes = theme.classes(css);
+	const themedCss = theme.classes(css);
 	const max = parseDate(properties().max);
 	const min = parseDate(properties().min);
 
@@ -148,14 +157,14 @@ export default factory(function({
 	}
 
 	return (
-		<div classes={[theme.variant(), classes.root]}>
+		<div classes={[theme.variant(), themedCss.root]}>
 			<input
 				type="hidden"
 				name={name}
 				value={formatDateISO(icache.get('value'))}
 				aria-hidden="true"
 			/>
-			<TriggerPopup key="popup">
+			<TriggerPopup key="popup" theme={themeProp} classes={classes} variant={variant}>
 				{{
 					trigger: (toggleOpen) => {
 						function openCalendar() {
@@ -165,7 +174,7 @@ export default factory(function({
 						}
 
 						return (
-							<div classes={classes.input}>
+							<div classes={themedCss.input}>
 								<TextInput
 									key="input"
 									focus={() => shouldFocus && focusNode === 'input'}
@@ -195,18 +204,24 @@ export default factory(function({
 											openCalendar();
 										}
 									}}
+									classes={classes}
+									variant={variant}
 								>
 									{{
 										label,
 										trailing: (
-											<Addon>
+											<Addon
+												theme={themeProp}
+												classes={classes}
+												variant={variant}
+											>
 												<button
 													key="dateIcon"
 													onclick={(e) => {
 														e.stopPropagation();
 														openCalendar();
 													}}
-													classes={classes.toggleCalendarButton}
+													classes={themedCss.toggleCalendarButton}
 													type="button"
 												>
 													<Icon type="dateIcon" />
@@ -226,7 +241,7 @@ export default factory(function({
 						}
 
 						return (
-							<div classes={classes.popup}>
+							<div classes={themedCss.popup}>
 								<Calendar
 									key="calendar"
 									focus={() => shouldFocus && focusNode === 'calendar'}
@@ -243,6 +258,9 @@ export default factory(function({
 										icache.set('shouldValidate', true);
 										closeCalendar();
 									}}
+									theme={themeProp}
+									classes={classes}
+									variant={variant}
 								/>
 							</div>
 						);

--- a/src/date-input/tests/unit/DateInput.spec.tsx
+++ b/src/date-input/tests/unit/DateInput.spec.tsx
@@ -54,7 +54,7 @@ const baseTemplate = (date?: Date) =>
 					value={formatDateISO(date || today)}
 					aria-hidden="true"
 				/>
-				<TriggerPopup key="popup">
+				<TriggerPopup variant={undefined} classes={undefined} theme={undefined} key="popup">
 					{{
 						trigger: () => <button />,
 						content: () => <div />
@@ -77,6 +77,8 @@ const buttonTemplate = assertionTemplate(() => {
 				initialValue={formatDate(today)}
 				helperText=""
 				onKeyDown={noop}
+				variant={undefined}
+				classes={undefined}
 			>
 				{{ trailing: undefined }}
 			</TextInput>
@@ -94,6 +96,9 @@ const calendarTemplate = assertionTemplate(() => {
 				minDate={undefined}
 				onValue={noop}
 				initialValue={today}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
 			/>
 		</div>
 	);

--- a/src/dialog/index.tsx
+++ b/src/dialog/index.tsx
@@ -72,7 +72,17 @@ export const Dialog = factory(function Dialog({
 }) {
 	const themeCss = theme.classes(css);
 
-	let { open, aria = {}, underlay, role = 'dialog', closeable = true, closeText } = properties();
+	let {
+		open,
+		aria = {},
+		underlay,
+		role = 'dialog',
+		closeable = true,
+		closeText,
+		classes,
+		theme: themeProp,
+		variant
+	} = properties();
 	const [{ title, actions, content }] = children();
 	const modal = role === 'alertdialog' || (properties() as DialogPropertiesDialogRole).modal;
 
@@ -172,7 +182,12 @@ export const Dialog = factory(function Dialog({
 									>
 										{closeText}
 										<span classes={themeCss.closeIcon}>
-											<Icon type="closeIcon" />
+											<Icon
+												theme={themeProp}
+												classes={classes}
+												variant={variant}
+												type="closeIcon"
+											/>
 										</span>
 									</button>
 								)}

--- a/src/dialog/tests/unit/Dialog.spec.tsx
+++ b/src/dialog/tests/unit/Dialog.spec.tsx
@@ -55,7 +55,12 @@ describe('Dialog', () => {
 							<button classes={themeCss.close} onclick={() => {}} type="button">
 								{'close foo'}
 								<span classes={themeCss.closeIcon}>
-									<Icon type="closeIcon" />
+									<Icon
+										type="closeIcon"
+										theme={undefined}
+										variant={undefined}
+										classes={undefined}
+									/>
 								</span>
 							</button>
 						</div>
@@ -109,7 +114,12 @@ describe('Dialog', () => {
 					<button classes={themeCss.close} onclick={() => {}} type="button">
 						{'foo'}
 						<span classes={themeCss.closeIcon}>
-							<Icon type="closeIcon" />
+							<Icon
+								type="closeIcon"
+								theme={undefined}
+								variant={undefined}
+								classes={undefined}
+							/>
 						</span>
 					</button>
 				])

--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -1,6 +1,6 @@
 import { RenderResult, VNodeProperties } from '@dojo/framework/core/interfaces';
 import icache from '@dojo/framework/core/middleware/icache';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
 
 import * as css from '../theme/default/form.m.css';

--- a/src/helper-text/index.tsx
+++ b/src/helper-text/index.tsx
@@ -1,4 +1,4 @@
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import * as css from '../theme/default/helper-text.m.css';
 

--- a/src/helper-text/tests/unit/HelperText.spec.tsx
+++ b/src/helper-text/tests/unit/HelperText.spec.tsx
@@ -19,11 +19,15 @@ const textTemplate = baseTemplate.setChildren('@root', [
 registerSuite('HelperText', {
 	tests: {
 		'without text'() {
-			const h = harness(() => <HelperText />);
+			const h = harness(() => (
+				<HelperText variant={undefined} classes={undefined} theme={undefined} />
+			));
 			h.expect(baseTemplate);
 		},
 		'with text'() {
-			const h = harness(() => <HelperText text="test" />);
+			const h = harness(() => (
+				<HelperText variant={undefined} classes={undefined} theme={undefined} text="test" />
+			));
 			h.expect(textTemplate);
 		},
 		valid() {
@@ -33,7 +37,15 @@ registerSuite('HelperText', {
 				css.valid,
 				null
 			]);
-			const h = harness(() => <HelperText text="test" valid={true} />);
+			const h = harness(() => (
+				<HelperText
+					variant={undefined}
+					classes={undefined}
+					theme={undefined}
+					text="test"
+					valid={true}
+				/>
+			));
 			h.expect(validTemplate);
 		},
 		invalid() {
@@ -43,7 +55,15 @@ registerSuite('HelperText', {
 				null,
 				css.invalid
 			]);
-			const h = harness(() => <HelperText text="test" valid={false} />);
+			const h = harness(() => (
+				<HelperText
+					variant={undefined}
+					classes={undefined}
+					theme={undefined}
+					text="test"
+					valid={false}
+				/>
+			));
 			h.expect(invalidTemplate);
 		}
 	}

--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -3,7 +3,7 @@ import { focus } from '@dojo/framework/core/middleware/focus';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import { Keys } from '../common/util';
-import theme from '../middleware/theme';
+import theme, { ThemeProperties } from '../middleware/theme';
 import offscreen from '../middleware/offscreen';
 import * as listItemCss from '../theme/default/list-item.m.css';
 import * as menuItemCss from '../theme/default/menu-item.m.css';
@@ -126,10 +126,12 @@ export const ListItem = listItemFactory(function ListItem({
 		onDrop,
 		movedUp,
 		movedDown,
-		collapsed
+		collapsed,
+		theme: themeProp,
+		variant
 	} = properties();
 
-	const classes = theme.classes(listItemCss);
+	const themedCss = theme.classes(listItemCss);
 
 	function select() {
 		!disabled && onSelect();
@@ -148,15 +150,15 @@ export const ListItem = listItemFactory(function ListItem({
 			}, 500)}
 			classes={[
 				theme.variant(),
-				classes.root,
-				selected && classes.selected,
-				active && classes.active,
-				disabled && classes.disabled,
-				movedUp && classes.movedUp,
-				movedDown && classes.movedDown,
-				collapsed && classes.collapsed,
-				dragged && classes.dragged,
-				draggable && classes.draggable
+				themedCss.root,
+				selected && themedCss.selected,
+				active && themedCss.active,
+				disabled && themedCss.disabled,
+				movedUp && themedCss.movedUp,
+				movedDown && themedCss.movedDown,
+				collapsed && themedCss.collapsed,
+				dragged && themedCss.dragged,
+				draggable && themedCss.draggable
 			]}
 			onclick={() => {
 				requestActive();
@@ -177,7 +179,9 @@ export const ListItem = listItemFactory(function ListItem({
 			{draggable && (
 				<Icon
 					type="barsIcon"
-					classes={{ '@dojo/widgets/icon': { icon: [classes.dragIcon] } }}
+					classes={{ '@dojo/widgets/icon': { icon: [themedCss.dragIcon] } }}
+					theme={themeProp}
+					variant={variant}
 				/>
 			)}
 		</div>
@@ -223,7 +227,7 @@ export interface ListChildren {
 	/** Custom renderer for item contents */
 	(
 		item: ItemRendererProperties,
-		properties: ListItemProperties & MenuItemProperties
+		properties: ListItemProperties & MenuItemProperties & ThemeProperties
 	): RenderResult;
 }
 
@@ -281,6 +285,7 @@ export const List = factory(function List({
 		onValue,
 		widgetId,
 		theme: themeProp,
+		variant,
 		resource: { template, options = createOptions(id) },
 		classes
 	} = properties();
@@ -407,7 +412,8 @@ export const List = factory(function List({
 				setActiveIndex(index);
 			},
 			disabled: true,
-			classes
+			classes,
+			variant
 		};
 		return menu ? (
 			<MenuItem
@@ -520,7 +526,8 @@ export const List = factory(function List({
 				setActiveIndex(index);
 			},
 			disabled: itemDisabled,
-			classes
+			classes,
+			variant
 		};
 		let item: RenderResult;
 
@@ -533,7 +540,7 @@ export const List = factory(function List({
 					active,
 					selected
 				},
-				itemProps
+				{ ...itemProps, theme: themeProp }
 			);
 		} else {
 			const children = label || value;

--- a/src/list/tests/List.spec.tsx
+++ b/src/list/tests/List.spec.tsx
@@ -115,6 +115,7 @@ const listWithListItemsAssertion = baseAssertion
 	.replaceChildren(WrappedItemContainer, () => [
 		<ListItem
 			classes={undefined}
+			variant={undefined}
 			active={true}
 			disabled={false}
 			key={'item-0'}
@@ -151,6 +152,7 @@ const listWithListItemsAssertion = baseAssertion
 		</ListItem>,
 		<ListItem
 			classes={undefined}
+			variant={undefined}
 			active={false}
 			disabled={false}
 			key={'item-1'}
@@ -187,6 +189,7 @@ const listWithListItemsAssertion = baseAssertion
 		</ListItem>,
 		<ListItem
 			classes={undefined}
+			variant={undefined}
 			active={false}
 			disabled={true}
 			key={'item-2'}
@@ -231,6 +234,7 @@ const listWithMenuItemsAssertion = baseAssertion
 	.replaceChildren(WrappedItemContainer, () => [
 		<MenuItem
 			classes={undefined}
+			variant={undefined}
 			active={true}
 			disabled={false}
 			key={'item-0'}
@@ -250,6 +254,7 @@ const listWithMenuItemsAssertion = baseAssertion
 		</MenuItem>,
 		<MenuItem
 			classes={undefined}
+			variant={undefined}
 			active={false}
 			disabled={false}
 			key={'item-1'}
@@ -269,6 +274,7 @@ const listWithMenuItemsAssertion = baseAssertion
 		</MenuItem>,
 		<MenuItem
 			classes={undefined}
+			variant={undefined}
 			active={false}
 			disabled={true}
 			key={'item-2'}
@@ -345,6 +351,7 @@ describe('List', () => {
 					children.push(
 						<ListItem
 							classes={undefined}
+							variant={undefined}
 							active={i === 0}
 							disabled={false}
 							key={`item-${i}`}
@@ -420,6 +427,7 @@ describe('List', () => {
 				children.push(
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={true}
 						key={`item-${i}`}
@@ -467,6 +475,7 @@ describe('List', () => {
 				children.push(
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={i === 59}
 						disabled={false}
 						key={`item-${i}`}
@@ -565,6 +574,7 @@ describe('List', () => {
 					children.push(
 						<MenuItem
 							classes={undefined}
+							variant={undefined}
 							active={i === 0}
 							disabled={false}
 							key={`item-${i}`}
@@ -629,6 +639,7 @@ describe('List', () => {
 				children.push(
 					<MenuItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={true}
 						key={`item-${i}`}
@@ -659,6 +670,7 @@ describe('List', () => {
 				children.push(
 					<MenuItem
 						classes={undefined}
+						variant={undefined}
 						active={59 === i}
 						disabled={false}
 						key={`item-${i}`}
@@ -688,6 +700,7 @@ describe('List', () => {
 			return new Array(6).fill(undefined).map((_, index) => (
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={index === activeIndex}
 					disabled={testData[index].value === '3'}
 					key={`item-${index}`}
@@ -1043,6 +1056,7 @@ describe('List', () => {
 			.replaceChildren(WrappedItemContainer, () => [
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={true}
 					disabled={false}
 					key={'item-0'}
@@ -1079,6 +1093,7 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={false}
 					key={'item-1'}
@@ -1115,6 +1130,7 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={false}
 					key={'item-2'}
@@ -1151,6 +1167,7 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={false}
 					key={'item-3'}
@@ -1187,6 +1204,7 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={false}
 					key={'item-4'}
@@ -1244,6 +1262,7 @@ describe('List', () => {
 				.replaceChildren(WrappedItemContainer, () => [
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-0'}
@@ -1280,6 +1299,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={true}
 						disabled={false}
 						key={'item-1'}
@@ -1316,6 +1336,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-2'}
@@ -1352,6 +1373,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-3'}
@@ -1388,6 +1410,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-4'}
@@ -1435,6 +1458,7 @@ describe('List', () => {
 				.replaceChildren(WrappedItemContainer, () => [
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-0'}
@@ -1471,6 +1495,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-1'}
@@ -1507,6 +1532,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-2'}
@@ -1543,6 +1569,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={true}
 						disabled={false}
 						key={'item-3'}
@@ -1579,6 +1606,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-4'}
@@ -1623,6 +1651,7 @@ describe('List', () => {
 				.replaceChildren(WrappedItemContainer, () => [
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-0'}
@@ -1659,6 +1688,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-1'}
@@ -1695,6 +1725,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-2'}
@@ -1731,6 +1762,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-3'}
@@ -1767,6 +1799,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={true}
 						disabled={false}
 						key={'item-4'}
@@ -1811,6 +1844,7 @@ describe('List', () => {
 				.replaceChildren(WrappedItemContainer, () => [
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-0'}
@@ -1847,6 +1881,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={true}
 						disabled={false}
 						key={'item-1'}
@@ -1883,6 +1918,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-2'}
@@ -1919,6 +1955,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-3'}
@@ -1955,6 +1992,7 @@ describe('List', () => {
 					</ListItem>,
 					<ListItem
 						classes={undefined}
+						variant={undefined}
 						active={false}
 						disabled={false}
 						key={'item-4'}
@@ -2033,6 +2071,7 @@ describe('List', () => {
 			.replaceChildren(WrappedItemContainer, () => [
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={true}
 					disabled={false}
 					key={'item-0'}
@@ -2069,6 +2108,7 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={false}
 					key={'item-1'}
@@ -2105,6 +2145,7 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={false}
 					key={'item-2'}
@@ -2141,6 +2182,7 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={false}
 					key={'item-3'}
@@ -2177,6 +2219,7 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={false}
 					key={'item-4'}
@@ -2229,6 +2272,8 @@ describe('List', () => {
 			.replaceChildren(WrappedItemContainer, () => [
 				<ListItem
 					classes={undefined}
+					variant={undefined}
+					theme={undefined}
 					active={true}
 					disabled={false}
 					key={'item-0'}
@@ -2240,6 +2285,8 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
+					theme={undefined}
 					active={false}
 					disabled={false}
 					key={'item-1'}
@@ -2251,6 +2298,8 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
+					theme={undefined}
 					active={false}
 					disabled={true}
 					key={'item-2'}
@@ -2271,7 +2320,7 @@ describe('List', () => {
 				>
 					{(item, itemProps) => {
 						return (
-							<ListItem classes={undefined} {...itemProps}>
+							<ListItem classes={undefined} variant={undefined} {...itemProps}>
 								{item.label || item.value}
 							</ListItem>
 						);
@@ -2303,6 +2352,7 @@ describe('List', () => {
 			.replaceChildren(WrappedItemContainer, () => [
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={true}
 					disabled={false}
 					key={'item-0'}
@@ -2339,6 +2389,7 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={false}
 					key={'item-1'}
@@ -2375,6 +2426,7 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={true}
 					key={'item-2'}
@@ -2436,6 +2488,7 @@ describe('List', () => {
 			.replaceChildren(WrappedItemContainer, () => [
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={true}
 					disabled={false}
 					key={'item-0'}
@@ -2472,6 +2525,7 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={false}
 					key={'item-1'}
@@ -2508,6 +2562,7 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={true}
 					key={'item-2'}
@@ -2552,6 +2607,7 @@ describe('List', () => {
 			.replaceChildren(WrappedItemContainer, () => [
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={true}
 					disabled={false}
 					key={'item-0'}
@@ -2588,6 +2644,7 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={false}
 					key={'item-1'}
@@ -2624,6 +2681,7 @@ describe('List', () => {
 				</ListItem>,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={true}
 					key={'item-2'}
@@ -2702,6 +2760,7 @@ describe('List', () => {
 			.replaceChildren(WrappedItemContainer, () => [
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={true}
 					disabled={false}
 					key={'item-0'}
@@ -2739,6 +2798,7 @@ describe('List', () => {
 				<hr classes={css.divider} />,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={false}
 					key={'item-1'}
@@ -2776,6 +2836,7 @@ describe('List', () => {
 				<hr classes={css.divider} />,
 				<ListItem
 					classes={undefined}
+					variant={undefined}
 					active={false}
 					disabled={true}
 					key={'item-2'}

--- a/src/native-select/index.tsx
+++ b/src/native-select/index.tsx
@@ -64,6 +64,7 @@ export const NativeSelect = factory(function NativeSelect({
 }) {
 	const {
 		classes,
+		variant,
 		disabled,
 		helperText,
 		initialValue,
@@ -73,7 +74,8 @@ export const NativeSelect = factory(function NativeSelect({
 		name,
 		size,
 		onFocus,
-		onBlur
+		onBlur,
+		theme: themeProp
 	} = properties();
 
 	const [labelChild] = children();
@@ -117,6 +119,7 @@ export const NativeSelect = factory(function NativeSelect({
 						css,
 						'label'
 					)}
+					variant={variant}
 					focused={inputFocused}
 					classes={classes}
 					disabled={disabled}
@@ -172,11 +175,18 @@ export const NativeSelect = factory(function NativeSelect({
 							css,
 							'icon'
 						)}
+						variant={variant}
 						classes={classes}
 					/>
 				</span>
 			</div>
-			<HelperText key="helperText" text={helperText} />
+			<HelperText
+				key="helperText"
+				text={helperText}
+				variant={variant}
+				classes={classes}
+				theme={themeProp}
+			/>
 		</div>
 	);
 });

--- a/src/native-select/tests/NativeSelect.spec.tsx
+++ b/src/native-select/tests/NativeSelect.spec.tsx
@@ -51,10 +51,16 @@ const baseTemplate = assertionTemplate(() => (
 				})}
 			</select>
 			<span classes={css.arrow}>
-				<Icon type="downIcon" theme={{}} classes={undefined} />
+				<Icon type="downIcon" theme={{}} classes={undefined} variant={undefined} />
 			</span>
 		</div>
-		<HelperText key="helperText" text={undefined} />
+		<HelperText
+			variant={undefined}
+			classes={undefined}
+			theme={undefined}
+			key="helperText"
+			text={undefined}
+		/>
 	</div>
 ));
 
@@ -105,6 +111,7 @@ describe('Native Select', () => {
 					assertion-key="label"
 					theme={{}}
 					classes={undefined}
+					variant={undefined}
 					disabled={true}
 					forId={'something'}
 					required={true}
@@ -157,6 +164,7 @@ describe('Native Select', () => {
 					assertion-key="label"
 					theme={{}}
 					classes={undefined}
+					variant={undefined}
 					disabled={true}
 					forId={'something'}
 					required={true}
@@ -209,6 +217,7 @@ describe('Native Select', () => {
 					assertion-key="label"
 					theme={{}}
 					classes={undefined}
+					variant={undefined}
 					disabled={true}
 					forId={'something'}
 					required={true}

--- a/src/pagination/PageLink.tsx
+++ b/src/pagination/PageLink.tsx
@@ -1,6 +1,6 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import i18n from '@dojo/framework/core/middleware/i18n';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 
 import * as css from '../theme/default/pagination.m.css';
 

--- a/src/pagination/index.tsx
+++ b/src/pagination/index.tsx
@@ -1,7 +1,7 @@
 import renderer, { create, tsx, diffProperty } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import i18n from '@dojo/framework/core/middleware/i18n';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import dimensions from '@dojo/framework/core/middleware/dimensions';
 import resize from '@dojo/framework/core/middleware/resize';
 import { RenderResult } from '@dojo/framework/core/interfaces';

--- a/src/popup-confirmation/index.tsx
+++ b/src/popup-confirmation/index.tsx
@@ -41,6 +41,7 @@ export default factory(function PopupConfirmation({
 		onConfirm,
 		classes,
 		theme: inheritedTheme,
+		variant,
 		...otherProperties
 	} = properties();
 	const [{ content, trigger }] = children();
@@ -52,6 +53,7 @@ export default factory(function PopupConfirmation({
 			<TriggerPopup
 				classes={classes}
 				theme={inheritedTheme}
+				variant={variant}
 				key="trigger-popup"
 				{...otherProperties}
 			>
@@ -76,6 +78,7 @@ export default factory(function PopupConfirmation({
 											css,
 											'cancel'
 										)}
+										variant={variant}
 										onClick={() => {
 											close();
 											onCancel && onCancel();
@@ -92,6 +95,7 @@ export default factory(function PopupConfirmation({
 											css,
 											'confirm'
 										)}
+										variant={variant}
 										onClick={() => {
 											close();
 											onConfirm && onConfirm();

--- a/src/popup-confirmation/tests/PopupConfirmation.spec.tsx
+++ b/src/popup-confirmation/tests/PopupConfirmation.spec.tsx
@@ -23,7 +23,12 @@ describe('PopupConfirmation', () => {
 	const ConfirmButtonWrap = wrap(Button);
 	const baseAssertion = assertion(() => (
 		<div classes={[css.root, undefined]}>
-			<TriggerPopupWrap classes={undefined} theme={undefined} key="trigger-popup">
+			<TriggerPopupWrap
+				classes={undefined}
+				variant={undefined}
+				theme={undefined}
+				key="trigger-popup"
+			>
 				{{
 					trigger: () => <button>Delete</button>,
 					content: () => (
@@ -34,6 +39,7 @@ describe('PopupConfirmation', () => {
 									<CancelButtonWrap
 										key="cancel-button"
 										classes={undefined}
+										variant={undefined}
 										type="button"
 										theme={{
 											'@dojo/widgets/button': buttonTheme
@@ -45,6 +51,7 @@ describe('PopupConfirmation', () => {
 									<ConfirmButtonWrap
 										key="confirm-button"
 										classes={undefined}
+										variant={undefined}
 										type="button"
 										theme={{
 											'@dojo/widgets/button': buttonTheme

--- a/src/popup/index.tsx
+++ b/src/popup/index.tsx
@@ -1,6 +1,6 @@
 import { dimensions } from '@dojo/framework/core/middleware/dimensions';
 import { resize } from '@dojo/framework/core/middleware/resize';
-import { theme } from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import { bodyScroll } from '../middleware/bodyScroll';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import * as css from '../theme/default/popup.m.css';
@@ -39,7 +39,7 @@ const factory = create({ dimensions, theme, bodyScroll, resize })
 	.properties<PopupProperties>()
 	.children<PopupChildren | RenderResult>();
 
-export const Popup = factory(function({
+export const Popup = factory(function Popup({
 	properties,
 	children,
 	middleware: { dimensions, theme, bodyScroll, resize }

--- a/src/radio-group/index.tsx
+++ b/src/radio-group/index.tsx
@@ -1,5 +1,5 @@
 import * as css from '../theme/default/radio-group.m.css';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import { Radio } from '../radio/index';
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import { create, tsx } from '@dojo/framework/core/vdom';
@@ -39,7 +39,16 @@ export const RadioGroup = factory(function({
 	properties,
 	middleware: { radioGroup, theme }
 }) {
-	const { name, options, onValue, value, initialValue } = properties();
+	const {
+		name,
+		options,
+		onValue,
+		value,
+		initialValue,
+		theme: themeCss,
+		classes,
+		variant
+	} = properties();
 	const [{ radios, label } = { radios: undefined, label: undefined }] = children();
 	const radio = radioGroup(onValue, initialValue || '', value);
 	const { root, legend } = theme.classes(css);
@@ -51,7 +60,15 @@ export const RadioGroup = factory(function({
 		return options.map(({ value, label }) => {
 			const { checked } = radio(value);
 			return (
-				<Radio checked={checked()} name={name} onValue={checked} value={value}>
+				<Radio
+					checked={checked()}
+					name={name}
+					onValue={checked}
+					value={value}
+					theme={themeCss}
+					classes={classes}
+					variant={variant}
+				>
 					{label || value}
 				</Radio>
 			);

--- a/src/radio-group/tests/RadioGroup.spec.tsx
+++ b/src/radio-group/tests/RadioGroup.spec.tsx
@@ -22,13 +22,37 @@ describe('RadioGroup', () => {
 			/>
 		));
 		const optionTemplate = template.setChildren('@root', () => [
-			<Radio name="test" value="cat" checked={false} onValue={noop}>
+			<Radio
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+			>
 				cat
 			</Radio>,
-			<Radio name="test" value="fish" checked={false} onValue={noop}>
+			<Radio
+				name="test"
+				value="fish"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+			>
 				fish
 			</Radio>,
-			<Radio name="test" value="dog" checked={false} onValue={noop}>
+			<Radio
+				name="test"
+				value="dog"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+			>
 				dog
 			</Radio>
 		]);
@@ -45,7 +69,15 @@ describe('RadioGroup', () => {
 		));
 		const labelTemplate = template.setChildren('@root', () => [
 			<legend classes={css.legend}>test label</legend>,
-			<Radio name="test" value="cat" checked={false} onValue={noop}>
+			<Radio
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+			>
 				cat
 			</Radio>
 		]);
@@ -62,13 +94,37 @@ describe('RadioGroup', () => {
 			/>
 		));
 		const optionTemplate = template.setChildren('@root', () => [
-			<Radio name="test" value="cat" checked={false} onValue={noop}>
+			<Radio
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+			>
 				cat
 			</Radio>,
-			<Radio name="test" value="fish" checked={true} onValue={noop}>
+			<Radio
+				name="test"
+				value="fish"
+				checked={true}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+			>
 				fish
 			</Radio>,
-			<Radio name="test" value="dog" checked={false} onValue={noop}>
+			<Radio
+				name="test"
+				value="dog"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+			>
 				dog
 			</Radio>
 		]);
@@ -86,13 +142,37 @@ describe('RadioGroup', () => {
 			/>
 		));
 		const optionTemplate = template.setChildren('@root', () => [
-			<Radio name="test" value="cat" checked={false} onValue={noop}>
+			<Radio
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+			>
 				cat
 			</Radio>,
-			<Radio name="test" value="fish" checked={true} onValue={noop}>
+			<Radio
+				name="test"
+				value="fish"
+				checked={true}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+			>
 				fish
 			</Radio>,
-			<Radio name="test" value="dog" checked={false} onValue={noop}>
+			<Radio
+				name="test"
+				value="dog"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+			>
 				dog
 			</Radio>
 		]);
@@ -109,7 +189,15 @@ describe('RadioGroup', () => {
 					radios: () => {
 						return [
 							<span>custom label</span>,
-							<Radio name="test" value="cat" checked={false} onValue={noop}>
+							<Radio
+								name="test"
+								value="cat"
+								checked={false}
+								onValue={noop}
+								theme={undefined}
+								variant={undefined}
+								classes={undefined}
+							>
 								cat
 							</Radio>,
 							<hr />
@@ -121,7 +209,15 @@ describe('RadioGroup', () => {
 		const customTemplate = template.setChildren('@root', () => [
 			<legend classes={css.legend}>custom render label</legend>,
 			<span>custom label</span>,
-			<Radio name="test" value="cat" checked={false} onValue={noop}>
+			<Radio
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+			>
 				cat
 			</Radio>,
 			<hr />

--- a/src/radio/index.tsx
+++ b/src/radio/index.tsx
@@ -73,6 +73,7 @@ export const Radio = factory(function Radio({
 		theme: themeProp,
 		valid,
 		value,
+		variant,
 		widgetId
 	} = properties();
 
@@ -139,6 +140,7 @@ export const Radio = factory(function Radio({
 					hidden={labelHidden}
 					required={required}
 					secondary={true}
+					variant={variant}
 				>
 					{label}
 				</Label>

--- a/src/radio/tests/unit/Radio.spec.tsx
+++ b/src/radio/tests/unit/Radio.spec.tsx
@@ -81,6 +81,7 @@ const expected = ({
 				<Label
 					key="label"
 					classes={undefined}
+					variant={undefined}
 					theme={undefined}
 					disabled={disabled}
 					focused={false}

--- a/src/range-slider/index.tsx
+++ b/src/range-slider/index.tsx
@@ -4,7 +4,7 @@ import * as fixedCss from './styles/range-slider.m.css';
 import Label from '../label/index';
 import dimensions from '@dojo/framework/core/middleware/dimensions';
 import focus from '@dojo/framework/core/middleware/focus';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import { RenderResult, AriaAttributes } from '@dojo/framework/core/interfaces';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
@@ -115,6 +115,7 @@ export const RangeSlider = factory(function RangeSlider({
 		step = 1,
 		theme: themeProp,
 		valid,
+		variant,
 		initialValue = {
 			max: maxRestraint,
 			min: minRestraint
@@ -234,6 +235,7 @@ export const RangeSlider = factory(function RangeSlider({
 			{label ? (
 				<Label
 					classes={classes}
+					variant={variant}
 					disabled={disabled}
 					focused={isFocused}
 					hidden={labelHidden}

--- a/src/range-slider/tests/unit/RangeSlider.spec.tsx
+++ b/src/range-slider/tests/unit/RangeSlider.spec.tsx
@@ -124,6 +124,7 @@ describe('RangeSlider', () => {
 		const testTemplate = template.prepend('@root', () => [
 			<Label
 				classes={undefined}
+				variant={undefined}
 				disabled={undefined}
 				focused={false}
 				hidden={undefined}

--- a/src/rate/index.tsx
+++ b/src/rate/index.tsx
@@ -50,10 +50,20 @@ export const Rate = factory(function Radio({
 	properties,
 	id,
 	children,
-	middleware: { focus, theme, icache }
+	middleware: { theme, icache }
 }) {
 	const idBase = `rate-${id}`;
-	const { onValue, max = 5, initialValue, allowHalf, name = idBase, readOnly } = properties();
+	const {
+		onValue,
+		max = 5,
+		initialValue,
+		allowHalf,
+		name = idBase,
+		readOnly,
+		theme: themeProp,
+		classes,
+		variant
+	} = properties();
 	let { value } = properties();
 	const [{ label, icon } = { label: undefined, icon: undefined }] = children();
 
@@ -105,7 +115,15 @@ export const Rate = factory(function Radio({
 				title={stringValue}
 			>
 				<span classes={fixedCss.iconWrapperFixed}>
-					{icon || <Icon size="medium" type="starIcon" />}
+					{icon || (
+						<Icon
+							size="medium"
+							type="starIcon"
+							theme={themeProp}
+							variant={variant}
+							classes={classes}
+						/>
+					)}
 				</span>
 				<input
 					classes={baseCss.visuallyHidden}
@@ -145,6 +163,9 @@ export const Rate = factory(function Radio({
 						onValue && onValue(numberVal);
 					}
 				}}
+				variant={variant}
+				theme={themeProp}
+				classes={classes}
 			>
 				{{
 					label,

--- a/src/rate/tests/Rate.spec.tsx
+++ b/src/rate/tests/Rate.spec.tsx
@@ -38,7 +38,15 @@ describe('Rate', () => {
 
 	const baseAssertion = assertion(() => (
 		<WrappedRootNode classes={[css.root, undefined, false]}>
-			<WrappedRadioGroup key="radio-group" name={'test'} options={baseOptions} onValue={noop}>
+			<WrappedRadioGroup
+				key="radio-group"
+				name={'test'}
+				options={baseOptions}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+			>
 				{{
 					label: 'test',
 					radios: () => []
@@ -109,7 +117,13 @@ describe('Rate', () => {
 							title={'1'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={true}
@@ -132,7 +146,13 @@ describe('Rate', () => {
 							title={'2'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={false}
@@ -180,7 +200,13 @@ describe('Rate', () => {
 							title={'0.5'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={false}
@@ -201,7 +227,13 @@ describe('Rate', () => {
 							title={'1'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={false}
@@ -224,7 +256,13 @@ describe('Rate', () => {
 							title={'1.5'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={true}
@@ -245,7 +283,13 @@ describe('Rate', () => {
 							title={'2'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={false}
@@ -296,7 +340,13 @@ describe('Rate', () => {
 							title={'1'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={true}
@@ -319,7 +369,13 @@ describe('Rate', () => {
 							title={'2'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={false}
@@ -342,7 +398,13 @@ describe('Rate', () => {
 							title={'3'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={false}
@@ -374,7 +436,13 @@ describe('Rate', () => {
 						title={'1'}
 					>
 						<span classes={fixedCss.iconWrapperFixed}>
-							<Icon size={'medium'} type={'starIcon'} />
+							<Icon
+								size={'medium'}
+								type={'starIcon'}
+								theme={undefined}
+								variant={undefined}
+								classes={undefined}
+							/>
 						</span>
 						<input
 							checked={true}
@@ -397,7 +465,13 @@ describe('Rate', () => {
 						title={'2'}
 					>
 						<span classes={fixedCss.iconWrapperFixed}>
-							<Icon size={'medium'} type={'starIcon'} />
+							<Icon
+								size={'medium'}
+								type={'starIcon'}
+								theme={undefined}
+								variant={undefined}
+								classes={undefined}
+							/>
 						</span>
 						<input
 							checked={false}
@@ -420,7 +494,13 @@ describe('Rate', () => {
 						title={'3'}
 					>
 						<span classes={fixedCss.iconWrapperFixed}>
-							<Icon size={'medium'} type={'starIcon'} />
+							<Icon
+								size={'medium'}
+								type={'starIcon'}
+								theme={undefined}
+								variant={undefined}
+								classes={undefined}
+							/>
 						</span>
 						<input
 							checked={false}
@@ -469,7 +549,13 @@ describe('Rate', () => {
 							title={'1'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={true}
@@ -492,7 +578,13 @@ describe('Rate', () => {
 							title={'2'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={false}
@@ -541,7 +633,13 @@ describe('Rate', () => {
 							title={'1'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={false}
@@ -564,7 +662,13 @@ describe('Rate', () => {
 							title={'2'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={false}
@@ -587,7 +691,13 @@ describe('Rate', () => {
 							title={'3'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={false}
@@ -625,7 +735,13 @@ describe('Rate', () => {
 						title={'1'}
 					>
 						<span classes={fixedCss.iconWrapperFixed}>
-							<Icon size={'medium'} type={'starIcon'} />
+							<Icon
+								size={'medium'}
+								type={'starIcon'}
+								theme={undefined}
+								variant={undefined}
+								classes={undefined}
+							/>
 						</span>
 						<input
 							checked={false}
@@ -648,7 +764,13 @@ describe('Rate', () => {
 						title={'2'}
 					>
 						<span classes={fixedCss.iconWrapperFixed}>
-							<Icon size={'medium'} type={'starIcon'} />
+							<Icon
+								size={'medium'}
+								type={'starIcon'}
+								theme={undefined}
+								variant={undefined}
+								classes={undefined}
+							/>
 						</span>
 						<input
 							checked={true}
@@ -671,7 +793,13 @@ describe('Rate', () => {
 						title={'3'}
 					>
 						<span classes={fixedCss.iconWrapperFixed}>
-							<Icon size={'medium'} type={'starIcon'} />
+							<Icon
+								size={'medium'}
+								type={'starIcon'}
+								theme={undefined}
+								variant={undefined}
+								classes={undefined}
+							/>
 						</span>
 						<input
 							checked={false}
@@ -723,7 +851,13 @@ describe('Rate', () => {
 							title={'1'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={false}
@@ -746,7 +880,13 @@ describe('Rate', () => {
 							title={'2'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<WrappedInput
 								checked={false}
@@ -781,7 +921,13 @@ describe('Rate', () => {
 							title={'1'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<input
 								checked={false}
@@ -804,7 +950,13 @@ describe('Rate', () => {
 							title={'2'}
 						>
 							<span classes={fixedCss.iconWrapperFixed}>
-								<Icon size={'medium'} type={'starIcon'} />
+								<Icon
+									size={'medium'}
+									type={'starIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							<WrappedInput
 								checked={false}
@@ -836,7 +988,13 @@ describe('Rate', () => {
 						title={'1'}
 					>
 						<span classes={fixedCss.iconWrapperFixed}>
-							<Icon size={'medium'} type={'starIcon'} />
+							<Icon
+								size={'medium'}
+								type={'starIcon'}
+								theme={undefined}
+								variant={undefined}
+								classes={undefined}
+							/>
 						</span>
 						<input
 							checked={false}
@@ -859,7 +1017,13 @@ describe('Rate', () => {
 						title={'2'}
 					>
 						<span classes={fixedCss.iconWrapperFixed}>
-							<Icon size={'medium'} type={'starIcon'} />
+							<Icon
+								size={'medium'}
+								type={'starIcon'}
+								theme={undefined}
+								variant={undefined}
+								classes={undefined}
+							/>
 						</span>
 						<WrappedInput
 							checked={false}

--- a/src/result/index.tsx
+++ b/src/result/index.tsx
@@ -36,7 +36,7 @@ const factory = create({ theme })
 
 export const Result = factory(function Result({ children, properties, middleware: { theme } }) {
 	const themeCss = theme.classes(css);
-	const { title, subtitle, status } = properties();
+	const { title, subtitle, status, classes, variant } = properties();
 	const { actionButtons, content, icon } = children()[0] || ({} as ResultChildren);
 
 	return (
@@ -61,6 +61,8 @@ export const Result = factory(function Result({ children, properties, middleware
 								css,
 								'icon'
 							)}
+							classes={classes}
+							variant={variant}
 						/>
 					)}
 				</div>

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -94,6 +94,8 @@ export const Select = factory(function Select({
 	const { createOptions, isLoading, meta, find } = resource;
 	const {
 		classes,
+		variant,
+		theme: themeProp,
 		disabled,
 		helperText,
 		initialValue,
@@ -162,6 +164,7 @@ export const Select = factory(function Select({
 						'label'
 					)}
 					classes={classes}
+					variant={variant}
 					disabled={disabled}
 					forId={triggerId}
 					valid={valid}
@@ -184,6 +187,9 @@ export const Select = factory(function Select({
 					}
 				}}
 				position={position}
+				theme={themeProp}
+				classes={classes}
+				variant={variant}
 			>
 				{{
 					trigger: (toggleOpen) => {
@@ -252,6 +258,7 @@ export const Select = factory(function Select({
 											'icon'
 										)}
 										classes={classes}
+										variant={variant}
 									/>
 								</span>
 							</button>
@@ -264,7 +271,12 @@ export const Select = factory(function Select({
 						}
 
 						return metaInfo === undefined && isLoading(template, options()) ? (
-							<LoadingIndicator key="loading" />
+							<LoadingIndicator
+								key="loading"
+								theme={themeProp}
+								variant={variant}
+								classes={classes}
+							/>
 						) : (
 							<div key="menu-wrapper" classes={themedCss.menuWrapper}>
 								<List
@@ -288,6 +300,7 @@ export const Select = factory(function Select({
 										'menu'
 									)}
 									classes={classes}
+									variant={variant}
 									widgetId={menuId}
 								>
 									{items}
@@ -301,6 +314,9 @@ export const Select = factory(function Select({
 				key="helperText"
 				text={valid === false ? messages.requiredMessage : helperText}
 				valid={valid}
+				classes={classes}
+				variant={variant}
+				theme={themeProp}
 			/>
 		</div>
 	);

--- a/src/select/tests/Select.spec.tsx
+++ b/src/select/tests/Select.spec.tsx
@@ -31,10 +31,25 @@ const harness = createHarness([compareTheme, compareResource]);
 
 const baseTemplate = assertionTemplate(() => (
 	<div classes={[undefined, css.root, undefined, false, false, false, undefined]} key="root">
-		<TriggerPopup key="popup" onClose={() => {}} onOpen={() => {}} position={undefined}>
+		<TriggerPopup
+			variant={undefined}
+			classes={undefined}
+			theme={undefined}
+			key="popup"
+			onClose={() => {}}
+			onOpen={() => {}}
+			position={undefined}
+		>
 			{{ trigger: () => <button />, content: () => <div /> }}
 		</TriggerPopup>
-		<HelperText key="helperText" text={undefined} valid={undefined} />
+		<HelperText
+			variant={undefined}
+			classes={undefined}
+			theme={undefined}
+			key="helperText"
+			text={undefined}
+			valid={undefined}
+		/>
 	</div>
 ));
 
@@ -58,7 +73,7 @@ const buttonTemplate = assertionTemplate(() => (
 			<span classes={css.placeholder} />
 		</span>
 		<span classes={css.arrow}>
-			<Icon type="downIcon" theme={{}} classes={undefined} />
+			<Icon type="downIcon" theme={{}} classes={undefined} variant={undefined} />
 		</span>
 	</button>
 ));
@@ -82,6 +97,7 @@ const menuTemplate = assertionTemplate(() => (
 			itemsInView={6}
 			theme={{}}
 			classes={undefined}
+			variant={undefined}
 			widgetId={'test'}
 		/>
 	</div>
@@ -118,6 +134,7 @@ describe('Select', () => {
 				<Label
 					theme={{}}
 					classes={undefined}
+					variant={undefined}
 					disabled={undefined}
 					forId={'id'}
 					valid={undefined}
@@ -277,7 +294,7 @@ describe('Select', () => {
 			buttonTemplate.setProperty('@trigger', 'value', 'dog').setChildren('@trigger', () => [
 				<span classes={[css.value, undefined]}>Dog</span>,
 				<span classes={css.arrow}>
-					<Icon type="downIcon" theme={{}} classes={undefined} />
+					<Icon type="downIcon" theme={{}} classes={undefined} variant={undefined} />
 				</span>
 			]),
 			() => triggerRenderResult
@@ -307,7 +324,7 @@ describe('Select', () => {
 			buttonTemplate.setProperty('@trigger', 'value', 'dog').setChildren('@trigger', () => [
 				<span classes={[css.value, undefined]}>Dog</span>,
 				<span classes={css.arrow}>
-					<Icon type="downIcon" theme={{}} classes={undefined} />
+					<Icon type="downIcon" theme={{}} classes={undefined} variant={undefined} />
 				</span>
 			]),
 			() => triggerRenderResult

--- a/src/slide-pane/index.tsx
+++ b/src/slide-pane/index.tsx
@@ -79,7 +79,10 @@ export const SlidePane = factory(function SlidePane({
 		title = '',
 		align = 'left',
 		width = DEFAULT_WIDTH,
-		underlay = false
+		underlay = false,
+		theme: themeProp,
+		variant,
+		classes
 	} = properties();
 	const themeCss = theme.classes(css);
 
@@ -258,7 +261,12 @@ export const SlidePane = factory(function SlidePane({
 						<button classes={themeCss.close} type="button" onclick={onCloseClick}>
 							{closeText}
 							<span classes={themeCss.closeIcon}>
-								<Icon type="closeIcon" />
+								<Icon
+									type="closeIcon"
+									theme={themeProp}
+									classes={classes}
+									variant={variant}
+								/>
 							</span>
 						</button>
 					</div>

--- a/src/slider/index.tsx
+++ b/src/slider/index.tsx
@@ -1,7 +1,7 @@
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import focus from '@dojo/framework/core/middleware/focus';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import { formatAriaProperties } from '../common/util';
 import Label from '../label/index';
@@ -101,6 +101,7 @@ export const Slider = factory(function Slider({
 		verticalHeight = '200px',
 		outputIsTooltip = false,
 		theme: themeProp,
+		variant,
 		classes,
 		onOut,
 		onOver,
@@ -214,6 +215,7 @@ export const Slider = factory(function Slider({
 			<Label
 				theme={themeProp}
 				classes={classes}
+				variant={variant}
 				disabled={disabled}
 				focused={focus.shouldFocus()}
 				valid={valid}

--- a/src/slider/tests/unit/Slider.spec.tsx
+++ b/src/slider/tests/unit/Slider.spec.tsx
@@ -54,6 +54,7 @@ const expected = function(
 				<Label
 					theme={undefined}
 					classes={undefined}
+					variant={undefined}
 					disabled={undefined}
 					focused={focused}
 					hidden={undefined}

--- a/src/snackbar/index.tsx
+++ b/src/snackbar/index.tsx
@@ -1,5 +1,5 @@
 import { RenderResult } from '@dojo/framework/core/interfaces';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import * as css from '../theme/default/snackbar.m.css';
 import * as fixedCss from './styles/snackbar.m.css';

--- a/src/speed-dial/index.tsx
+++ b/src/speed-dial/index.tsx
@@ -17,7 +17,7 @@ export interface ActionProperties {
 const actionFactory = create({ theme }).properties<ActionProperties>();
 
 export const Action = actionFactory(({ properties, children, middleware: { theme } }) => {
-	const { onClick, title } = properties();
+	const { onClick, title, variant, classes } = properties();
 
 	const fab = (
 		<FloatingActionButton
@@ -31,6 +31,8 @@ export const Action = actionFactory(({ properties, children, middleware: { theme
 			onClick={() => {
 				onClick();
 			}}
+			classes={classes}
+			variant={variant}
 		>
 			{children()}
 		</FloatingActionButton>
@@ -75,10 +77,12 @@ export const SpeedDial = factory(function SpeedDial({
 		onOpen,
 		onClose,
 		theme: themeProp,
+		classes,
+		variant,
 		delay = 30,
 		iconType = 'plusIcon'
 	} = properties();
-	const classes = theme.classes(css);
+	const themedCss = theme.classes(css);
 
 	let { open } = properties();
 
@@ -116,12 +120,12 @@ export const SpeedDial = factory(function SpeedDial({
 			key="root"
 			classes={[
 				theme.variant(),
-				classes.root,
+				themedCss.root,
 				fixedCss.root,
-				direction === 'left' && classes.left,
-				direction === 'right' && classes.right,
-				direction === 'down' && classes.down,
-				direction === 'up' && classes.up
+				direction === 'left' && themedCss.left,
+				direction === 'right' && themedCss.right,
+				direction === 'down' && themedCss.down,
+				direction === 'up' && themedCss.up
 			]}
 			onmouseleave={toggleClose}
 		>
@@ -141,12 +145,20 @@ export const SpeedDial = factory(function SpeedDial({
 						toggleOpen();
 					}
 				}}
+				classes={classes}
+				variant={variant}
 			>
-				<Icon size="large" theme={themeProp} type={iconType} />
+				<Icon
+					size="large"
+					theme={themeProp}
+					type={iconType}
+					classes={classes}
+					variant={variant}
+				/>
 			</FloatingActionButton>
 			<div
 				key="actions"
-				classes={[classes.actions, open ? classes.open : undefined]}
+				classes={[themedCss.actions, open ? themedCss.open : undefined]}
 				onpointerdown={toggleClose}
 			>
 				{actions.map((child, index) => {
@@ -156,7 +168,7 @@ export const SpeedDial = factory(function SpeedDial({
 						<div
 							key={`action-wrapper-${index}`}
 							styles={{ transitionDelay: calculatedDelay }}
-							classes={[classes.action, classes.actionTransition]}
+							classes={[themedCss.action, themedCss.actionTransition]}
 						>
 							{child}
 						</div>

--- a/src/speed-dial/tests/unit/SpeedDial.spec.tsx
+++ b/src/speed-dial/tests/unit/SpeedDial.spec.tsx
@@ -27,8 +27,16 @@ const baseTemplate = assertionTemplate(() => (
 			}}
 			onOver={noop}
 			onClick={noop}
+			variant={undefined}
+			classes={undefined}
 		>
-			<Icon size="large" theme={undefined} type="plusIcon" />
+			<Icon
+				size="large"
+				theme={undefined}
+				type="plusIcon"
+				variant={undefined}
+				classes={undefined}
+			/>
 		</FloatingActionButton>
 		<div key="actions" classes={[css.actions, undefined]} onpointerdown={noop}>
 			<div

--- a/src/switch/index.tsx
+++ b/src/switch/index.tsx
@@ -1,6 +1,6 @@
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import focus from '@dojo/framework/core/middleware/focus';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
 
 import { formatAriaProperties } from '../common/util';
@@ -65,6 +65,7 @@ export default factory(function Switch({ children, properties, id, middleware: {
 		required,
 		theme: themeProp,
 		valid,
+		variant,
 		value = false
 	} = properties();
 
@@ -143,6 +144,7 @@ export default factory(function Switch({ children, properties, id, middleware: {
 					key="label"
 					classes={classes}
 					theme={themeProp}
+					variant={variant}
 					disabled={disabled}
 					focused={focus.isFocused('root')}
 					valid={valid}

--- a/src/switch/tests/unit/Switch.spec.tsx
+++ b/src/switch/tests/unit/Switch.spec.tsx
@@ -97,6 +97,7 @@ const expected = ({
 					key="label"
 					theme={undefined}
 					classes={undefined}
+					variant={undefined}
 					disabled={disabled}
 					focused={false}
 					hidden={undefined}

--- a/src/tab-container/index.tsx
+++ b/src/tab-container/index.tsx
@@ -1,7 +1,7 @@
 import focus from '@dojo/framework/core/middleware/focus';
 import i18n from '@dojo/framework/core/middleware/i18n';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Icon from '../icon';
 
@@ -56,7 +56,10 @@ export const TabContainer = factory(function TabContainer({
 		initialActiveIndex = 0,
 		tabs,
 		onActiveIndex,
-		onClose
+		onClose,
+		theme: themeProp,
+		classes,
+		variant
 	} = properties();
 	let { activeIndex } = properties();
 
@@ -153,7 +156,14 @@ export const TabContainer = factory(function TabContainer({
 								}
 							}}
 						>
-							<Icon type="closeIcon" altText={messages.close} size="small" />
+							<Icon
+								type="closeIcon"
+								altText={messages.close}
+								size="small"
+								theme={themeProp}
+								classes={classes}
+								variant={variant}
+							/>
 						</button>
 					) : null}
 					<span classes={[themeCss.indicator, active && themeCss.indicatorActive]}>

--- a/src/tab-container/tests/TabContainer.spec.tsx
+++ b/src/tab-container/tests/TabContainer.spec.tsx
@@ -280,7 +280,14 @@ registerSuite('TabContainer', {
 									type="button"
 									onclick={noop}
 								>
-									<Icon type="closeIcon" altText="close" size="small" />
+									<Icon
+										type="closeIcon"
+										altText="close"
+										size="small"
+										theme={undefined}
+										variant={undefined}
+										classes={undefined}
+									/>
 								</button>
 								<span classes={[css.indicator, false]}>
 									<span classes={css.indicatorContent} />

--- a/src/text-area/index.tsx
+++ b/src/text-area/index.tsx
@@ -171,7 +171,8 @@ export const TextArea = factory(function TextArea({
 		classes,
 		labelHidden,
 		helperText,
-		onValidate
+		onValidate,
+		variant
 	} = properties();
 
 	let { value } = properties();
@@ -217,6 +218,7 @@ export const TextArea = factory(function TextArea({
 							'label'
 						)}
 						classes={classes}
+						variant={variant}
 						disabled={disabled}
 						valid={valid}
 						readOnly={readOnly}
@@ -300,6 +302,7 @@ export const TextArea = factory(function TextArea({
 				valid={valid}
 				classes={classes}
 				theme={themeProp}
+				variant={variant}
 			/>
 		</div>
 	);

--- a/src/text-area/tests/unit/TextArea.spec.tsx
+++ b/src/text-area/tests/unit/TextArea.spec.tsx
@@ -68,6 +68,7 @@ const expected = function(
 					<Label
 						theme={{}}
 						classes={undefined}
+						variant={undefined}
 						disabled={disabled}
 						hidden={undefined}
 						valid={valid}
@@ -112,10 +113,11 @@ const expected = function(
 				</div>
 			</div>
 			<HelperText
-				text={helperTextValue}
-				valid={valid}
+				variant={undefined}
 				classes={undefined}
 				theme={undefined}
+				text={helperTextValue}
+				valid={valid}
 			/>
 		</div>
 	);
@@ -127,11 +129,12 @@ const baseAssertion = assertionTemplate(() => (
 			{textarea()}
 		</div>
 		<HelperText
+			variant={undefined}
+			classes={undefined}
+			theme={undefined}
 			assertion-key="helperText"
 			text={undefined}
 			valid={true}
-			classes={undefined}
-			theme={undefined}
 		/>
 	</div>
 ));

--- a/src/text-input/index.tsx
+++ b/src/text-input/index.tsx
@@ -1,7 +1,7 @@
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import focus from '@dojo/framework/core/middleware/focus';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import validity from '@dojo/framework/core/middleware/validity';
 import { create, diffProperty, invalidator, tsx } from '@dojo/framework/core/vdom';
 import { formatAriaProperties } from '../common/util';
@@ -166,7 +166,8 @@ export const TextInput = factory(function TextInput({
 		type = 'text',
 		initialValue,
 		valid: validValue = { valid: undefined, message: '' },
-		widgetId = `text-input-${id}`
+		widgetId = `text-input-${id}`,
+		variant
 	} = properties();
 
 	let { value } = properties();
@@ -244,6 +245,8 @@ export const TextInput = factory(function TextInput({
 				{label && (
 					<Label
 						theme={themeProp}
+						classes={classes}
+						variant={variant}
 						disabled={disabled}
 						valid={valid}
 						focused={inputFocused}
@@ -325,6 +328,7 @@ export const TextInput = factory(function TextInput({
 				valid={valid}
 				classes={classes}
 				theme={themeProp}
+				variant={variant}
 			/>
 		</div>
 	);

--- a/src/text-input/tests/unit/TextInput.spec.tsx
+++ b/src/text-input/tests/unit/TextInput.spec.tsx
@@ -92,6 +92,8 @@ const expected = function({
 						hidden={labelHidden}
 						forId={''}
 						active={false}
+						classes={undefined}
+						variant={undefined}
 					>
 						foo
 					</Label>
@@ -138,6 +140,7 @@ const expected = function({
 				text={helperTextValue}
 				valid={valid}
 				classes={undefined}
+				variant={undefined}
 				theme={undefined}
 			/>
 		</div>
@@ -159,6 +162,7 @@ const baseAssertion = assertionTemplate(() => {
 				text={undefined}
 				valid={undefined}
 				classes={undefined}
+				variant={undefined}
 				theme={undefined}
 			/>
 		</div>

--- a/src/time-picker/index.tsx
+++ b/src/time-picker/index.tsx
@@ -223,7 +223,7 @@ export const TimePicker = factory(function TimePicker({
 	properties,
 	children
 }) {
-	const classes = theme.classes(css);
+	const themedCss = theme.classes(css);
 	const { messages } = i18n.localize(bundle);
 
 	const formatTime = (time: Date) => {
@@ -356,20 +356,20 @@ export const TimePicker = factory(function TimePicker({
 		return options;
 	};
 
-	const { name } = properties();
+	const { name, theme: themeProp, classes, variant } = properties();
 	const [labelChild] = children();
 	const label = isTimePickerChildren(labelChild) ? labelChild.label : labelChild;
 	const options = generateOptions();
 
 	return (
-		<div classes={[theme.variant(), classes.root]}>
+		<div classes={[theme.variant(), themedCss.root]}>
 			<input
 				type="hidden"
 				name={name}
 				value={icache.getOrSet('value', '')}
 				aria-hidden="true"
 			/>
-			<TriggerPopup key="popup">
+			<TriggerPopup key="popup" theme={themeProp} classes={classes} variant={variant}>
 				{{
 					trigger: (toggleOpen) => {
 						function openMenu() {
@@ -381,7 +381,7 @@ export const TimePicker = factory(function TimePicker({
 						const { disabled, required } = properties();
 
 						return (
-							<div classes={classes.input}>
+							<div classes={themedCss.input}>
 								<TextInput
 									key="input"
 									disabled={disabled}
@@ -392,6 +392,8 @@ export const TimePicker = factory(function TimePicker({
 										css,
 										'input'
 									)}
+									classes={classes}
+									variant={variant}
 									initialValue={icache.get('inputValue')}
 									onBlur={() => icache.set('shouldValidate', true)}
 									onValue={(v) =>
@@ -417,7 +419,11 @@ export const TimePicker = factory(function TimePicker({
 									{{
 										label,
 										trailing: (
-											<Addon>
+											<Addon
+												theme={themeProp}
+												classes={classes}
+												variant={variant}
+											>
 												<button
 													disabled={disabled}
 													key="clockIcon"
@@ -425,7 +431,7 @@ export const TimePicker = factory(function TimePicker({
 														e.stopPropagation();
 														openMenu();
 													}}
-													classes={classes.toggleMenuButton}
+													classes={themedCss.toggleMenuButton}
 													type="button"
 												>
 													<Icon type="clockIcon" />
@@ -445,8 +451,11 @@ export const TimePicker = factory(function TimePicker({
 						}
 
 						return (
-							<div key="menu-wrapper" classes={classes.menuWrapper}>
+							<div key="menu-wrapper" classes={themedCss.menuWrapper}>
 								<List
+									theme={themeProp}
+									classes={classes}
+									variant={variant}
 									key="menu"
 									focus={() => shouldFocus && focusNode === 'menu'}
 									resource={resource({

--- a/src/time-picker/tests/unit/TimePicker.spec.tsx
+++ b/src/time-picker/tests/unit/TimePicker.spec.tsx
@@ -55,7 +55,7 @@ const baseTemplate = (date?: Date) =>
 					value={date ? format24HourTime(date) : ''}
 					aria-hidden="true"
 				/>
-				<TriggerPopup key="popup">
+				<TriggerPopup variant={undefined} classes={undefined} theme={undefined} key="popup">
 					{{
 						trigger: () => <button />,
 						content: () => <div />
@@ -82,6 +82,8 @@ const buttonTemplate = assertionTemplate(() => {
 				helperText=""
 				onKeyDown={noop}
 				type="text"
+				variant={undefined}
+				classes={undefined}
 			>
 				{{ label: undefined, trailing: undefined }}
 			</TextInput>
@@ -136,6 +138,9 @@ const menuTemplate = assertionTemplate(() => {
 				onBlur={noop}
 				initialValue={''}
 				menu
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
 			/>
 		</div>
 	);

--- a/src/title-pane/index.tsx
+++ b/src/title-pane/index.tsx
@@ -51,7 +51,9 @@ export const TitlePane = factory(function TitlePane({
 		onClose,
 		onOpen,
 		name,
-		theme: themeProp
+		theme: themeProp,
+		classes,
+		variant
 	} = properties();
 	let { open } = properties();
 
@@ -105,7 +107,12 @@ export const TitlePane = factory(function TitlePane({
 					type="button"
 				>
 					<span classes={themeCss.arrow}>
-						<Icon type={open ? 'downIcon' : 'rightIcon'} theme={themeProp} />
+						<Icon
+							type={open ? 'downIcon' : 'rightIcon'}
+							theme={themeProp}
+							classes={classes}
+							variant={variant}
+						/>
 					</span>
 					{name}
 				</button>

--- a/src/title-pane/tests/unit/TitlePane.spec.tsx
+++ b/src/title-pane/tests/unit/TitlePane.spec.tsx
@@ -52,7 +52,12 @@ describe('TitlePane', () => {
 							type="button"
 						>
 							<span classes={themeCss.arrow}>
-								<Icon type={isOpen ? 'downIcon' : 'rightIcon'} theme={undefined} />
+								<Icon
+									type={isOpen ? 'downIcon' : 'rightIcon'}
+									theme={undefined}
+									variant={undefined}
+									classes={undefined}
+								/>
 							</span>
 							title
 						</button>

--- a/src/tree/index.tsx
+++ b/src/tree/index.tsx
@@ -2,7 +2,7 @@ import { create, tsx, diffProperty } from '@dojo/framework/core/vdom';
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
 import { createResourceMiddleware } from '@dojo/framework/core/middleware/resources';
-import theme from '@dojo/framework/core/middleware/theme';
+import theme from '../middleware/theme';
 import focus from '@dojo/framework/core/middleware/focus';
 import { flat } from '@dojo/framework/shim/array';
 
@@ -93,9 +93,12 @@ export default factory(function Tree({
 		onExpand,
 		disabledIds,
 		resource: { template },
-		parentSelection = false
+		parentSelection = false,
+		theme: themeProp,
+		classes,
+		variant
 	} = properties();
-	const classes = theme.classes(css);
+	const themedCss = theme.classes(css);
 	const defaultRenderer = (n: TreeNodeOption) => n.value;
 	const [itemRenderer] = children();
 
@@ -224,7 +227,7 @@ export default factory(function Tree({
 		const info = meta(template, options({ query: { parent: nodeId } }), true);
 
 		if (info === undefined || isLoading(template, options())) {
-			return <LoadingIndicator />;
+			return <LoadingIndicator theme={themeProp} classes={classes} variant={variant} />;
 		}
 
 		const results = getOrRead(
@@ -237,8 +240,8 @@ export default factory(function Tree({
 		return (
 			<ol
 				classes={[
-					nodeId === 'root' ? classes.root : null,
-					classes.nodeParent,
+					nodeId === 'root' ? themedCss.root : null,
+					themedCss.nodeParent,
 					theme.variant()
 				]}
 				onkeydown={onKeyDown}
@@ -250,14 +253,17 @@ export default factory(function Tree({
 					return (
 						<li
 							classes={[
-								classes.node,
-								node.hasChildren && classes.leaf,
-								selectable && classes.selectable,
-								node.id === selectedNode && classes.selected
+								themedCss.node,
+								node.hasChildren && themedCss.leaf,
+								selectable && themedCss.selectable,
+								node.id === selectedNode && themedCss.selected
 							]}
 							role={'treeitem'}
 						>
 							<TreeNode
+								classes={classes}
+								theme={themeProp}
+								variant={variant}
 								activeNode={activeNode}
 								checkable={checkable}
 								selectable={selectable}
@@ -334,10 +340,13 @@ export const TreeNode = treeNodeFactory(function TreeNode({
 		onValue,
 		onCheck,
 		onExpand,
-		parentSelection
+		parentSelection,
+		theme: themeProp,
+		classes,
+		variant
 	} = properties();
 	const [itemRenderer] = children();
-	const classes = theme.classes(css);
+	const themedCss = theme.classes(css);
 	const isActive = node.id === activeNode;
 	const isExpandable = node.hasChildren;
 
@@ -357,12 +366,20 @@ export const TreeNode = treeNodeFactory(function TreeNode({
 			}}
 			disabled={disabled}
 			widgetId={node.id}
+			classes={classes}
+			theme={themeProp}
+			variant={variant}
 		>
-			<div classes={classes.contentWrapper}>
-				<div classes={classes.content}>
+			<div classes={themedCss.contentWrapper}>
+				<div classes={themedCss.content}>
 					{isExpandable && (
-						<div classes={classes.expander}>
-							<Icon type={expanded ? 'downIcon' : 'rightIcon'} />
+						<div classes={themedCss.expander}>
+							<Icon
+								type={expanded ? 'downIcon' : 'rightIcon'}
+								theme={themeProp}
+								classes={classes}
+								variant={variant}
+							/>
 						</div>
 					)}
 					{checkable && (parentSelection || !isExpandable) && (
@@ -378,10 +395,13 @@ export const TreeNode = treeNodeFactory(function TreeNode({
 									onCheck(value);
 								}}
 								disabled={disabled}
+								classes={classes}
+								theme={themeProp}
+								variant={variant}
 							/>
 						</div>
 					)}
-					<div classes={classes.title}>{itemRenderer(node)}</div>
+					<div classes={themedCss.title}>{itemRenderer(node)}</div>
 				</div>
 			</div>
 		</ListItem>

--- a/src/tree/tests/unit/Tree.spec.tsx
+++ b/src/tree/tests/unit/Tree.spec.tsx
@@ -51,12 +51,24 @@ const baseAssertion = assertion(() => (
 
 const simpleTreeAssertion = baseAssertion.replaceChildren(WrappedRoot, () => [
 	<WrappedListItem1 role={'treeitem'} classes={[css.node, css.leaf, false, false]}>
-		<WrappedNode1 {...defaultNodeProps} node={simpleTree[0]}>
+		<WrappedNode1
+			{...defaultNodeProps}
+			node={simpleTree[0]}
+			theme={undefined}
+			classes={undefined}
+			variant={undefined}
+		>
 			{() => 'node-1'}
 		</WrappedNode1>
 	</WrappedListItem1>,
 	<WrappedListItem2 role={'treeitem'} classes={[css.node, false, false, false]}>
-		<WrappedNode2 {...defaultNodeProps} node={simpleTree[2]}>
+		<WrappedNode2
+			{...defaultNodeProps}
+			node={simpleTree[2]}
+			theme={undefined}
+			classes={undefined}
+			variant={undefined}
+		>
 			{() => 'node-2'}
 		</WrappedNode2>
 	</WrappedListItem2>
@@ -199,6 +211,9 @@ describe('Tree', () => {
 									{...defaultNodeProps}
 									expanded={false}
 									node={simpleTree[1]}
+									theme={undefined}
+									classes={undefined}
+									variant={undefined}
 								>
 									{() => ''}
 								</WrappedNode3>
@@ -242,7 +257,13 @@ describe('Tree', () => {
 									role={'group'}
 								>
 									<li role={'treeitem'} classes={[css.node, false, false, false]}>
-										<TreeNode {...nodeProps} node={simpleTree[1]}>
+										<TreeNode
+											{...nodeProps}
+											node={simpleTree[1]}
+											theme={undefined}
+											classes={undefined}
+											variant={undefined}
+										>
 											{() => ''}
 										</TreeNode>
 									</li>
@@ -288,7 +309,13 @@ describe('Tree', () => {
 									role={'group'}
 								>
 									<li role={'treeitem'} classes={[css.node, false, false, false]}>
-										<TreeNode {...nodeProps} node={simpleTree[1]}>
+										<TreeNode
+											{...nodeProps}
+											node={simpleTree[1]}
+											theme={undefined}
+											classes={undefined}
+											variant={undefined}
+										>
 											{() => ''}
 										</TreeNode>
 									</li>
@@ -695,7 +722,9 @@ describe('Tree', () => {
 	});
 
 	describe('Loading tree state', () => {
-		const loadingAssertion = assertion(() => <LoadingIndicator />);
+		const loadingAssertion = assertion(() => (
+			<LoadingIndicator theme={undefined} classes={undefined} variant={undefined} />
+		));
 		it('should have loading indicator when there is not data', () => {
 			let resolvePromise = (value: any) => {};
 			const dataPromise: Promise<TreeNodeOption[]> = new Promise((res) => {

--- a/src/tree/tests/unit/TreeNode.spec.tsx
+++ b/src/tree/tests/unit/TreeNode.spec.tsx
@@ -47,11 +47,19 @@ const baseAssertion = assertion(() => (
 		onSelect={noop}
 		disabled={false}
 		widgetId={node.id}
+		theme={undefined}
+		classes={undefined}
+		variant={undefined}
 	>
 		<WrappedContentWrapper classes={css.contentWrapper}>
 			<WrappedContent classes={css.content}>
 				<WrappedExpander classes={css.expander}>
-					<WrappedExpanderIcon type="rightIcon" />
+					<WrappedExpanderIcon
+						type="rightIcon"
+						theme={undefined}
+						classes={undefined}
+						variant={undefined}
+					/>
 				</WrappedExpander>
 				<WrappedTitle classes={css.title}>{node.value}</WrappedTitle>
 			</WrappedContent>
@@ -111,7 +119,14 @@ describe('TreeNode', () => {
 			() =>
 				(
 					<WrappedCheckboxContainer onpointerdown={onPointerDown}>
-						<WrappedCheckbox checked={false} onValue={noop} disabled={false} />
+						<WrappedCheckbox
+							checked={false}
+							onValue={noop}
+							disabled={false}
+							variant={undefined}
+							theme={undefined}
+							classes={undefined}
+						/>
 					</WrappedCheckboxContainer>
 				) as any
 		);
@@ -229,7 +244,14 @@ describe('TreeNode', () => {
 				() =>
 					(
 						<div onpointerdown={onPointerDown}>
-							<WrappedCheckbox checked={false} onValue={noop} disabled={false} />
+							<WrappedCheckbox
+								checked={false}
+								onValue={noop}
+								disabled={false}
+								variant={undefined}
+								theme={undefined}
+								classes={undefined}
+							/>
 						</div>
 					) as any
 			);

--- a/src/trigger-popup/index.tsx
+++ b/src/trigger-popup/index.tsx
@@ -66,6 +66,7 @@ export const TriggerPopup = factory(function TriggerPopup({
 			<Popup
 				key="popup"
 				{...otherProperties}
+				classes={classes}
 				yTop={triggerBottom}
 				yBottom={triggerTop}
 				xLeft={triggerPosition.left}

--- a/src/trigger-popup/tests/TriggerPopup.spec.tsx
+++ b/src/trigger-popup/tests/TriggerPopup.spec.tsx
@@ -20,6 +20,7 @@ const baseTemplate = assertionTemplate(() => (
 			xRight={0}
 			onClose={() => {}}
 			open={undefined}
+			classes={undefined}
 		>
 			{(position) => (
 				<div key="trigger-wrapper" styles={{ width: '0' }}>

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -110,7 +110,9 @@ export const Typeahead = factory(function Typeahead({
 		value: controlledValue,
 		itemDisabled,
 		resource: { template, options = createOptions(id) },
-		classes
+		classes,
+		theme: themeProp,
+		variant
 	} = properties();
 	const themedCss = theme.classes(css);
 	const { messages } = i18n.localize(bundle);
@@ -264,6 +266,9 @@ export const Typeahead = factory(function Typeahead({
 					}
 				}}
 				position={position}
+				classes={classes}
+				theme={themeProp}
+				variant={variant}
 			>
 				{{
 					trigger: (toggleOpen) => {
@@ -365,6 +370,7 @@ export const Typeahead = factory(function Typeahead({
 										root: [themedCss.trigger]
 									}
 								}}
+								variant={variant}
 								onClick={openMenu}
 								onKeyDown={(event, preventDefault) => {
 									onKeyDown(event, preventDefault, openMenu, closeMenu);
@@ -384,7 +390,12 @@ export const Typeahead = factory(function Typeahead({
 						const { itemDisabled } = properties();
 
 						return metaInfo === undefined && isLoading(template, options()) ? (
-							<LoadingIndicator key="loading" />
+							<LoadingIndicator
+								key="loading"
+								theme={themeProp}
+								classes={classes}
+								variant={variant}
+							/>
 						) : (
 							<div key="menu-wrapper" classes={themedCss.menuWrapper}>
 								<List
@@ -411,6 +422,7 @@ export const Typeahead = factory(function Typeahead({
 										css,
 										'menu'
 									)}
+									variant={variant}
 									widgetId={listId}
 								>
 									{items}
@@ -424,6 +436,9 @@ export const Typeahead = factory(function Typeahead({
 				key="helperText"
 				text={valid === false ? messages.requiredMessage : helperText}
 				valid={valid}
+				classes={classes}
+				theme={themeProp}
+				variant={variant}
 			/>
 		</div>
 	);

--- a/src/typeahead/tests/unit/Typeahead.spec.tsx
+++ b/src/typeahead/tests/unit/Typeahead.spec.tsx
@@ -78,6 +78,7 @@ const triggerAssertion = assertion(() => (
 				root: [css.trigger]
 			}
 		}}
+		variant={undefined}
 	>
 		{{ label: undefined, leading: undefined }}
 	</WrappedTrigger>
@@ -93,6 +94,7 @@ const contentAssertion = assertion(() => (
 	<div key="menu-wrapper" classes={css.menuWrapper}>
 		<WrappedList
 			classes={undefined}
+			variant={undefined}
 			activeIndex={0}
 			disabled={undefined}
 			focusable={false}
@@ -126,13 +128,28 @@ const contentAssertion = assertion(() => (
 
 const baseAssertion = assertion(() => (
 	<WrappedRoot classes={[null, css.root, null, false, false]} key="root">
-		<WrappedPopup key="popup" onClose={noop} onOpen={noop} position={undefined}>
+		<WrappedPopup
+			variant={undefined}
+			classes={undefined}
+			theme={undefined}
+			key="popup"
+			onClose={noop}
+			onOpen={noop}
+			position={undefined}
+		>
 			{{
 				trigger: triggerAssertion,
 				content: contentAssertion
 			}}
 		</WrappedPopup>
-		<WrappedHelperText key="helperText" text={undefined} valid={undefined} />
+		<WrappedHelperText
+			variant={undefined}
+			classes={undefined}
+			theme={undefined}
+			key="helperText"
+			text={undefined}
+			valid={undefined}
+		/>
 	</WrappedRoot>
 ));
 

--- a/src/wizard/index.tsx
+++ b/src/wizard/index.tsx
@@ -64,8 +64,16 @@ const factory = create({ theme })
 	.properties<WizardProperties>();
 
 export default factory(function Wizard({ properties, children, middleware: { theme } }) {
-	const classes = theme.classes(css);
-	const { activeStep, direction = 'horizontal', onStep, clickable = false } = properties();
+	const themedCss = theme.classes(css);
+	const {
+		activeStep,
+		direction = 'horizontal',
+		onStep,
+		clickable = false,
+		classes,
+		variant,
+		theme: themeProp
+	} = properties();
 
 	const stepNodes = children();
 
@@ -86,10 +94,14 @@ export default factory(function Wizard({ properties, children, middleware: { the
 		const { status = defaultStatus } = step.properties;
 		switch (status) {
 			case 'complete':
-				content = <Icon type="checkIcon" />;
+				content = (
+					<Icon type="checkIcon" theme={themeProp} classes={classes} variant={variant} />
+				);
 				break;
 			case 'error':
-				content = <Icon type="closeIcon" />;
+				content = (
+					<Icon type="closeIcon" theme={themeProp} classes={classes} variant={variant} />
+				);
 				break;
 			default:
 				content = String(index + 1);
@@ -97,13 +109,15 @@ export default factory(function Wizard({ properties, children, middleware: { the
 		return {
 			content: (
 				<virtual>
-					<div classes={classes.stepIcon}>
+					<div classes={themedCss.stepIcon}>
 						<Avatar
 							theme={theme.compose(
 								avatarCss,
 								css,
 								'avatar'
 							)}
+							classes={classes}
+							variant={variant}
 							outline={Boolean(status !== 'inProgress')}
 						>
 							{content}
@@ -121,19 +135,19 @@ export default factory(function Wizard({ properties, children, middleware: { the
 			key="root"
 			classes={[
 				theme.variant(),
-				classes.root,
-				direction === 'horizontal' ? classes.horizontal : classes.vertical,
-				clickable && classes.clickable
+				themedCss.root,
+				direction === 'horizontal' ? themedCss.horizontal : themedCss.vertical,
+				clickable && themedCss.clickable
 			]}
 		>
 			{stepWrappers.map(({ content, status }, index) => (
 				<div
 					key={`step${index + 1}`}
 					classes={[
-						classes.step,
-						status === 'complete' && classes.complete,
-						status === 'pending' && classes.pending,
-						status === 'error' && classes.error
+						themedCss.step,
+						status === 'complete' && themedCss.complete,
+						status === 'pending' && themedCss.pending,
+						status === 'error' && themedCss.error
 					]}
 					onclick={() => {
 						if (clickable && onStep) {
@@ -141,7 +155,7 @@ export default factory(function Wizard({ properties, children, middleware: { the
 						}
 					}}
 				>
-					<div classes={classes.tail} />
+					<div classes={themedCss.tail} />
 					{content}
 				</div>
 			))}

--- a/src/wizard/tests/unit/Wizard.spec.tsx
+++ b/src/wizard/tests/unit/Wizard.spec.tsx
@@ -55,8 +55,15 @@ describe('Wizard', () => {
 								}
 							}}
 							outline={true}
+							classes={undefined}
+							variant={undefined}
 						>
-							<Icon type="checkIcon" />
+							<Icon
+								type="checkIcon"
+								classes={undefined}
+								variant={undefined}
+								theme={undefined}
+							/>
 						</Avatar>
 					</div>
 					<div>Step 1</div>
@@ -81,6 +88,8 @@ describe('Wizard', () => {
 									square: avatarCss.square
 								}
 							}}
+							classes={undefined}
+							variant={undefined}
 							outline={false}
 						>
 							2
@@ -113,6 +122,8 @@ describe('Wizard', () => {
 								}
 							}}
 							outline={true}
+							classes={undefined}
+							variant={undefined}
 						>
 							3
 						</Avatar>
@@ -215,6 +226,8 @@ describe('Wizard', () => {
 									}
 								}}
 								outline={false}
+								classes={undefined}
+								variant={undefined}
 							>
 								2
 							</WrappedAvatar>
@@ -223,7 +236,14 @@ describe('Wizard', () => {
 					</virtual>
 				])
 				.setProperty(WrappedAvatar, 'outline', true)
-				.setChildren(WrappedAvatar, () => [<Icon type="closeIcon" />])
+				.setChildren(WrappedAvatar, () => [
+					<Icon
+						type="closeIcon"
+						classes={undefined}
+						variant={undefined}
+						theme={undefined}
+					/>
+				])
 				.setProperty(WrappedStep3, 'classes', [css.step, false, css.pending, false])
 		);
 	});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Widgets that compose other widgets should pass all theme related properties down, such as `theme`, `classes` and `variant`. Also we should consistently use the `theme` middleware from widgets across the codebase and not mix and match between that and the core middleware from framework.