### PR TITLE
Add leading/trailing example for NumberInput

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -117,6 +117,7 @@ import DuplicatesChipTypeahead from './widgets/chip-typeahead/Duplicates';
 import FreeTextChipTypeahead from './widgets/chip-typeahead/FreeText';
 import BasicNumberInput from './widgets/number-input/Basic';
 import ValidatedNumberInput from './widgets/number-input/Validation';
+import LeadingTrailingNumberInput from './widgets/number-input/LeadingTrailing';
 import BasicOutlinedButton from './widgets/outlined-button/Basic';
 import OutlinedButtonKinds from './widgets/outlined-button/Kinds';
 import OutlinedDisabledSubmit from './widgets/outlined-button/DisabledSubmit';
@@ -1228,6 +1229,11 @@ export const config = {
 					title: 'Validation',
 					filename: 'Validation',
 					module: ValidatedNumberInput
+				},
+				{
+					filename: 'LeadingTrailing',
+					module: LeadingTrailingNumberInput,
+					title: 'NumberInput with leading and trailing'
 				}
 			]
 		},

--- a/src/examples/src/widgets/number-input/LeadingTrailing.tsx
+++ b/src/examples/src/widgets/number-input/LeadingTrailing.tsx
@@ -1,0 +1,20 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import NumberInput from '@dojo/widgets/number-input';
+import { Addon } from '@dojo/widgets/text-input';
+import Example from '../../Example';
+
+const factory = create();
+
+export default factory(function Basic() {
+	return (
+		<Example>
+			<NumberInput>
+				{{
+					label: 'Number Input',
+					leading: <Addon>$</Addon>,
+					trailing: <Addon filled>MM</Addon>
+				}}
+			</NumberInput>
+		</Example>
+	);
+});


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
This adds a leading/trailing example for the number input widget.

Relates to #1578 which indicated a styling issue with the NumberInput

![Dojo theme number input example](https://user-images.githubusercontent.com/11273838/110189963-e3e6ec80-7dd5-11eb-9b6d-80973de5b2bf.png)
![Material theme number input example](https://user-images.githubusercontent.com/11273838/110189962-e34e5600-7dd5-11eb-9e27-79b5b4b712d1.png)
![Material dark theme number input example](https://user-images.githubusercontent.com/11273838/110189961-e34e5600-7dd5-11eb-8dc7-b0fc9c356512.png)

