### PR TITLE
Do no default the input to todays date and support clearing the date input

### DIFF
--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -150,6 +150,8 @@ export default factory(function({
 				}
 			} else if (testValue) {
 				validationMessages.push(messages.invalidDate);
+			} else {
+				onValue && onValue('');
 			}
 
 			isValid = validationMessages.length === 0;

--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -47,7 +47,7 @@ interface DateInputICache {
 	/** The most recent "initialValue" property passed */
 	initialValue: string;
 	/** Current user-inputted value */
-	inputValue: string;
+	inputValue?: string;
 	/** The last valid Date of value */
 	value: Date;
 	/** The last "value" property passed */
@@ -114,8 +114,7 @@ export default factory(function({
 
 	const inputValue = icache.getOrSet('inputValue', () => {
 		const parsed = initialValue && parseDate(initialValue);
-
-		return formatDate(parsed || new Date());
+		return parsed ? formatDate(parsed) : undefined;
 	});
 	const shouldValidate = icache.getOrSet('shouldValidate', true);
 	const shouldFocus = focus.shouldFocus();
@@ -149,7 +148,7 @@ export default factory(function({
 						onValue(formatDateISO(newDate));
 					}
 				}
-			} else {
+			} else if (testValue) {
 				validationMessages.push(messages.invalidDate);
 			}
 
@@ -257,7 +256,9 @@ export default factory(function({
 									focus={() => shouldFocus && focusNode === 'calendar'}
 									maxDate={max}
 									minDate={min}
-									initialValue={icache.get('value')}
+									initialValue={
+										icache.get('value') || parseDate(formatDateISO(new Date()))
+									}
 									onValue={(date) => {
 										icache.set(
 											controlledValue === undefined

--- a/src/date-input/tests/unit/DateInput.spec.tsx
+++ b/src/date-input/tests/unit/DateInput.spec.tsx
@@ -51,7 +51,7 @@ const baseTemplate = (date?: Date) =>
 					assertion-key="input"
 					type="hidden"
 					name="dateInput"
-					value={formatDateISO(date || today)}
+					value={date ? formatDateISO(date) : ''}
 					aria-hidden="true"
 				/>
 				<TriggerPopup variant={undefined} classes={undefined} theme={undefined} key="popup">
@@ -76,7 +76,7 @@ const buttonTemplate = assertionTemplate(() => {
 				type="text"
 				onBlur={noop}
 				onValue={noop}
-				initialValue={formatDate(today)}
+				initialValue={undefined}
 				helperText=""
 				onKeyDown={noop}
 				variant={undefined}
@@ -113,12 +113,6 @@ describe('DateInput', () => {
 		onValue.resetHistory();
 	});
 
-	it('renders with default date', () => {
-		const h = harness(() => <DateInput name="dateInput" onValue={onValue} />);
-		h.expect(baseTemplate());
-		sinon.assert.calledWith(onValue, formatDateISO(today));
-	});
-
 	it('renders with default date when provided an invalid initial date', () => {
 		const h = harness(() => (
 			<DateInput name="dateInput" initialValue="not a date" onValue={onValue} />
@@ -131,7 +125,6 @@ describe('DateInput', () => {
 			<DateInput name="dateInput" value="not a date" onValue={onValue} />
 		));
 		h.expect(baseTemplate().setProperty('@input', 'value', ''));
-		sinon.assert.calledWith(onValue, formatDateISO(today));
 	});
 
 	it('renders with initial value', () => {

--- a/src/examples/src/widgets/date-input/Basic.tsx
+++ b/src/examples/src/widgets/date-input/Basic.tsx
@@ -1,13 +1,22 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
+import icache from '@dojo/framework/core/middleware/icache';
 import DateInput from '@dojo/widgets/date-input';
 import Example from '../../Example';
 
-const factory = create();
+const factory = create({ icache });
 
-export default factory(function Basic() {
+export default factory(function Basic({ middleware: { icache } }) {
 	return (
 		<Example>
-			<DateInput name="dateInput" />
+			<div>
+				<div>{icache.get('date')}</div>
+				<DateInput
+					name="dateInput"
+					onValue={(value) => {
+						icache.set('date', value);
+					}}
+				/>
+			</div>
 		</Example>
 	);
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Stops the date input from defaulting the value to todays date and adds support to clear the input.

Resolves #1661 
