### PR TITLE
moving mdc-tab__content class from tab body to tab itself.

### DIFF
--- a/src/theme/material/tab-container.m.css
+++ b/src/theme/material/tab-container.m.css
@@ -15,6 +15,7 @@
 
 .tabButtonContent {
 	composes: mdc-tab__text-label from '@material/tab/dist/mdc.tab.css';
+	composes: mdc-tab__content from '@material/tab/dist/mdc.tab.css';
 }
 
 .activeTabButton {
@@ -54,10 +55,6 @@
 }
 
 /* TABS */
-.tab {
-	composes: mdc-tab__content from '@material/tab/dist/mdc.tab.css';
-}
-
 .root {
 	background-color: var(--mdc-tab-background);
 }


### PR DESCRIPTION
resolves #1650

**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixing an issue that makes nothing clickable inside of a TabContainer.

Resolves #1650 
