### PR TITLE
fix material card header margin

### DIFF
--- a/src/theme/material/card.m.css
+++ b/src/theme/material/card.m.css
@@ -90,7 +90,13 @@
 
 .title {
 	composes: mdc-typography mdc-typography--headline6 from '@material/typography/dist/mdc.typography.css';
-	margin: 0;
+	margin-bottom: 0;
+}
+
+/* If the title isn't the first element it shouldn't have a margin */
+.content:not(:first-child) .title,
+.titleWrapper:not(:first-child) .title {
+	margin-top: 0;
 }
 
 .subtitle {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Allows material card title margin styles if it is the first element. To do so we need to check that there isn't a media element or header before the title.

Resolves #1588

![material card title example](https://user-images.githubusercontent.com/11273838/110560832-7ef40500-80fb-11eb-8590-eafc5b76aeb0.png)
![material card media and title example](https://user-images.githubusercontent.com/11273838/110560834-80bdc880-80fb-11eb-9336-0c933004a804.png)

