### PR TITLE
moving mdc-tab__content class from tab body to tab itself. (#1651)

### DIFF
--- a/src/theme/material/tab-container.m.css
+++ b/src/theme/material/tab-container.m.css
@@ -15,6 +15,7 @@
 
 .tabButtonContent {
 	composes: mdc-tab__text-label from '@material/tab/dist/mdc.tab.css';
+	composes: mdc-tab__content from '@material/tab/dist/mdc.tab.css';
 }
 
 .activeTabButton {
@@ -54,10 +55,6 @@
 }
 
 /* TABS */
-.tab {
-	composes: mdc-tab__content from '@material/tab/dist/mdc.tab.css';
-}
-
 .root {
 	background-color: var(--mdc-tab-background);
 }


### PR DESCRIPTION
Backport of tab container fix!