### PR TITLE
Add property to configure the list to be able to set the height to auto

### DIFF
--- a/src/context-menu/index.tsx
+++ b/src/context-menu/index.tsx
@@ -24,6 +24,7 @@ export const ContextMenu = factory(function({ properties, children, middleware: 
 				content: ({ close, shouldFocus }) => (
 					<List
 						key="menu"
+						height="auto"
 						focus={shouldFocus}
 						theme={theme.compose(
 							menuCss,

--- a/src/context-menu/tests/ContextMenu.spec.tsx
+++ b/src/context-menu/tests/ContextMenu.spec.tsx
@@ -78,6 +78,7 @@ describe('ContextMenu', () => {
 			() => (
 				<List
 					key="menu"
+					height="auto"
 					menu
 					focus={() => null as any}
 					theme={{}}

--- a/src/examples/src/widgets/select/Basic.tsx
+++ b/src/examples/src/widgets/select/Basic.tsx
@@ -17,6 +17,7 @@ export default factory(function Basic({ id, middleware: { icache, resource } }) 
 	return (
 		<Example>
 			<Select
+				itemsInView={4}
 				resource={resource({
 					template,
 					transform: { value: 'id', label: 'summary' },

--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -221,6 +221,8 @@ export interface ListProperties {
 	widgetId?: string;
 	/** Callback to determine if a list item is disabled. If not provided, ListOption.disabled will be used */
 	disabled?: (item: ListOption) => boolean;
+	/** Specifies if the list should fix the area determined by the items in view */
+	height?: 'auto' | 'fixed';
 }
 
 export interface ListChildren {
@@ -287,7 +289,8 @@ export const List = factory(function List({
 		theme: themeProp,
 		variant,
 		resource: { template, options = createOptions(id) },
-		classes
+		classes,
+		height = 'fixed'
 	} = properties();
 	const [itemRenderer] = children();
 
@@ -643,7 +646,9 @@ export const List = factory(function List({
 
 	const menuHeight = icache.get('menuHeight');
 	const idBase = widgetId || `menu-${id}`;
-	const rootStyles = menuHeight ? { height: `${menuHeight}px` } : {};
+	const rootStyles = menuHeight
+		? { [height === 'fixed' ? 'height' : 'maxHeight']: `${menuHeight}px` }
+		: {};
 	const shouldFocus = focus.shouldFocus();
 	const themedCss = theme.classes(css);
 	const itemHeight = icache.getOrSet('itemHeight', 0);

--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -221,7 +221,7 @@ export interface ListProperties {
 	widgetId?: string;
 	/** Callback to determine if a list item is disabled. If not provided, ListOption.disabled will be used */
 	disabled?: (item: ListOption) => boolean;
-	/** Specifies if the list should fix the area determined by the items in view */
+	/** Specifies if the list height should by fixed to the height of the items in view */
 	height?: 'auto' | 'fixed';
 }
 

--- a/src/list/index.tsx
+++ b/src/list/index.tsx
@@ -646,9 +646,11 @@ export const List = factory(function List({
 
 	const menuHeight = icache.get('menuHeight');
 	const idBase = widgetId || `menu-${id}`;
-	const rootStyles = menuHeight
-		? { [height === 'fixed' ? 'height' : 'maxHeight']: `${menuHeight}px` }
-		: {};
+	let rootStyles: Partial<CSSStyleDeclaration> = {};
+	if (menuHeight) {
+		rootStyles =
+			height === 'fixed' ? { height: `${menuHeight}px` } : { maxHeight: `${menuHeight}px` };
+	}
 	const shouldFocus = focus.shouldFocus();
 	const themedCss = theme.classes(css);
 	const itemHeight = icache.getOrSet('itemHeight', 0);

--- a/src/list/tests/List.spec.tsx
+++ b/src/list/tests/List.spec.tsx
@@ -517,6 +517,26 @@ describe('List', () => {
 		r.expect(listWithListItemsAssertion);
 	});
 
+	it('should render list with auto height', () => {
+		const r = renderer(
+			() => (
+				<List
+					height="auto"
+					resource={{
+						template: { template, id: 'test', initOptions: { data, id: 'test' } }
+					}}
+					onValue={onValueStub}
+				/>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry]] }
+		);
+		r.expect(
+			listWithListItemsAssertion.setProperty(WrappedRoot, 'styles', {
+				maxHeight: '450px'
+			})
+		);
+	});
+
 	it('should render list with menu items data', () => {
 		const r = renderer(
 			() => (

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -280,6 +280,7 @@ export const Select = factory(function Select({
 							<div key="menu-wrapper" classes={themedCss.menuWrapper}>
 								<List
 									key="menu"
+									height="auto"
 									focus={() => focusNode === 'menu' && shouldFocus}
 									resource={resource({ template, options })}
 									onValue={(value) => {

--- a/src/select/tests/Select.spec.tsx
+++ b/src/select/tests/Select.spec.tsx
@@ -89,6 +89,7 @@ const menuTemplate = assertionTemplate(() => (
 	<div key="menu-wrapper" classes={css.menuWrapper}>
 		<List
 			key="menu"
+			height="auto"
 			focus={() => false}
 			resource={createTestResource(options)}
 			onValue={() => {}}

--- a/src/time-picker/index.tsx
+++ b/src/time-picker/index.tsx
@@ -453,6 +453,7 @@ export const TimePicker = factory(function TimePicker({
 						return (
 							<div key="menu-wrapper" classes={themedCss.menuWrapper}>
 								<List
+									height="auto"
 									theme={themeProp}
 									classes={classes}
 									variant={variant}

--- a/src/time-picker/tests/unit/TimePicker.spec.tsx
+++ b/src/time-picker/tests/unit/TimePicker.spec.tsx
@@ -131,6 +131,7 @@ const menuTemplate = assertionTemplate(() => {
 		<div key="menu-wrapper" classes={css.menuWrapper}>
 			<List
 				key="menu"
+				height="auto"
 				focus={() => false}
 				resource={createTestResource(options30Minutes)}
 				onValue={noop}

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -400,6 +400,7 @@ export const Typeahead = factory(function Typeahead({
 							<div key="menu-wrapper" classes={themedCss.menuWrapper}>
 								<List
 									key="menu"
+									height="auto"
 									focusable={false}
 									activeIndex={icache.get('activeIndex')}
 									resource={resource({ template, options })}

--- a/src/typeahead/tests/unit/Typeahead.spec.tsx
+++ b/src/typeahead/tests/unit/Typeahead.spec.tsx
@@ -93,6 +93,7 @@ const expandedTriggerAssertion = triggerAssertion.setProperty(WrappedTrigger, 'a
 const contentAssertion = assertion(() => (
 	<div key="menu-wrapper" classes={css.menuWrapper}>
 		<WrappedList
+			height="auto"
 			classes={undefined}
 			variant={undefined}
 			activeIndex={0}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

The height of the list should be able to shrink to fit if there are less items than the specified items in view, this is for widgets such as the select and typeahead. By default the list will take up all the space required to fix the number of items in view in.