### PR TITLE
support more date formats and custom date parsers

### DIFF
--- a/src/date-input/date-utils.tsx
+++ b/src/date-input/date-utils.tsx
@@ -14,18 +14,47 @@ const dateExpressions = () => {
 	];
 
 	const usCanary = Intl.DateTimeFormat().format(new Date(2018, 3, 3)); // April 3
-	if (usCanary === '4/3/2018') {
-		// US-only 'mm/dd/yyyy' format
-		tokens.push([
-			new RegExp(`^${components.month}\/${components.day}\/${components.year}$`),
-			{ month: 1, day: 2, year: 3 }
-		]);
-	} else {
-		// standard 'dd/mm/yyyy' format
-		tokens.push([
-			new RegExp(`^${components.day}\/${components.month}\/${components.year}$`),
-			{ month: 2, day: 1, year: 3 }
-		]);
+	switch (usCanary) {
+		case '4/3/2018':
+		case '04/03/2018':
+			// US-only 'mm/dd/yyyy' format
+			tokens.push([
+				new RegExp(`^${components.month}\/${components.day}\/${components.year}$`),
+				{ month: 1, day: 2, year: 3 }
+			]);
+			break;
+		case '3/4/2018':
+		case '03/04/2018':
+			// standard 'dd/mm/yyyy' format
+			tokens.push([
+				new RegExp(`^${components.day}\/${components.month}\/${components.year}$`),
+				{ month: 2, day: 1, year: 3 }
+			]);
+			break;
+		case '3.4.2018':
+		case '03.04.2018':
+			// standard 'dd.mm.yyyy' format
+			tokens.push([
+				new RegExp(`^${components.day}\\.${components.month}\\.${components.year}$`),
+				{ month: 2, day: 1, year: 3 }
+			]);
+			break;
+		case '3-4-2018':
+		case '03-04-2018':
+			// standard 'dd.mm.yyyy' format
+			tokens.push([
+				new RegExp(`^${components.day}\-${components.month}\-${components.year}$`),
+				{ month: 2, day: 1, year: 3 }
+			]);
+			break;
+		case '2018/4/3':
+		case '2018/04/03':
+			// standard 'yyyy/mm/dd' format
+			tokens.push([
+				new RegExp(`^${components.year}\/${components.month}\/${components.day}$`),
+				{ month: 2, day: 3, year: 1 }
+			]);
+			break;
 	}
 
 	return tokens;

--- a/src/date-input/date-utils.tsx
+++ b/src/date-input/date-utils.tsx
@@ -96,5 +96,11 @@ export function formatDateISO(date: Date | undefined) {
 }
 
 export function formatDate(date: Date) {
-	return Intl.DateTimeFormat().format(date);
+	const formattedDate = Intl.DateTimeFormat().format(date);
+	// Check if is a supported date format
+	const parsedDate = parseDate(formattedDate);
+	if (parsedDate && parsedDate.valueOf() === date.valueOf()) {
+		return formattedDate;
+	}
+	return formatDateISO(date);
 }

--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -32,6 +32,10 @@ export interface DateInputProperties extends ThemeProperties, FocusProperties {
 	onValue?(date: string): void;
 	/** Callback fired when input validation changes */
 	onValidate?: (valid: boolean | undefined, message: string) => void;
+	/** Custom date string parser function to allow custom date formats. Must work with dateFormatter */
+	dateParser?(date?: string): Date | undefined;
+	/** Custom date formatter function to convert Dates to strings. Must work with dateParser */
+	dateFormatter?(date?: Date): string | undefined;
 	/** The disabled property of the input */
 	disabled?: boolean;
 	/** The readonly attribute of the input */
@@ -81,9 +85,13 @@ export default factory(function({
 		name,
 		onValue,
 		onValidate,
+		dateParser = parseDate,
+		dateFormatter = formatDate,
 		value: controlledValue,
 		disabled = false,
 		readOnly = false,
+		min: minInput,
+		max: maxInput,
 		theme: themeProp,
 		variant,
 		classes,
@@ -91,27 +99,27 @@ export default factory(function({
 	} = properties();
 	const { messages } = i18n.localize(bundle);
 	const themedCss = theme.classes(css);
-	const max = parseDate(properties().max);
-	const min = parseDate(properties().min);
+	const max = (Boolean(maxInput) && dateParser(maxInput)) || undefined;
+	const min = (Boolean(minInput) && dateParser(minInput)) || undefined;
 
 	if (
 		initialValue !== undefined &&
 		controlledValue === undefined &&
 		icache.get('initialValue') !== initialValue
 	) {
-		const parsed = initialValue && parseDate(initialValue);
+		const parsed = initialValue && dateParser(initialValue);
 
 		if (parsed) {
-			icache.set('inputValue', formatDate(parsed));
+			icache.set('inputValue', dateFormatter(parsed));
 		}
 		icache.set('initialValue', initialValue);
 		icache.delete('callOnValue');
 	}
 
 	if (controlledValue !== undefined && icache.get('lastValue') !== controlledValue) {
-		const parsed = controlledValue && parseDate(controlledValue);
+		const parsed = controlledValue && dateParser(controlledValue);
 		if (parsed) {
-			icache.set('inputValue', formatDate(parsed));
+			icache.set('inputValue', dateFormatter(parsed));
 			icache.set('value', parsed);
 		}
 		icache.set('lastValue', controlledValue);
@@ -133,7 +141,7 @@ export default factory(function({
 			validationMessages.push(messages.invalidProps);
 			isValid = false;
 		} else {
-			const newDate = parseDate(testValue);
+			const newDate = dateParser(testValue);
 
 			if (newDate !== undefined) {
 				if (min && newDate < min) {
@@ -143,7 +151,7 @@ export default factory(function({
 				} else {
 					if (controlledValue === undefined) {
 						icache.set('value', newDate);
-						icache.set('inputValue', formatDate(newDate));
+						icache.set('inputValue', dateFormatter(newDate));
 					}
 					if (onValue) {
 						onValue(formatDateISO(newDate));
@@ -291,7 +299,7 @@ export default factory(function({
 											controlledValue === undefined
 												? 'inputValue'
 												: 'nextValue',
-											formatDate(date)
+											dateFormatter(date)
 										);
 										callOnValue();
 										closeCalendar();

--- a/src/date-input/tests/unit/date-utils.spec.tsx
+++ b/src/date-input/tests/unit/date-utils.spec.tsx
@@ -3,7 +3,7 @@ const { assert } = intern.getPlugin('chai');
 
 import * as sinon from 'sinon';
 
-import { parseDate } from '../../date-utils';
+import { parseDate, formatDate, formatDateISO } from '../../date-utils';
 
 describe('DateInput Date Utils', () => {
 	describe('parseDate', () => {
@@ -62,6 +62,41 @@ describe('DateInput Date Utils', () => {
 		it('handles invalid formats', () => {
 			const actual = parseDate('not-a-date');
 			assert.isUndefined(actual);
+		});
+	});
+
+	describe('formatDate', () => {
+		it('formats a date using DateTimeFormat', () => {
+			const stub = sinon.stub(Intl, 'DateTimeFormat');
+			stub.onFirstCall().returns({ format: () => '3/30/2021' });
+			stub.onSecondCall().returns({ format: () => '4/3/2018' }); // forces "canary" date to match "en-us"
+
+			const value = new Date(2021, 2, 30);
+			const actual = formatDate(value);
+
+			assert.equal(actual, '3/30/2021');
+			stub.restore();
+		});
+
+		it('defaults to ISO date strings if DateTimeFormat locale is unsupported', () => {
+			const stub = sinon.stub(Intl, 'DateTimeFormat');
+			stub.onFirstCall().returns({ format: () => '30. 3. 2021' }); // Format returned by "sl" locale
+			stub.onSecondCall().returns({ format: () => '3. 4. 2018' }); // unrecognized "canary" date
+
+			const value = new Date(2021, 2, 30);
+			const actual = formatDate(value);
+
+			assert.equal(actual, '2021-03-30');
+			stub.restore();
+		});
+	});
+
+	describe('formatDateISO', () => {
+		it('formats a date', () => {
+			const value = new Date(2021, 2, 30);
+			const actual = formatDateISO(value);
+
+			assert.equal(actual, '2021-03-30');
 		});
 	});
 });

--- a/src/date-input/tests/unit/date-utils.spec.tsx
+++ b/src/date-input/tests/unit/date-utils.spec.tsx
@@ -1,29 +1,12 @@
-const { describe, it, beforeEach, afterEach } = intern.getInterface('bdd');
+const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 
-import { createSandbox, SinonSandbox } from 'sinon';
+import * as sinon from 'sinon';
 
 import { parseDate } from '../../date-utils';
 
 describe('DateInput Date Utils', () => {
-	let sandbox: SinonSandbox;
-
-	beforeEach(() => {
-		sandbox = createSandbox();
-	});
-
-	afterEach(() => {
-		sandbox.restore();
-	});
-
 	describe('parseDate', () => {
-		function stubFormatForLocale(locale: string) {
-			const localeDateTimeFormat = Intl.DateTimeFormat(locale);
-			const stub = sandbox.stub(Intl, 'DateTimeFormat');
-			stub.returns({ format: (date: Date) => localeDateTimeFormat.format(date) });
-			return stub;
-		}
-
 		it('handles empty input', () => {
 			const value = undefined;
 			const actual = parseDate(value);
@@ -36,37 +19,41 @@ describe('DateInput Date Utils', () => {
 		});
 
 		it('can parse US format', () => {
-			const stub = stubFormatForLocale('en-US');
+			const stub = sinon.stub(Intl, 'DateTimeFormat');
+			stub.onFirstCall().returns({ format: () => '4/3/2018' }); // forces "canary" date to match "en-us"
 			const actual = parseDate('6/1/2018');
 			assert.equal(actual && actual.getTime(), new Date(2018, 5, 1).getTime());
 			stub.restore();
 		});
 
 		it('can parse non-US format', () => {
-			const stub = stubFormatForLocale('fr-fr');
-			stub.onCall(0).returns({ format: () => '3/4/2018' }); // forces "canary" date down non-US path
+			const stub = sinon.stub(Intl, 'DateTimeFormat');
+			stub.onFirstCall().returns({ format: () => '03/04/2018' }); // forces "canary" date to match "fr-fr"
 
-			const actual = parseDate('1/6/2018');
+			const actual = parseDate('01/06/2018');
 			assert.equal(actual && actual.getTime(), new Date(2018, 5, 1).getTime());
 			stub.restore();
 		});
 
 		it('can parse period separated date format', () => {
-			const stub = stubFormatForLocale('de-de');
+			const stub = sinon.stub(Intl, 'DateTimeFormat');
+			stub.onFirstCall().returns({ format: () => '3.4.2018' }); // forces "canary" date to match "de-de"
 			const actual = parseDate('1.6.2018');
 			assert.equal(actual && actual.getTime(), new Date(2018, 5, 1).getTime());
 			stub.restore();
 		});
 
 		it('can parse dash separated date format', () => {
-			const stub = stubFormatForLocale('nl-nl');
+			const stub = sinon.stub(Intl, 'DateTimeFormat');
+			stub.onFirstCall().returns({ format: () => '3-4-2018' }); // forces "canary" date to match "nl-nl"
 			const actual = parseDate('1-6-2018');
 			assert.equal(actual && actual.getTime(), new Date(2018, 5, 1).getTime());
 			stub.restore();
 		});
 
 		it('can parse YYYY/MM/DD format', () => {
-			const stub = stubFormatForLocale('zh-cn');
+			const stub = sinon.stub(Intl, 'DateTimeFormat');
+			stub.onFirstCall().returns({ format: () => '2018/4/3' }); // forces "canary" date to match "zh-cn"
 			const actual = parseDate('2018/6/1');
 			assert.equal(actual && actual.getTime(), new Date(2018, 5, 1).getTime());
 			stub.restore();

--- a/src/date-input/tests/unit/date-utils.spec.tsx
+++ b/src/date-input/tests/unit/date-utils.spec.tsx
@@ -1,12 +1,29 @@
-const { describe, it } = intern.getInterface('bdd');
+const { describe, it, beforeEach, afterEach } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
 
-import * as sinon from 'sinon';
+import { createSandbox, SinonSandbox } from 'sinon';
 
 import { parseDate } from '../../date-utils';
 
 describe('DateInput Date Utils', () => {
+	let sandbox: SinonSandbox;
+
+	beforeEach(() => {
+		sandbox = createSandbox();
+	});
+
+	afterEach(() => {
+		sandbox.restore();
+	});
+
 	describe('parseDate', () => {
+		function stubFormatForLocale(locale: string) {
+			const localeDateTimeFormat = Intl.DateTimeFormat(locale);
+			const stub = sandbox.stub(Intl, 'DateTimeFormat');
+			stub.returns({ format: (date: Date) => localeDateTimeFormat.format(date) });
+			return stub;
+		}
+
 		it('handles empty input', () => {
 			const value = undefined;
 			const actual = parseDate(value);
@@ -19,19 +36,38 @@ describe('DateInput Date Utils', () => {
 		});
 
 		it('can parse US format', () => {
-			const stub = sinon.stub(Intl, 'DateTimeFormat');
-			stub.onCall(0).returns({ format: () => '4/3/2018' }); // forces "canary" date down US path
-
+			const stub = stubFormatForLocale('en-US');
 			const actual = parseDate('6/1/2018');
 			assert.equal(actual && actual.getTime(), new Date(2018, 5, 1).getTime());
 			stub.restore();
 		});
 
 		it('can parse non-US format', () => {
-			const stub = sinon.stub(Intl, 'DateTimeFormat');
+			const stub = stubFormatForLocale('fr-fr');
 			stub.onCall(0).returns({ format: () => '3/4/2018' }); // forces "canary" date down non-US path
 
 			const actual = parseDate('1/6/2018');
+			assert.equal(actual && actual.getTime(), new Date(2018, 5, 1).getTime());
+			stub.restore();
+		});
+
+		it('can parse period separated date format', () => {
+			const stub = stubFormatForLocale('de-de');
+			const actual = parseDate('1.6.2018');
+			assert.equal(actual && actual.getTime(), new Date(2018, 5, 1).getTime());
+			stub.restore();
+		});
+
+		it('can parse dash separated date format', () => {
+			const stub = stubFormatForLocale('nl-nl');
+			const actual = parseDate('1-6-2018');
+			assert.equal(actual && actual.getTime(), new Date(2018, 5, 1).getTime());
+			stub.restore();
+		});
+
+		it('can parse YYYY/MM/DD format', () => {
+			const stub = stubFormatForLocale('zh-cn');
+			const actual = parseDate('2018/6/1');
 			assert.equal(actual && actual.getTime(), new Date(2018, 5, 1).getTime());
 			stub.restore();
 		});

--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -233,6 +233,7 @@ import ControlledDateInput from './widgets/date-input/Controlled';
 import DisabledDateInput from './widgets/date-input/Disabled';
 import ReadOnlyDateInput from './widgets/date-input/ReadOnly';
 import RequiredDateInput from './widgets/date-input/Required';
+import CustomParserDateInput from './widgets/date-input/CustomParser';
 import BasicLoadingIndicator from './widgets/loading-indicator/Basic';
 import BasicHeader from './widgets/header/Basic';
 import LeadingHeader from './widgets/header/Leading';
@@ -707,6 +708,13 @@ export const config = {
 					sandbox: true,
 					size: 'large',
 					title: 'Required date input'
+				},
+				{
+					filename: 'CustomParser',
+					module: CustomParserDateInput,
+					sandbox: true,
+					size: 'large',
+					title: 'Custom parser date input'
 				}
 			]
 		},

--- a/src/examples/src/widgets/date-input/CustomParser.tsx
+++ b/src/examples/src/widgets/date-input/CustomParser.tsx
@@ -19,25 +19,14 @@ export default factory(function Basic({ middleware: { icache } }) {
 						if (!input) {
 							return undefined;
 						}
-						const parts = input.split('#');
-						if (
-							parts.length === 3 &&
-							parts.every((part) => Number.isInteger(Number(part)))
-						) {
-							return new Date(
-								Number(parts[0]),
-								Number(parts[1]) - 1,
-								Number(parts[2])
-							);
-						}
+						const date = new Date(input);
+						return isNaN(date.valueOf()) ? undefined : date;
 					}}
 					dateFormatter={(input?: Date) => {
 						if (!input || isNaN(input.valueOf())) {
 							return undefined;
 						}
-						return [input.getFullYear(), input.getMonth() + 1, input.getDate()].join(
-							'#'
-						);
+						return input.toISOString();
 					}}
 				/>
 			</div>

--- a/src/examples/src/widgets/date-input/CustomParser.tsx
+++ b/src/examples/src/widgets/date-input/CustomParser.tsx
@@ -1,0 +1,46 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import icache from '@dojo/framework/core/middleware/icache';
+import DateInput from '@dojo/widgets/date-input';
+import Example from '../../Example';
+
+const factory = create({ icache });
+
+export default factory(function Basic({ middleware: { icache } }) {
+	return (
+		<Example>
+			<div>
+				<div>{icache.get('date')}</div>
+				<DateInput
+					name="dateInput"
+					onValue={(value) => {
+						icache.set('date', value);
+					}}
+					dateParser={(input?: string) => {
+						if (!input) {
+							return undefined;
+						}
+						const parts = input.split('#');
+						if (
+							parts.length === 3 &&
+							parts.every((part) => Number.isInteger(Number(part)))
+						) {
+							return new Date(
+								Number(parts[0]),
+								Number(parts[1]) - 1,
+								Number(parts[2])
+							);
+						}
+					}}
+					dateFormatter={(input?: Date) => {
+						if (!input || isNaN(input.valueOf())) {
+							return undefined;
+						}
+						return [input.getFullYear(), input.getMonth() + 1, input.getDate()].join(
+							'#'
+						);
+					}}
+				/>
+			</div>
+		</Example>
+	);
+});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Adds support for more date formats and the ability to pass a custom date parser. This resolves an issue with the date handling outside of a few select locales and adds support for several common date formats (as defined by `Intl.DateTimeFormat().format()`). For other locales or for more flexible date parsing (such as to support multiple formats at once), a custom date formatter/parser combo can be passed.

For locales where `Intl.DateTimeFormat().format()` produces something that is not supported, selecting a date from the calendar was resulting in an invalid date warning. This was because the Date value is formatted as a string using `DateTimeFormat` and later parsed. The fix was adding a check to the date-to-string formatter that avoids outputting un-parseable strings and defaults to ISO strings.

Resolves #1563
