### PR TITLE
[WIP] Offer option to set the card to full height

### DIFF
--- a/src/card/index.tsx
+++ b/src/card/index.tsx
@@ -11,6 +11,7 @@ export interface CardProperties {
 	title?: string;
 	subtitle?: string;
 	outlined?: boolean;
+	stretch?: boolean;
 }
 
 export interface CardChildren {
@@ -33,12 +34,21 @@ export const Card = factory(function Card({ children, properties, middleware: { 
 		square,
 		title,
 		subtitle,
-		outlined = false
+		outlined = false,
+		stretch = false
 	} = properties();
 	const { header, content, actionButtons, actionIcons } = children()[0] || ({} as CardChildren);
 
 	return (
-		<div key="root" classes={[theme.variant(), themeCss.root, outlined && themeCss.outlined]}>
+		<div
+			key="root"
+			classes={[
+				theme.variant(),
+				themeCss.root,
+				outlined && themeCss.outlined,
+				stretch && themeCss.stretch
+			]}
+		>
 			{header && (
 				<div key="header" classes={themeCss.header}>
 					{header}
@@ -46,7 +56,11 @@ export const Card = factory(function Card({ children, properties, middleware: { 
 			)}
 			<div
 				key="content"
-				classes={[themeCss.content, onAction ? themeCss.primary : null]}
+				classes={[
+					themeCss.content,
+					onAction ? themeCss.primary : null,
+					stretch && themeCss.stretch
+				]}
 				onClick={() => onAction && onAction()}
 			>
 				{mediaSrc && (
@@ -67,7 +81,11 @@ export const Card = factory(function Card({ children, properties, middleware: { 
 						{subtitle && <h3 classes={themeCss.subtitle}>{subtitle}</h3>}
 					</div>
 				)}
-				{content && <div classes={themeCss.contentWrapper}>{content}</div>}
+				{content && (
+					<div classes={[themeCss.contentWrapper, stretch && themeCss.stretch]}>
+						{content}
+					</div>
+				)}
 			</div>
 			{(actionButtons || actionIcons) && (
 				<div key="actions" classes={themeCss.actions}>

--- a/src/card/tests/unit/Card.spec.tsx
+++ b/src/card/tests/unit/Card.spec.tsx
@@ -14,8 +14,8 @@ const Root = wrap('div');
 const Content = wrap('div');
 
 const template = assertion(() => (
-	<Root key="root" classes={[undefined, css.root, false]}>
-		<Content key="content" classes={[css.content, null]} onClick={noop} />
+	<Root key="root" classes={[undefined, css.root, false, false]}>
+		<Content key="content" classes={[css.content, null, false]} onClick={noop} />
 	</Root>
 ));
 
@@ -30,16 +30,21 @@ describe('Card', () => {
 		const outlinedTemplate = template.setProperty(Root, 'classes', [
 			undefined,
 			css.root,
-			css.outlined
+			css.outlined,
+			false
 		]);
 		r.expect(outlinedTemplate);
 	});
 
-	describe('action', () => {
+	it('action', () => {
 		const onAction = spy();
 		const r = renderer(() => <Card onAction={onAction} />);
 
-		const actionTemplate = template.setProperty(Content, 'classes', [css.content, css.primary]);
+		const actionTemplate = template.setProperty(Content, 'classes', [
+			css.content,
+			css.primary,
+			false
+		]);
 
 		r.expect(actionTemplate);
 		r.property(Content, 'onClick');
@@ -78,7 +83,7 @@ describe('Card', () => {
 			));
 
 			const contentTemplate = template.setChildren(Content, () => [
-				<div classes={css.contentWrapper}>Hello, World</div>
+				<div classes={[css.contentWrapper, false]}>Hello, World</div>
 			]);
 			r.expect(contentTemplate);
 		});
@@ -107,7 +112,7 @@ describe('Card', () => {
 					{<h2 classes={css.title}>Hello, World</h2>}
 					<h3 classes={css.subtitle}>this is a test</h3>
 				</div>,
-				<div classes={css.contentWrapper}>test</div>
+				<div classes={[css.contentWrapper, false]}>test</div>
 			]);
 			r.expect(contentTemplate);
 		});
@@ -237,7 +242,7 @@ describe('Card', () => {
 						{<h2 classes={css.title}>Hello, World</h2>}
 						<h3 classes={css.subtitle}>this is a test</h3>
 					</div>,
-					<div classes={css.contentWrapper}>Content</div>
+					<div classes={[css.contentWrapper, false]}>Content</div>
 				])
 				.append(Root, () => [
 					<div key="actions" classes={css.actions}>

--- a/src/theme/default/card.m.css
+++ b/src/theme/default/card.m.css
@@ -9,6 +9,9 @@
 	align-items: center;
 }
 
+.stretch {
+}
+
 /* May be added to action buttons supplied by the actionsRenderer */
 .actionButtons {
 }

--- a/src/theme/default/card.m.css.d.ts
+++ b/src/theme/default/card.m.css.d.ts
@@ -14,3 +14,4 @@ export const title: string;
 export const subtitle: string;
 export const outlined: string;
 export const textWrapper: string;
+export const stretch: string;

--- a/src/theme/material/card.m.css
+++ b/src/theme/material/card.m.css
@@ -4,6 +4,10 @@
 	color: var(--mdc-text-color);
 }
 
+.stretch {
+	height: 100%;
+}
+
 .actions {
 	composes: mdc-card__action from '@material/card/dist/mdc.card.css';
 	padding: 1rem;

--- a/src/theme/material/card.m.css.d.ts
+++ b/src/theme/material/card.m.css.d.ts
@@ -1,4 +1,5 @@
 export const root: string;
+export const stretch: string;
 export const actions: string;
 export const actionButtons: string;
 export const actionIcons: string;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

There are occasions that you might want the card to stretch to the full height (i.e. 100%), passing `stretch` would enable that.