### PR TITLE
Fix setting values in date input and time picker when submitting as part of the form

### DIFF
--- a/src/date-input/tests/unit/DateInput.spec.tsx
+++ b/src/date-input/tests/unit/DateInput.spec.tsx
@@ -74,6 +74,7 @@ const buttonTemplate = assertionTemplate(() => {
 				focus={() => false}
 				theme={{}}
 				type="text"
+				onFocus={noop}
 				onBlur={noop}
 				onValue={noop}
 				initialValue={undefined}
@@ -306,6 +307,7 @@ describe('DateInput', () => {
 		// Find the input widget and trigger it's value changed
 		const [input] = select('@input', triggerResult);
 		onValue.resetHistory();
+		input.properties.onFocus();
 		input.properties.onValue(formatDate(expected));
 
 		h.expect(baseTemplate());
@@ -409,6 +411,7 @@ describe('DateInput', () => {
 		let [input] = select('@input', triggerResult);
 		onValidate.resetHistory();
 		onValue.resetHistory();
+		input.properties.onFocus();
 		input.properties.onValue('foobar');
 		input.properties.onBlur();
 		h.expect(baseTemplate());
@@ -452,6 +455,7 @@ describe('DateInput', () => {
 		onValidate.resetHistory();
 		let [input] = select('@input', triggerResult);
 		onValue.resetHistory();
+		input.properties.onFocus();
 		input.properties.onValue(formatDate(tooEarly));
 		input.properties.onBlur();
 		h.expect(baseTemplate(initialValue));
@@ -468,6 +472,7 @@ describe('DateInput', () => {
 		// Set value after the max date
 		onValidate.resetHistory();
 		onValue.resetHistory();
+		input.properties.onFocus();
 		input.properties.onValue(formatDate(tooLate));
 		input.properties.onBlur();
 		h.expect(baseTemplate(initialValue));

--- a/src/examples/src/widgets/form/SubmitForm.tsx
+++ b/src/examples/src/widgets/form/SubmitForm.tsx
@@ -3,6 +3,8 @@ import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
 import Form, { FormField, FormGroup } from '@dojo/widgets/form';
 import TextInput from '@dojo/widgets/text-input';
+import TimePicker from '@dojo/widgets/time-picker';
+import DateInput from '@dojo/widgets/date-input';
 
 import Example from '../../Example';
 
@@ -17,6 +19,8 @@ interface Fields {
 	middleName?: string;
 	lastName: string;
 	email?: string;
+	time: string;
+	date: string;
 }
 
 const App = factory(function({ middleware: { icache } }) {
@@ -24,85 +28,113 @@ const App = factory(function({ middleware: { icache } }) {
 
 	return (
 		<Example>
-			<Form onSubmit={(values) => icache.set('basic', values)}>
-				{(form) => {
-					const { valid, field } = form<Fields>();
-					const firstName = field('firstName', true);
-					const middleName = field('middleName');
-					const lastName = field('lastName', true);
-					const email = field('email');
+			<virtual>
+				<Form
+					onSubmit={(values) => {
+						icache.set('basic', values);
+					}}
+				>
+					{(form) => {
+						const { valid, field } = form<Fields>();
+						const firstName = field('firstName');
+						const middleName = field('middleName');
+						const lastName = field('lastName');
+						const email = field('email');
+						const time = field('time');
+						const date = field('date');
 
-					return (
-						<virtual>
-							<FormGroup>
-								<FormField>
-									<TextInput
-										key="firstName"
-										placeholder="Enter first name (must be Billy)"
-										required={true}
-										initialValue={firstName.value()}
-										valid={firstName.valid()}
-										onValue={firstName.value}
-										onValidate={firstName.valid}
-									>
-										{{ label: 'First Name' }}
-									</TextInput>
-								</FormField>
-								<FormField>
-									<TextInput
-										key="middleName"
-										placeholder="Enter a middle name"
-										initialValue={middleName.value()}
-										onValue={middleName.value}
-									>
-										{{ label: 'Middle Name' }}
-									</TextInput>
-								</FormField>
-								<FormField>
-									<TextInput
-										key="lastName"
-										placeholder="Enter a last name"
-										required={true}
-										initialValue={lastName.value()}
-										valid={lastName.valid()}
-										onValue={lastName.value}
-										onValidate={lastName.valid}
-									>
-										{{ label: 'Last Name' }}
-									</TextInput>
-								</FormField>
-							</FormGroup>
-							<FormGroup>
-								<FormField>
-									<TextInput
-										key="email"
-										placeholder="Enter an email address"
-										initialValue={email.value()}
-										onValue={email.value}
-										type="email"
-									>
-										{{ label: 'Email' }}
-									</TextInput>
-								</FormField>
-							</FormGroup>
-							<Button key="submit" type="submit" disabled={!valid()}>
-								Submit
-							</Button>
-						</virtual>
-					);
-				}}
-			</Form>
-			{results && (
-				<div key="onSubmitResults">
-					<h2>onSubmit Results</h2>
-					<ul>
-						<li>First Name: {results.firstName}</li>
-						<li>Middle Name: {results.middleName}</li>
-						<li>Last Name: {results.lastName}</li>
-						<li>Email: {results.email}</li>
-					</ul>
-				</div>
-			)}
+						return (
+							<virtual>
+								<FormGroup>
+									<FormField>
+										<TextInput
+											key="firstName"
+											placeholder="Enter first name (must be Billy)"
+											initialValue={firstName.value()}
+											valid={firstName.valid()}
+											onValue={firstName.value}
+											onValidate={firstName.valid}
+										>
+											{{ label: 'First Name' }}
+										</TextInput>
+									</FormField>
+									<FormField>
+										<TextInput
+											key="middleName"
+											placeholder="Enter a middle name"
+											initialValue={middleName.value()}
+											onValue={middleName.value}
+										>
+											{{ label: 'Middle Name' }}
+										</TextInput>
+									</FormField>
+									<FormField>
+										<TextInput
+											key="lastName"
+											placeholder="Enter a last name"
+											initialValue={lastName.value()}
+											valid={lastName.valid()}
+											onValue={lastName.value}
+											onValidate={lastName.valid}
+										>
+											{{ label: 'Last Name' }}
+										</TextInput>
+									</FormField>
+								</FormGroup>
+								<FormGroup>
+									<FormField>
+										<TextInput
+											key="email"
+											placeholder="Enter an email address"
+											initialValue={email.value()}
+											onValue={email.value}
+											type="email"
+										>
+											{{ label: 'Email' }}
+										</TextInput>
+									</FormField>
+									<FormField>
+										<TimePicker
+											itemsInView={5}
+											format="12"
+											step={900}
+											value={time.value()}
+											onValue={(value) => {
+												time.value(value);
+											}}
+											onValidate={time.valid}
+										>
+											{{
+												label: 'Time'
+											}}
+										</TimePicker>
+									</FormField>
+									<FormField>
+										<DateInput
+											value={date.value()}
+											onValue={(value) => {
+												date.value(value);
+											}}
+											onValidate={date.valid}
+										>
+											{{ label: 'Date' }}
+										</DateInput>
+									</FormField>
+								</FormGroup>
+								<Button key="submit" type="submit" disabled={!valid()}>
+									Submit
+								</Button>
+							</virtual>
+						);
+					}}
+				</Form>
+				{results && (
+					<div key="onSubmitResults">
+						<h2>onSubmit Results</h2>
+						<pre>{JSON.stringify(results, null, 4)}</pre>
+					</div>
+				)}
+			</virtual>
 		</Example>
 	);
 });

--- a/src/time-picker/tests/unit/TimePicker.spec.tsx
+++ b/src/time-picker/tests/unit/TimePicker.spec.tsx
@@ -74,6 +74,7 @@ const buttonTemplate = assertionTemplate(() => {
 				focus={() => false}
 				theme={{}}
 				onBlur={noop}
+				onFocus={noop}
 				onValue={noop}
 				initialValue={''}
 				onValidate={noop}
@@ -321,6 +322,7 @@ describe('TimePicker', () => {
 		// Find the input widget and trigger it's value changed
 		const [input] = select('@input', triggerResult);
 		onValue.resetHistory();
+		input.properties.onFocus();
 		input.properties.onValue(format24HourTime(expected));
 
 		h.expect(baseTemplate());
@@ -458,6 +460,7 @@ describe('TimePicker', () => {
 		let [input] = select('@input', triggerResult);
 		onValidate.resetHistory();
 		onValue.resetHistory();
+		input.properties.onFocus();
 		input.properties.onValue('foobar');
 		input.properties.onBlur();
 		h.expect(baseTemplate());
@@ -495,6 +498,7 @@ describe('TimePicker', () => {
 		onValidate.resetHistory();
 		let [input] = select('@input', triggerResult);
 		onValue.resetHistory();
+		input.properties.onFocus();
 		input.properties.onValue('12:29:59');
 		input.properties.onBlur();
 		h.expect(baseTemplate());
@@ -511,6 +515,7 @@ describe('TimePicker', () => {
 		// Set value after the max date
 		onValidate.resetHistory();
 		onValue.resetHistory();
+		input.properties.onFocus();
 		input.properties.onValue('13:30:01');
 		input.properties.onBlur();
 		h.expect(baseTemplate());


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

When using the inputs as part of a form the setting of the values on "Enter" was actually done on the next render, which meant that the submit of the form happened with "stale" data before it was updated. This changes to set the value immediately so it is correct for a form submission