### PR TITLE
Support actions in the header section of the header card

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -30,6 +30,8 @@ import CardWithMediaContent from './widgets/card/CardWithMediaContent';
 import CardWithMediaRectangle from './widgets/card/CardWithMediaRectangle';
 import CardWithMediaSquare from './widgets/card/CardWithMediaSquare';
 import BasicHeaderCard from './widgets/header-card/Basic';
+import HeaderActionsHeaderCard from './widgets/header-card/HeaderActions';
+import OverflowActionsHeaderCard from './widgets/header-card/OverflowActions';
 import MediaHeaderCard from './widgets/header-card/MediaCard';
 import ActionHeaderCard from './widgets/header-card/ActionCard';
 import BasicCheckboxGroup from './widgets/checkbox-group/Basic';
@@ -512,6 +514,18 @@ export const config = {
 					title: 'Header Card with media',
 					module: MediaHeaderCard,
 					filename: 'MediaCard'
+				},
+				{
+					title: 'Card with header actions',
+					module: HeaderActionsHeaderCard,
+					filename: 'HeaderActions'
+				},
+				{
+					title: 'Card with overflow actions',
+					module: OverflowActionsHeaderCard,
+					filename: 'OverflowActions',
+					sandbox: true,
+					size: 'large'
 				}
 			],
 			filename: 'index',
@@ -708,7 +722,7 @@ export const config = {
 				{
 					filename: 'CloseableDialog',
 					module: CloseableDialog,
-					title: 'Dialog with Configurable Closeability',
+					title: 'Closeable Dialog with Configurable',
 					sandbox: true,
 					size: 'medium'
 				},
@@ -1088,7 +1102,7 @@ export const config = {
 			},
 			examples: [
 				{
-					title: 'Contolled Native Select',
+					title: 'Controlled Native Select',
 					filename: 'ControlledNativeSelect',
 					module: ControlledNativeSelect
 				}

--- a/src/examples/src/widgets/header-card/HeaderActions.tsx
+++ b/src/examples/src/widgets/header-card/HeaderActions.tsx
@@ -1,0 +1,28 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import HeaderCard from '@dojo/widgets/header-card';
+import Avatar from '@dojo/widgets/avatar';
+import Example from '../../Example';
+import Button from '@dojo/widgets/button';
+import Icon from '@dojo/widgets/icon';
+
+const factory = create();
+
+export default factory(function HeaderActions() {
+	return (
+		<Example>
+			<div styles={{ maxWidth: '400px' }}>
+				<HeaderCard title="Hello, World" subtitle="Lorem ipsum">
+					{{
+						avatar: <Avatar>D</Avatar>,
+						headerActions: (
+							<Button>
+								<Icon type="editIcon" />
+							</Button>
+						),
+						content: <p styles={{ margin: '0' }}>Lorem ipsum</p>
+					}}
+				</HeaderCard>
+			</div>
+		</Example>
+	);
+});

--- a/src/examples/src/widgets/header-card/OverflowActions.tsx
+++ b/src/examples/src/widgets/header-card/OverflowActions.tsx
@@ -1,0 +1,58 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import HeaderCard from '@dojo/widgets/header-card';
+import Avatar from '@dojo/widgets/avatar';
+import Example from '../../Example';
+import Button from '@dojo/widgets/button';
+import Icon from '@dojo/widgets/icon';
+import List, { MenuItem } from '@dojo/widgets/list';
+
+import TriggerPopup from '@dojo/widgets/trigger-popup';
+
+const factory = create();
+
+export default factory(function HeaderActions({ id }) {
+	return (
+		<Example>
+			<div styles={{ maxWidth: '400px' }}>
+				<HeaderCard title="Hello, World" subtitle="Lorem ipsum">
+					{{
+						avatar: <Avatar>D</Avatar>,
+						headerActions: (
+							<TriggerPopup>
+								{{
+									trigger: (onToggleOpen) => (
+										<Button onClick={onToggleOpen}>
+											<Icon type="barsIcon" />
+										</Button>
+									),
+									content: (onClose) => (
+										<div styles={{ background: 'white' }}>
+											<List
+												menu
+												onValue={onClose}
+												resource={{
+													id,
+													idKey: 'value',
+													data: [{ value: 'editIcon', label: 'Edit' }]
+												}}
+											>
+												{({ value }, props) => {
+													return (
+														<MenuItem {...props}>
+															<Icon type={value as any} />
+														</MenuItem>
+													);
+												}}
+											</List>
+										</div>
+									)
+								}}
+							</TriggerPopup>
+						),
+						content: <p styles={{ margin: '0' }}>Lorem ipsum</p>
+					}}
+				</HeaderCard>
+			</div>
+		</Example>
+	);
+});

--- a/src/header-card/index.tsx
+++ b/src/header-card/index.tsx
@@ -12,6 +12,7 @@ export interface HeaderCardProperties extends CardProperties {
 
 export interface HeaderCardChildren extends Omit<CardChildren, 'header'> {
 	avatar?: RenderResult;
+	headerActions?: RenderResult;
 }
 
 const factory = create({ theme })
@@ -25,7 +26,7 @@ export const HeaderCard = factory(function HeaderCard({
 }) {
 	const themeCss = theme.classes(css);
 	const { title, subtitle, ...cardProps } = properties();
-	const [{ avatar, ...cardChildren } = {} as HeaderCardChildren] = children();
+	const [{ avatar, headerActions, ...cardChildren } = {} as HeaderCardChildren] = children();
 	return (
 		<Card key="root" {...cardProps}>
 			{{
@@ -36,6 +37,7 @@ export const HeaderCard = factory(function HeaderCard({
 							{<h2 classes={themeCss.title}>{title}</h2>}
 							{subtitle && <h3 classes={themeCss.subtitle}>{subtitle}</h3>}
 						</div>
+						{headerActions && <div classes={themeCss.actions}>{headerActions}</div>}
 					</div>
 				),
 				...cardChildren

--- a/src/header-card/tests/unit/HeaderCard.spec.tsx
+++ b/src/header-card/tests/unit/HeaderCard.spec.tsx
@@ -6,6 +6,7 @@ import HeaderCard from '../../index';
 import Card from '../../../card';
 import Avatar from '../../../avatar';
 import * as css from '../../../theme/default/header-card.m.css';
+import Button from '../../../button';
 
 describe('HeaderCard', () => {
 	const template = assertionTemplate(() => (
@@ -49,7 +50,7 @@ describe('HeaderCard', () => {
 		);
 	});
 
-	it('renders with a an avatar', () => {
+	it('renders with an avatar', () => {
 		const avatar = <Avatar>D</Avatar>;
 		const h = harness(() => (
 			<HeaderCard square title="title" subtitle="subtitle">
@@ -69,6 +70,34 @@ describe('HeaderCard', () => {
 										{<h2 classes={css.title}>title</h2>}
 										<h3 classes={css.subtitle}>subtitle</h3>
 									</div>
+								</div>
+							)
+						}
+					] as any
+			)
+		);
+	});
+
+	it('renders with an action', () => {
+		const headerActions = <Button>D</Button>;
+		const h = harness(() => (
+			<HeaderCard square title="title" subtitle="subtitle">
+				{{ headerActions }}
+			</HeaderCard>
+		));
+		h.expect(
+			template.setProperty('@root', 'square', true).setChildren(
+				'@root',
+				() =>
+					[
+						{
+							header: () => (
+								<div key="header" classes={css.header}>
+									<div key="headerContent" classes={css.headerContent}>
+										{<h2 classes={css.title}>title</h2>}
+										<h3 classes={css.subtitle}>subtitle</h3>
+									</div>
+									<Button>D</Button>
 								</div>
 							)
 						}

--- a/src/theme/default/header-card.m.css
+++ b/src/theme/default/header-card.m.css
@@ -5,6 +5,9 @@
 .headerContent {
 }
 
+.actions {
+}
+
 .avatar {
 }
 

--- a/src/theme/default/header-card.m.css.d.ts
+++ b/src/theme/default/header-card.m.css.d.ts
@@ -1,5 +1,6 @@
 export const header: string;
 export const headerContent: string;
+export const actions: string;
 export const avatar: string;
 export const title: string;
 export const subtitle: string;

--- a/src/theme/dojo/header-card.m.css
+++ b/src/theme/dojo/header-card.m.css
@@ -7,6 +7,7 @@
 	display: flex;
 	padding-top: calc(2 * var(--spacing-regular));
 	align-items: center;
+	width: 100%;
 }
 
 .headerContent {
@@ -15,6 +16,10 @@
 
 .avatar {
 	margin-right: calc(2 * var(--spacing-regular));
+	flex: 0 0 auto;
+}
+
+.actions {
 	flex: 0 0 auto;
 }
 

--- a/src/theme/dojo/header-card.m.css.d.ts
+++ b/src/theme/dojo/header-card.m.css.d.ts
@@ -2,5 +2,6 @@ export const root: string;
 export const header: string;
 export const headerContent: string;
 export const avatar: string;
+export const actions: string;
 export const title: string;
 export const subtitle: string;

--- a/src/theme/material/header-card.m.css
+++ b/src/theme/material/header-card.m.css
@@ -3,6 +3,7 @@
 	display: flex;
 	padding-top: 1rem;
 	align-items: center;
+	width: 100%;
 }
 
 .headerContent {
@@ -11,6 +12,10 @@
 
 .avatar {
 	margin-right: 1rem;
+	flex: 0 0 auto;
+}
+
+.actions {
 	flex: 0 0 auto;
 }
 

--- a/src/theme/material/header-card.m.css.d.ts
+++ b/src/theme/material/header-card.m.css.d.ts
@@ -1,5 +1,6 @@
 export const header: string;
 export const headerContent: string;
 export const avatar: string;
+export const actions: string;
 export const title: string;
 export const subtitle: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Adds support for aligning "actions" on the right of a header in the card. This has only been added to the `header-card` which is the card to use if you want support with the header layout.