### PR TITLE
Ensure that the id is used to get the label for async templates

### DIFF
--- a/src/examples/src/widgets/select/Controlled.tsx
+++ b/src/examples/src/widgets/select/Controlled.tsx
@@ -3,8 +3,9 @@ import Select from '@dojo/widgets/select';
 import icache from '@dojo/framework/core/middleware/icache';
 import Example from '../../Example';
 import {
-	createMemoryResourceTemplate,
-	createResourceMiddleware
+	createResourceTemplate,
+	createResourceMiddleware,
+	defaultFind
 } from '@dojo/framework/core/middleware/resources';
 import { ListOption } from '@dojo/widgets/list';
 
@@ -16,14 +17,19 @@ const options = [
 	{ value: '3', label: 'Fish' }
 ];
 
-const template = createMemoryResourceTemplate<ListOption>();
+const template = createResourceTemplate<{ value: string; label: string }>({
+	find: defaultFind,
+	read: async (req, { put }) => {
+		put({ data: options, total: options.length }, req);
+	}
+});
 
-export default factory(function Controlled({ id, middleware: { icache, resource } }) {
+export default factory(function Controlled({ middleware: { icache, resource } }) {
 	const currentValue = icache.get<ListOption>('value');
 	return (
 		<Example>
 			<Select
-				resource={resource({ template, initOptions: { id, data: options } })}
+				resource={resource({ template })}
 				onValue={(value) => {
 					icache.set('value', value);
 				}}

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -109,7 +109,6 @@ export const Select = factory(function Select({
 		resource: { template, options = createOptions(id) }
 	} = properties();
 	const [{ items, label } = { items: undefined, label: undefined }] = children();
-
 	let { value } = properties();
 
 	if (value === undefined) {
@@ -207,7 +206,7 @@ export const Select = factory(function Select({
 								find(template, {
 									options: options(),
 									start: 0,
-									query: { value: `${value}` },
+									query: { value },
 									type: 'exact'
 								}) || {
 									item: undefined

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -130,7 +130,7 @@ export const Select = factory(function Select({
 	const { messages } = i18n.localize(bundle);
 	const expanded = icache.get('expanded');
 	const metaInfo = icache.set('meta', (current) => {
-		const newMeta = meta(template, options());
+		const newMeta = meta(template, options(), true);
 		return newMeta || current;
 	});
 
@@ -202,12 +202,12 @@ export const Select = factory(function Select({
 						}
 
 						let valueOption: ListOption | undefined;
-						if (value) {
+						if (value && metaInfo) {
 							valueOption = (
 								find(template, {
 									options: options(),
 									start: 0,
-									query: { value },
+									query: { value: `${value}` },
 									type: 'exact'
 								}) || {
 									item: undefined


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Use the associated label for the id passed as the initial value or controlled value
