### PR TITLE
Wrap Helper Text

### DIFF
--- a/src/theme/material/helper-text.m.css
+++ b/src/theme/material/helper-text.m.css
@@ -8,9 +8,7 @@
 }
 
 .root .text {
-	white-space: nowrap;
-	overflow: hidden;
-	text-overflow: ellipsis;
+	white-space: normal;
 	color: var(--mdc-disabled-text-color) !important;
 }
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Helper text has to wrap as there is no set width it cannot be truncated.