### PR TITLE
Set trigger input to full width

### DIFF
--- a/src/examples/src/widgets/form/KitchenSinkForm.tsx
+++ b/src/examples/src/widgets/form/KitchenSinkForm.tsx
@@ -3,6 +3,8 @@ import { create, tsx } from '@dojo/framework/core/vdom';
 import Button from '@dojo/widgets/button';
 import Form, { FormField, FormGroup } from '@dojo/widgets/form';
 import TextInput from '@dojo/widgets/text-input';
+import TimePicker from '@dojo/widgets/time-picker';
+import DateInput from '@dojo/widgets/date-input';
 
 import Example from '../../Example';
 
@@ -107,6 +109,27 @@ const App = factory(function({ middleware: { icache } }) {
 									>
 										{{ label: 'Email' }}
 									</TextInput>
+								</FormField>
+							</FormGroup>
+							<FormGroup>
+								<FormField>
+									<DateInput />
+								</FormField>
+							</FormGroup>
+							<FormGroup>
+								<FormField>
+									<TimePicker />
+								</FormField>
+							</FormGroup>
+							<FormGroup>
+								<FormField>
+									<DateInput />
+								</FormField>
+								<FormField>
+									<TimePicker />
+								</FormField>
+								<FormField>
+									<TimePicker />
 								</FormField>
 							</FormGroup>
 							<Button

--- a/src/theme/dojo/time-picker.m.css
+++ b/src/theme/dojo/time-picker.m.css
@@ -2,6 +2,7 @@
 }
 
 .input {
+	width: 100%;
 }
 
 .toggleMenuButton {

--- a/src/trigger-popup/trigger-popup.m.css
+++ b/src/trigger-popup/trigger-popup.m.css
@@ -2,5 +2,6 @@
 }
 
 .trigger {
+	width: 100%;
 	display: inline-block;
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Set the trigger to full width, it will be controlled by the content.

Resolves #1579