### PR TITLE
fix test warnings

### DIFF
--- a/src/avatar/tests/unit/Avatar.spec.tsx
+++ b/src/avatar/tests/unit/Avatar.spec.tsx
@@ -148,7 +148,7 @@ describe('Avatar', () => {
 					.setProperty('@root', 'role', 'image')
 					.setProperty('@root', 'aria-label', 'test')
 					.setProperty('@root', 'styles', { backgroundImage: 'url(img.jpg)' })
-					.setChildren('@root', [])
+					.setChildren('@root', () => [])
 			);
 		});
 

--- a/src/button/tests/unit/Button.spec.tsx
+++ b/src/button/tests/unit/Button.spec.tsx
@@ -128,7 +128,9 @@ registerSuite('Button', {
 
 		'renders labels'() {
 			const h = harness(() => <Button>{{ label: 'Text' }}</Button>, [compareId]);
-			h.expect(template.replaceChildren('button', [<span classes={css.label}>Text</span>]));
+			h.expect(
+				template.replaceChildren('button', () => [<span classes={css.label}>Text</span>])
+			);
 		},
 
 		'renders icons before labels'() {
@@ -144,7 +146,7 @@ registerSuite('Button', {
 				[compareId]
 			);
 			h.expect(
-				template.replaceChildren('button', [
+				template.replaceChildren('button', () => [
 					<span classes={css.icon}>
 						<Icon type="starIcon" size="small" />
 					</span>,
@@ -166,7 +168,7 @@ registerSuite('Button', {
 				[compareId]
 			);
 			h.expect(
-				template.replaceChildren('button', [
+				template.replaceChildren('button', () => [
 					<span classes={css.label}>Text</span>,
 					<span classes={css.icon}>
 						<Icon type="starIcon" size="small" />

--- a/src/calendar/tests/unit/Calendar.spec.tsx
+++ b/src/calendar/tests/unit/Calendar.spec.tsx
@@ -622,7 +622,7 @@ registerSuite('Calendar', {
 			h.trigger('@date-4', 'onKeyDown', Keys.Left, () => {});
 			h.expect(
 				baseTemplate
-					.setChildren('tbody', mayDates(-1, 31))
+					.setChildren('tbody', () => mayDates(-1, 31))
 					.setProperty('@date-picker', 'month', 4)
 					.setProperty('@date-31', 'focusable', true)
 			);

--- a/src/helper-text/tests/unit/HelperText.spec.tsx
+++ b/src/helper-text/tests/unit/HelperText.spec.tsx
@@ -10,7 +10,7 @@ const baseTemplate = assertationTemplate(() => {
 	return <div key="root" classes={[undefined, css.root, null, null]} />;
 });
 
-const textTemplate = baseTemplate.setChildren('@root', [
+const textTemplate = baseTemplate.setChildren('@root', () => [
 	<p key="text" classes={css.text} aria-hidden="true" title="test">
 		test
 	</p>

--- a/src/number-input/tests/unit/NumberInput.spec.tsx
+++ b/src/number-input/tests/unit/NumberInput.spec.tsx
@@ -73,9 +73,10 @@ registerSuite('NumberInput', {
 						type: 'number',
 						theme: { '@dojo/widgets/text-input': textInputCss }
 					})
-					.setChildren(':root', [
-						{ label: 'label', leading: <div />, trailing: <div /> }
-					] as any)
+					.setChildren(
+						':root',
+						() => [{ label: 'label', leading: <div />, trailing: <div /> }] as any
+					)
 			);
 		},
 		'passes correct value to underlying TextInput'() {

--- a/src/pagination/tests/Pagination.spec.tsx
+++ b/src/pagination/tests/Pagination.spec.tsx
@@ -255,7 +255,7 @@ describe('Pagination', () => {
 		);
 
 		h.expect(
-			visibleAssertion.replaceChildren('@links', [
+			visibleAssertion.replaceChildren('@links', () => [
 				prev,
 				...makeLinks(5, 9),
 				<div key="current" classes={css.currentPage}>
@@ -268,7 +268,7 @@ describe('Pagination', () => {
 	});
 
 	describe('page size selector', () => {
-		const sizeSelectorAssertion = visibleAssertion.append(':root', [
+		const sizeSelectorAssertion = visibleAssertion.append(':root', () => [
 			<div classes={css.selectWrapper}>
 				<Select
 					key="page-size-select"
@@ -357,7 +357,7 @@ describe('Pagination', () => {
 				}
 			);
 			h.expect(
-				visibleAssertion.setChildren('@links', [
+				visibleAssertion.setChildren('@links', () => [
 					prev,
 					...makeLinks(7, 9),
 					<div key="current" classes={css.currentPage}>
@@ -384,7 +384,7 @@ describe('Pagination', () => {
 					.setProperty('@links', 'styles', {
 						opacity: '1'
 					})
-					.setChildren('@links', [
+					.setChildren('@links', () => [
 						prev,
 						...makeLinks(8, 9),
 						<div key="current" classes={css.currentPage}>
@@ -408,7 +408,7 @@ describe('Pagination', () => {
 			});
 
 			h.expect(
-				visibleAssertion.setChildren('@links', [
+				visibleAssertion.setChildren('@links', () => [
 					prev,
 					...makeLinks(1),
 					<div key="current" classes={css.currentPage}>

--- a/src/popup/tests/Popup.spec.tsx
+++ b/src/popup/tests/Popup.spec.tsx
@@ -448,7 +448,7 @@ describe('Popup', () => {
 					opacity: '1',
 					top: '300px'
 				})
-				.setChildren('@wrapper', [<div>hello world</div>])
+				.setChildren('@wrapper', () => [<div>hello world</div>])
 		);
 		// despite widget given position="above", the effective position is "below"
 		// due to space restrictions

--- a/src/slide-pane/tests/unit/SlidePane.spec.tsx
+++ b/src/slide-pane/tests/unit/SlidePane.spec.tsx
@@ -57,7 +57,7 @@ const closedTemplateRight = closedTemplate.setProperty('@content', 'classes', [
 ]);
 
 const openTemplate = closedTemplate
-	.insertBefore('@content', [
+	.insertBefore('@content', () => [
 		v('div', {
 			classes: [null, fixedCss.underlay],
 			enterAnimation: animations.fadeIn,
@@ -137,7 +137,7 @@ registerSuite('SlidePane', {
 		'Render correct children'() {
 			const h = harness(() => <SlidePane key="foo" underlay={false} />);
 
-			h.expect(closedTemplate.setChildren('~textContent', []));
+			h.expect(closedTemplate.setChildren('~textContent', () => []));
 		},
 
 		'change property to close'() {

--- a/src/slider/tests/unit/Slider.spec.tsx
+++ b/src/slider/tests/unit/Slider.spec.tsx
@@ -220,7 +220,7 @@ registerSuite('Slider', {
 						.setProperty('~fill', 'styles', { width: '20%' })
 						.setProperty('~thumb', 'styles', { left: '20%' })
 						.setProperty('~output', 'styles', { top: '80%' })
-						.setChildren('~output', ['6'])
+						.setChildren('~output', () => ['6'])
 				);
 			}
 		},
@@ -233,7 +233,7 @@ registerSuite('Slider', {
 					.setProperty('@input', 'max', '40')
 					.setProperty('~fill', 'styles', { width: '100%' })
 					.setProperty('~thumb', 'styles', { left: '100%' })
-					.setChildren('~output', ['40'])
+					.setChildren('~output', () => ['40'])
 			);
 		},
 
@@ -246,7 +246,7 @@ registerSuite('Slider', {
 					.setProperty('@input', 'min', '30')
 					.setProperty('~fill', 'styles', { width: '0%' })
 					.setProperty('~thumb', 'styles', { left: '0%' })
-					.setChildren('~output', ['30'])
+					.setChildren('~output', () => ['30'])
 			);
 		},
 
@@ -260,7 +260,7 @@ registerSuite('Slider', {
 						.setProperty('@input', 'max', '40')
 						.setProperty('~fill', 'styles', { width: '100%' })
 						.setProperty('~thumb', 'styles', { left: '100%' })
-						.setChildren('~output', ['40'])
+						.setChildren('~output', () => ['40'])
 				);
 			},
 			'min value should be respected'() {
@@ -272,7 +272,7 @@ registerSuite('Slider', {
 						.setProperty('@input', 'min', '30')
 						.setProperty('~fill', 'styles', { width: '0%' })
 						.setProperty('~thumb', 'styles', { left: '0%' })
-						.setChildren('~output', ['30'])
+						.setChildren('~output', () => ['30'])
 				);
 			},
 			'max value should be respected'() {
@@ -283,7 +283,7 @@ registerSuite('Slider', {
 						.setProperty('@input', 'max', '40')
 						.setProperty('~fill', 'styles', { width: '100%' })
 						.setProperty('~thumb', 'styles', { left: '100%' })
-						.setChildren('~output', ['40'])
+						.setChildren('~output', () => ['40'])
 				);
 			},
 			events() {

--- a/src/snackbar/tests/unit/Snackbar.spec.tsx
+++ b/src/snackbar/tests/unit/Snackbar.spec.tsx
@@ -49,7 +49,7 @@ describe('Snackbar', () => {
 				}}
 			</Snackbar>
 		));
-		const nonStringTemplate = template.setChildren('@label', [<div>test</div>]);
+		const nonStringTemplate = template.setChildren('@label', () => [<div>test</div>]);
 		h.expect(nonStringTemplate);
 	});
 
@@ -61,7 +61,7 @@ describe('Snackbar', () => {
 				}}
 			</Snackbar>
 		));
-		const multipleNonStringTemplate = template.setChildren('@label', [
+		const multipleNonStringTemplate = template.setChildren('@label', () => [
 			<div>test</div>,
 			<div>test2</div>
 		]);
@@ -177,7 +177,7 @@ describe('Snackbar', () => {
 				}}
 			</Snackbar>
 		));
-		const actionsTemplate = template.insertAfter('~label', [
+		const actionsTemplate = template.insertAfter('~label', () => [
 			<div key="actions" classes={css.actions}>
 				<Button>Dismiss</Button>
 			</div>
@@ -194,7 +194,7 @@ describe('Snackbar', () => {
 				}}
 			</Snackbar>
 		));
-		const actionsTemplate = template.insertAfter('~label', [
+		const actionsTemplate = template.insertAfter('~label', () => [
 			<div key="actions" classes={css.actions}>
 				<Button>Retry</Button>
 				<Button>Close</Button>


### PR DESCRIPTION
**Type:** refactor

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Updates tests to not pass raw arrays. This removes warnings from unit tests and helps avoid mutation.
