### PR TITLE
fix: outline button dojo theme

### DIFF
--- a/src/theme/dojo/outlined-button.m.css
+++ b/src/theme/dojo/outlined-button.m.css
@@ -16,6 +16,10 @@
 	font-family: var(--font-family);
 }
 
+.root:focus {
+	outline: none;
+}
+
 .iconOnly {
 	min-width: 0;
 }
@@ -29,7 +33,6 @@
 .pressed {
 	background-color: var(--color-highlight);
 	border-color: var(--color-highlight);
-	color: var(--color-text-inverted);
 }
 
 .label {
@@ -37,6 +40,10 @@
 }
 
 .root:hover .label {
+	color: var(--color-text-inverted);
+}
+
+.pressed .label {
 	color: var(--color-text-inverted);
 }
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request fixes focus styling and pressed state styling for the `OutlinedButton` using the Dojo theme.

Resolves #1682
