### PR TITLE
Add disabled to CheckboxGroup and RadioGroup

### DIFF
--- a/src/checkbox-group/index.tsx
+++ b/src/checkbox-group/index.tsx
@@ -5,7 +5,7 @@ import { RenderResult } from '@dojo/framework/core/interfaces';
 import theme from '../middleware/theme';
 import * as css from '../theme/default/checkbox-group.m.css';
 
-type CheckboxOptions = { value: string; label?: string }[];
+type CheckboxOptions = { value: string; label?: string; disabled?: boolean }[];
 
 export interface CheckboxGroupProperties {
 	/** The name attribute for this form group */
@@ -59,7 +59,7 @@ export const CheckboxGroup = factory(function({
 		if (checkboxes) {
 			return checkboxes(name, checkbox, options);
 		}
-		return options.map(({ value, label }) => {
+		return options.map(({ value, label, disabled }) => {
 			const { checked } = checkbox(value);
 			return (
 				<Checkbox
@@ -70,6 +70,7 @@ export const CheckboxGroup = factory(function({
 					classes={classes}
 					theme={themeProp}
 					variant={variant}
+					disabled={disabled}
 				>
 					{label || value}
 				</Checkbox>

--- a/src/checkbox-group/tests/CheckboxGroup.spec.tsx
+++ b/src/checkbox-group/tests/CheckboxGroup.spec.tsx
@@ -30,6 +30,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Checkbox>,
@@ -41,6 +42,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				fish
 			</Checkbox>,
@@ -52,6 +54,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				dog
 			</Checkbox>
@@ -77,6 +80,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Checkbox>
@@ -102,6 +106,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Checkbox>,
@@ -113,6 +118,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				fish
 			</Checkbox>,
@@ -124,6 +130,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				dog
 			</Checkbox>
@@ -149,6 +156,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Checkbox>,
@@ -160,6 +168,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				fish
 			</Checkbox>,
@@ -171,6 +180,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				dog
 			</Checkbox>
@@ -194,6 +204,7 @@ describe('CheckboxGroup', () => {
 								theme={undefined}
 								classes={undefined}
 								variant={undefined}
+								disabled={undefined}
 							>
 								cat
 							</Checkbox>,
@@ -214,11 +225,62 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Checkbox>,
 			<hr />
 		]);
 		h.expect(customTemplate);
+	});
+
+	it('renders with disabled value', () => {
+		const h = harness(() => (
+			<CheckboxGroup
+				onValue={noop}
+				name="test"
+				options={[{ value: 'cat', disabled: true }, { value: 'fish' }, { value: 'dog' }]}
+				value={['fish']}
+			/>
+		));
+		const optionTemplate = template.setChildren('@root', () => [
+			<Checkbox
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+				disabled={true}
+			>
+				cat
+			</Checkbox>,
+			<Checkbox
+				name="test"
+				value="fish"
+				checked={true}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+				disabled={undefined}
+			>
+				fish
+			</Checkbox>,
+			<Checkbox
+				name="test"
+				value="dog"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+				disabled={undefined}
+			>
+				dog
+			</Checkbox>
+		]);
+		h.expect(optionTemplate);
 	});
 });

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -38,6 +38,7 @@ import ActionHeaderCard from './widgets/header-card/ActionCard';
 import BasicCheckboxGroup from './widgets/checkbox-group/Basic';
 import CustomLabelCheckboxGroup from './widgets/checkbox-group/CustomLabel';
 import CustomRendererCheckboxGroup from './widgets/checkbox-group/CustomRenderer';
+import DisabledCheckboxGroup from './widgets/checkbox-group/Disabled';
 import InitialValueCheckboxGroup from './widgets/checkbox-group/InitialValue';
 import ControlledCheckboxGroup from './widgets/checkbox-group/Controlled';
 import BasicCheckbox from './widgets/checkbox/Basic';
@@ -593,6 +594,11 @@ export const config = {
 					filename: 'Controlled',
 					module: ControlledCheckboxGroup,
 					title: 'Controlled'
+				},
+				{
+					filename: 'Disabled',
+					module: DisabledCheckboxGroup,
+					title: 'Disabled'
 				}
 			],
 			filename: 'index',

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -146,6 +146,7 @@ import BasicRadioGroup from './widgets/radio-group/Basic';
 import ControlledRadioGroup from './widgets/radio-group/Basic';
 import CustomLabelRadioGroup from './widgets/radio-group/CustomLabel';
 import CustomRendererRadioGroup from './widgets/radio-group/CustomRenderer';
+import DisabledRadioGroup from './widgets/radio-group/Disabled';
 import InitialValueRadioGroup from './widgets/radio-group/InitialValue';
 import BasicRaisedButton from './widgets/raised-button/Basic';
 import RaisedDisabledSubmit from './widgets/raised-button/DisabledSubmit';
@@ -1413,6 +1414,11 @@ export const config = {
 					filename: 'CustomRenderer',
 					module: CustomRendererRadioGroup,
 					title: 'Custom Renderer'
+				},
+				{
+					filename: 'Disabled',
+					module: DisabledRadioGroup,
+					title: 'Disabled'
 				}
 			],
 			filename: 'index',

--- a/src/examples/src/widgets/checkbox-group/Disabled.tsx
+++ b/src/examples/src/widgets/checkbox-group/Disabled.tsx
@@ -1,0 +1,29 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import CheckboxGroup from '@dojo/widgets/checkbox-group';
+import { icache } from '@dojo/framework/core/middleware/icache';
+import Example from '../../Example';
+
+const factory = create({ icache });
+
+const App = factory(function({ properties, middleware: { icache } }) {
+	const { get, set } = icache;
+
+	return (
+		<Example>
+			<CheckboxGroup
+				name="standard"
+				options={[{ value: 'cat', disabled: true }, { value: 'dog' }, { value: 'fish' }]}
+				onValue={(value) => {
+					set('standard', value);
+				}}
+			>
+				{{
+					label: 'pets'
+				}}
+			</CheckboxGroup>
+			<pre>{`${get('standard')}`}</pre>
+		</Example>
+	);
+});
+
+export default App;

--- a/src/examples/src/widgets/radio-group/Disabled.tsx
+++ b/src/examples/src/widgets/radio-group/Disabled.tsx
@@ -1,0 +1,29 @@
+import RadioGroup from '@dojo/widgets/radio-group';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import { icache } from '@dojo/framework/core/middleware/icache';
+import Example from '../../Example';
+
+const factory = create({ icache });
+
+const App = factory(function({ properties, middleware: { icache } }) {
+	const { get, set } = icache;
+
+	return (
+		<Example>
+			<RadioGroup
+				name="standard"
+				options={[{ value: 'cat', disabled: true }, { value: 'dog' }, { value: 'fish' }]}
+				onValue={(value) => {
+					set('standard', value);
+				}}
+			>
+				{{
+					label: 'pets'
+				}}
+			</RadioGroup>
+			<pre>{`${get('standard')}`}</pre>
+		</Example>
+	);
+});
+
+export default App;

--- a/src/radio-group/index.tsx
+++ b/src/radio-group/index.tsx
@@ -5,7 +5,7 @@ import { RenderResult } from '@dojo/framework/core/interfaces';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import { radioGroup } from './middleware';
 
-type RadioOptions = { value: string; label?: string }[];
+type RadioOptions = { value: string; label?: string; disabled?: boolean }[];
 
 export interface RadioGroupProperties {
 	/** Initial value of the radio group */
@@ -57,7 +57,7 @@ export const RadioGroup = factory(function({
 		if (radios) {
 			return radios(name, radio, options);
 		}
-		return options.map(({ value, label }) => {
+		return options.map(({ value, label, disabled }) => {
 			const { checked } = radio(value);
 			return (
 				<Radio
@@ -68,6 +68,7 @@ export const RadioGroup = factory(function({
 					theme={themeCss}
 					classes={classes}
 					variant={variant}
+					disabled={disabled}
 				>
 					{label || value}
 				</Radio>

--- a/src/radio-group/tests/RadioGroup.spec.tsx
+++ b/src/radio-group/tests/RadioGroup.spec.tsx
@@ -30,6 +30,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Radio>,
@@ -41,6 +42,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				fish
 			</Radio>,
@@ -52,6 +54,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				dog
 			</Radio>
@@ -77,6 +80,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Radio>
@@ -102,6 +106,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Radio>,
@@ -113,6 +118,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				fish
 			</Radio>,
@@ -124,6 +130,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				dog
 			</Radio>
@@ -150,6 +157,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Radio>,
@@ -161,6 +169,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				fish
 			</Radio>,
@@ -172,6 +181,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				dog
 			</Radio>
@@ -197,6 +207,7 @@ describe('RadioGroup', () => {
 								theme={undefined}
 								variant={undefined}
 								classes={undefined}
+								disabled={undefined}
 							>
 								cat
 							</Radio>,
@@ -217,11 +228,64 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Radio>,
 			<hr />
 		]);
 		h.expect(customTemplate);
+	});
+
+	it('renders with disabled value', () => {
+		const h = harness(() => (
+			<RadioGroup
+				value="fish"
+				name="test"
+				onValue={noop}
+				options={[{ value: 'cat', disabled: true }, { value: 'fish' }, { value: 'dog' }]}
+			/>
+		));
+		const optionTemplate = template.setChildren('@root', () => [
+			<Radio
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+				disabled={true}
+			>
+				cat
+			</Radio>,
+			<Radio
+				name="test"
+				value="fish"
+				checked={true}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+				disabled={undefined}
+			>
+				fish
+			</Radio>,
+			<Radio
+				name="test"
+				value="dog"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+				disabled={undefined}
+			>
+				dog
+			</Radio>
+		]);
+		h.expect(optionTemplate);
+		h.trigger('[value="cat"]', 'onValue', true);
+		h.expect(optionTemplate);
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**
- Adds `disabled` field to `RadioGroup` `options` property
- - Adds `disabled` field to `CheckboxGroup` `options` property

Resolves #1698 
