### PR TITLE
Update form input widget material theme

### DIFF
--- a/src/theme/material/select.m.css
+++ b/src/theme/material/select.m.css
@@ -54,7 +54,7 @@
 }
 
 .value::before {
-	border-bottom-color: var(--mdc-text-color) !important;
+	border-bottom-color: var(--mdc-border-color) !important;
 }
 
 .valueExpanded {
@@ -68,7 +68,7 @@
 .labelRoot {
 	composes: mdc-floating-label from '@material/select/dist/mdc.select.css';
 	z-index: 10;
-	color: var(--mdc-text-color) !important;
+	color: var(--mdc-secondary-text-color) !important;
 }
 
 .labelActive {
@@ -88,7 +88,7 @@
 
 .iconDownIcon {
 	composes: downAltIcon from './icon.m.css';
-	color: var(--mdc-text-color);
+	color: var(--mdc-secondary-text-color);
 }
 
 .focused .iconDownIcon {

--- a/src/theme/material/text-input.m.css
+++ b/src/theme/material/text-input.m.css
@@ -106,7 +106,3 @@
 .input::-ms-clear {
 	display: none;
 }
-
-.input::placeholder {
-	color: var(--mdc-secondary-text-color) !important;
-}

--- a/src/theme/material/text-input.m.css
+++ b/src/theme/material/text-input.m.css
@@ -106,3 +106,7 @@
 .input::-ms-clear {
 	display: none;
 }
+
+.input::placeholder {
+	color: var(--mdc-secondary-text-color) !important;
+}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
- Updates the `border-bottom-color` on the `Select` widget material theme to match coloring of other input widgets
- Updates placeholder color for `TextInput` widget with material theme to be the same color as the label of the `Select` widget with material theme.

<img width="651" alt="Screen Shot 2021-01-15 at 4 49 11 PM" src="https://user-images.githubusercontent.com/3914018/104782062-9d6bfe80-5751-11eb-979f-3c81feb12648.png">


Resolves #1629
