### PR TITLE
Fix filtering and selecting an item in non-strict mode when a template is loading

### DIFF
--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -223,9 +223,11 @@ export const Typeahead = factory(function Typeahead({
 	}
 
 	const { page, size } = options();
-	const currentItems = flat(getOrRead(template, options()));
+	const result = getOrRead(template, options());
+	const isCurrentlyLoading = isLoading(template, options());
+	const currentItems = isCurrentlyLoading ? [] : flat(result);
 	const index = icache.set('activeIndex', (currentIndex = strict ? 0 : -1) => {
-		if (currentItems && currentIndex === -1 && !strict && labelValue) {
+		if (currentItems && currentItems.length && currentIndex === -1 && !strict && labelValue) {
 			return findIndex(currentItems, (item) => {
 				return Boolean(labelValue && item.label.toLowerCase() === labelValue.toLowerCase());
 			});
@@ -239,7 +241,6 @@ export const Typeahead = factory(function Typeahead({
 			: 0
 		: 0;
 	const activeIndex = index === -1 ? -1 : pageIndex * size + (index % size);
-	const isCurrentlyLoading = isLoading(template, options());
 	const metaInfo = icache.set('meta', (current) => {
 		const newMeta = meta(template, options());
 		return newMeta || current;

--- a/src/typeahead/tests/unit/Typeahead.spec.tsx
+++ b/src/typeahead/tests/unit/Typeahead.spec.tsx
@@ -16,7 +16,6 @@ import * as inputCss from '../../../theme/default/text-input.m.css';
 import * as listCss from '../../../theme/default/list.m.css';
 import List from '../../../list';
 import { Keys } from '../../../common/util';
-// import LoadingIndicator from '../../../loading-indicator';
 
 const { ' _key': key, ...inputTheme } = inputCss as any;
 const { ' _key': listKey, ...listTheme } = listCss as any;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Changes the behaviour to only check for matching items when the template is not loading.

Resolves #1625 
