### PR TITLE
Bug: Fixes non-strict Typeahead behaviour related to onValue and validation

### DIFF
--- a/src/examples/src/widgets/typeahead/FreeText.tsx
+++ b/src/examples/src/widgets/typeahead/FreeText.tsx
@@ -27,7 +27,7 @@ export default factory(function FreeText({ id, middleware: { icache, resource } 
 				strict={false}
 				resource={resource({ template, initOptions: { id, data: options } })}
 				onValidate={(valid) => {
-					console.log('is valid', valid);
+					icache.set('valid', valid);
 				}}
 				onValue={(value) => {
 					icache.set('value', value);
@@ -37,7 +37,13 @@ export default factory(function FreeText({ id, middleware: { icache, resource } 
 					label: 'Basic Typeahead'
 				}}
 			</Typeahead>
-			<pre>{JSON.stringify(icache.getOrSet('value', ''))}</pre>
+			<div>
+				<div>
+					<span>Value: </span>
+					<pre>{JSON.stringify(icache.getOrSet('value', ''))}</pre>
+				</div>
+				<div>{`Valid: ${icache.getOrSet('valid', 'not set')}`}</div>
+			</div>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/typeahead/FreeText.tsx
+++ b/src/examples/src/widgets/typeahead/FreeText.tsx
@@ -26,6 +26,9 @@ export default factory(function FreeText({ id, middleware: { icache, resource } 
 				required={true}
 				strict={false}
 				resource={resource({ template, initOptions: { id, data: options } })}
+				onValidate={(valid) => {
+					console.log('is valid', valid);
+				}}
 				onValue={(value) => {
 					icache.set('value', value);
 				}}

--- a/src/examples/src/widgets/typeahead/FreeText.tsx
+++ b/src/examples/src/widgets/typeahead/FreeText.tsx
@@ -23,6 +23,7 @@ export default factory(function FreeText({ id, middleware: { icache, resource } 
 	return (
 		<Example>
 			<Typeahead
+				required={true}
 				strict={false}
 				resource={resource({ template, initOptions: { id, data: options } })}
 				onValue={(value) => {

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -166,15 +166,6 @@ export const Typeahead = factory(function Typeahead({
 	const triggerId = `typeahead-trigger-${id}`;
 	const dirty = icache.get('dirty');
 
-	if (required && dirty) {
-		const isValid = Boolean(value);
-		if (isValid !== valid) {
-			icache.set('valid', isValid);
-			valid = isValid;
-			onValidate && onValidate(isValid);
-		}
-	}
-
 	function callOnValue(value: ListOption) {
 		const { onValidate, onValue, required } = properties();
 		const lastValue = icache.get('lastValue');
@@ -297,6 +288,16 @@ export const Typeahead = factory(function Typeahead({
 		icache.set('selectionType', 'none');
 	}
 
+	const selectedOption = icache.get('selectedOption');
+	if (required && dirty) {
+		const isValid = Boolean(selectedOption) || Boolean(!strict && !!labelValue);
+		if (isValid !== valid) {
+			icache.set('valid', isValid);
+			valid = isValid;
+			onValidate && onValidate(isValid);
+		}
+	}
+
 	if (!icache.get('selectedOption') && !isCurrentlyLoading && value) {
 		const option = currentItems.find((item) => item.value === controlledValue);
 		if (option) {
@@ -391,15 +392,21 @@ export const Typeahead = factory(function Typeahead({
 									const { onBlur } = properties();
 									if (!strict) {
 										const value = icache.getOrSet('labelValue', '');
-										icache.set('value', value);
 										const currentOption = icache.get('selectedOption');
 										const selectedOption = icache.set(
 											'selectedOption',
 											(selectedOption) => {
-												return selectedOption
-													? selectedOption
-													: { value, label: value };
+												if (selectedOption) {
+													return selectedOption;
+												}
+												if (value) {
+													return { value, label: value };
+												}
 											}
+										);
+										icache.set(
+											'value',
+											selectedOption ? selectedOption.value : value
 										);
 										if (selectedOption) {
 											if (

--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -364,6 +364,9 @@ export const Typeahead = factory(function Typeahead({
 								toggleOpen();
 								icache.set('expanded', false);
 							}
+							if (!icache.get('dirty')) {
+								icache.set('dirty', true);
+							}
 						}
 
 						const selectedOption = icache.get('selectedOption');


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Fixes issues relating to the Typeahead non-strict behaviour

Resolves #1620
Resolves #1621 
