### PR TITLE
The content wrapper needs to be height 100%

### DIFF
--- a/src/theme/default/card.m.css
+++ b/src/theme/default/card.m.css
@@ -29,6 +29,7 @@
 
 /* Wrapper around the content child */
 .contentWrapper {
+	height: 100%;
 }
 
 /* The wrapper around the header content area */

--- a/src/theme/dojo/card.m.css
+++ b/src/theme/dojo/card.m.css
@@ -87,6 +87,7 @@
 
 .contentWrapper {
 	padding: 0 calc(2 * var(--grid-base)) var(--grid-base);
+	height: 100%;
 }
 
 .title {

--- a/src/theme/material/card.m.css
+++ b/src/theme/material/card.m.css
@@ -40,6 +40,7 @@
 	padding: 0 1rem 8px;
 	color: var(--mdc-text-secondary-color);
 	composes: mdc-typography mdc-typography--body2 from '@material/typography/dist/mdc.typography.css';
+	height: 100%;
 }
 
 .textWrapper:first-child {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

To support content using height 100% the content wrapper needs to have height 100%.