### PR TITLE
[1696] - disabled state material theme issues

### DIFF
--- a/src/chip-typeahead/index.tsx
+++ b/src/chip-typeahead/index.tsx
@@ -172,6 +172,7 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 					}
 				}}
 				variant={variant}
+				disabled={disabled}
 				onClose={
 					disabled
 						? undefined
@@ -199,6 +200,7 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 			key="root"
 			classes={[
 				theme.variant(),
+				disabled ? themeCss.disabled : null,
 				themeCss.root,
 				selectedOptions.length > 0 ? themeCss.hasValue : null,
 				focused ? themeCss.focused : null,
@@ -208,6 +210,7 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 			{label && (
 				<Label
 					focused={focused}
+					disabled={disabled}
 					active={active}
 					theme={theme.compose(
 						labelCss,

--- a/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
+++ b/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
@@ -30,7 +30,7 @@ const animalOptions: ListOption[] = [
 ];
 
 const baseAssertion = assertionTemplate(() => (
-	<div key="root" classes={[undefined, themeCss.root, null, null, null]}>
+	<div key="root" classes={[undefined, null, themeCss.root, null, null, null]}>
 		<Typeahead
 			strict={undefined}
 			key="typeahead"
@@ -67,16 +67,27 @@ const baseAssertion = assertionTemplate(() => (
 
 const hasValueAssertion = baseAssertion.setProperty('@root', 'classes', [
 	undefined,
+	null,
 	themeCss.root,
 	themeCss.hasValue,
 	null,
 	null
 ]);
 
-const disabledAssertion = hasValueAssertion.setProperty('@typeahead', 'disabled', true);
+const disabledAssertion = hasValueAssertion
+	.setProperty('@typeahead', 'disabled', true)
+	.setProperty('@root', 'classes', [
+		undefined,
+		themeCss.disabled,
+		themeCss.root,
+		themeCss.hasValue,
+		null,
+		null
+	]);
 
 const focusedAssertion = baseAssertion.setProperty('@root', 'classes', [
 	undefined,
+	null,
 	themeCss.root,
 	null,
 	themeCss.focused,
@@ -87,6 +98,7 @@ const bottomAssertion = hasValueAssertion.insertAfter('@typeahead', () => [
 	<div classes={themeCss.values}>
 		<Chip
 			theme={{ '@dojo/widgets/chip': chipCss }}
+			disabled={undefined}
 			key="value-2"
 			classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 			onClose={stub}
@@ -98,9 +110,17 @@ const bottomAssertion = hasValueAssertion.insertAfter('@typeahead', () => [
 ]);
 
 const labeledAssertion = baseAssertion
-	.setProperty('@root', 'classes', [undefined, themeCss.root, null, null, themeCss.hasLabel])
+	.setProperty('@root', 'classes', [
+		undefined,
+		null,
+		themeCss.root,
+		null,
+		null,
+		themeCss.hasLabel
+	])
 	.insertBefore('@typeahead', () => [
 		<Label
+			disabled={undefined}
 			focused={false}
 			active={false}
 			theme={{ '@dojo/widgets/Label': labelCss }}
@@ -148,6 +168,7 @@ registerSuite('ChipTypeahead', {
 				() => [
 					<Chip
 						theme={{ '@dojo/widgets/chip': chipCss }}
+						disabled={undefined}
 						key="value-2"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={stub}
@@ -184,6 +205,7 @@ registerSuite('ChipTypeahead', {
 				() => [
 					<Chip
 						theme={{ '@dojo/widgets/chip': chipCss }}
+						disabled={undefined}
 						key="value-2"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={stub}
@@ -206,6 +228,7 @@ registerSuite('ChipTypeahead', {
 				() => [
 					<Chip
 						theme={{ '@dojo/widgets/chip': chipCss }}
+						disabled={undefined}
 						key="value-1"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={stub}
@@ -238,6 +261,7 @@ registerSuite('ChipTypeahead', {
 				() => [
 					<Chip
 						theme={{ '@dojo/widgets/chip': chipCss }}
+						disabled={undefined}
 						key="value-2"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={stub}
@@ -304,6 +328,7 @@ registerSuite('ChipTypeahead', {
 				() => [
 					<Chip
 						theme={{ '@dojo/widgets/chip': chipCss }}
+						disabled={undefined}
 						key="value-2"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={stub}
@@ -439,6 +464,7 @@ registerSuite('ChipTypeahead', {
 				() => [
 					<Chip
 						theme={{ '@dojo/widgets/chip': chipCss }}
+						disabled={true}
 						key="value-2"
 						classes={{ '@dojo/widgets/chip': { root: [themeCss.value] } }}
 						onClose={undefined}

--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -248,6 +248,7 @@ export default factory(function({
 										trailing: (
 											<button
 												key="dateIcon"
+												disabled={disabled}
 												onclick={(e) => {
 													e.stopPropagation();
 													openCalendar();

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -128,6 +128,7 @@ import OutlinedDisabledSubmit from './widgets/outlined-button/DisabledSubmit';
 import OutlinedToggleButton from './widgets/outlined-button/ToggleButton';
 import BasicPassword from './widgets/password-input/Basic';
 import NoRules from './widgets/password-input/NoRules';
+import DisabledPassword from './widgets/password-input/Disabled';
 import BasicTriggerPopup from './widgets/trigger-popup/Basic';
 import MenuTriggerPopup from './widgets/trigger-popup/MenuPopup';
 import SetWidth from './widgets/trigger-popup/SetWidth';
@@ -1156,6 +1157,11 @@ export const config = {
 					title: 'No Rules',
 					filename: 'NoRules',
 					module: NoRules
+				},
+				{
+					title: 'Disabled',
+					filename: 'Disabled',
+					module: DisabledPassword
 				}
 			]
 		},

--- a/src/examples/src/widgets/password-input/Disabled.tsx
+++ b/src/examples/src/widgets/password-input/Disabled.tsx
@@ -1,0 +1,13 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import PasswordInput from '@dojo/widgets/password-input';
+import Example from '../../Example';
+
+const factory = create();
+
+export default factory(function Disabled() {
+	return (
+		<Example>
+			<PasswordInput disabled>{{ label: 'Enter Password' }}</PasswordInput>
+		</Example>
+	);
+});

--- a/src/theme/default/chip-typeahead.m.css
+++ b/src/theme/default/chip-typeahead.m.css
@@ -2,6 +2,9 @@
 .root {
 }
 
+.disabled {
+}
+
 /* Added when the MultiSelectTypeahead is focused */
 .focused {
 }

--- a/src/theme/default/chip-typeahead.m.css.d.ts
+++ b/src/theme/default/chip-typeahead.m.css.d.ts
@@ -1,4 +1,5 @@
 export const root: string;
+export const disabled: string;
 export const focused: string;
 export const values: string;
 export const value: string;

--- a/src/theme/material/chip-typeahead.m.css
+++ b/src/theme/material/chip-typeahead.m.css
@@ -1,16 +1,15 @@
 .root {
 	composes: mdc-text-field from '@material/textfield/dist/mdc.textfield.css';
-	background-color: var(--mdc-theme-on-surface) !important;
 	height: auto !important;
 	display: block !important;
 }
 
-.focused {
-	composes: mdc-text-field--focused from '@material/textfield/dist/mdc.textfield.css';
+.disabled {
+	composes: mdc-text-field--disabled from '@material/textfield/dist/mdc.textfield.css';
 }
 
-.root:hover:not(.disabled) {
-	background-color: var(--mdc-theme-on-surface-hover) !important;
+.focused {
+	composes: mdc-text-field--focused from '@material/textfield/dist/mdc.textfield.css';
 }
 
 .value {

--- a/src/theme/material/chip-typeahead.m.css.d.ts
+++ b/src/theme/material/chip-typeahead.m.css.d.ts
@@ -1,6 +1,6 @@
 export const root: string;
-export const focused: string;
 export const disabled: string;
+export const focused: string;
 export const value: string;
 export const hasLabel: string;
 export const wrapper: string;

--- a/src/theme/material/chip.m.css
+++ b/src/theme/material/chip.m.css
@@ -42,7 +42,8 @@
 	cursor: pointer;
 }
 
-.disabled {
+.root.disabled {
+	cursor: default;
 }
 
 .root .icon {

--- a/src/theme/material/date-input.m.css
+++ b/src/theme/material/date-input.m.css
@@ -6,8 +6,12 @@
 	color: var(--mdc-secondary-text-color);
 }
 
-.toggleCalendarButton:hover {
+.toggleCalendarButton:hover:not([disabled]) {
 	color: var(--mdc-text-color);
+}
+
+.toggleCalendarButton[disabled] {
+	cursor: default;
 }
 
 .popup {

--- a/src/theme/material/password-input.m.css
+++ b/src/theme/material/password-input.m.css
@@ -6,6 +6,6 @@
 	color: var(--mdc-secondary-text-color);
 }
 
-.toggleButton:hover {
+.toggleButton:hover:not([disabled]) {
 	color: var(--mdc-text-color);
 }

--- a/src/theme/material/radio.m.css
+++ b/src/theme/material/radio.m.css
@@ -34,4 +34,5 @@
 
 .root.disabled .inputWrapper {
 	opacity: 0.5;
+	cursor: default;
 }

--- a/src/theme/material/select.m.css
+++ b/src/theme/material/select.m.css
@@ -4,8 +4,8 @@
 	flex-direction: column;
 }
 
-.root:not(.disabled) .trigger {
-	background-color: var(--mdc-theme-on-surface);
+.root .trigger {
+	background-color: var(--mdc-theme-on-surface) !important;
 }
 
 .root:hover:not(.disabled) .trigger {
@@ -28,7 +28,6 @@
 
 .disabled {
 	composes: mdc-select--disabled from '@material/select/dist/mdc.select.css';
-	background-color: var(--mdc-disabled-color);
 }
 
 .required {
@@ -41,6 +40,10 @@
 	padding: 0;
 	width: 100%;
 	outline: none;
+}
+
+.root .trigger {
+	display: flex;
 }
 
 .value {
@@ -66,14 +69,14 @@
 }
 
 .labelRoot {
+	composes: root from './label.m.css';
 	composes: mdc-floating-label from '@material/select/dist/mdc.select.css';
 	z-index: 10;
-	color: var(--mdc-secondary-text-color) !important;
 }
 
 .labelActive {
-	composes: mdc-floating-label--float-above from '@material/textfield/dist/mdc.textfield.css';
-	color: var(--mdc-theme-primary) !important;
+	composes: active from './label.m.css';
+	composes: mdc-floating-label--float-above from '@material/select/dist/mdc.select.css';
 }
 
 .root .labelActive {

--- a/src/theme/material/select.m.css
+++ b/src/theme/material/select.m.css
@@ -56,6 +56,10 @@
 	color: var(--mdc-disabled-text-color) !important;
 }
 
+.disabled .value:before {
+	border-bottom-style: solid !important;
+}
+
 .value::before {
 	border-bottom-color: var(--mdc-border-color) !important;
 }

--- a/src/theme/material/select.m.css.d.ts
+++ b/src/theme/material/select.m.css.d.ts
@@ -1,6 +1,6 @@
 export const root: string;
-export const disabled: string;
 export const trigger: string;
+export const disabled: string;
 export const expanded: string;
 export const focused: string;
 export const valid: string;

--- a/src/theme/material/text-input.m.css
+++ b/src/theme/material/text-input.m.css
@@ -22,7 +22,7 @@
 	background-color: var(--mdc-theme-on-surface);
 }
 
-.root:hover:not(.disabled) .wrapper {
+.root:hover .wrapper:not(.disabled) {
 	background-color: var(--mdc-theme-on-surface-hover);
 }
 

--- a/src/theme/material/time-picker.m.css
+++ b/src/theme/material/time-picker.m.css
@@ -6,8 +6,12 @@
 	color: var(--mdc-secondary-text-color);
 }
 
-.toggleMenuButton:hover {
+.toggleMenuButton:hover:not([disabled]) {
 	color: var(--mdc-text-color);
+}
+
+.toggleMenuButton[disabled] {
+	cursor: default;
 }
 
 .popup {


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Fixes various material theme issues where widgets are disabled including:
- typeahead
- chip typeahead
- date input
- time input
- radio
- chip
- password input


Resolves #1696 
