### PR TITLE
Render list shell based on the item size and items in view

### DIFF
--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -643,7 +643,7 @@ export const List = factory(function List({
 
 	const menuHeight = icache.get('menuHeight');
 	const idBase = widgetId || `menu-${id}`;
-	const rootStyles = menuHeight ? { maxHeight: `${menuHeight}px` } : {};
+	const rootStyles = menuHeight ? { height: `${menuHeight}px` } : {};
 	const shouldFocus = focus.shouldFocus();
 	const themedCss = theme.classes(css);
 	const itemHeight = icache.getOrSet('itemHeight', 0);
@@ -705,58 +705,52 @@ export const List = factory(function List({
 	const items = renderItems(startNode, renderedItemsCount, startNode);
 	const metaInfo = meta(template, options(), true);
 
-	if (!metaInfo || metaInfo.total === undefined) {
-		return;
-	}
-
-	const total = metaInfo.total;
+	const total = metaInfo && metaInfo.total ? metaInfo.total : 0;
 	const totalContentHeight = total * itemHeight;
 
 	return (
-		!!total && (
+		<div
+			key="root"
+			classes={[theme.variant(), themedCss.root, fixedCss.root]}
+			tabIndex={focusable ? 0 : -1}
+			onkeydown={(e) => {
+				onKeyDown(e, total);
+			}}
+			focus={() => shouldFocus}
+			onfocus={onFocus}
+			onpointerdown={focusable ? undefined : (event) => event.preventDefault()}
+			onblur={onBlur}
+			scrollTop={scrollTop}
+			onscroll={(e) => {
+				const newScrollTop = (e.target as HTMLElement).scrollTop;
+				if (scrollTop !== newScrollTop) {
+					icache.set('scrollTop', newScrollTop);
+				}
+			}}
+			styles={rootStyles}
+			role={menu ? 'menu' : 'listbox'}
+			aria-orientation="vertical"
+			aria-activedescendant={`${idBase}-item-${computedActiveIndex}`}
+			id={idBase}
+		>
 			<div
-				key="root"
-				classes={[theme.variant(), themedCss.root, fixedCss.root]}
-				tabIndex={focusable ? 0 : -1}
-				onkeydown={(e) => {
-					onKeyDown(e, total);
+				classes={fixedCss.wrapper}
+				styles={{
+					height: `${totalContentHeight}px`
 				}}
-				focus={() => shouldFocus}
-				onfocus={onFocus}
-				onpointerdown={focusable ? undefined : (event) => event.preventDefault()}
-				onblur={onBlur}
-				scrollTop={scrollTop}
-				onscroll={(e) => {
-					const newScrollTop = (e.target as HTMLElement).scrollTop;
-					if (scrollTop !== newScrollTop) {
-						icache.set('scrollTop', newScrollTop);
-					}
-				}}
-				styles={rootStyles}
-				role={menu ? 'menu' : 'listbox'}
-				aria-orientation="vertical"
-				aria-activedescendant={`${idBase}-item-${computedActiveIndex}`}
-				id={idBase}
+				key="wrapper"
 			>
 				<div
-					classes={fixedCss.wrapper}
+					classes={fixedCss.transformer}
 					styles={{
-						height: `${totalContentHeight}px`
+						transform: `translateY(${offsetY}px)`
 					}}
-					key="wrapper"
+					key="transformer"
 				>
-					<div
-						classes={fixedCss.transformer}
-						styles={{
-							transform: `translateY(${offsetY}px)`
-						}}
-						key="transformer"
-					>
-						{items}
-					</div>
+					{items}
 				</div>
 			</div>
-		)
+		</div>
 	);
 });
 

--- a/src/list/tests/List.spec.tsx
+++ b/src/list/tests/List.spec.tsx
@@ -86,7 +86,7 @@ const baseAssertion = assertion(() => (
 		role={'listbox'}
 		scrollTop={0}
 		styles={{
-			maxHeight: '450px'
+			height: '450px'
 		}}
 		tabIndex={0}
 	>
@@ -310,21 +310,6 @@ describe('List', () => {
 		sb.restore();
 	});
 
-	it('should not render with no data', () => {
-		const r = renderer(
-			() => (
-				<List
-					resource={{
-						template: { template, id: 'test', initOptions: { data: [], id: 'test' } }
-					}}
-					onValue={onValueStub}
-				/>
-			),
-			{ middleware: [[getRegistry, mockGetRegistry]] }
-		);
-		r.expect(assertion(() => undefined));
-	});
-
 	it('should render with list item placeholders', async () => {
 		const data: any[] = [];
 		for (let i = 0; i < 60; i++) {
@@ -343,7 +328,7 @@ describe('List', () => {
 				height: '2700px'
 			})
 			.setProperty(WrappedRoot, 'styles', {
-				maxHeight: '450px'
+				height: '450px'
 			})
 			.replaceChildren(WrappedItemContainer, () => {
 				const children: any[] = [];
@@ -412,7 +397,7 @@ describe('List', () => {
 			() => <List resource={{ template: { template, id: 'test' } }} onValue={onValueStub} />,
 			{ middleware: [[getRegistry, mockGetRegistry]] }
 		);
-		r.expect(assertion(() => null));
+		r.expect(baseAssertion);
 		pageOneResolver!({ data: data.slice(0, 30), total: data.length });
 		await pageOnePromise;
 		r.expect(listAssertion);
@@ -566,7 +551,7 @@ describe('List', () => {
 				height: '2700px'
 			})
 			.setProperty(WrappedRoot, 'styles', {
-				maxHeight: '450px'
+				height: '450px'
 			})
 			.replaceChildren(WrappedItemContainer, () => {
 				const children: any[] = [];
@@ -624,7 +609,7 @@ describe('List', () => {
 			),
 			{ middleware: [[getRegistry, mockGetRegistry]] }
 		);
-		r.expect(assertion(() => null));
+		r.expect(baseAssertion.setProperty(WrappedRoot, 'role', 'menu'));
 		pageOneResolver!({ data: data.slice(0, 30), total: data.length });
 		await pageOnePromise;
 		r.expect(menuAssertion);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

The list should be rendered to the requested size of the items in view, by default 10. This will prevent the list "popping" in once items have been fetched.