### PR TITLE
Cache things to make the current timepicker usable

### DIFF
--- a/src/time-picker/tests/unit/TimePicker.spec.tsx
+++ b/src/time-picker/tests/unit/TimePicker.spec.tsx
@@ -131,6 +131,7 @@ const menuTemplate = assertionTemplate(() => {
 		<div key="menu-wrapper" classes={css.menuWrapper}>
 			<List
 				key="menu"
+				itemsInView={undefined}
 				height="auto"
 				focus={() => false}
 				resource={createTestResource(options30Minutes, 'value')}


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

The options for the time-picker are created every render, this is super costly and causes issues through out applications.