### PR TITLE
Add variable for chip color

### DIFF
--- a/src/theme/material/chip.m.css
+++ b/src/theme/material/chip.m.css
@@ -1,7 +1,7 @@
 .root {
 	composes: mdc-chip from '@material/chips/dist/mdc.chips.css';
 	background: var(--mdc-chip-background);
-	color: var(--mdc-text-color);
+	color: var(--mdc-chip-color);
 }
 
 .root.disabled .label {
@@ -13,7 +13,7 @@
 }
 
 .root:not(.disabled):hover .label {
-	color: var(--mdc-text-color);
+	color: var(--mdc-chip-color);
 }
 
 .iconWrapper,
@@ -25,7 +25,7 @@
 .iconWrapper {
 	composes: mdc-chip__icon--leading from '@material/chips/dist/mdc.chips.css';
 	font-size: 18px;
-	color: var(--mdc-text-color);
+	color: var(--mdc-chip-color);
 }
 
 .label {
@@ -35,7 +35,7 @@
 .closeIconWrapper {
 	composes: mdc-chip__icon--trailing from '@material/chips/dist/mdc.chips.css';
 	cursor: pointer;
-	color: var(--mdc-text-color);
+	color: var(--mdc-chip-color);
 }
 
 .clickable {

--- a/src/theme/material/variants/dark.m.css
+++ b/src/theme/material/variants/dark.m.css
@@ -83,6 +83,7 @@
 	--mdc-tab-background: var(--mdc-raised-surface-background);
 	--mdc-tooltip-background: #6d6d6d;
 	--mdc-chip-background: #6d6d6d;
+	--mdc-chip-color: var(--mdc-text-color);
 	--mdc-chip-background-hover: #8d8d8d;
 	--mdc-snackbar-background: var(--mdc-raised-surface-background);
 }

--- a/src/theme/material/variants/default.m.css
+++ b/src/theme/material/variants/default.m.css
@@ -92,6 +92,7 @@
 	--mdc-tab-background: var(--mdc-theme-surface);
 	--mdc-tooltip-background: #6d6d6d;
 	--mdc-chip-background: var(--mdc-theme-on-surface);
+	--mdc-chip-color: var(--mdc-text-color);
 	--mdc-chip-background-hover: var(--mdc-theme-on-surface-hover);
 	--mdc-snackbar-background: #333333;
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds a variable for the chip color in the material theme
Resolves #1633 
