### PR TITLE
Refactoring wizard to be more customizable

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -250,6 +250,7 @@ import ErrorResult from './widgets/result/Error';
 import SuccessResult from './widgets/result/Success';
 import CustomIconResult from './widgets/result/CustomIcon';
 import BasicWizard from './widgets/wizard/Basic';
+import CustomWizard from './widgets/wizard/Custom';
 import VerticalWizard from './widgets/wizard/Vertical';
 import ErrorWizard from './widgets/wizard/Error';
 import BasicTree from './widgets/tree/Basic';
@@ -1966,6 +1967,11 @@ export const config = {
 					filename: 'Error',
 					module: ErrorWizard,
 					title: 'Wizard with an error'
+				},
+				{
+					filename: 'Custom',
+					module: CustomWizard,
+					title: 'Custom step renderer'
 				}
 			]
 		}

--- a/src/examples/src/widgets/wizard/Basic.tsx
+++ b/src/examples/src/widgets/wizard/Basic.tsx
@@ -1,6 +1,6 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Example from '../../Example';
-import Wizard, { Step } from '@dojo/widgets/wizard';
+import Wizard from '@dojo/widgets/wizard';
 import Button from '@dojo/widgets/button';
 import icache from '@dojo/framework/core/middleware/icache';
 
@@ -8,6 +8,18 @@ const factory = create({ icache }).properties();
 
 export default factory(function Basic({ middleware: { icache } }) {
 	let activeStep = icache.getOrSet('activeStep', 1);
+	const steps = [
+		{},
+		{
+			title: 'Title',
+			subTitle: 'SubTitle'
+		},
+		{
+			title: 'Title',
+			subTitle: 'SubTitle',
+			description: 'This is a description'
+		}
+	];
 	return (
 		<Example>
 			<Wizard
@@ -16,22 +28,8 @@ export default factory(function Basic({ middleware: { icache } }) {
 				onStep={(stepIndex) => {
 					icache.set('activeStep', stepIndex);
 				}}
-			>
-				<Step />
-				<Step>
-					{{
-						title: 'Title',
-						subTitle: 'SubTitle'
-					}}
-				</Step>
-				<Step>
-					{{
-						title: 'Title',
-						subTitle: 'SubTitle',
-						description: 'This is a description'
-					}}
-				</Step>
-			</Wizard>
+				steps={steps}
+			/>
 			<div>
 				<Button
 					onClick={() => {

--- a/src/examples/src/widgets/wizard/Custom.tsx
+++ b/src/examples/src/widgets/wizard/Custom.tsx
@@ -1,0 +1,47 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Example from '../../Example';
+import Wizard from '@dojo/widgets/wizard';
+import icache from '@dojo/framework/core/middleware/icache';
+
+const factory = create({ icache }).properties();
+
+export default factory(function Custom({ middleware: { icache } }) {
+	const steps = [
+		{
+			title: 'Complete'
+		},
+		{
+			title: 'In Progress'
+		},
+		{
+			title: 'Pending'
+		}
+	];
+	return (
+		<Example>
+			<Wizard clickable activeStep={1} steps={steps}>
+				{{
+					step: (status, index, step) => {
+						let icon;
+						switch (status) {
+							case 'complete':
+								icon = '⊛';
+								break;
+							case 'inProgress':
+								icon = '⌾';
+								break;
+							case 'pending':
+								icon = '⃝';
+								break;
+						}
+						return (
+							<div>
+								{icon} {step.title || ''}
+							</div>
+						);
+					}
+				}}
+			</Wizard>
+		</Example>
+	);
+});

--- a/src/examples/src/widgets/wizard/Error.tsx
+++ b/src/examples/src/widgets/wizard/Error.tsx
@@ -1,28 +1,30 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Example from '../../Example';
-import Wizard, { Step } from '@dojo/widgets/wizard';
+import Wizard from '@dojo/widgets/wizard';
 
 const factory = create().properties();
 
 export default factory(function Error() {
 	return (
 		<Example>
-			<Wizard>
-				<Step status="complete" />
-				<Step status="error">
-					{{
+			<Wizard
+				steps={[
+					{
+						status: 'complete'
+					},
+					{
+						status: 'error',
 						title: 'Title',
 						subTitle: 'SubTitle'
-					}}
-				</Step>
-				<Step status="pending">
-					{{
+					},
+					{
+						status: 'pending',
 						title: 'Title',
 						subTitle: 'SubTitle',
 						description: 'Description'
-					}}
-				</Step>
-			</Wizard>
+					}
+				]}
+			/>
 		</Example>
 	);
 });

--- a/src/examples/src/widgets/wizard/Vertical.tsx
+++ b/src/examples/src/widgets/wizard/Vertical.tsx
@@ -1,52 +1,52 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Example from '../../Example';
-import Wizard, { Step, StepStatus } from '@dojo/widgets/wizard';
+import Wizard, { StepStatus } from '@dojo/widgets/wizard';
 import { icache } from '@dojo/framework/core/middleware/icache';
 
 const factory = create({ icache }).properties();
 
 export default factory(function Vertical({ middleware: { icache } }) {
-	let steps = icache.getOrSet<StepStatus[]>('steps', ['complete', 'inProgress', 'pending']);
+	let statuses = icache.getOrSet<StepStatus[]>('statuses', ['complete', 'inProgress', 'pending']);
+	const steps = [
+		{
+			status: statuses[0],
+			title: 'Title',
+			subTitle: 'SubTitle'
+		},
+		{
+			status: statuses[1],
+			title: ' Title',
+			subTitle: 'SubTitle',
+			description: 'This is a description'
+		},
+		{
+			status: statuses[2],
+			title: 'Title',
+			subTitle: 'SubTitle',
+			description: 'Description'
+		}
+	];
+
 	return (
 		<Example>
 			<Wizard
 				onStep={(stepIndex) => {
-					icache.set(
-						'steps',
-						steps.map((_, index) => {
+					icache.set('statuses', (statuses: StepStatus[]) =>
+						statuses.map((_, index) => {
 							if (index < stepIndex) {
-								return { status: 'complete' };
+								return 'complete';
 							} else if (index === stepIndex) {
-								return { status: 'inProgress' };
+								return 'inProgress';
 							} else {
-								return { status: 'pending' };
+								return 'pending';
 							}
 						})
 					);
 				}}
 				direction="vertical"
-			>
-				<Step status={steps[0]}>
-					{{
-						title: 'Title',
-						subTitle: 'SubTitle'
-					}}
-				</Step>
-				<Step status={steps[1]}>
-					{{
-						title: 'Title',
-						subTitle: 'SubTitle',
-						description: 'This is a description'
-					}}
-				</Step>
-				<Step status={steps[2]}>
-					{{
-						title: 'Title',
-						subTitle: 'SubTitle',
-						description: 'Description'
-					}}
-				</Step>
-			</Wizard>
+				steps={steps}
+				clickable
+			/>
 		</Example>
 	);
 });

--- a/src/wizard/tests/unit/Wizard.spec.tsx
+++ b/src/wizard/tests/unit/Wizard.spec.tsx
@@ -148,15 +148,6 @@ describe('Wizard', () => {
 			</WrappedStep3>
 		</WrappedRoot>
 	));
-	const WrappedStepRoot = wrap('div');
-	const baseStepAssertion = assertion(() => (
-		<WrappedStepRoot classes={[undefined, css.stepContent]}>
-			<div classes={[css.stepTitle, css.noTitle, css.noDescription]}>
-				<div classes={css.stepSubTitle} />
-			</div>
-			<div classes={css.stepDescription} />
-		</WrappedStepRoot>
-	));
 
 	it('renders', () => {
 		const r = mockedRenderer(() => (

--- a/src/wizard/tests/unit/Wizard.spec.tsx
+++ b/src/wizard/tests/unit/Wizard.spec.tsx
@@ -3,7 +3,7 @@ const { it, describe } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 import { renderer, assertion, wrap } from '@dojo/framework/testing/renderer';
 
-import Wizard, { Step } from '../../index';
+import Wizard from '../../index';
 import * as css from '../../../theme/default/wizard.m.css';
 import * as avatarCss from '../../../theme/default/avatar.m.css';
 import Avatar from '../../../avatar';
@@ -66,7 +66,12 @@ describe('Wizard', () => {
 							/>
 						</Avatar>
 					</div>
-					<div>Step 1</div>
+					<div classes={[null, css.stepContent]}>
+						<div classes={[css.stepTitle, false, css.noDescription]}>
+							Step 1<div classes={css.stepSubTitle}>{''}</div>
+						</div>
+						<div classes={css.stepDescription}>{''}</div>
+					</div>
 				</virtual>
 			</WrappedStep1>
 			<WrappedStep2 key="step2" classes={[css.step, false, false, false]} onclick={noop}>
@@ -95,7 +100,12 @@ describe('Wizard', () => {
 							2
 						</WrappedAvatar>
 					</div>
-					<div>Step 2</div>
+					<div classes={[null, css.stepContent]}>
+						<div classes={[css.stepTitle, false, css.noDescription]}>
+							Step 2<div classes={css.stepSubTitle}>{''}</div>
+						</div>
+						<div classes={css.stepDescription}>{''}</div>
+					</div>
 				</virtual>
 			</WrappedStep2>
 			<WrappedStep3
@@ -128,7 +138,12 @@ describe('Wizard', () => {
 							3
 						</Avatar>
 					</div>
-					<div>Step 3</div>
+					<div classes={[null, css.stepContent]}>
+						<div classes={[css.stepTitle, false, css.noDescription]}>
+							Step 3<div classes={css.stepSubTitle}>{''}</div>
+						</div>
+						<div classes={css.stepDescription}>{''}</div>
+					</div>
 				</virtual>
 			</WrappedStep3>
 		</WrappedRoot>
@@ -145,11 +160,10 @@ describe('Wizard', () => {
 
 	it('renders', () => {
 		const r = mockedRenderer(() => (
-			<Wizard activeStep={1}>
-				<div>Step 1</div>
-				<div>Step 2</div>
-				<div>Step 3</div>
-			</Wizard>
+			<Wizard
+				activeStep={1}
+				steps={[{ title: 'Step 1' }, { title: 'Step 2' }, { title: 'Step 3' }]}
+			/>
 		));
 
 		r.expect(baseAssertion);
@@ -157,11 +171,11 @@ describe('Wizard', () => {
 
 	it('renders vertically', () => {
 		const r = mockedRenderer(() => (
-			<Wizard direction="vertical" activeStep={1}>
-				<div>Step 1</div>
-				<div>Step 2</div>
-				<div>Step 3</div>
-			</Wizard>
+			<Wizard
+				direction="vertical"
+				activeStep={1}
+				steps={[{ title: 'Step 1' }, { title: 'Step 2' }, { title: 'Step 3' }]}
+			/>
 		));
 
 		r.expect(
@@ -176,11 +190,11 @@ describe('Wizard', () => {
 
 	it('renders with "clickable" set to true', () => {
 		const r = mockedRenderer(() => (
-			<Wizard clickable activeStep={1}>
-				<div>Step 1</div>
-				<div>Step 2</div>
-				<div>Step 3</div>
-			</Wizard>
+			<Wizard
+				clickable
+				activeStep={1}
+				steps={[{ title: 'Step 1' }, { title: 'Step 2' }, { title: 'Step 3' }]}
+			/>
 		));
 
 		r.expect(
@@ -195,11 +209,14 @@ describe('Wizard', () => {
 
 	it('renders with an error', () => {
 		const r = mockedRenderer(() => (
-			<Wizard activeStep={1}>
-				<div>Step 1</div>
-				<Step status="error" />
-				<div>Step 3</div>
-			</Wizard>
+			<Wizard
+				activeStep={1}
+				steps={[
+					{ title: 'Step 1' },
+					{ status: 'error', title: 'Step 2' },
+					{ title: 'Step 3' }
+				]}
+			/>
 		));
 
 		r.expect(
@@ -232,7 +249,12 @@ describe('Wizard', () => {
 								2
 							</WrappedAvatar>
 						</div>
-						<Step status="error" />
+						<div classes={[null, css.stepContent]}>
+							<div classes={[css.stepTitle, false, css.noDescription]}>
+								Step 2<div classes={css.stepSubTitle}>{''}</div>
+							</div>
+							<div classes={css.stepDescription}>{''}</div>
+						</div>
 					</virtual>
 				])
 				.setProperty(WrappedAvatar, 'outline', true)
@@ -257,11 +279,8 @@ describe('Wizard', () => {
 					requestIndex = step;
 				}}
 				activeStep={1}
-			>
-				<div>Step 1</div>
-				<div>Step 2</div>
-				<div>Step 3</div>
-			</Wizard>
+				steps={[{ title: 'Step 1' }, { title: 'Step 2' }, { title: 'Step 3' }]}
+			/>
 		));
 
 		r.expect(
@@ -287,31 +306,28 @@ describe('Wizard', () => {
 		assert.equal(requestIndex, 2);
 	});
 
-	describe('step', () => {
-		it('renders step by default', () => {
-			const r = mockedRenderer(() => <Step />);
-			r.expect(baseStepAssertion);
-		});
+	it('calls a custom renderer', () => {
+		const r = mockedRenderer(() => (
+			<Wizard activeStep={0} steps={[{ title: 'Step 1' }]}>
+				{{
+					step: (status, index, step) => (
+						<div>
+							{status} {String(index)} {step.title}
+						</div>
+					)
+				}}
+			</Wizard>
+		));
 
-		it('renders with title, subtitle, and description', () => {
-			const r = mockedRenderer(() => (
-				<Step>
-					{{
-						title: 'title',
-						subTitle: 'subTitle',
-						description: 'description'
-					}}
-				</Step>
-			));
-			r.expect(
-				baseStepAssertion.replaceChildren(WrappedStepRoot, () => [
-					<div classes={[css.stepTitle, false, false]}>
-						title
-						<div classes={css.stepSubTitle}>subTitle</div>
-					</div>,
-					<div classes={css.stepDescription}>description</div>
-				])
-			);
-		});
+		r.expect(
+			baseAssertion.setChildren(WrappedRoot, () => [
+				<div key="step1" classes={[css.step, false, false, false]} onclick={noop}>
+					<div classes={css.tail} />
+					<div>
+						{'inProgress'} {'0'} {'Step 1'}
+					</div>
+				</div>
+			])
+		);
 	});
 });


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding additional widget customization options by using a custom renderer for the wizard steps. Also removing the `Step` widget as it is now just part of the custom renderer.  The widget also now takes a `steps` property that defines the step data. This pattern comes from tab container / checkbox group.

Resolves #1636 
