### PR TITLE
Add specific css variables to control tab colors

### DIFF
--- a/src/date-input/tests/unit/DateInput.spec.tsx
+++ b/src/date-input/tests/unit/DateInput.spec.tsx
@@ -539,8 +539,6 @@ describe('DateInput', () => {
 
 		input.properties.onBlur();
 
-		console.log('onValidate', onValidate.callsArg);
-
 		h.expect(baseTemplate().setProperty('@input', 'required', true));
 		sinon.assert.calledWith(onValidate, false, messages.requiredDate);
 	});

--- a/src/tab-container/index.tsx
+++ b/src/tab-container/index.tsx
@@ -140,7 +140,10 @@ export const TabContainer = factory(function TabContainer({
 				role="tab"
 				tabIndex={active ? 0 : -1}
 			>
-				<span key="tabButtonContent" classes={themeCss.tabButtonContent}>
+				<span
+					key="tabButtonContent"
+					classes={[themeCss.tabButtonContent, active && themeCss.activeTabButtonLabel]}
+				>
 					{name}
 					{closeable ? (
 						<button

--- a/src/tab-container/tests/TabContainer.spec.tsx
+++ b/src/tab-container/tests/TabContainer.spec.tsx
@@ -89,7 +89,10 @@ registerSuite('TabContainer', {
 				.setProperty('@root', 'aria-describedby', 'foo')
 				.setChildren('@buttons', () => [
 					<div {...tabButtonProperties}>
-						<span key="tabButtonContent" classes={css.tabButtonContent}>
+						<span
+							key="tabButtonContent"
+							classes={[css.tabButtonContent, css.activeTabButtonLabel]}
+						>
 							test
 							<span classes={[css.indicator, css.indicatorActive]}>
 								<span classes={css.indicatorContent} />
@@ -117,7 +120,10 @@ registerSuite('TabContainer', {
 			const orientationTemplate = reverseOrientationTemplate
 				.setChildren('@buttons', () => [
 					<div {...tabButtonProperties}>
-						<span key="tabButtonContent" classes={css.tabButtonContent}>
+						<span
+							key="tabButtonContent"
+							classes={[css.tabButtonContent, css.activeTabButtonLabel]}
+						>
 							test
 							<span classes={[css.indicator, css.indicatorActive]}>
 								<span classes={css.indicatorContent} />
@@ -150,7 +156,10 @@ registerSuite('TabContainer', {
 			const twoChildTemplate = baseTemplate
 				.setChildren('@buttons', () => [
 					<div {...tabButtonProperties}>
-						<span key="tabButtonContent" classes={css.tabButtonContent}>
+						<span
+							key="tabButtonContent"
+							classes={[css.tabButtonContent, css.activeTabButtonLabel]}
+						>
 							tab0
 							<span classes={[css.indicator, css.indicatorActive]}>
 								<span classes={css.indicatorContent} />
@@ -165,7 +174,7 @@ registerSuite('TabContainer', {
 						tabIndex={-1}
 						key="1-tabbutton"
 					>
-						<span key="tabButtonContent" classes={css.tabButtonContent}>
+						<span key="tabButtonContent" classes={[css.tabButtonContent, false]}>
 							tab1
 							<span classes={[css.indicator, false]}>
 								<span classes={css.indicatorContent} />
@@ -205,7 +214,7 @@ registerSuite('TabContainer', {
 						classes={[css.tabButton, null, null, null]}
 						tabIndex={-1}
 					>
-						<span key="tabButtonContent" classes={css.tabButtonContent}>
+						<span key="tabButtonContent" classes={[css.tabButtonContent, false]}>
 							tab0
 							<span classes={[css.indicator, false]}>
 								<span classes={css.indicatorContent} />
@@ -213,7 +222,10 @@ registerSuite('TabContainer', {
 						</span>
 					</div>,
 					<div {...tabButtonProperties} aria-controls="test-tab-1" key="1-tabbutton">
-						<span key="tabButtonContent" classes={css.tabButtonContent}>
+						<span
+							key="tabButtonContent"
+							classes={[css.tabButtonContent, css.activeTabButtonLabel]}
+						>
 							tab1
 							<span classes={[css.indicator, css.indicatorActive]}>
 								<span classes={css.indicatorContent} />
@@ -255,7 +267,10 @@ registerSuite('TabContainer', {
 							{...tabButtonProperties}
 							classes={[css.tabButton, css.activeTabButton, null, null]}
 						>
-							<span key="tabButtonContent" classes={css.tabButtonContent}>
+							<span
+								key="tabButtonContent"
+								classes={[css.tabButtonContent, css.activeTabButtonLabel]}
+							>
 								tab0
 								<span classes={[css.indicator, css.indicatorActive]}>
 									<span classes={css.indicatorContent} />
@@ -270,7 +285,7 @@ registerSuite('TabContainer', {
 							classes={[css.tabButton, null, css.closeable, null]}
 							tabIndex={-1}
 						>
-							<span key="tabButtonContent" classes={css.tabButtonContent}>
+							<span key="tabButtonContent" classes={[css.tabButtonContent, false]}>
 								tab1
 								<button
 									disabled={undefined}
@@ -373,7 +388,10 @@ registerSuite('TabContainer', {
 			const disabledTemplate = baseTemplate
 				.setChildren('@buttons', () => [
 					<div {...tabButtonProperties}>
-						<span key="tabButtonContent" classes={css.tabButtonContent}>
+						<span
+							key="tabButtonContent"
+							classes={[css.tabButtonContent, css.activeTabButtonLabel]}
+						>
 							tab0
 							<span classes={[css.indicator, css.indicatorActive]}>
 								<span classes={css.indicatorContent} />
@@ -389,7 +407,7 @@ registerSuite('TabContainer', {
 						classes={[css.tabButton, null, null, css.disabledTabButton]}
 						tabIndex={-1}
 					>
-						<span key="tabButtonContent" classes={css.tabButtonContent}>
+						<span key="tabButtonContent" classes={[css.tabButtonContent, false]}>
 							tab1
 							<span classes={[css.indicator, false]}>
 								<span classes={css.indicatorContent} />

--- a/src/theme/default/tab-container.m.css
+++ b/src/theme/default/tab-container.m.css
@@ -45,6 +45,10 @@
 .tabButtonContent {
 }
 
+/* Controls the label of a TabButton when active*/
+.activeTabButtonLabel {
+}
+
 /* Added to an active TabButton */
 .activeTabButton {
 	background: #fff;

--- a/src/theme/default/tab-container.m.css.d.ts
+++ b/src/theme/default/tab-container.m.css.d.ts
@@ -5,6 +5,7 @@ export const indicator: string;
 export const indicatorActive: string;
 export const indicatorContent: string;
 export const tabButtonContent: string;
+export const activeTabButtonLabel: string;
 export const activeTabButton: string;
 export const root: string;
 export const tabButton: string;

--- a/src/theme/dojo/tab-container.m.css
+++ b/src/theme/dojo/tab-container.m.css
@@ -11,11 +11,11 @@
 }
 
 .tabButton {
-	border-bottom: var(--border-width) solid var(--color-border);
+	border-bottom: var(--border-width) solid var(--tab-button-disabled-color);
 	border-left: var(--border-width) solid transparent;
 	border-right: var(--border-width) solid transparent;
 	border-top: var(--border-width) solid transparent;
-	color: var(--color-text-faded);
+	color: var(--tab-button-color);
 	cursor: pointer;
 	display: inline-block;
 	flex: 1;
@@ -29,7 +29,7 @@
 	white-space: nowrap;
 	width: var(--tab-width);
 	margin: 0;
-	background-color: var(--color-background);
+	background-color: var(--tab-button-background);
 }
 
 .tabButton:hover:not(.disabledTabButton):not(.activeTabButton) {
@@ -39,17 +39,21 @@
 }
 
 .tabButton:focus:not(.disabledTabButton) {
-	border-color: var(--color-highlight);
+	border-color: var(--tab-button-active-color);
 	box-shadow: var(--box-shadow-dimensions-small) var(--color-box-shadow-highlight);
 }
 
 .activeTabButton {
-	border-bottom-color: var(--color-highlight);
-	color: var(--color-highlight);
+	border-bottom-color: var(--tab-button-active-color);
+	color: var(--tab-button-active-color);
+}
+
+.activeTabButtonLabel {
+	color: var(--tab-button-active-color);
 }
 
 .disabledTabButton {
-	color: var(--color-border);
+	color: var(--tab-button-disabled-color);
 	cursor: default;
 }
 
@@ -72,7 +76,7 @@
 
 .tab {
 	position: relative;
-	background-color: var(--color-background);
+	background-color: var(--tab-content-background);
 }
 
 .alignLeft .tabs {
@@ -89,14 +93,14 @@
 .alignLeft .tabButton {
 	border-bottom: var(--border-width) solid transparent;
 	border-left: var(--border-width) solid transparent;
-	border-right: var(--border-width) solid var(--color-border);
+	border-right: var(--border-width) solid var(--tab-button-disabled-color);
 	border-top: var(--border-width) solid transparent;
 	display: block;
 }
 
 .alignLeft .activeTabButton {
-	border-right-color: var(--color-highlight);
-	color: var(--color-highlight);
+	border-right-color: var(--tab-button-active-color);
+	color: var(--tab-button-active-color);
 }
 
 .alignRight .tabs {
@@ -112,23 +116,23 @@
 
 .alignRight .tabButton {
 	border-bottom: var(--border-width) solid transparent;
-	border-left: var(--border-width) solid var(--color-border);
+	border-left: var(--border-width) solid var(--tab-button-disabled-color);
 	border-right: var(--border-width) solid transparent;
 	border-top: var(--border-width) solid transparent;
 	display: block;
 }
 
 .alignRight .activeTabButton {
-	border-left-color: var(--color-highlight);
-	color: var(--color-highlight);
+	border-left-color: var(--tab-button-active-color);
+	color: var(--tab-button-active-color);
 }
 
 .alignBottom .tabButton {
 	border-bottom-color: transparent;
-	border-top-color: var(--color-border);
+	border-top-color: var(--tab-button-disabled-color);
 }
 
 .alignBottom .activeTabButton {
 	border-bottom-color: transparent;
-	border-top-color: var(--color-highlight);
+	border-top-color: var(--tab-button-active-color);
 }

--- a/src/theme/dojo/tab-container.m.css.d.ts
+++ b/src/theme/dojo/tab-container.m.css.d.ts
@@ -3,6 +3,7 @@ export const tabButtons: string;
 export const tabButton: string;
 export const disabledTabButton: string;
 export const activeTabButton: string;
+export const activeTabButtonLabel: string;
 export const close: string;
 export const closeable: string;
 export const tab: string;

--- a/src/theme/dojo/variants/dark.m.css
+++ b/src/theme/dojo/variants/dark.m.css
@@ -64,4 +64,10 @@
 	--avatar-size-large: 56px;
 
 	--tab-width: calc(var(--grid-base) * 16);
+	--tab-background: var(--color-background);
+	--tab-content-background: var(--tab-background);
+	--tab-button-background: var(--tab-background);
+	--tab-button-color: var(--color-text-faded);
+	--tab-button-active-color: var(--color-highlight);
+	--tab-button-disabled-color: var(--color-border);
 }

--- a/src/theme/dojo/variants/default.m.css
+++ b/src/theme/dojo/variants/default.m.css
@@ -69,6 +69,12 @@
 	--divider-width: 9px;
 
 	--tab-width: calc(var(--grid-base) * 16);
+	--tab-background: var(--color-background);
+	--tab-content-background: var(--tab-background);
+	--tab-button-background: var(--tab-background);
+	--tab-button-color: var(--color-text-faded);
+	--tab-button-active-color: var(--color-highlight);
+	--tab-button-disabled-color: var(--color-border);
 
 	--color-primary: #ffffff;
 	--color-secondary: rgb(199, 222, 209);

--- a/src/theme/material/tab-container.m.css
+++ b/src/theme/material/tab-container.m.css
@@ -10,7 +10,7 @@
 }
 
 .tabButton:not(.activeTabButton) .tabButtonContent {
-	color: var(--mdc-secondary-text-color);
+	color: var(--mdc-tab-button-text-color);
 }
 
 .tabButtonContent {
@@ -21,12 +21,16 @@
 	composes: mdc-tab--active from '@material/tab/dist/mdc.tab.css';
 }
 
+.root .activeTabButtonLabel {
+	color: var(--mdc-tab-button-active-text-color);
+}
+
 .root .disabledTabButton {
 	cursor: default;
 }
 
 .root .disabledTabButton .tabButtonContent {
-	color: var(--mdc-disabled-text-color);
+	color: var(--mdc-tab-button-disabled-text-color);
 }
 
 .close {
@@ -55,10 +59,11 @@
 
 /* TABS */
 .root {
-	background-color: var(--mdc-tab-background);
+	background-color: var(--mdc-tab-button-background);
 }
 
 .root .tab {
+	background-color: var(--mdc-tab-content-background);
 	color: var(--mdc-text-color);
 }
 

--- a/src/theme/material/tab-container.m.css
+++ b/src/theme/material/tab-container.m.css
@@ -57,6 +57,10 @@
 	composes: mdc-tab-indicator__content mdc-tab-indicator__content--underline from '@material/tab-indicator/dist/mdc.tab-indicator.css';
 }
 
+.root .indicatorContent {
+	border-color: var(--mdc-tab-button-active-text-color);
+}
+
 /* TABS */
 .root {
 	background-color: var(--mdc-tab-button-background);

--- a/src/theme/material/tab-container.m.css.d.ts
+++ b/src/theme/material/tab-container.m.css.d.ts
@@ -3,6 +3,7 @@ export const tabButton: string;
 export const activeTabButton: string;
 export const tabButtonContent: string;
 export const root: string;
+export const activeTabButtonLabel: string;
 export const disabledTabButton: string;
 export const close: string;
 export const indicator: string;

--- a/src/theme/material/variants/dark.m.css
+++ b/src/theme/material/variants/dark.m.css
@@ -81,6 +81,12 @@
 	--mdc-disabled-color: var(--mdc-theme-text-hint-on-dark);
 
 	--mdc-tab-background: var(--mdc-raised-surface-background);
+	--mdc-tab-content-background: var(--mdc-tab-background);
+	--mdc-tab-button-background: var(--mdc-tab-background);
+	--mdc-tab-button-text-color: var(--mdc-secondary-text-color);
+	--mdc-tab-button-active-text-color: var(--mdc-theme-primary);
+	--mdc-tab-button-disabled-text-color: var(--mdc-disabled-text-color);
+
 	--mdc-tooltip-background: #6d6d6d;
 	--mdc-chip-background: #6d6d6d;
 	--mdc-chip-color: var(--mdc-text-color);

--- a/src/theme/material/variants/default.m.css
+++ b/src/theme/material/variants/default.m.css
@@ -90,6 +90,12 @@
 	--mdc-disabled-color: #bbb;
 
 	--mdc-tab-background: var(--mdc-theme-surface);
+	--mdc-tab-content-background: var(--mdc-tab-background);
+	--mdc-tab-button-background: var(--mdc-tab-background);
+	--mdc-tab-button-text-color: var(--mdc-secondary-text-color);
+	--mdc-tab-button-active-text-color: var(--mdc-theme-primary);
+	--mdc-tab-button-disabled-text-color: var(--mdc-disabled-text-color);
+
 	--mdc-tooltip-background: #6d6d6d;
 	--mdc-chip-background: var(--mdc-theme-on-surface);
 	--mdc-chip-color: var(--mdc-text-color);


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Adds more specific CSS variables that allow control of tab colours and backgrounds, defaulting to the current CSS variables used.