### PR TITLE
feat: easier FloatingActionButton theming

### DIFF
--- a/src/theme/dojo/floating-action-button.m.css
+++ b/src/theme/dojo/floating-action-button.m.css
@@ -7,6 +7,7 @@
 	justify-content: center;
 	box-sizing: border-box;
 	padding: 0;
+	background-color: var(--fab-background);
 }
 
 .root:not(.extended) {
@@ -21,7 +22,7 @@
 }
 
 .root:not(.pressed) {
-	color: inherit;
+	color: var(--fab-color);
 }
 
 .pressed {

--- a/src/theme/dojo/variants/default.m.css
+++ b/src/theme/dojo/variants/default.m.css
@@ -76,6 +76,9 @@
 	--tab-button-active-color: var(--color-highlight);
 	--tab-button-disabled-color: var(--color-border);
 
+	--fab-background: var(--color-background);
+	--fab-color: inherit;
+
 	--color-primary: #ffffff;
 	--color-secondary: rgb(199, 222, 209);
 }

--- a/src/theme/material/floating-action-button.m.css
+++ b/src/theme/material/floating-action-button.m.css
@@ -1,5 +1,7 @@
 .root {
 	composes: mdc-fab from '@material/fab/dist/mdc.fab.css';
+	background-color: var(--mdc-fab-background);
+	color: var(--mdc-fab-color);
 }
 
 .small {

--- a/src/theme/material/variants/default.m.css
+++ b/src/theme/material/variants/default.m.css
@@ -101,4 +101,6 @@
 	--mdc-chip-color: var(--mdc-text-color);
 	--mdc-chip-background-hover: var(--mdc-theme-on-surface-hover);
 	--mdc-snackbar-background: #333333;
+	--mdc-fab-background: var(--mdc-theme-secondary);
+	--mdc-fab-color: var(--mdc-text-color);
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request uses variables that are specific to the `FloatingActionButton` so that basic theming (background color and text color, for now) is easier. Previously, `Button` defaults were used, which prevented buttons and FABs from being themed independently.

Resolves #1649 
