### PR TITLE
Allow the slidepane title to be a render result

### DIFF
--- a/src/examples/src/widgets/slide-pane/Basic.tsx
+++ b/src/examples/src/widgets/slide-pane/Basic.tsx
@@ -10,13 +10,12 @@ export default factory(function Basic({ middleware: { icache } }) {
 	return (
 		<Example>
 			<SlidePane
-				title="Basic SlidePane"
 				open={icache.getOrSet('open', true)}
 				onRequestClose={() => {
 					icache.set('open', false);
 				}}
 			>
-				{DEMO_TEXT}
+				{{ content: DEMO_TEXT, title: 'Basic SlidePane' }}
 			</SlidePane>
 			<button onclick={() => icache.set('open', !icache.get('open'))}>Toggle</button>
 		</Example>

--- a/src/examples/src/widgets/slide-pane/BottomAlignSlidePane.tsx
+++ b/src/examples/src/widgets/slide-pane/BottomAlignSlidePane.tsx
@@ -10,14 +10,13 @@ export default factory(function BottomWidthSlidePane({ middleware: { icache } })
 	return (
 		<Example>
 			<SlidePane
-				title="Bottom Aligned SlidePane"
 				open={icache.getOrSet('open', true)}
 				align="bottom"
 				onRequestClose={() => {
 					icache.set('open', false);
 				}}
 			>
-				{DEMO_TEXT}
+				{{ content: DEMO_TEXT, title: 'Bottom Aligned SlidePane' }}
 			</SlidePane>
 		</Example>
 	);

--- a/src/examples/src/widgets/slide-pane/FixedWidthSlidePane.tsx
+++ b/src/examples/src/widgets/slide-pane/FixedWidthSlidePane.tsx
@@ -10,7 +10,6 @@ export default factory(function FixedWidthSlidePane({ middleware: { icache } }) 
 	return (
 		<Example>
 			<SlidePane
-				title="Fixed Width"
 				open={icache.getOrSet('open', true)}
 				width={250}
 				align="right"
@@ -18,7 +17,7 @@ export default factory(function FixedWidthSlidePane({ middleware: { icache } }) 
 					icache.set('open', false);
 				}}
 			>
-				{DEMO_TEXT}
+				{{ content: DEMO_TEXT, title: 'Fixed Width' }}
 			</SlidePane>
 		</Example>
 	);

--- a/src/examples/src/widgets/slide-pane/LeftAlignSlidePane.tsx
+++ b/src/examples/src/widgets/slide-pane/LeftAlignSlidePane.tsx
@@ -10,7 +10,6 @@ export default factory(function LeftAlignSlidePane({ middleware: { icache } }) {
 	return (
 		<Example>
 			<SlidePane
-				title="Left Aligned SlidePane"
 				open={icache.getOrSet('open', true)}
 				underlay={false}
 				align="left"
@@ -19,7 +18,7 @@ export default factory(function LeftAlignSlidePane({ middleware: { icache } }) {
 					icache.set('open', false);
 				}}
 			>
-				{DEMO_TEXT}
+				{{ content: DEMO_TEXT, title: 'Left Aligned SlidePane' }}
 			</SlidePane>
 		</Example>
 	);

--- a/src/examples/src/widgets/slide-pane/RightAlignSlidePane.tsx
+++ b/src/examples/src/widgets/slide-pane/RightAlignSlidePane.tsx
@@ -10,7 +10,6 @@ export default factory(function RightAlignSlidePane({ middleware: { icache } }) 
 	return (
 		<Example>
 			<SlidePane
-				title="Right Aligned SlidePane"
 				open={icache.getOrSet('open', true)}
 				underlay={false}
 				align="right"
@@ -18,7 +17,7 @@ export default factory(function RightAlignSlidePane({ middleware: { icache } }) 
 					icache.set('open', false);
 				}}
 			>
-				{DEMO_TEXT}
+				{{ content: DEMO_TEXT, title: 'Right Aligned SlidePane' }}
 			</SlidePane>
 		</Example>
 	);

--- a/src/examples/src/widgets/slide-pane/UnderlaySlidePane.tsx
+++ b/src/examples/src/widgets/slide-pane/UnderlaySlidePane.tsx
@@ -10,7 +10,6 @@ export default factory(function UnderlaySlidePane({ middleware: { icache } }) {
 	return (
 		<Example>
 			<SlidePane
-				title="Underlay SlidePane"
 				open={icache.getOrSet('open', true)}
 				underlay={true}
 				align="right"
@@ -18,7 +17,7 @@ export default factory(function UnderlaySlidePane({ middleware: { icache } }) {
 					icache.set('open', false);
 				}}
 			>
-				{DEMO_TEXT}
+				{{ content: DEMO_TEXT, title: 'Underlay SlidePane' }}
 			</SlidePane>
 		</Example>
 	);

--- a/src/slide-pane/index.tsx
+++ b/src/slide-pane/index.tsx
@@ -63,7 +63,9 @@ export interface SlidePaneICache {
 }
 
 export interface SlidePaneChildren {
+	/** The title of the slide pane */
 	title?: RenderResult;
+	/** The slide pane content */
 	content?: RenderResult;
 }
 

--- a/src/slide-pane/index.tsx
+++ b/src/slide-pane/index.tsx
@@ -1,5 +1,6 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
+import { RenderResult } from '@dojo/framework/core/interfaces';
 import theme from '../middleware/theme';
 import i18n from '@dojo/framework/core/middleware/i18n';
 import bundle from './nls/SlidePane';
@@ -28,10 +29,10 @@ export interface SlidePaneProperties {
 
 	/** Determines whether the pane is open or closed */
 	open?: boolean;
-	/** Title to display in the pane */
-	title?: string;
+
 	/** Determines whether a semi-transparent background shows behind the pane */
 	underlay?: boolean;
+
 	/** Width of the pane in pixels */
 	width?: number;
 }
@@ -61,11 +62,18 @@ export interface SlidePaneICache {
 	open: boolean;
 }
 
+export interface SlidePaneChildren {
+	title?: RenderResult;
+	content?: RenderResult;
+}
+
 const factory = create({
 	icache: createICacheMiddleware<SlidePaneICache>(),
 	theme,
 	i18n
-}).properties<SlidePaneProperties>();
+})
+	.properties<SlidePaneProperties>()
+	.children<SlidePaneChildren | undefined>();
 
 export const SlidePane = factory(function SlidePane({
 	middleware: { icache, theme, i18n },
@@ -76,7 +84,6 @@ export const SlidePane = factory(function SlidePane({
 		aria = {},
 		closeText,
 		open = false,
-		title = '',
 		align = 'left',
 		width = DEFAULT_WIDTH,
 		underlay = false,
@@ -85,7 +92,8 @@ export const SlidePane = factory(function SlidePane({
 		classes
 	} = properties();
 	const themeCss = theme.classes(css);
-
+	const [slidePaneChildren = {}] = children();
+	const { title, content } = slidePaneChildren;
 	if (icache.get('open') !== open) {
 		const wasOpen = icache.get('open');
 		icache.set('open', open);
@@ -271,7 +279,7 @@ export const SlidePane = factory(function SlidePane({
 						</button>
 					</div>
 				) : null}
-				<div classes={[themeCss.content, fixedCss.contentFixed]}>{children()}</div>
+				<div classes={[themeCss.content, fixedCss.contentFixed]}>{content}</div>
 			</div>
 		</div>
 	);

--- a/src/slide-pane/tests/unit/SlidePane.spec.tsx
+++ b/src/slide-pane/tests/unit/SlidePane.spec.tsx
@@ -90,7 +90,7 @@ registerSuite('SlidePane', {
 		'Should construct SlidePane with passed properties'() {
 			const h = harness(() => (
 				<SlidePane key="foo" align="left" aria={{ describedBy: 'foo' }} open underlay>
-					{GREEKING}
+					{{ content: GREEKING }}
 				</SlidePane>
 			));
 
@@ -273,14 +273,17 @@ registerSuite('SlidePane', {
 			let called = false;
 
 			const h = harness(() =>
-				w(SlidePane, {
-					open: true,
-					title: 'foo',
-					closeText: 'close',
-					onRequestClose() {
-						called = true;
-					}
-				})
+				w(
+					SlidePane,
+					{
+						open: true,
+						closeText: 'close',
+						onRequestClose() {
+							called = true;
+						}
+					},
+					[{ title: 'foo' }]
+				)
 			);
 
 			h.trigger(`.${css.close}`, 'onclick', stubEvent);
@@ -518,7 +521,7 @@ registerSuite('SlidePane', {
 			};
 			properties.onRequestClose = () => (properties.open = false);
 
-			const h = harness(() => <SlidePane {...properties}>{GREEKING}</SlidePane>);
+			const h = harness(() => <SlidePane {...properties}>{{ content: GREEKING }}</SlidePane>);
 
 			h.expect(
 				openTemplate.setProperty('@content', 'classes', [
@@ -565,7 +568,7 @@ registerSuite('SlidePane', {
 			};
 			properties.onRequestClose = () => (properties.open = false);
 
-			const h = harness(() => <SlidePane {...properties}>{GREEKING}</SlidePane>);
+			const h = harness(() => <SlidePane {...properties}>{{ content: GREEKING }}</SlidePane>);
 			h.expect(
 				openTemplateRight.setProperty('@content', 'classes', [
 					css.pane,


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Changes the title for the slidepane to be a child over a property so that a render result can be used.