### PR TITLE
[555] Fix exported Enums for properties

### DIFF
--- a/src/result/index.tsx
+++ b/src/result/index.tsx
@@ -8,7 +8,7 @@ import Icon from '../icon';
 
 type ResultStatus = 'alert' | 'error' | 'info' | 'success';
 
-export enum StatusIcon {
+enum StatusIcon {
 	alert = 'alertIcon',
 	error = 'cancelIcon',
 	info = 'infoIcon',

--- a/src/tooltip/index.tsx
+++ b/src/tooltip/index.tsx
@@ -12,7 +12,7 @@ export interface TooltipProperties {
 	/** Determines if this tooltip is visible */
 	open?: boolean;
 	/** Where this tooltip should render relative to its child */
-	orientation?: Orientation;
+	orientation?: 'bottom' | 'left' | 'right' | 'top' | Orientation;
 }
 
 export interface TooltipChildren {
@@ -20,7 +20,9 @@ export interface TooltipChildren {
 	content: RenderResult;
 }
 
-// Enum used to position the Tooltip
+/**
+ * @deprecated this enum will be removed in the next major release
+ */
 export enum Orientation {
 	bottom = 'bottom',
 	left = 'left',
@@ -33,7 +35,7 @@ const factory = create({ theme })
 	.children<TooltipChildren>();
 
 export const Tooltip = factory(function Tooltip({ children, properties, middleware: { theme } }) {
-	const { open, aria = {}, orientation = Orientation.right } = properties();
+	const { open, aria = {}, orientation = 'right' } = properties();
 	const classes = theme.classes(css);
 	const fixedClasses = theme.classes(fixedCss);
 	const [{ trigger, content }] = children();

--- a/src/tooltip/tests/unit/Tooltip.spec.tsx
+++ b/src/tooltip/tests/unit/Tooltip.spec.tsx
@@ -3,7 +3,7 @@ const { registerSuite } = intern.getInterface('object');
 import { tsx } from '@dojo/framework/core/vdom';
 import harness from '@dojo/framework/testing/harness/harness';
 
-import Tooltip, { Orientation } from '../../index';
+import Tooltip from '../../index';
 import Button from '../../../button/index';
 import * as css from '../../../theme/default/tooltip.m.css';
 import * as fixedCss from '../../styles/tooltip.m.css';
@@ -54,7 +54,7 @@ registerSuite('Tooltip', {
 
 		'should render correct orientation'() {
 			const h = harness(() => (
-				<Tooltip orientation={Orientation.bottom}>{{ content: 'foobar' }}</Tooltip>
+				<Tooltip orientation="bottom">{{ content: 'foobar' }}</Tooltip>
 			));
 
 			h.expect(() => (


### PR DESCRIPTION
**Type:** bug 

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

This PR 
- deprecates tooltip position enum
- allows tooltip to accept a position string
- removes unused, exported result widget enum 

Resolves #555
