### PR TITLE
Updated text input to not show error by default

### DIFF
--- a/src/text-input/index.tsx
+++ b/src/text-input/index.tsx
@@ -201,7 +201,7 @@ export const TextInput = factory(function TextInput({
 	}
 
 	if (onValidate) {
-		if (value === '' && !dirty) {
+		if (value === undefined && !dirty) {
 			_callOnValidate(undefined, '');
 		} else {
 			icache.set('dirty', true);

--- a/src/text-input/tests/unit/TextInput.spec.tsx
+++ b/src/text-input/tests/unit/TextInput.spec.tsx
@@ -446,7 +446,7 @@ registerSuite('TextInput', {
 			assert.isTrue(validateSpy.calledWith(true, ''));
 		},
 
-		'onValidate only called when validity or message changed'() {
+		'onValidate called when validity or message changed'() {
 			const focusMock = createFocusMock();
 			const validityMock = createValidityMock();
 
@@ -478,6 +478,23 @@ registerSuite('TextInput', {
 			);
 
 			assert.isFalse(validateSpy.called);
+		},
+
+		'does not show error message on initial render'() {
+			const focusMock = createFocusMock();
+			const validityMock = createValidityMock();
+
+			focusMock('isFocused', false);
+			validityMock('input', { valid: false, message: 'test' });
+
+			let validateSpy = sinon.spy();
+
+			const h = harness(() => <TextInput onValidate={validateSpy} />, {
+				middleware: [[focus, focusMock], [validity, validityMock]]
+			});
+
+			h.expect(expected);
+			validateSpy.calledWith(undefined, '');
 		},
 
 		'customValidator not called when native validation fails'() {

--- a/src/text-input/tests/unit/TextInput.spec.tsx
+++ b/src/text-input/tests/unit/TextInput.spec.tsx
@@ -480,7 +480,7 @@ registerSuite('TextInput', {
 			assert.isFalse(validateSpy.called);
 		},
 
-		'does not show error message on initial render'() {
+		'onValidate called with undefined on initial render'() {
 			const focusMock = createFocusMock();
 			const validityMock = createValidityMock();
 


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Updates `TextInput` widget so it will not show errors before the user interacts with the input. This was happening when a `TextInput` widget used the onValidate and valid fields and had required marked as `true`. You can view the error here: https://widgets.dojo.io/#widget/text-input/example/validated

Resolves #1580 
