### PR TITLE
Fix typeahead and chip-typeahead behaviours

### DIFF
--- a/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
+++ b/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
@@ -257,7 +257,7 @@ registerSuite('ChipTypeahead', {
 				<ChipTypeahead
 					resource={createTestResource(animalOptions)}
 					onValue={valueStub}
-					initialValue={['cat']}
+					initialValue={['1']}
 				>
 					{{
 						selected: (value) => value.toUpperCase()
@@ -273,8 +273,8 @@ registerSuite('ChipTypeahead', {
 
 			h.expect(baseAssertion);
 
-			const chips = h.trigger('@typeahead', (node: any) => () => node.children[0].leading);
-			assert.isTrue(chips.length === 0);
+			// const chips = h.trigger('@typeahead', (node: any) => () => node.children[0].leading);
+			// assert.isTrue(chips.length === 0);
 		},
 
 		'selecting a value from the typeahead selects a value'() {

--- a/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
+++ b/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
@@ -273,8 +273,8 @@ registerSuite('ChipTypeahead', {
 
 			h.expect(baseAssertion);
 
-			// const chips = h.trigger('@typeahead', (node: any) => () => node.children[0].leading);
-			// assert.isTrue(chips.length === 0);
+			const chips = h.trigger('@typeahead', (node: any) => () => node.children[0].leading);
+			assert.isTrue(chips.length === 0);
 		},
 
 		'selecting a value from the typeahead selects a value'() {

--- a/src/common/tests/support/test-helpers.ts
+++ b/src/common/tests/support/test-helpers.ts
@@ -122,7 +122,7 @@ export const compareResource = {
 	comparator: isResourceComparator
 };
 
-export function createTestResource(data: any[], options?: any, transform?: any) {
+export function createTestResource(data: any[], options?: any, transform?: any): any {
 	return {
 		template: {
 			id: 'test',

--- a/src/examples/src/widgets/typeahead/FreeText.tsx
+++ b/src/examples/src/widgets/typeahead/FreeText.tsx
@@ -11,9 +11,10 @@ import { ListOption } from '@dojo/widgets/list';
 const resource = createResourceMiddleware();
 const factory = create({ icache, resource });
 const options = [
-	{ value: '1', label: 'Cat' },
 	{ value: '2', label: 'Dog' },
-	{ value: '3', label: 'Fish' }
+	{ value: '3', label: 'Fish' },
+	{ value: '5', label: 'Catfish' },
+	{ value: '4', label: 'Cat' }
 ];
 
 const template = createMemoryResourceTemplate<ListOption>();

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -65,8 +65,9 @@ export interface TypeaheadICache {
 	focusNode: string;
 	initial: string;
 	valid: boolean | undefined;
-	selected: boolean;
 	meta?: ResourceMeta;
+	selectedOption?: ListOption;
+	selectionType: 'keyboard' | 'mouse' | 'none';
 }
 
 export interface TypeaheadChildren {
@@ -119,6 +120,21 @@ export const Typeahead = factory(function Typeahead({
 
 	const [{ label, items, leading } = {} as TypeaheadChildren] = children();
 
+	function getQuery({ value, label }: { value?: string; label?: string }) {
+		let existingQuery = { ...options().query } as any;
+		if (!value) {
+			delete existingQuery.value;
+		} else {
+			existingQuery = { ...existingQuery, value };
+		}
+		if (!label) {
+			delete existingQuery.label;
+		} else {
+			existingQuery = { ...existingQuery, label };
+		}
+		return existingQuery;
+	}
+
 	if (
 		initialValue !== undefined &&
 		controlledValue === undefined &&
@@ -128,12 +144,18 @@ export const Typeahead = factory(function Typeahead({
 		icache.set('value', initialValue);
 		icache.delete('labelValue');
 	}
-
-	if (controlledValue !== undefined && icache.get('lastValue') !== controlledValue) {
+	const updatedValue = icache.get('lastValue') !== controlledValue;
+	if (controlledValue !== undefined && updatedValue) {
 		icache.set('value', controlledValue);
 		icache.set('lastValue', controlledValue);
 		icache.delete('labelValue');
-		options({ query: { value: controlledValue } });
+		icache.set('selectedOption', (option) => {
+			if (option && option.value !== controlledValue) {
+				return undefined;
+			}
+			return option;
+		});
+		options({ query: getQuery({ value: controlledValue }) });
 	}
 
 	let valid = icache.get('valid');
@@ -177,7 +199,6 @@ export const Typeahead = factory(function Typeahead({
 		onOpen: () => boolean,
 		onClose: () => void
 	) {
-		const activeIndex = icache.getOrSet('activeIndex', 0);
 		const metaInfo = meta(template, options()) || icache.get('meta');
 		const total = (metaInfo && metaInfo.total) || 0;
 		switch (event) {
@@ -187,62 +208,106 @@ export const Typeahead = factory(function Typeahead({
 			case Keys.Down:
 				preventDefault();
 				if (!onOpen()) {
-					icache.set('activeIndex', total ? (activeIndex + 1) % total : total);
+					icache.set('activeIndex', (activeIndex = strict ? 0 : -1) => {
+						return total ? (activeIndex + 1) % total : total;
+					});
 				}
 				break;
 			case Keys.Up:
 				preventDefault();
 				if (!onOpen()) {
-					icache.set('activeIndex', total ? (activeIndex - 1 + total) % total : total);
+					icache.set('activeIndex', (activeIndex = 0) => {
+						activeIndex = activeIndex === -1 ? 0 : activeIndex;
+						return total ? (activeIndex - 1 + total) % total : total;
+					});
 				}
 				break;
 			case Keys.Enter:
 				preventDefault();
-				icache.set('selected', true);
+				icache.set('selectionType', 'keyboard');
 				onClose();
 				break;
 		}
 	}
 
 	const { page, size } = options();
-	const index = icache.getOrSet('activeIndex', 0);
+	const index = icache.getOrSet('activeIndex', strict ? 0 : -1);
 	const currentPage = Math.ceil((index + 1) / size);
 	const pageIndex = Array.isArray(page)
 		? page.indexOf(currentPage) !== -1
 			? page.indexOf(currentPage)
 			: 0
 		: 0;
-	const activeIndex = pageIndex * size + (index % size);
+	const activeIndex = index === -1 ? -1 : pageIndex * size + (index % size);
 	const currentItems = flat(getOrRead(template, options()));
 	const isCurrentlyLoading = isLoading(template, options());
 	const metaInfo = icache.set('meta', (current) => {
 		const newMeta = meta(template, options());
 		return newMeta || current;
 	});
+	const selectionType = icache.getOrSet('selectionType', 'none');
 	const activeItem = currentItems[activeIndex];
-	if (icache.get('selected') && !isCurrentlyLoading) {
-		if (currentItems && currentItems.length === 0) {
+	if (selectionType === 'keyboard' && !isCurrentlyLoading) {
+		const option = icache.set('selectedOption', () => {
 			if (strict) {
-				if (required) {
-					valid = icache.set('valid', false);
-					onValidate && onValidate(false);
+				if (currentItems && currentItems.length === 0) {
+					if (required) {
+						valid = icache.set('valid', false);
+						onValidate && onValidate(false);
+					}
+					labelValue = icache.set('labelValue', '');
+				} else {
+					let disabled = itemDisabled ? itemDisabled(activeItem) : !!activeItem.disabled;
+					if (!disabled) {
+						const { value: itemValue, label, disabled, divider } = activeItem;
+						value = icache.set('value', activeItem.value);
+						return { value: itemValue, label, disabled, divider };
+					}
 				}
 			} else {
-				const labelValue = icache.getOrSet('labelValue', '');
-				icache.set('value', labelValue);
-				value = labelValue;
-				callOnValue({ value: labelValue, label: labelValue });
+				let disabled = activeItem
+					? itemDisabled
+						? itemDisabled(activeItem)
+						: !!activeItem.disabled
+					: false;
+				const labelValue = icache.get('labelValue');
+				if (activeItem && !disabled) {
+					const { value: itemValue, label, disabled, divider } = activeItem;
+					value = icache.set('value', activeItem.value);
+					return { value: itemValue, label, disabled, divider };
+				} else if (labelValue) {
+					icache.set('value', labelValue);
+					value = labelValue;
+					return { value: labelValue, label: labelValue };
+				}
 			}
-			icache.set('selected', false);
-		} else if (activeItem) {
-			let disabled = itemDisabled ? itemDisabled(activeItem) : !!activeItem.disabled;
-			if (!disabled) {
-				const { value: itemValue, label, disabled, divider } = activeItem;
-				value = icache.set('value', activeItem.value);
-				callOnValue({ value: itemValue, label, disabled, divider });
+			return undefined;
+		});
+		if (option) {
+			callOnValue(option);
+		}
+		icache.set('selectionType', 'none');
+	}
+
+	if (!icache.get('selectedOption') && !isCurrentlyLoading && value) {
+		const option = currentItems.find((item) => item.value === controlledValue);
+		if (option) {
+			icache.set('selectedOption', option);
+		} else {
+			const findOptions = createOptions(`find-${id}`);
+			const item = find(template, {
+				options: findOptions({
+					page: options().page,
+					size: options().size,
+					query: getQuery({})
+				}),
+				start: 0,
+				query: { value }
+			});
+			if (item) {
+				icache.set('selectedOption', item.item);
 			}
 		}
-		icache.set('selected', false);
 	}
 
 	return (
@@ -278,7 +343,7 @@ export const Typeahead = factory(function Typeahead({
 							if (!disabled && !icache.get('expanded')) {
 								toggleOpen();
 								icache.set('expanded', true);
-								icache.set('activeIndex', 0);
+								icache.set('activeIndex', strict ? 0 : -1);
 								return true;
 							}
 
@@ -292,35 +357,18 @@ export const Typeahead = factory(function Typeahead({
 							}
 						}
 
-						let valueOption: ListOption | undefined;
-						if (value) {
-							const findOptions = createOptions(`${id}-find`);
-							valueOption = (
-								find(template, {
-									options: findOptions({
-										page: options().page,
-										size: options().size
-									}),
-									start: 0,
-									query: { value },
-									type: 'exact'
-								}) || {
-									item: undefined
-								}
-							).item;
-							if (valueOption && icache.get('labelValue') !== valueOption.label) {
-								options({ query: { label: valueOption.label } });
-							}
-						}
+						const selectedOption = icache.get('selectedOption');
 
 						return (
 							<TextInput
 								autocomplete={false}
 								onValue={(value) => {
 									openMenu();
-									options({ query: { label: value } });
+									options({ query: getQuery({ label: value }) });
 									icache.set('labelValue', value || '');
+									icache.set('activeIndex', strict ? 0 : -1);
 									icache.delete('value');
+									icache.delete('selectedOption');
 								}}
 								theme={theme.compose(
 									inputCss,
@@ -333,27 +381,33 @@ export const Typeahead = factory(function Typeahead({
 								}}
 								onBlur={() => {
 									const { onBlur } = properties();
-
 									if (!strict) {
 										const value = icache.getOrSet('labelValue', '');
 										icache.set('value', value);
-										callOnValue(
-											valueOption
-												? {
-														value: valueOption.value,
-														label: valueOption.label,
-														divider: valueOption.divider,
-														disabled: valueOption.disabled
-												  }
-												: { value, label: value }
+										const currentOption = icache.get('selectedOption');
+										const selectedOption = icache.set(
+											'selectedOption',
+											(selectedOption) => {
+												return selectedOption
+													? selectedOption
+													: { value, label: value };
+											}
 										);
+										if (selectedOption) {
+											if (
+												!currentOption ||
+												currentOption.value !== selectedOption.value
+											) {
+												callOnValue(selectedOption);
+											}
+										}
 									}
 
 									closeMenu();
 									onBlur && onBlur();
 								}}
 								name={name}
-								initialValue={valueOption ? valueOption.label : labelValue}
+								value={selectedOption ? selectedOption.label : labelValue || ''}
 								focus={() =>
 									icache.get('focusNode') === 'trigger' && focus.shouldFocus()
 								}
@@ -411,6 +465,7 @@ export const Typeahead = factory(function Typeahead({
 										closeMenu();
 										if (value.value !== icache.get('value')) {
 											icache.set('value', value.value);
+											icache.set('selectedOption', value);
 										}
 										callOnValue(value);
 									}}

--- a/src/typeahead/tests/unit/Typeahead.spec.tsx
+++ b/src/typeahead/tests/unit/Typeahead.spec.tsx
@@ -63,7 +63,7 @@ const triggerAssertion = assertion(() => (
 		}}
 		disabled={undefined}
 		focus={noop}
-		initialValue={undefined}
+		value=""
 		key={'trigger'}
 		name={undefined}
 		onClick={noop}
@@ -127,6 +127,8 @@ const contentAssertion = assertion(() => (
 	</div>
 ));
 
+const nonStrictModeContent = contentAssertion.setProperty(WrappedList, 'activeIndex', -1);
+
 const baseAssertion = assertion(() => (
 	<WrappedRoot classes={[null, css.root, null, false, false]} key="root">
 		<WrappedPopup
@@ -141,6 +143,33 @@ const baseAssertion = assertion(() => (
 			{{
 				trigger: triggerAssertion,
 				content: contentAssertion
+			}}
+		</WrappedPopup>
+		<WrappedHelperText
+			variant={undefined}
+			classes={undefined}
+			theme={undefined}
+			key="helperText"
+			text={undefined}
+			valid={undefined}
+		/>
+	</WrappedRoot>
+));
+
+const nonStrictModeBaseAssertion = assertion(() => (
+	<WrappedRoot classes={[null, css.root, null, false, false]} key="root">
+		<WrappedPopup
+			variant={undefined}
+			classes={undefined}
+			theme={undefined}
+			key="popup"
+			onClose={noop}
+			onOpen={noop}
+			position={undefined}
+		>
+			{{
+				trigger: triggerAssertion,
+				content: nonStrictModeContent
 			}}
 		</WrappedPopup>
 		<WrappedHelperText
@@ -185,7 +214,7 @@ describe('Typeahead', () => {
 		});
 		r.expect(
 			baseAssertion.replaceChildren(WrappedPopup, () => ({
-				trigger: triggerAssertion.setProperty(WrappedTrigger, 'initialValue', 'Cat'),
+				trigger: triggerAssertion.setProperty(WrappedTrigger, 'value', 'Cat'),
 				content: contentAssertion.setProperty(WrappedList, 'initialValue', '2')
 			}))
 		);
@@ -207,14 +236,14 @@ describe('Typeahead', () => {
 		});
 		r.expect(
 			baseAssertion.replaceChildren(WrappedPopup, () => ({
-				trigger: triggerAssertion.setProperty(WrappedTrigger, 'initialValue', 'Cat'),
+				trigger: triggerAssertion.setProperty(WrappedTrigger, 'value', 'Cat'),
 				content: contentAssertion.setProperty(WrappedList, 'initialValue', '2')
 			}))
 		);
 		properties.value = '1';
 		r.expect(
 			baseAssertion.replaceChildren(WrappedPopup, () => ({
-				trigger: triggerAssertion.setProperty(WrappedTrigger, 'initialValue', 'Dog'),
+				trigger: triggerAssertion.setProperty(WrappedTrigger, 'value', 'Dog'),
 				content: contentAssertion.setProperty(WrappedList, 'initialValue', '1')
 			}))
 		);
@@ -257,7 +286,7 @@ describe('Typeahead', () => {
 				.setProperty(WrappedHelperText, 'valid', true)
 				.replaceChildren(WrappedPopup, () => ({
 					trigger: triggerAssertion
-						.setProperty(WrappedTrigger, 'initialValue', 'Cat')
+						.setProperty(WrappedTrigger, 'value', 'Cat')
 						.setProperty(WrappedTrigger, 'valid', true),
 					content: contentAssertion
 						.setProperty(WrappedList, 'initialValue', '2')
@@ -273,7 +302,7 @@ describe('Typeahead', () => {
 				.replaceChildren(WrappedPopup, () => ({
 					trigger: expandedTriggerAssertion
 						.setProperty(WrappedTrigger, 'valid', false)
-						.setProperty(WrappedTrigger, 'initialValue', ''),
+						.setProperty(WrappedTrigger, 'value', ''),
 					content: contentAssertion.setProperty(WrappedList, 'initialValue', undefined)
 				}))
 		);
@@ -306,9 +335,7 @@ describe('Typeahead', () => {
 				.setProperty(WrappedHelperText, 'valid', false)
 				.setProperty(WrappedHelperText, 'text', 'Please select a value.')
 				.replaceChildren(WrappedPopup, () => ({
-					trigger: triggerAssertion
-						.setProperty(WrappedTrigger, 'valid', false)
-						.setProperty(WrappedTrigger, 'initialValue', 'unknown'),
+					trigger: triggerAssertion.setProperty(WrappedTrigger, 'valid', false),
 					content: contentAssertion.setProperty(WrappedList, 'initialValue', 'unknown')
 				}))
 		);
@@ -421,7 +448,7 @@ describe('Typeahead', () => {
 		r.property(WrappedTrigger, 'onKeyDown', Keys.Enter, () => {});
 		r.expect(
 			baseAssertion.replaceChildren(WrappedPopup, () => ({
-				trigger: triggerAssertion.setProperty(WrappedTrigger, 'initialValue', 'Cat'),
+				trigger: triggerAssertion.setProperty(WrappedTrigger, 'value', 'Cat'),
 				content: contentAssertion
 					.setProperty(WrappedList, 'initialValue', '2')
 					.setProperty(WrappedList, 'activeIndex', 1)
@@ -441,7 +468,7 @@ describe('Typeahead', () => {
 		r.child(WrappedPopup, {
 			trigger: [() => {}]
 		});
-		r.expect(baseAssertion);
+		r.expect(nonStrictModeBaseAssertion);
 		// open the drop down
 		r.property(WrappedTrigger, 'onClick');
 		// focus second item from the drop down, `cat`
@@ -449,11 +476,9 @@ describe('Typeahead', () => {
 		// blur to select the second item from the drop down, `cat`
 		r.property(WrappedTrigger, 'onBlur');
 		r.expect(
-			baseAssertion.replaceChildren(WrappedPopup, () => ({
-				trigger: triggerAssertion.setProperty(WrappedTrigger, 'initialValue', 'c'),
-				content: contentAssertion
-					.setProperty(WrappedList, 'initialValue', 'c')
-					.setProperty(WrappedList, 'activeIndex', 0)
+			nonStrictModeBaseAssertion.replaceChildren(WrappedPopup, () => ({
+				trigger: triggerAssertion.setProperty(WrappedTrigger, 'value', 'c'),
+				content: nonStrictModeContent.setProperty(WrappedList, 'initialValue', 'c')
 			}))
 		);
 		assert.strictEqual(onValueStub.callCount, 1);
@@ -536,12 +561,7 @@ describe('Typeahead', () => {
 		r.property(WrappedTrigger, 'onClick');
 		r.property(WrappedTrigger, 'onValue', 'Unknown');
 		r.property(WrappedTrigger, 'onKeyDown', Keys.Enter, () => {});
-		r.expect(
-			baseAssertion.replaceChildren(WrappedPopup, () => ({
-				trigger: triggerAssertion.setProperty(WrappedTrigger, 'initialValue', 'Unknown'),
-				content: contentAssertion.setProperty(WrappedList, 'activeIndex', 0)
-			}))
-		);
+		r.expect(baseAssertion);
 		assert.strictEqual(onValueStub.callCount, 0);
 	});
 
@@ -556,16 +576,14 @@ describe('Typeahead', () => {
 		r.child(WrappedPopup, {
 			trigger: [() => {}]
 		});
-		r.expect(baseAssertion);
+		r.expect(nonStrictModeBaseAssertion);
 		r.property(WrappedTrigger, 'onClick');
 		r.property(WrappedTrigger, 'onValue', 'Unknown');
 		r.property(WrappedTrigger, 'onKeyDown', Keys.Enter, () => {});
 		r.expect(
-			baseAssertion.replaceChildren(WrappedPopup, () => ({
-				trigger: triggerAssertion.setProperty(WrappedTrigger, 'initialValue', 'Unknown'),
-				content: contentAssertion
-					.setProperty(WrappedList, 'initialValue', 'Unknown')
-					.setProperty(WrappedList, 'activeIndex', 0)
+			nonStrictModeBaseAssertion.replaceChildren(WrappedPopup, () => ({
+				trigger: triggerAssertion.setProperty(WrappedTrigger, 'value', 'Unknown'),
+				content: nonStrictModeContent.setProperty(WrappedList, 'initialValue', 'Unknown')
 			}))
 		);
 		assert.strictEqual(onValueStub.callCount, 1);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

This fixes behaviours related to non strict mode, controlled values and item labels