### PR TITLE
fix: wizard styling and responsiveness

### DIFF
--- a/src/theme/default/wizard.m.css
+++ b/src/theme/default/wizard.m.css
@@ -2,6 +2,7 @@
 .root {
 	display: flex;
 	width: 100%;
+	flex-wrap: wrap;
 }
 /* Class added to the root when the wizard is rendered vertically */
 .vertical {

--- a/src/theme/dojo/wizard.m.css
+++ b/src/theme/dojo/wizard.m.css
@@ -1,6 +1,8 @@
 .root {
 	display: flex;
 	width: 100%;
+	box-sizing: border-box;
+	flex-wrap: wrap;
 }
 
 .vertical {
@@ -10,6 +12,10 @@
 .horizontal .step {
 	margin-right: 16px;
 	white-space: nowrap;
+}
+
+.tail {
+	box-sizing: border-box;
 }
 
 .vertical .tail {

--- a/src/theme/material/wizard.m.css
+++ b/src/theme/material/wizard.m.css
@@ -1,6 +1,7 @@
 .root {
 	display: flex;
 	width: 100%;
+	flex-wrap: wrap;
 }
 
 .vertical {
@@ -10,6 +11,10 @@
 .horizontal .step {
 	margin-right: 16px;
 	white-space: nowrap;
+}
+
+.tail {
+	box-sizing: border-box;
 }
 
 .vertical .tail {


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request fixes vertical wizard rendering and base responsiveness by wrapping flex appropriately.

Resolves #1615
Resolves #1616
