### PR TITLE
Trigger onValidate when inital value is set on Select widget

### DIFF
--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -139,7 +139,7 @@ export const Select = factory(function Select({
 		data
 	} = get(options(), { read, meta: true });
 
-	if (required && dirty) {
+	if ((required && dirty) || value !== undefined) {
 		const isValid = value !== undefined;
 		if (isValid !== valid) {
 			icache.set('valid', isValid);

--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -139,7 +139,7 @@ export const Select = factory(function Select({
 		data
 	} = get(options(), { read, meta: true });
 
-	if ((required && dirty) || value !== undefined) {
+	if (required && (dirty || value !== undefined)) {
 		const isValid = value !== undefined;
 		if (isValid !== valid) {
 			icache.set('valid', isValid);

--- a/src/select/tests/Select.spec.tsx
+++ b/src/select/tests/Select.spec.tsx
@@ -399,7 +399,7 @@ describe('Select', () => {
 		assert.isTrue(onValidate.calledWith(false));
 	});
 
-	it('calls onValidate on initial value', () => {
+	it('calls onValidate on initial value when required', () => {
 		const onValidate = stub();
 		const h = harness(() => (
 			<Select

--- a/src/select/tests/Select.spec.tsx
+++ b/src/select/tests/Select.spec.tsx
@@ -398,4 +398,32 @@ describe('Select', () => {
 
 		assert.isTrue(onValidate.calledWith(false));
 	});
+
+	it('calls onValidate on initial value', () => {
+		const onValidate = stub();
+		const h = harness(() => (
+			<Select
+				onValue={() => {}}
+				resource={{ data: options, idKey: 'value', id: 'test' }}
+				required={true}
+				value={'1'}
+				onValidate={onValidate}
+			/>
+		));
+		h.expect(
+			baseTemplate
+				.setProperty(':root', 'classes', [
+					undefined,
+					css.root,
+					undefined,
+					css.valid,
+					false,
+					false,
+					undefined
+				])
+				.setProperty('@helperText', 'valid', true)
+		);
+
+		assert.isTrue(onValidate.calledWith(true));
+	});
 });


### PR DESCRIPTION
**Type:** bug

**Description:**
`Select` widget was not validating when there was an initial value set. Pending unit test

Resolves #1653
