### PR TITLE
Offer option to fill the available height with items when using the list

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -102,6 +102,7 @@ import InvalidLabel from './widgets/label/InvalidLabel';
 import DisabledLabel from './widgets/label/DisabledLabel';
 import SecondaryLabel from './widgets/label/SecondaryLabel';
 import BasicList from './widgets/list/Basic';
+import FillList from './widgets/list/Fill';
 import DividedList from './widgets/list/Dividers';
 import ControlledList from './widgets/list/Controlled';
 import ItemRenderer from './widgets/list/ItemRenderer';
@@ -1112,6 +1113,13 @@ export const config = {
 					filename: 'Draggable',
 					module: DraggableList,
 					title: 'Draggable'
+				},
+				{
+					description:
+						'This example shows how the list can fill available space when the container has a height',
+					filename: 'Fill',
+					module: FillList,
+					title: 'Fill'
 				}
 			],
 			overview: {

--- a/src/examples/src/widgets/list/Fill.tsx
+++ b/src/examples/src/widgets/list/Fill.tsx
@@ -1,0 +1,34 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import List, { ListItem } from '@dojo/widgets/list';
+import icache from '@dojo/framework/core/middleware/icache';
+import Example from '../../Example';
+import { listOptionTemplate } from '../../template';
+
+const factory = create({ icache });
+
+export default factory(function Basic({ middleware: { icache } }) {
+	return (
+		<Example>
+			<virtual>
+				<div styles={{ height: '250px' }}>
+					<List
+						itemsInView="fill"
+						resource={{ template: listOptionTemplate }}
+						onValue={(value) => {
+							icache.set('value', value);
+						}}
+					>
+						{({ label, selected }, props) => {
+							return (
+								<ListItem {...props} selected={selected}>
+									<h1>{label}</h1>
+								</ListItem>
+							);
+						}}
+					</List>
+				</div>
+				<p>{`Clicked on: ${JSON.stringify(icache.getOrSet('value', ''))}`}</p>
+			</virtual>
+		</Example>
+	);
+});

--- a/src/list/tests/List.spec.tsx
+++ b/src/list/tests/List.spec.tsx
@@ -643,10 +643,239 @@ describe('List', () => {
 			]);
 
 		const factory = create();
+		let height = 0;
+		let width = 0;
 		const mockDimensions = factory(() => {
 			return {
 				get() {
-					return { size: { height: 90 } };
+					return { size: { height, width } };
+				}
+			};
+		});
+		const r = renderer(
+			() => (
+				<List
+					itemsInView="fill"
+					resource={{ data, id: 'test', idKey: 'value' }}
+					onValue={onValueStub}
+				/>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry], [dimensions, mockDimensions]] }
+		);
+		r.expect(assertion(() => <div key="fill-root" styles={{ height: '100%' }} />));
+		height = 90;
+		r.expect(listWithListItemsAssertion);
+	});
+
+	it('should fall back to default number of items for "fill" when no height can be determined', () => {
+		const data = [
+			{
+				value: '1',
+				label: 'Dog'
+			},
+			{
+				value: '2',
+				label: 'Cat'
+			},
+			{
+				value: '3',
+				label: 'Fish',
+				disabled: true
+			},
+			{
+				value: '4',
+				label: 'Dog'
+			},
+			{
+				value: '5',
+				label: 'Cat'
+			},
+			{
+				value: '6',
+				label: 'Fish',
+				disabled: true
+			},
+			{
+				value: '7',
+				label: 'Dog'
+			}
+		];
+		const listWithListItemsAssertion = baseAssertion
+			.setProperty(WrappedRoot, 'styles', {
+				height: '450px'
+			})
+			.setProperty(WrappedItemWrapper, 'styles', {
+				height: '315px'
+			})
+			.replaceChildren(WrappedItemContainer, () => [
+				<ListItem
+					classes={undefined}
+					variant={undefined}
+					active={true}
+					disabled={false}
+					key={'item-0'}
+					onRequestActive={noop}
+					onSelect={noop}
+					selected={false}
+					theme={listItemTheme}
+					widgetId={'menu-test-item-0'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
+				>
+					Dog
+				</ListItem>,
+				<ListItem
+					classes={undefined}
+					variant={undefined}
+					active={false}
+					disabled={false}
+					key={'item-1'}
+					onRequestActive={noop}
+					onSelect={noop}
+					selected={false}
+					theme={listItemTheme}
+					widgetId={'menu-test-item-1'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
+				>
+					Cat
+				</ListItem>,
+				<ListItem
+					classes={undefined}
+					variant={undefined}
+					active={false}
+					disabled={true}
+					key={'item-2'}
+					onRequestActive={noop}
+					onSelect={noop}
+					selected={false}
+					theme={listItemTheme}
+					widgetId={'menu-test-item-2'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
+				>
+					Fish
+				</ListItem>,
+				<ListItem
+					classes={undefined}
+					variant={undefined}
+					active={false}
+					disabled={false}
+					key={'item-3'}
+					onRequestActive={noop}
+					onSelect={noop}
+					selected={false}
+					theme={listItemTheme}
+					widgetId={'menu-test-item-3'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
+				>
+					Dog
+				</ListItem>,
+				<ListItem
+					classes={undefined}
+					variant={undefined}
+					active={false}
+					disabled={false}
+					key={'item-4'}
+					onRequestActive={noop}
+					onSelect={noop}
+					selected={false}
+					theme={listItemTheme}
+					widgetId={'menu-test-item-4'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
+				>
+					Cat
+				</ListItem>,
+				<ListItem
+					classes={undefined}
+					variant={undefined}
+					active={false}
+					disabled={true}
+					key={'item-5'}
+					onRequestActive={noop}
+					onSelect={noop}
+					selected={false}
+					theme={listItemTheme}
+					widgetId={'menu-test-item-5'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
+				>
+					Fish
+				</ListItem>,
+				<ListItem
+					classes={undefined}
+					variant={undefined}
+					active={false}
+					disabled={false}
+					key={'item-6'}
+					onRequestActive={noop}
+					onSelect={noop}
+					selected={false}
+					theme={listItemTheme}
+					widgetId={'menu-test-item-6'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
+				>
+					Dog
+				</ListItem>
+			]);
+
+		const factory = create();
+		const mockDimensions = factory(() => {
+			return {
+				get() {
+					return { size: { width: 90 } };
 				}
 			};
 		});

--- a/src/list/tests/List.spec.tsx
+++ b/src/list/tests/List.spec.tsx
@@ -15,6 +15,7 @@ import * as menuItemCss from '../../theme/default/menu-item.m.css';
 import Registry from '@dojo/framework/core/Registry';
 import RegistryHandler from '@dojo/framework/core/RegistryHandler';
 import { createResourceTemplate } from '@dojo/framework/core/middleware/resources';
+import dimensions from '@dojo/framework/core/middleware/dimensions';
 
 const mockGetRegistry = create()(function() {
 	const registry = new Registry();
@@ -436,6 +437,230 @@ describe('List', () => {
 				maxHeight: '450px'
 			})
 		);
+	});
+
+	it('should render list showing the number of items to fit height', () => {
+		const data = [
+			{
+				value: '1',
+				label: 'Dog'
+			},
+			{
+				value: '2',
+				label: 'Cat'
+			},
+			{
+				value: '3',
+				label: 'Fish',
+				disabled: true
+			},
+			{
+				value: '4',
+				label: 'Dog'
+			},
+			{
+				value: '5',
+				label: 'Cat'
+			},
+			{
+				value: '6',
+				label: 'Fish',
+				disabled: true
+			},
+			{
+				value: '7',
+				label: 'Dog'
+			},
+			{
+				value: '8',
+				label: 'Cat'
+			},
+			{
+				value: '9',
+				label: 'Fish',
+				disabled: true
+			},
+			{
+				value: '10',
+				label: 'Dog'
+			},
+			{
+				value: '11',
+				label: 'Cat'
+			},
+			{
+				value: '12',
+				label: 'Fish',
+				disabled: true
+			}
+		];
+		const listWithListItemsAssertion = baseAssertion
+			.setProperty(WrappedRoot, 'styles', {
+				height: '90px'
+			})
+			.setProperty(WrappedItemWrapper, 'styles', {
+				height: '540px'
+			})
+			.replaceChildren(WrappedItemContainer, () => [
+				<ListItem
+					classes={undefined}
+					variant={undefined}
+					active={true}
+					disabled={false}
+					key={'item-0'}
+					onRequestActive={noop}
+					onSelect={noop}
+					selected={false}
+					theme={listItemTheme}
+					widgetId={'menu-test-item-0'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
+				>
+					Dog
+				</ListItem>,
+				<ListItem
+					classes={undefined}
+					variant={undefined}
+					active={false}
+					disabled={false}
+					key={'item-1'}
+					onRequestActive={noop}
+					onSelect={noop}
+					selected={false}
+					theme={listItemTheme}
+					widgetId={'menu-test-item-1'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
+				>
+					Cat
+				</ListItem>,
+				<ListItem
+					classes={undefined}
+					variant={undefined}
+					active={false}
+					disabled={true}
+					key={'item-2'}
+					onRequestActive={noop}
+					onSelect={noop}
+					selected={false}
+					theme={listItemTheme}
+					widgetId={'menu-test-item-2'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
+				>
+					Fish
+				</ListItem>,
+				<ListItem
+					classes={undefined}
+					variant={undefined}
+					active={false}
+					disabled={false}
+					key={'item-3'}
+					onRequestActive={noop}
+					onSelect={noop}
+					selected={false}
+					theme={listItemTheme}
+					widgetId={'menu-test-item-3'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
+				>
+					Dog
+				</ListItem>,
+				<ListItem
+					classes={undefined}
+					variant={undefined}
+					active={false}
+					disabled={false}
+					key={'item-4'}
+					onRequestActive={noop}
+					onSelect={noop}
+					selected={false}
+					theme={listItemTheme}
+					widgetId={'menu-test-item-4'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
+				>
+					Cat
+				</ListItem>,
+				<ListItem
+					classes={undefined}
+					variant={undefined}
+					active={false}
+					disabled={true}
+					key={'item-5'}
+					onRequestActive={noop}
+					onSelect={noop}
+					selected={false}
+					theme={listItemTheme}
+					widgetId={'menu-test-item-5'}
+					collapsed={false}
+					draggable={undefined}
+					dragged={false}
+					movedDown={false}
+					movedUp={false}
+					onDragEnd={noop}
+					onDragOver={noop}
+					onDragStart={noop}
+					onDrop={noop}
+				>
+					Fish
+				</ListItem>
+			]);
+
+		const factory = create();
+		const mockDimensions = factory(() => {
+			return {
+				get() {
+					return { size: { height: 90 } };
+				}
+			};
+		});
+		const r = renderer(
+			() => (
+				<List
+					itemsInView="fill"
+					resource={{ data, id: 'test', idKey: 'value' }}
+					onValue={onValueStub}
+				/>
+			),
+			{ middleware: [[getRegistry, mockGetRegistry], [dimensions, mockDimensions]] }
+		);
+		r.expect(listWithListItemsAssertion);
 	});
 
 	it('should render list with menu items data', () => {


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

If would be nice if the list could offer a mode that would fill the available space (height) with as many items that fit, instead of having to provide a number of items to render. The is issue is, that the list itself does the list item height calculation so as a user we'd have to duplicate that to calculated how many items could be visible in the space.

The other option would be to pass a "height" property that gives the list the height and then uses that to determine how many items should be in view.
