### PR TITLE
Auto complete off by default for inputs

### DIFF
--- a/src/text-input/index.tsx
+++ b/src/text-input/index.tsx
@@ -138,7 +138,7 @@ export const TextInput = factory(function TextInput({
 
 	const {
 		aria = {},
-		autocomplete,
+		autocomplete = false,
 		classes,
 		customValidator,
 		disabled,

--- a/src/text-input/tests/unit/TextInput.spec.tsx
+++ b/src/text-input/tests/unit/TextInput.spec.tsx
@@ -84,7 +84,7 @@ const expected = function({
 				>
 					<input
 						aria-invalid={valid === false ? 'true' : undefined}
-						autocomplete={undefined}
+						autocomplete="off"
 						classes={css.input}
 						disabled={disabled}
 						id={''}
@@ -189,7 +189,7 @@ const input = () => (
 			id=""
 			disabled={undefined}
 			aria-invalid={undefined}
-			autocomplete={undefined}
+			autocomplete="off"
 			maxlength={null}
 			minlength={null}
 			name={undefined}


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Auto complete off by default for inputs

