### PR TITLE
Adding button kinds

### DIFF
--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -37,7 +37,7 @@ export interface ButtonProperties {
 	/** The title text for the button node */
 	title?: string;
 	/** The kind of button */
-	kind?: 'primary' | 'secondary' | 'cancel';
+	kind?: 'primary' | 'secondary' | 'default';
 }
 
 const factory = create({ focus, theme }).properties<ButtonProperties>();
@@ -64,7 +64,7 @@ export const Button = factory(function Button({
 		onBlur,
 		onFocus,
 		title,
-		kind = 'primary'
+		kind = 'default'
 	} = properties();
 
 	const themeCss = theme.classes(css);
@@ -77,8 +77,8 @@ export const Button = factory(function Button({
 				themeCss.root,
 				disabled ? themeCss.disabled : null,
 				pressed ? themeCss.pressed : null,
-				kind === 'secondary' ? themeCss.secondary : null,
-				kind === 'cancel' ? themeCss.cancel : null
+				kind === 'secondary' ? themeCss.secondaryKind : null,
+				kind === 'default' ? themeCss.defaultKind : null
 			]}
 			title={title}
 			disabled={disabled}

--- a/src/button/index.tsx
+++ b/src/button/index.tsx
@@ -36,6 +36,8 @@ export interface ButtonProperties {
 	widgetId?: string;
 	/** The title text for the button node */
 	title?: string;
+	/** The kind of button */
+	kind?: 'primary' | 'secondary' | 'cancel';
 }
 
 const factory = create({ focus, theme }).properties<ButtonProperties>();
@@ -61,7 +63,8 @@ export const Button = factory(function Button({
 		onUp,
 		onBlur,
 		onFocus,
-		title
+		title,
+		kind = 'primary'
 	} = properties();
 
 	const themeCss = theme.classes(css);
@@ -73,7 +76,9 @@ export const Button = factory(function Button({
 				theme.variant(),
 				themeCss.root,
 				disabled ? themeCss.disabled : null,
-				pressed ? themeCss.pressed : null
+				pressed ? themeCss.pressed : null,
+				kind === 'secondary' ? themeCss.secondary : null,
+				kind === 'cancel' ? themeCss.cancel : null
 			]}
 			title={title}
 			disabled={disabled}

--- a/src/button/tests/unit/Button.spec.tsx
+++ b/src/button/tests/unit/Button.spec.tsx
@@ -26,7 +26,7 @@ function createMockFocusMiddleware({
 
 const template = assertionTemplate(() => (
 	<button
-		classes={[undefined, css.root, null, null]}
+		classes={[undefined, css.root, null, null, null, null]}
 		disabled={undefined}
 		id="button-test"
 		focus={false}

--- a/src/button/tests/unit/Button.spec.tsx
+++ b/src/button/tests/unit/Button.spec.tsx
@@ -93,6 +93,34 @@ registerSuite('Button', {
 			assert.isTrue(blurred);
 			assert.isTrue(clicked);
 			assert.isTrue(focused);
+		},
+
+		'renders secondary button kinds'() {
+			const h = harness(() => <Button kind="secondary" />, [compareId]);
+			h.expect(
+				template.setProperty('button', 'classes', [
+					undefined,
+					css.root,
+					null,
+					null,
+					css.secondary,
+					null
+				])
+			);
+		},
+
+		'renders cancel button kinds'() {
+			const h = harness(() => <Button kind="cancel" />, [compareId]);
+			h.expect(
+				template.setProperty('button', 'classes', [
+					undefined,
+					css.root,
+					null,
+					null,
+					null,
+					css.cancel
+				])
+			);
 		}
 	}
 });

--- a/src/button/tests/unit/Button.spec.tsx
+++ b/src/button/tests/unit/Button.spec.tsx
@@ -26,7 +26,7 @@ function createMockFocusMiddleware({
 
 const template = assertionTemplate(() => (
 	<button
-		classes={[undefined, css.root, null, null, null, null]}
+		classes={[undefined, css.root, null, null, null, css.defaultKind]}
 		disabled={undefined}
 		id="button-test"
 		focus={false}
@@ -103,14 +103,14 @@ registerSuite('Button', {
 					css.root,
 					null,
 					null,
-					css.secondary,
+					css.secondaryKind,
 					null
 				])
 			);
 		},
 
-		'renders cancel button kinds'() {
-			const h = harness(() => <Button kind="cancel" />, [compareId]);
+		'renders primary button kinds'() {
+			const h = harness(() => <Button kind="primary" />, [compareId]);
 			h.expect(
 				template.setProperty('button', 'classes', [
 					undefined,
@@ -118,7 +118,7 @@ registerSuite('Button', {
 					null,
 					null,
 					null,
-					css.cancel
+					null
 				])
 			);
 		}

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -14,6 +14,7 @@ import BasicBreadcrumbGroup from './widgets/breadcrumb-group/Basic';
 import CustomRendererBreadcrumbGroup from './widgets/breadcrumb-group/CustomRenderer';
 import BasicButton from './widgets/button/Basic';
 import DisabledSubmit from './widgets/button/DisabledSubmit';
+import KindButton from './widgets/button/Kinds';
 import ToggleButton from './widgets/button/ToggleButton';
 import BasicCalendar from './widgets/calendar/Basic';
 import FirstDayOfWeekCalendar from './widgets/calendar/CustomFirstWeekDay';
@@ -115,6 +116,7 @@ import FreeTextChipTypeahead from './widgets/chip-typeahead/FreeText';
 import BasicNumberInput from './widgets/number-input/Basic';
 import ValidatedNumberInput from './widgets/number-input/Validation';
 import BasicOutlinedButton from './widgets/outlined-button/Basic';
+import OutlinedButtonKinds from './widgets/outlined-button/Kinds';
 import OutlinedDisabledSubmit from './widgets/outlined-button/DisabledSubmit';
 import OutlinedToggleButton from './widgets/outlined-button/ToggleButton';
 import BasicPassword from './widgets/password-input/Basic';
@@ -139,6 +141,7 @@ import CustomRendererRadioGroup from './widgets/radio-group/CustomRenderer';
 import InitialValueRadioGroup from './widgets/radio-group/InitialValue';
 import BasicRaisedButton from './widgets/raised-button/Basic';
 import RaisedDisabledSubmit from './widgets/raised-button/DisabledSubmit';
+import RaisedButtonKinds from './widgets/raised-button/Kinds';
 import RaisedToggleButton from './widgets/raised-button/ToggleButton';
 import BasicRangeSlider from './widgets/range-slider/Basic';
 import MinMaxRangeSlider from './widgets/range-slider/MinMax';
@@ -400,6 +403,11 @@ export const config = {
 					filename: 'ToggleButton',
 					module: ToggleButton,
 					title: 'Toggle Button'
+				},
+				{
+					filename: 'Kinds',
+					module: KindButton,
+					title: 'Kinds'
 				}
 			],
 			filename: 'index',
@@ -1211,6 +1219,11 @@ export const config = {
 					filename: 'ToggleButton',
 					module: OutlinedToggleButton,
 					title: 'Toggle Button'
+				},
+				{
+					filename: 'Kinds',
+					module: OutlinedButtonKinds,
+					title: 'Kinds'
 				}
 			],
 			overview: {
@@ -1357,6 +1370,11 @@ export const config = {
 					filename: 'ToggleButton',
 					module: RaisedToggleButton,
 					title: 'Toggle Button'
+				},
+				{
+					filename: 'Kinds',
+					module: RaisedButtonKinds,
+					title: 'Kinds'
 				}
 			],
 			overview: {

--- a/src/examples/src/widgets/button/Kinds.tsx
+++ b/src/examples/src/widgets/button/Kinds.tsx
@@ -8,10 +8,13 @@ export default factory(function Kinds() {
 	return (
 		<Example>
 			<div>
+				<Button kind="primary">Primary</Button>
+				<br />
+				<br />
 				<Button kind="secondary">Secondary</Button>
 				<br />
 				<br />
-				<Button kind="cancel">Cancel</Button>
+				<Button kind="default">Default</Button>
 			</div>
 		</Example>
 	);

--- a/src/examples/src/widgets/button/Kinds.tsx
+++ b/src/examples/src/widgets/button/Kinds.tsx
@@ -1,0 +1,18 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Button from '@dojo/widgets/button';
+import Example from '../../Example';
+
+const factory = create();
+
+export default factory(function Kinds() {
+	return (
+		<Example>
+			<div>
+				<Button kind="secondary">Secondary</Button>
+				<br />
+				<br />
+				<Button kind="cancel">Cancel</Button>
+			</div>
+		</Example>
+	);
+});

--- a/src/examples/src/widgets/outlined-button/Kinds.tsx
+++ b/src/examples/src/widgets/outlined-button/Kinds.tsx
@@ -1,0 +1,23 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import OutlinedButton from '@dojo/widgets/outlined-button';
+import Example from '../../Example';
+
+const factory = create();
+
+export default factory(function Kinds() {
+	return (
+		<Example>
+			<div>
+				<OutlinedButton kind="primary">Primary</OutlinedButton>
+				<br />
+				<br />
+				<OutlinedButton kind="secondary">Secondary</OutlinedButton>
+				<br />
+				<br />
+				<OutlinedButton kind="cancel">Cancel</OutlinedButton>
+				<br />
+				<br />
+			</div>
+		</Example>
+	);
+});

--- a/src/examples/src/widgets/outlined-button/Kinds.tsx
+++ b/src/examples/src/widgets/outlined-button/Kinds.tsx
@@ -14,7 +14,7 @@ export default factory(function Kinds() {
 				<OutlinedButton kind="secondary">Secondary</OutlinedButton>
 				<br />
 				<br />
-				<OutlinedButton kind="cancel">Cancel</OutlinedButton>
+				<OutlinedButton kind="default">Default</OutlinedButton>
 				<br />
 				<br />
 			</div>

--- a/src/examples/src/widgets/raised-button/Kinds.tsx
+++ b/src/examples/src/widgets/raised-button/Kinds.tsx
@@ -1,0 +1,21 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import RaisedButton from '@dojo/widgets/raised-button';
+import Example from '../../Example';
+
+const factory = create();
+
+export default factory(function Kinds() {
+	return (
+		<Example>
+			<div>
+				<RaisedButton kind="primary">Primary</RaisedButton>
+				<br />
+				<br />
+				<RaisedButton kind="secondary">Secondary</RaisedButton>
+				<br />
+				<br />
+				<RaisedButton kind="cancel">Cancel</RaisedButton>
+			</div>
+		</Example>
+	);
+});

--- a/src/examples/src/widgets/raised-button/Kinds.tsx
+++ b/src/examples/src/widgets/raised-button/Kinds.tsx
@@ -14,7 +14,7 @@ export default factory(function Kinds() {
 				<RaisedButton kind="secondary">Secondary</RaisedButton>
 				<br />
 				<br />
-				<RaisedButton kind="cancel">Cancel</RaisedButton>
+				<RaisedButton kind="default">Default</RaisedButton>
 			</div>
 		</Example>
 	);

--- a/src/theme/default/button.m.css
+++ b/src/theme/default/button.m.css
@@ -32,9 +32,9 @@
 }
 
 /* Applied to secondary buttons */
-.secondary {
+.secondaryKind {
 }
 
 /* Applied to cancel buttons */
-.cancel {
+.defaultKind {
 }

--- a/src/theme/default/button.m.css
+++ b/src/theme/default/button.m.css
@@ -30,3 +30,11 @@
 /* The button label */
 .label {
 }
+
+/* Applied to secondary buttons */
+.secondary {
+}
+
+/* Applied to cancel buttons */
+.cancel {
+}

--- a/src/theme/default/button.m.css.d.ts
+++ b/src/theme/default/button.m.css.d.ts
@@ -3,5 +3,5 @@ export const pressed: string;
 export const popup: string;
 export const disabled: string;
 export const label: string;
-export const secondary: string;
-export const cancel: string;
+export const secondaryKind: string;
+export const defaultKind: string;

--- a/src/theme/default/button.m.css.d.ts
+++ b/src/theme/default/button.m.css.d.ts
@@ -3,3 +3,5 @@ export const pressed: string;
 export const popup: string;
 export const disabled: string;
 export const label: string;
+export const secondary: string;
+export const cancel: string;

--- a/src/theme/dojo/button.m.css
+++ b/src/theme/dojo/button.m.css
@@ -48,3 +48,11 @@
 .pressed .label {
 	color: var(--color-text-inverted);
 }
+
+.secondary .label {
+	color: var(--color-text-secondary);
+}
+
+.cancel .label {
+	color: var(--color-alert);
+}

--- a/src/theme/dojo/button.m.css
+++ b/src/theme/dojo/button.m.css
@@ -49,10 +49,10 @@
 	color: var(--color-text-inverted);
 }
 
-.secondary .label {
-	color: var(--color-text-secondary);
+.secondaryKind .label {
+	color: var(--color-text-faded);
 }
 
-.cancel .label {
-	color: var(--color-alert);
+.defaultKind .label {
+	color: var(--color-text);
 }

--- a/src/theme/dojo/button.m.css.d.ts
+++ b/src/theme/dojo/button.m.css.d.ts
@@ -2,3 +2,4 @@ export const root: string;
 export const pressed: string;
 export const disabled: string;
 export const label: string;
+export const secondary: string;

--- a/src/theme/dojo/button.m.css.d.ts
+++ b/src/theme/dojo/button.m.css.d.ts
@@ -3,3 +3,4 @@ export const pressed: string;
 export const disabled: string;
 export const label: string;
 export const secondary: string;
+export const cancel: string;

--- a/src/theme/dojo/outlined-button.m.css
+++ b/src/theme/dojo/outlined-button.m.css
@@ -40,3 +40,11 @@
 .disabled:hover .label {
 	color: var(--color-text-faded);
 }
+
+.secondary {
+	border-color: var(--color-secondary);
+}
+
+.cancel {
+	border-color: var(--color-alert);
+}

--- a/src/theme/dojo/outlined-button.m.css
+++ b/src/theme/dojo/outlined-button.m.css
@@ -41,10 +41,12 @@
 	color: var(--color-text-faded);
 }
 
-.secondary {
+.secondaryKind {
 	border-color: var(--color-secondary);
+	color: var(--color-text-faded);
 }
 
-.cancel {
-	border-color: var(--color-alert);
+.defaultKind {
+	border-color: var(--color-text);
+	color: var(--color-text);
 }

--- a/src/theme/dojo/outlined-button.m.css.d.ts
+++ b/src/theme/dojo/outlined-button.m.css.d.ts
@@ -2,3 +2,5 @@ export const root: string;
 export const pressed: string;
 export const label: string;
 export const disabled: string;
+export const secondary: string;
+export const cancel: string;

--- a/src/theme/dojo/raised-button.m.css
+++ b/src/theme/dojo/raised-button.m.css
@@ -35,18 +35,14 @@
 	box-shadow: var(--box-shadow-dimensions-small) var(--color-box-shadow);
 }
 
-.secondary {
+.secondaryKind {
 	background-color: var(--color-secondary);
 }
 
-.secondary .label {
+.secondaryKind .label {
 	color: var(--color-text-secondary);
 }
 
-.cancel {
-	background-color: var(--color-alert);
-}
-
-.cancel .label {
-	color: var(--color-text-inverted);
+.defaultKind .label {
+	color: var(--color-text);
 }

--- a/src/theme/dojo/raised-button.m.css
+++ b/src/theme/dojo/raised-button.m.css
@@ -34,3 +34,19 @@
 .disabled:hover {
 	box-shadow: var(--box-shadow-dimensions-small) var(--color-box-shadow);
 }
+
+.secondary {
+	background-color: var(--color-secondary);
+}
+
+.secondary .label {
+	color: var(--color-text-secondary);
+}
+
+.cancel {
+	background-color: var(--color-alert);
+}
+
+.cancel .label {
+	color: var(--color-text-inverted);
+}

--- a/src/theme/dojo/raised-button.m.css.d.ts
+++ b/src/theme/dojo/raised-button.m.css.d.ts
@@ -2,3 +2,5 @@ export const root: string;
 export const pressed: string;
 export const label: string;
 export const disabled: string;
+export const secondary: string;
+export const cancel: string;

--- a/src/theme/dojo/variants/default.m.css
+++ b/src/theme/dojo/variants/default.m.css
@@ -23,6 +23,7 @@
 	/* Color hex values */
 	--color-dark: #333;
 	--color-text-primary: #000000;
+	--color-text-secondary: #000000;
 	--color-text-faded: #5c6c7c;
 	--color-text-inverted: #ffffff;
 	--color-highlight: #006be6;
@@ -68,4 +69,7 @@
 	--divider-width: 9px;
 
 	--tab-width: calc(var(--grid-base) * 16);
+
+	--color-primary: #ffffff;
+	--color-secondary: rgb(199, 222, 209);
 }

--- a/src/theme/material/button.m.css
+++ b/src/theme/material/button.m.css
@@ -35,11 +35,11 @@
 
 .root.cancel:before,
 .root.cancel:after {
-	background-color: var(--mdc-theme-on-surface);
+	background-color: var(--mdc-text-color);
 }
 
 .root.secondary:not(.disabled) {
-	color: var(--mdc-secondary-text-color);
+	color: var(--mdc-theme-secondary);
 }
 
 .root.secondary:before,

--- a/src/theme/material/button.m.css
+++ b/src/theme/material/button.m.css
@@ -28,3 +28,21 @@
 	color: var(--mdc-disabled-text-color);
 	border-color: var(--mdc-disabled-text-color);
 }
+
+.root.cancel:not(.disabled) {
+	color: var(--mdc-text-color);
+}
+
+.root.cancel:before,
+.root.cancel:after {
+	background-color: var(--mdc-theme-on-surface);
+}
+
+.root.secondary:not(.disabled) {
+	color: var(--mdc-secondary-text-color);
+}
+
+.root.secondary:before,
+.root.secondary:after {
+	background-color: var(--mdc-theme-secondary);
+}

--- a/src/theme/material/button.m.css
+++ b/src/theme/material/button.m.css
@@ -29,20 +29,20 @@
 	border-color: var(--mdc-disabled-text-color);
 }
 
-.root.cancel:not(.disabled) {
+.root.defaultKind:not(.disabled) {
 	color: var(--mdc-text-color);
 }
 
-.root.cancel:before,
-.root.cancel:after {
+.root.defaultKind:before,
+.root.defaultKind:after {
 	background-color: var(--mdc-text-color);
 }
 
-.root.secondary:not(.disabled) {
+.root.secondaryKind:not(.disabled) {
 	color: var(--mdc-theme-secondary);
 }
 
-.root.secondary:before,
-.root.secondary:after {
+.root.secondaryKind:before,
+.root.secondaryKind:after {
 	background-color: var(--mdc-theme-secondary);
 }

--- a/src/theme/material/button.m.css.d.ts
+++ b/src/theme/material/button.m.css.d.ts
@@ -2,3 +2,5 @@ export const nativeResetRoot: string;
 export const root: string;
 export const pressed: string;
 export const disabled: string;
+export const cancel: string;
+export const secondary: string;

--- a/src/theme/material/outlined-button.m.css
+++ b/src/theme/material/outlined-button.m.css
@@ -7,22 +7,22 @@
 	composes: mdc-button--unelevated from '@material/button/dist/mdc.button.css';
 }
 
-.root.cancel:not(:disabled) {
+.root.defaultKind:not(:disabled) {
 	border-color: var(--mdc-theme-on-surface);
 	color: var(--mdc-text-color);
 }
 
-.root.cancel:before,
-.root.cancel:after {
+.root.defaultKind:before,
+.root.defaultKind:after {
 	background-color: var(--mdc-theme-on-surface);
 }
 
-.root.secondary:not(:disabled) {
+.root.secondaryKind:not(:disabled) {
 	border-color: var(--mdc-theme-secondary) !important;
 	color: var(--mdc-secondary-text-color);
 }
 
-.root.secondary:before,
-.root.secondary:after {
+.root.secondaryKind:before,
+.root.secondaryKind:after {
 	background-color: var(--mdc-theme-secondary);
 }

--- a/src/theme/material/outlined-button.m.css
+++ b/src/theme/material/outlined-button.m.css
@@ -6,3 +6,23 @@
 .pressed {
 	composes: mdc-button--unelevated from '@material/button/dist/mdc.button.css';
 }
+
+.root.cancel:not(:disabled) {
+	border-color: var(--mdc-theme-on-surface);
+	color: var(--mdc-text-color);
+}
+
+.root.cancel:before,
+.root.cancel:after {
+	background-color: var(--mdc-theme-on-surface);
+}
+
+.root.secondary:not(:disabled) {
+	border-color: var(--mdc-theme-secondary) !important;
+	color: var(--mdc-secondary-text-color);
+}
+
+.root.secondary:before,
+.root.secondary:after {
+	background-color: var(--mdc-theme-secondary);
+}

--- a/src/theme/material/outlined-button.m.css.d.ts
+++ b/src/theme/material/outlined-button.m.css.d.ts
@@ -1,2 +1,4 @@
 export const root: string;
 export const pressed: string;
+export const cancel: string;
+export const secondary: string;

--- a/src/theme/material/raised-button.m.css
+++ b/src/theme/material/raised-button.m.css
@@ -17,22 +17,22 @@
 	background-color: var(--mdc-disabled-text-color);
 }
 
-.root.cancel:not(:disabled) {
+.root.defaultKind:not(:disabled) {
 	background-color: var(--mdc-theme-on-surface);
 	color: var(--mdc-text-color);
 }
 
-.root.cancel:before,
-.root.cancel:after {
+.root.defaultKind:before,
+.root.defaultKind:after {
 	background-color: var(--mdc-theme-on-surface);
 }
 
-.root.secondary:not(:disabled) {
+.root.secondaryKind:not(:disabled) {
 	background-color: var(--mdc-theme-secondary);
 	color: var(--mdc-theme-on-secondary);
 }
 
-.root.secondary:before,
-.root.secondary:after {
+.root.secondaryKind:before,
+.root.secondaryKind:after {
 	background-color: var(--mdc-theme-secondary);
 }

--- a/src/theme/material/raised-button.m.css
+++ b/src/theme/material/raised-button.m.css
@@ -16,3 +16,23 @@
 .root.disabled:disabled {
 	background-color: var(--mdc-disabled-text-color);
 }
+
+.root.cancel:not(:disabled) {
+	background-color: var(--mdc-theme-on-surface);
+	color: var(--mdc-text-color);
+}
+
+.root.cancel:before,
+.root.cancel:after {
+	background-color: var(--mdc-theme-on-surface);
+}
+
+.root.secondary:not(:disabled) {
+	background-color: var(--mdc-theme-secondary);
+	color: var(--mdc-theme-on-secondary);
+}
+
+.root.secondary:before,
+.root.secondary:after {
+	background-color: var(--mdc-theme-secondary);
+}

--- a/src/theme/material/raised-button.m.css.d.ts
+++ b/src/theme/material/raised-button.m.css.d.ts
@@ -1,3 +1,5 @@
 export const root: string;
 export const pressed: string;
 export const disabled: string;
+export const cancel: string;
+export const secondary: string;


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Adding button kinds "secondary" and "cancel" and corresponding styles.

![image](https://user-images.githubusercontent.com/2008858/105215194-f86d6f00-5b1e-11eb-982b-c2078cb7311f.png)

Resolves #1637 
