### PR TITLE
Loading-indicator active property

### DIFF
--- a/src/examples/src/widgets/loading-indicator/Basic.tsx
+++ b/src/examples/src/widgets/loading-indicator/Basic.tsx
@@ -1,13 +1,29 @@
 import LoadingIndicator from '@dojo/widgets/loading-indicator';
+import Switch from '@dojo/widgets/switch';
+import icache from '@dojo/framework/core/middleware/icache';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Example from '../../Example';
 
-const factory = create();
+const factory = create({ icache });
 
-export default factory(function Basic() {
+export default factory(function Basic({ middleware: { icache } }) {
+	const active = icache.getOrSet('active', true);
 	return (
 		<Example>
-			<LoadingIndicator />
+			<virtual>
+				<LoadingIndicator active={active} />
+				<div styles={{ marginTop: '20px' }}>
+					<Switch
+						value={active}
+						name="Active"
+						onValue={(value) => {
+							icache.set('active', value);
+						}}
+					>
+						{{ label: 'Active' }}
+					</Switch>
+				</div>
+			</virtual>
 		</Example>
 	);
 });

--- a/src/loading-indicator/README.md
+++ b/src/loading-indicator/README.md
@@ -5,3 +5,4 @@ Dojo's `LoadingIndicator` widget provides an indeterminate progress indicator.
 ### Features
 
 - Render a horizontal loading indicator
+- Easy hiding via active property

--- a/src/loading-indicator/index.tsx
+++ b/src/loading-indicator/index.tsx
@@ -3,19 +3,31 @@ import theme from '../middleware/theme';
 import { ThemedProperties } from '@dojo/framework/core/mixins/Themed';
 import { create, tsx } from '@dojo/framework/core/vdom';
 
-export interface LoadingIndicatorProperties extends ThemedProperties {}
+export interface LoadingIndicatorProperties extends ThemedProperties {
+	/** If the element is actively loading. Defaults to true */
+	active?: boolean;
+}
 
 const factory = create({ theme }).properties<LoadingIndicatorProperties>();
 
-export const LoadingIndicator = factory(function LoadingIndicator({ middleware: { theme } }) {
+export const LoadingIndicator = factory(function LoadingIndicator({
+	properties,
+	middleware: { theme }
+}) {
 	const classes = theme.classes(css);
+	const { active = true } = properties();
 
 	return (
-		<div classes={[theme.variant(), classes.root]} role="progressbar">
+		<div
+			classes={[theme.variant(), classes.root, !active && classes.inactive]}
+			role="progressbar"
+		>
 			<div classes={classes.buffer} />
-			<div classes={[classes.bar, classes.primary]}>
-				<span classes={classes.inner} />
-			</div>
+			{active ? (
+				<div classes={[classes.bar, classes.primary]}>
+					<span classes={classes.inner} />
+				</div>
+			) : null}
 		</div>
 	);
 });

--- a/src/loading-indicator/tests/unit/LoadingIndicator.spec.tsx
+++ b/src/loading-indicator/tests/unit/LoadingIndicator.spec.tsx
@@ -6,9 +6,9 @@ import harness from '@dojo/framework/testing/harness/harness';
 import { tsx } from '@dojo/framework/core/vdom';
 
 const baseTemplate = assertionTemplate(() => (
-	<div classes={[undefined, classes.root]} role="progressbar">
+	<div assertion-key="root" classes={[undefined, classes.root, false]} role="progressbar">
 		<div classes={classes.buffer} />
-		<div classes={[classes.bar, classes.primary]}>
+		<div assertion-key="bar" classes={[classes.bar, classes.primary]}>
 			<span classes={classes.inner} />
 		</div>
 	</div>
@@ -18,5 +18,14 @@ describe('LoadingIndicator', () => {
 	it('Renders default state', () => {
 		const h = harness(() => <LoadingIndicator />);
 		h.expect(baseTemplate);
+	});
+
+	it('does not render the bar when inactive', () => {
+		const h = harness(() => <LoadingIndicator active={false} />);
+		h.expect(
+			baseTemplate
+				.remove('~bar')
+				.setProperty('~root', 'classes', [undefined, classes.root, classes.inactive])
+		);
 	});
 });

--- a/src/theme/default/loading-indicator.m.css
+++ b/src/theme/default/loading-indicator.m.css
@@ -2,6 +2,10 @@
 .root {
 }
 
+/* Not actively loading, outermost container */
+.inactive {
+}
+
 /* Loading track background */
 .buffer {
 }

--- a/src/theme/default/loading-indicator.m.css.d.ts
+++ b/src/theme/default/loading-indicator.m.css.d.ts
@@ -1,4 +1,5 @@
 export const root: string;
+export const inactive: string;
 export const buffer: string;
 export const bar: string;
 export const primary: string;

--- a/src/theme/dojo/loading-indicator.m.css
+++ b/src/theme/dojo/loading-indicator.m.css
@@ -7,6 +7,10 @@
 	width: 100%;
 }
 
+.inactive {
+	visibility: hidden;
+}
+
 .buffer {
 }
 

--- a/src/theme/dojo/loading-indicator.m.css.d.ts
+++ b/src/theme/dojo/loading-indicator.m.css.d.ts
@@ -1,4 +1,5 @@
 export const root: string;
+export const inactive: string;
 export const buffer: string;
 export const bar: string;
 export const primary: string;

--- a/src/theme/material/loading-indicator.m.css
+++ b/src/theme/material/loading-indicator.m.css
@@ -2,6 +2,10 @@
 	composes: mdc-linear-progress mdc-linear-progress--indeterminate from '@material/linear-progress/dist/mdc.linear-progress.css';
 }
 
+.inactive {
+	visibility: hidden;
+}
+
 .buffer {
 	composes: mdc-linear-progress__buffer from '@material/linear-progress/dist/mdc.linear-progress.css';
 }

--- a/src/theme/material/loading-indicator.m.css.d.ts
+++ b/src/theme/material/loading-indicator.m.css.d.ts
@@ -1,4 +1,5 @@
 export const root: string;
+export const inactive: string;
 export const buffer: string;
 export const bar: string;
 export const primary: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds an active property to the loading indicator. When the active property is false, the loading bar is hidden. This allows easily hiding the loading indicator without shifting the page layout.

![localhost_9999_(iPad) (8)](https://user-images.githubusercontent.com/11273838/109886865-96cc1480-7c35-11eb-826a-60de40d6f770.png)
![localhost_9999_(iPad) (7)](https://user-images.githubusercontent.com/11273838/109886869-9895d800-7c35-11eb-9972-414bae6847ed.png)


Resolves #1608
