### PR TITLE
fix: rename CardProperties.onAction to onContentClick

### DIFF
--- a/src/card/index.tsx
+++ b/src/card/index.tsx
@@ -4,7 +4,7 @@ import * as css from '../theme/default/card.m.css';
 import theme from '../middleware/theme';
 
 export interface CardProperties {
-	onContentClick?: () => void;
+	onClick?: () => void;
 	mediaSrc?: string;
 	mediaTitle?: string;
 	square?: boolean;
@@ -27,7 +27,7 @@ const factory = create({ theme })
 export const Card = factory(function Card({ children, properties, middleware: { theme } }) {
 	const themeCss = theme.classes(css);
 	const {
-		onContentClick,
+		onClick,
 		mediaSrc,
 		mediaTitle,
 		square,
@@ -39,16 +39,16 @@ export const Card = factory(function Card({ children, properties, middleware: { 
 
 	return (
 		<div key="root" classes={[theme.variant(), themeCss.root, outlined && themeCss.outlined]}>
-			{header && (
-				<div key="header" classes={themeCss.header}>
-					{header}
-				</div>
-			)}
 			<div
 				key="content"
-				classes={[themeCss.content, onContentClick ? themeCss.primary : null]}
-				onClick={() => onContentClick && onContentClick()}
+				classes={[themeCss.content, onClick ? themeCss.primary : null]}
+				onclick={() => onClick && onClick()}
 			>
+				{header && (
+					<div key="header" classes={themeCss.header}>
+						{header}
+					</div>
+				)}
 				{mediaSrc && (
 					<div
 						title={mediaTitle}

--- a/src/card/index.tsx
+++ b/src/card/index.tsx
@@ -4,7 +4,7 @@ import * as css from '../theme/default/card.m.css';
 import theme from '../middleware/theme';
 
 export interface CardProperties {
-	onAction?: () => void;
+	onContentClick?: () => void;
 	mediaSrc?: string;
 	mediaTitle?: string;
 	square?: boolean;
@@ -27,7 +27,7 @@ const factory = create({ theme })
 export const Card = factory(function Card({ children, properties, middleware: { theme } }) {
 	const themeCss = theme.classes(css);
 	const {
-		onAction,
+		onContentClick,
 		mediaSrc,
 		mediaTitle,
 		square,
@@ -46,8 +46,8 @@ export const Card = factory(function Card({ children, properties, middleware: { 
 			)}
 			<div
 				key="content"
-				classes={[themeCss.content, onAction ? themeCss.primary : null]}
-				onClick={() => onAction && onAction()}
+				classes={[themeCss.content, onContentClick ? themeCss.primary : null]}
+				onClick={() => onContentClick && onContentClick()}
 			>
 				{mediaSrc && (
 					<div

--- a/src/card/tests/unit/Card.spec.tsx
+++ b/src/card/tests/unit/Card.spec.tsx
@@ -36,15 +36,15 @@ describe('Card', () => {
 	});
 
 	describe('action', () => {
-		const onAction = spy();
-		const r = renderer(() => <Card onAction={onAction} />);
+		const onContentClick = spy();
+		const r = renderer(() => <Card onContentClick={onContentClick} />);
 
 		const actionTemplate = template.setProperty(Content, 'classes', [css.content, css.primary]);
 
 		r.expect(actionTemplate);
 		r.property(Content, 'onClick');
 		r.expect(actionTemplate);
-		assert.isTrue(onAction.calledOnce);
+		assert.isTrue(onContentClick.calledOnce);
 	});
 
 	describe('header', () => {

--- a/src/card/tests/unit/Card.spec.tsx
+++ b/src/card/tests/unit/Card.spec.tsx
@@ -15,7 +15,7 @@ const Content = wrap('div');
 
 const template = assertion(() => (
 	<Root key="root" classes={[undefined, css.root, false]}>
-		<Content key="content" classes={[css.content, null]} onClick={noop} />
+		<Content key="content" classes={[css.content, null]} onclick={noop} />
 	</Root>
 ));
 
@@ -36,15 +36,15 @@ describe('Card', () => {
 	});
 
 	describe('action', () => {
-		const onContentClick = spy();
-		const r = renderer(() => <Card onContentClick={onContentClick} />);
+		const onClick = spy();
+		const r = renderer(() => <Card onClick={onClick} />);
 
 		const actionTemplate = template.setProperty(Content, 'classes', [css.content, css.primary]);
 
 		r.expect(actionTemplate);
-		r.property(Content, 'onClick');
+		r.property(Content, 'onclick');
 		r.expect(actionTemplate);
-		assert.isTrue(onContentClick.calledOnce);
+		assert.isTrue(onClick.calledOnce);
 	});
 
 	describe('header', () => {
@@ -57,7 +57,7 @@ describe('Card', () => {
 				</Card>
 			));
 
-			const headerTemplate = template.prepend(Root, () => [
+			const headerTemplate = template.prepend(Content, () => [
 				<div key="header" classes={css.header}>
 					Hello, World
 				</div>
@@ -220,12 +220,10 @@ describe('Card', () => {
 
 		r.expect(
 			template
-				.prepend(Root, () => [
+				.setChildren(Content, () => [
 					<div key="header" classes={css.header}>
 						Header Content
-					</div>
-				])
-				.setChildren(Content, () => [
+					</div>,
 					<div
 						title="test"
 						classes={[css.media, css.mediaSquare]}

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -274,6 +274,7 @@ import RemoteSource from './widgets/tree/RemoteSource';
 import InitialStateTree from './widgets/tree/InitialState';
 import PopupConfirmation from './widgets/popup-confirmation/Basic';
 import PopupConfirmationUnderlay from './widgets/popup-confirmation/Underlay';
+import ClickableCard from './widgets/card/ClickableCard';
 
 import * as dojoDarkVariant from '@dojo/widgets/theme/dojo/variants/dark.m.css';
 import * as materialDarkVariant from '@dojo/widgets/theme/material/variants/dark.m.css';
@@ -508,6 +509,11 @@ export const config = {
 					title: 'Card with header, content, media, and actions',
 					module: CardCombined,
 					filename: 'CardCombined'
+				},
+				{
+					title: 'Clickable Card',
+					module: ClickableCard,
+					filename: 'ClickableCard'
 				}
 			],
 			filename: 'index',

--- a/src/examples/src/widgets/card/CardCombined.tsx
+++ b/src/examples/src/widgets/card/CardCombined.tsx
@@ -12,7 +12,7 @@ export default factory(function CardWithMediaContent() {
 		<Example>
 			<div styles={{ maxWidth: '400px' }}>
 				<Card
-					onAction={() => {}}
+					onContentClick={() => {}}
 					mediaSrc={mediaSrc}
 					title="Hello, World"
 					subtitle="A pretty picture"

--- a/src/examples/src/widgets/card/CardCombined.tsx
+++ b/src/examples/src/widgets/card/CardCombined.tsx
@@ -11,12 +11,7 @@ export default factory(function CardWithMediaContent() {
 	return (
 		<Example>
 			<div styles={{ maxWidth: '400px' }}>
-				<Card
-					onContentClick={() => {}}
-					mediaSrc={mediaSrc}
-					title="Hello, World"
-					subtitle="A pretty picture"
-				>
+				<Card mediaSrc={mediaSrc} title="Hello, World" subtitle="A pretty picture">
 					{{
 						header: <div>Header Content</div>,
 						content: <span>Travel the world today.</span>,

--- a/src/examples/src/widgets/card/ClickableCard.tsx
+++ b/src/examples/src/widgets/card/ClickableCard.tsx
@@ -1,0 +1,28 @@
+import icache from '@dojo/framework/core/middleware/icache';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Card from '@dojo/widgets/card';
+import Example from '../../Example';
+
+const factory = create({ icache });
+
+export default factory(function ClickableCard({ middleware: { icache } }) {
+	const clickable = icache.getOrSet<number>('clickable', 0);
+
+	return (
+		<Example>
+			<div styles={{ maxWidth: '400px' }}>
+				<Card
+					title="Hello, World"
+					onClick={() => {
+						icache.set('clickable', icache.getOrSet<number>('clickable', 0) + 1);
+					}}
+				>
+					{{
+						content: <span>Lorem ipsum</span>
+					}}
+				</Card>
+			</div>
+			<div>Clicked {String(clickable)} times</div>
+		</Example>
+	);
+});

--- a/src/theme/dojo/card.m.css
+++ b/src/theme/dojo/card.m.css
@@ -33,10 +33,6 @@
 }
 
 .primary {
-	position: relative;
-	display: flex;
-	flex-direction: column;
-	overflow: hidden;
 	cursor: pointer;
 }
 
@@ -77,7 +73,10 @@
 	border-top-right-radius: inherit;
 }
 
-.header,
+.header {
+	padding: calc(2 * var(--grid-base));
+}
+
 .titleWrapper {
 	padding: 0 calc(2 * var(--grid-base)) var(--grid-base);
 }

--- a/src/theme/material/card.m.css
+++ b/src/theme/material/card.m.css
@@ -49,9 +49,9 @@
 
 .header {
 	display: flex;
+	padding: 1rem;
 }
 
-.header,
 .titleWrapper {
 	padding: 0 1rem 8px;
 	align-items: center;


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request renames the `Card` prop `onAction` to `onContentClick`, since it more-accurately describes what the prop actually does.

Resolves #1648
