### PR TITLE
add text-input autocomplete hook

### DIFF
--- a/src/text-input/index.tsx
+++ b/src/text-input/index.tsx
@@ -106,6 +106,7 @@ interface TextInputICache {
 	dirty: boolean;
 	value?: string;
 	initialValue?: string;
+	autofilled?: boolean;
 }
 
 const factory = create({
@@ -223,6 +224,7 @@ export const TextInput = factory(function TextInput({
 
 	const computedHelperText = (valid === false && message) || helperText;
 	const inputFocused = focus.isFocused('input');
+	const autofilled = Boolean(icache.get('autofilled'));
 
 	return (
 		<div key="root" classes={[theme.variant(), themeCss.root]} role="presentation">
@@ -254,7 +256,7 @@ export const TextInput = factory(function TextInput({
 						required={required}
 						hidden={labelHidden}
 						forId={widgetId}
-						active={!!value || inputFocused}
+						active={!!value || inputFocused || autofilled}
 					>
 						{label}
 					</Label>
@@ -318,6 +320,11 @@ export const TextInput = factory(function TextInput({
 						}}
 						onpointerleave={() => {
 							onOut && onOut();
+						}}
+						onanimationstart={(event: AnimationEvent) => {
+							if (event.animationName === themeCss.onAutofillShown) {
+								icache.set('autofilled', true);
+							}
 						}}
 					/>
 					{trailing}

--- a/src/theme/default/text-input.m.css
+++ b/src/theme/default/text-input.m.css
@@ -65,3 +65,13 @@
 .valid .input {
 	border-color: var(--success-color);
 }
+
+/*
+ * Handle chrome autofill not triggering change event
+ * Context: https://github.com/dojo/widgets/issues/1610
+ */
+@keyframes onAutofillShown {
+}
+.input:-webkit-autofill {
+	animation-name: onAutofillShown;
+}

--- a/src/theme/default/text-input.m.css.d.ts
+++ b/src/theme/default/text-input.m.css.d.ts
@@ -16,3 +16,4 @@ export const noLabel: string;
 export const label: string;
 export const helperText: string;
 export const valid: string;
+export const onAutofillShown: string;

--- a/src/theme/material/text-input.m.css
+++ b/src/theme/material/text-input.m.css
@@ -106,3 +106,13 @@
 .input::-ms-clear {
 	display: none;
 }
+
+/*
+ * Handle chrome autofill not triggering change event
+ * Context: https://github.com/dojo/widgets/issues/1610
+ */
+@keyframes onAutofillShown {
+}
+.input:-webkit-autofill {
+	animation-name: onAutofillShown;
+}

--- a/src/theme/material/text-input.m.css.d.ts
+++ b/src/theme/material/text-input.m.css.d.ts
@@ -13,3 +13,4 @@ export const addonRoot: string;
 export const hasLeading: string;
 export const hasTrailing: string;
 export const valid: string;
+export const onAutofillShown: string;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Use keyframes to trigger an event when 

Resolves #1610
