### PR TITLE
fix: disabled input backgrounds

### DIFF
--- a/src/theme/material/select.m.css
+++ b/src/theme/material/select.m.css
@@ -28,7 +28,6 @@
 
 .disabled {
 	composes: mdc-select--disabled from '@material/select/dist/mdc.select.css';
-	background-color: var(--mdc-disabled-color);
 }
 
 .required {

--- a/src/theme/material/text-input.m.css
+++ b/src/theme/material/text-input.m.css
@@ -18,11 +18,11 @@
 	composes: mdc-line-ripple from '@material/textfield/dist/mdc.textfield.css';
 }
 
-.root .wrapper {
+.root .wrapper:not(.disabled) {
 	background-color: var(--mdc-theme-on-surface);
 }
 
-.root:hover:not(.disabled) .wrapper {
+.root:hover .wrapper:not(.disabled) {
 	background-color: var(--mdc-theme-on-surface-hover);
 }
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request consolidates disabled backgrounds between `Select` and other inputs. A few different underlying issues caused the difference in background color: `Select` used an unnecessary explicit background color, and `Input` incorrectly applied background styles.

Resolves #1703 
