### PR TITLE
Make dialog close icons square

### DIFF
--- a/src/theme/dojo/dialog.m.css
+++ b/src/theme/dojo/dialog.m.css
@@ -57,6 +57,7 @@
 }
 
 .close .closeIcon {
+	display: flex;
 	font-size: var(--font-size-title);
 }
 

--- a/src/theme/material/dialog.m.css
+++ b/src/theme/material/dialog.m.css
@@ -54,6 +54,7 @@
 }
 
 .closeIcon {
+	display: flex;
 	font-size: 1.25rem;
 	color: var(--mdc-secondary-text-color);
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #1575

<img width="526" alt="dialog close button material size" src="https://user-images.githubusercontent.com/11273838/110404118-25280800-8033-11eb-972e-67389c4298fc.png">
<img width="526" alt="dialog close button dojo size" src="https://user-images.githubusercontent.com/11273838/110404122-26593500-8033-11eb-8e52-5d37f945afef.png">

