### PR TITLE
Feature/action groups - 1574

### DIFF
--- a/src/card/index.tsx
+++ b/src/card/index.tsx
@@ -1,7 +1,29 @@
-import { tsx, create } from '@dojo/framework/core/vdom';
 import { RenderResult } from '@dojo/framework/core/interfaces';
-import * as css from '../theme/default/card.m.css';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import ActionButton, { ActionButtonProperties } from '../action-button/index';
+import Icon, { IconProperties } from '../icon/index';
 import theme from '../middleware/theme';
+import * as css from '../theme/default/card.m.css';
+
+export interface ActionProperties extends ActionButtonProperties {}
+
+const actionFactory = create().properties<ActionProperties>();
+
+export const Action = actionFactory(({ properties, children }) => {
+	const action = <ActionButton {...properties()}>{children()}</ActionButton>;
+
+	return action;
+});
+
+export interface ActionIconProperties extends IconProperties {}
+
+const actionIconFactory = create().properties<ActionIconProperties>();
+
+export const ActionIcon = actionIconFactory(({ properties, children }) => {
+	const action = <Icon {...properties()}>{children()}</Icon>;
+
+	return action;
+});
 
 export interface CardProperties {
 	onAction?: () => void;

--- a/src/card/tests/unit/Card.spec.tsx
+++ b/src/card/tests/unit/Card.spec.tsx
@@ -1,12 +1,10 @@
 const { describe, it } = intern.getInterface('bdd');
 const { assert } = intern.getPlugin('chai');
-import renderer, { assertion, wrap } from '@dojo/framework/testing/renderer';
 import { tsx } from '@dojo/framework/core/vdom';
-import Card from '../../index';
-import Button from '../../../button/index';
-import Icon from '../../../icon';
-import * as css from '../../../theme/default/card.m.css';
+import renderer, { assertion, wrap } from '@dojo/framework/testing/renderer';
 import { spy } from 'sinon';
+import * as css from '../../../theme/default/card.m.css';
+import Card, { Action, ActionIcon } from '../../index';
 
 const noop = () => {};
 
@@ -151,13 +149,13 @@ describe('Card', () => {
 			const r = renderer(() => (
 				<Card>
 					{{
-						actionButtons: <Button>test</Button>
+						actionButtons: <Action>test</Action>
 					}}
 				</Card>
 			));
 			const childrenTemplate = actionsTemplate.setChildren(Actions, () => [
 				<div classes={css.actionButtons}>
-					<Button>test</Button>
+					<Action>test</Action>
 				</div>
 			]);
 			r.expect(childrenTemplate);
@@ -167,13 +165,13 @@ describe('Card', () => {
 			const r = renderer(() => (
 				<Card>
 					{{
-						actionIcons: <Icon type="upIcon" />
+						actionIcons: <ActionIcon type="upIcon" />
 					}}
 				</Card>
 			));
 			const childrenTemplate = actionsTemplate.setChildren(Actions, () => [
 				<div classes={css.actionIcons}>
-					<Icon type="upIcon" />
+					<ActionIcon type="upIcon" />
 				</div>
 			]);
 			r.expect(childrenTemplate);
@@ -183,17 +181,17 @@ describe('Card', () => {
 			const r = renderer(() => (
 				<Card>
 					{{
-						actionButtons: <Button>test</Button>,
-						actionIcons: <Icon type="upIcon" />
+						actionButtons: <Action>test</Action>,
+						actionIcons: <ActionIcon type="upIcon" />
 					}}
 				</Card>
 			));
 			const childrenTemplate = actionsTemplate.setChildren(Actions, () => [
 				<div classes={css.actionButtons}>
-					<Button>test</Button>
+					<Action>test</Action>
 				</div>,
 				<div classes={css.actionIcons}>
-					<Icon type="upIcon" />
+					<ActionIcon type="upIcon" />
 				</div>
 			]);
 			r.expect(childrenTemplate);
@@ -212,8 +210,8 @@ describe('Card', () => {
 				{{
 					header: 'Header Content',
 					content: 'Content',
-					actionButtons: <Button>test</Button>,
-					actionIcons: <Icon type="upIcon" />
+					actionButtons: <Action>test</Action>,
+					actionIcons: <ActionIcon type="upIcon" />
 				}}
 			</Card>
 		));
@@ -242,10 +240,10 @@ describe('Card', () => {
 				.append(Root, () => [
 					<div key="actions" classes={css.actions}>
 						<div classes={css.actionButtons}>
-							<Button>test</Button>
+							<Action>test</Action>
 						</div>
 						<div classes={css.actionIcons}>
-							<Icon type="upIcon" />
+							<ActionIcon type="upIcon" />
 						</div>
 					</div>
 				])

--- a/src/card/tests/unit/Card.spec.tsx
+++ b/src/card/tests/unit/Card.spec.tsx
@@ -3,6 +3,8 @@ const { assert } = intern.getPlugin('chai');
 import { tsx } from '@dojo/framework/core/vdom';
 import renderer, { assertion, wrap } from '@dojo/framework/testing/renderer';
 import { spy } from 'sinon';
+import ActionButton from '../../../action-button';
+import Icon from '../../../icon';
 import * as css from '../../../theme/default/card.m.css';
 import Card, { Action, ActionIcon } from '../../index';
 
@@ -145,7 +147,7 @@ describe('Card', () => {
 			<Actions key="actions" classes={css.actions} />
 		]);
 
-		it('renders action buttons', () => {
+		it('renders actions', () => {
 			const r = renderer(() => (
 				<Card>
 					{{
@@ -159,6 +161,11 @@ describe('Card', () => {
 				</div>
 			]);
 			r.expect(childrenTemplate);
+		});
+
+		it('renders action buttons', () => {
+			const h = renderer(() => <Action name="testButton">test</Action>);
+			h.expect(assertion(() => <ActionButton name="testButton">test</ActionButton>));
 		});
 
 		it('renders action icons', () => {
@@ -175,6 +182,11 @@ describe('Card', () => {
 				</div>
 			]);
 			r.expect(childrenTemplate);
+		});
+
+		it('renders action icons as icons', () => {
+			const h = renderer(() => <ActionIcon type="alertIcon" />);
+			h.expect(assertion(() => <Icon type="alertIcon" />));
 		});
 
 		it('renders action buttons and icons', () => {

--- a/src/dialog/index.tsx
+++ b/src/dialog/index.tsx
@@ -1,17 +1,28 @@
 import { DNode } from '@dojo/framework/core/interfaces';
 import i18n from '@dojo/framework/core/middleware/i18n';
 import { createICacheMiddleware } from '@dojo/framework/core/middleware/icache';
+import inert from '@dojo/framework/core/middleware/inert';
 import { uuid } from '@dojo/framework/core/util';
 import { create, tsx } from '@dojo/framework/core/vdom';
+import ActionButton, { ActionButtonProperties } from '../action-button';
 import { formatAriaProperties, Keys } from '../common/util';
-import Icon from '../icon';
-import theme from '../middleware/theme';
-import bodyScroll from '../middleware/bodyScroll';
-import * as css from '../theme/default/dialog.m.css';
-import * as fixedCss from './styles/dialog.m.css';
-import bundle from './nls/Dialog';
 import GlobalEvent from '../global-event';
-import inert from '@dojo/framework/core/middleware/inert';
+import Icon from '../icon';
+import bodyScroll from '../middleware/bodyScroll';
+import theme from '../middleware/theme';
+import * as css from '../theme/default/dialog.m.css';
+import bundle from './nls/Dialog';
+import * as fixedCss from './styles/dialog.m.css';
+
+export interface ActionProperties extends ActionButtonProperties {}
+
+const actionFactory = create().properties<ActionProperties>();
+
+export const Action = actionFactory(({ properties, children }) => {
+	const action = <ActionButton {...properties()}>{children()}</ActionButton>;
+
+	return action;
+});
 
 export interface DialogPropertiesBase {
 	/** Custom aria attributes */

--- a/src/dialog/tests/unit/Dialog.spec.tsx
+++ b/src/dialog/tests/unit/Dialog.spec.tsx
@@ -1,6 +1,7 @@
 import { tsx } from '@dojo/framework/core/vdom';
 import assertionTemplate from '@dojo/framework/testing/harness/assertionTemplate';
 import * as sinon from 'sinon';
+import ActionButton from '../../../action-button';
 import {
 	compareAriaLabelledBy,
 	compareId,
@@ -260,5 +261,10 @@ describe('Dialog', () => {
 					</div>
 				])
 		);
+	});
+
+	it('renders action buttons', () => {
+		const h = harness(() => <Action name="testButton">test</Action>);
+		h.expect(assertionTemplate(() => <ActionButton name="testButton">test</ActionButton>));
 	});
 });

--- a/src/dialog/tests/unit/Dialog.spec.tsx
+++ b/src/dialog/tests/unit/Dialog.spec.tsx
@@ -1,22 +1,21 @@
-import { Keys } from '../../../common/util';
-
-const { describe, it } = intern.getInterface('bdd');
-const { assert } = intern.getPlugin('chai');
 import { tsx } from '@dojo/framework/core/vdom';
 import assertionTemplate from '@dojo/framework/testing/harness/assertionTemplate';
-import Icon from '../../../icon';
+import * as sinon from 'sinon';
 import {
 	compareAriaLabelledBy,
 	compareId,
 	createHarness,
 	stubEvent
 } from '../../../common/tests/support/test-helpers';
-import * as themeCss from '../../../theme/default/dialog.m.css';
-import * as fixedCss from '../../styles/dialog.m.css';
-import * as sinon from 'sinon';
-
-import Dialog, { DialogProperties } from '../../index';
+import { Keys } from '../../../common/util';
 import GlobalEvent from '../../../global-event';
+import Icon from '../../../icon';
+import * as themeCss from '../../../theme/default/dialog.m.css';
+import Dialog, { Action, DialogProperties } from '../../index';
+import * as fixedCss from '../../styles/dialog.m.css';
+
+const { describe, it } = intern.getInterface('bdd');
+const { assert } = intern.getPlugin('chai');
 
 const harness = createHarness([compareId, compareAriaLabelledBy]);
 
@@ -247,7 +246,7 @@ describe('Dialog', () => {
 				{{
 					title: 'foo',
 					content: 'bar',
-					actions: 'action'
+					actions: <Action>Action</Action>
 				}}
 			</Dialog>
 		));
@@ -257,7 +256,7 @@ describe('Dialog', () => {
 				.setChildren('@content', () => ['bar'])
 				.insertAfter('@content', () => [
 					<div classes={themeCss.actions} key="actions">
-						action
+						<Action>Action</Action>
 					</div>
 				])
 		);

--- a/src/examples/src/widgets/card/ActionButtons.tsx
+++ b/src/examples/src/widgets/card/ActionButtons.tsx
@@ -1,7 +1,6 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import { icache } from '@dojo/framework/core/middleware/icache';
-import Card from '@dojo/widgets/card';
-import Button from '@dojo/widgets/button';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Card, { Action } from '@dojo/widgets/card';
 import Example from '../../Example';
 
 const factory = create({ icache });
@@ -14,11 +13,11 @@ export default factory(function ActionButtons({ middleware: { icache } }) {
 				<Card title="Hello, World">
 					{{
 						actionButtons: (
-							<Button onClick={() => icache.set('clickCount', clickCount + 1)}>
+							<Action onClick={() => icache.set('clickCount', clickCount + 1)}>
 								{clickCount === 0
 									? 'Action'
 									: `Clicked: ${clickCount} time${clickCount > 1 ? 's' : ''}`}
-							</Button>
+							</Action>
 						),
 						content: <span>Lorem ipsum</span>
 					}}

--- a/src/examples/src/widgets/card/ActionButtonsAndIcons.tsx
+++ b/src/examples/src/widgets/card/ActionButtonsAndIcons.tsx
@@ -1,8 +1,6 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
 import { icache } from '@dojo/framework/core/middleware/icache';
-import Card from '@dojo/widgets/card';
-import Button from '@dojo/widgets/button';
-import Icon from '@dojo/widgets/icon';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Card, { Action, ActionIcon } from '@dojo/widgets/card';
 import Example from '../../Example';
 
 const factory = create({ icache });
@@ -16,17 +14,17 @@ export default factory(function ActionButtonsAndIcons({ middleware: { icache } }
 					{{
 						content: <span>Lorem ipsum</span>,
 						actionButtons: (
-							<Button onClick={() => icache.set('clickCount', clickCount + 1)}>
+							<Action onClick={() => icache.set('clickCount', clickCount + 1)}>
 								{clickCount === 0
 									? 'Action'
 									: `Clicked: ${clickCount} time${clickCount > 1 ? 's' : ''}`}
-							</Button>
+							</Action>
 						),
 						actionIcons: (
 							<virtual>
-								<Icon type="secureIcon" />
-								<Icon type="downIcon" />
-								<Icon type="upIcon" />
+								<ActionIcon type="secureIcon" />
+								<ActionIcon type="downIcon" />
+								<ActionIcon type="upIcon" />
 							</virtual>
 						)
 					}}

--- a/src/examples/src/widgets/card/ActionIcons.tsx
+++ b/src/examples/src/widgets/card/ActionIcons.tsx
@@ -1,6 +1,5 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Card from '@dojo/widgets/card';
-import Icon from '@dojo/widgets/icon';
+import Card, { ActionIcon } from '@dojo/widgets/card';
 import Example from '../../Example';
 
 const factory = create();
@@ -14,9 +13,9 @@ export default factory(function ActionIcons() {
 						content: <h2>Hello, World</h2>,
 						actionIcons: (
 							<virtual>
-								<Icon type="secureIcon" />
-								<Icon type="downIcon" />
-								<Icon type="upIcon" />
+								<ActionIcon type="secureIcon" />
+								<ActionIcon type="downIcon" />
+								<ActionIcon type="upIcon" />
 							</virtual>
 						)
 					}}

--- a/src/examples/src/widgets/card/CardCombined.tsx
+++ b/src/examples/src/widgets/card/CardCombined.tsx
@@ -1,7 +1,5 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Card from '@dojo/widgets/card';
-import Button from '@dojo/widgets/button';
-import Icon from '@dojo/widgets/icon';
+import Card, { Action, ActionIcon } from '@dojo/widgets/card';
 import Example from '../../Example';
 const mediaSrc = require('./img/card-photo.jpg');
 
@@ -22,15 +20,15 @@ export default factory(function CardWithMediaContent() {
 						content: <span>Travel the world today.</span>,
 						actionButtons: (
 							<virtual>
-								<Button>Read</Button>
-								<Button>Bookmark</Button>
+								<Action>Read</Action>
+								<Action>Bookmark</Action>
 							</virtual>
 						),
 						actionIcons: (
 							<virtual>
-								<Icon type="secureIcon" />
-								<Icon type="downIcon" />
-								<Icon type="upIcon" />
+								<ActionIcon type="secureIcon" />
+								<ActionIcon type="downIcon" />
+								<ActionIcon type="upIcon" />
 							</virtual>
 						)
 					}}

--- a/src/examples/src/widgets/dialog/ActionsDialog.tsx
+++ b/src/examples/src/widgets/dialog/ActionsDialog.tsx
@@ -1,7 +1,7 @@
-import { create, tsx } from '@dojo/framework/core/vdom';
-import Dialog from '@dojo/widgets/dialog';
-import Button from '@dojo/widgets/button';
 import icache from '@dojo/framework/core/middleware/icache';
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Button from '@dojo/widgets/button';
+import Dialog, { Action } from '@dojo/widgets/dialog';
 import Example from '../../Example';
 
 const factory = create({ icache });
@@ -26,7 +26,7 @@ export default factory(function ActionsDialog({ middleware: { icache } }) {
 						),
 						actions: (
 							<virtual>
-								<Button onClick={() => icache.set('isOpen', false)}>OK</Button>
+								<Action onClick={() => icache.set('isOpen', false)}>OK</Action>
 							</virtual>
 						)
 					}}

--- a/src/examples/src/widgets/header/Basic.tsx
+++ b/src/examples/src/widgets/header/Basic.tsx
@@ -1,5 +1,4 @@
-import Header from '@dojo/widgets/header';
-import { Link } from '@dojo/framework/routing/Link';
+import Header, { Action } from '@dojo/widgets/header';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Example from '../../Example';
 
@@ -12,9 +11,9 @@ export default factory(function Basic() {
 				{{
 					title: 'My App',
 					actions: [
-						<Link to="#foo">Foo</Link>,
-						<Link to="#bar">Bar</Link>,
-						<Link to="#baz">Baz</Link>
+						<Action to="#foo">Foo</Action>,
+						<Action to="#bar">Bar</Action>,
+						<Action to="#baz">Baz</Action>
 					]
 				}}
 			</Header>

--- a/src/examples/src/widgets/header/Leading.tsx
+++ b/src/examples/src/widgets/header/Leading.tsx
@@ -1,6 +1,5 @@
-import Header from '@dojo/widgets/header';
+import Header, { Action } from '@dojo/widgets/header';
 import Icon from '@dojo/widgets/icon';
-import { Link } from '@dojo/framework/routing/Link';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import Example from '../../Example';
 
@@ -14,9 +13,9 @@ export default factory(function Basic() {
 					leading: <Icon type="barsIcon" />,
 					title: 'My App',
 					actions: [
-						<Link to="#foo">Foo</Link>,
-						<Link to="#bar">Bar</Link>,
-						<Link to="#baz">Baz</Link>
+						<Action to="#foo">Foo</Action>,
+						<Action to="#bar">Bar</Action>,
+						<Action to="#baz">Baz</Action>
 					]
 				}}
 			</Header>

--- a/src/examples/src/widgets/header/Sticky.tsx
+++ b/src/examples/src/widgets/header/Sticky.tsx
@@ -1,6 +1,5 @@
-import Header from '@dojo/widgets/header';
-import { Link } from '@dojo/framework/routing/Link';
 import { create, tsx } from '@dojo/framework/core/vdom';
+import Header, { Action } from '@dojo/widgets/header';
 import Example from '../../Example';
 
 const factory = create();
@@ -12,9 +11,9 @@ export default factory(function Basic() {
 				{{
 					title: 'My App',
 					actions: [
-						<Link to="#foo">Foo</Link>,
-						<Link to="#bar">Bar</Link>,
-						<Link to="#baz">Baz</Link>
+						<Action to="#foo">Foo</Action>,
+						<Action to="#bar">Bar</Action>,
+						<Action to="#baz">Baz</Action>
 					]
 				}}
 			</Header>

--- a/src/examples/src/widgets/header/Trailing.tsx
+++ b/src/examples/src/widgets/header/Trailing.tsx
@@ -1,7 +1,6 @@
-import Header from '@dojo/widgets/header';
-import Icon from '@dojo/widgets/icon';
-import { Link } from '@dojo/framework/routing/Link';
 import { create, tsx } from '@dojo/framework/core/vdom';
+import Header, { Action } from '@dojo/widgets/header';
+import Icon from '@dojo/widgets/icon';
 import Example from '../../Example';
 
 const factory = create();
@@ -13,9 +12,9 @@ export default factory(function Basic() {
 				{{
 					title: 'My App',
 					actions: [
-						<Link to="#foo">Foo</Link>,
-						<Link to="#bar">Bar</Link>,
-						<Link to="#baz">Baz</Link>
+						<Action to="#foo">Foo</Action>,
+						<Action to="#bar">Bar</Action>,
+						<Action to="#baz">Baz</Action>
 					],
 					trailing: <Icon type="searchIcon" />
 				}}

--- a/src/examples/src/widgets/result/Alert.tsx
+++ b/src/examples/src/widgets/result/Alert.tsx
@@ -1,6 +1,5 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Result from '@dojo/widgets/result';
-import Button from '@dojo/widgets/button';
+import Result, { Action } from '@dojo/widgets/result';
 import Example from '../../Example';
 
 const factory = create();
@@ -13,7 +12,7 @@ export default factory(function Alert() {
 					content: <span>Content describing the alert.</span>,
 					actionButtons: (
 						<virtual>
-							<Button>Alert Action</Button>
+							<Action>Alert Action</Action>
 						</virtual>
 					)
 				}}

--- a/src/examples/src/widgets/result/CustomIcon.tsx
+++ b/src/examples/src/widgets/result/CustomIcon.tsx
@@ -1,6 +1,5 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Result from '@dojo/widgets/result';
-import Button from '@dojo/widgets/button';
+import Result, { Action } from '@dojo/widgets/result';
 import Example from '../../Example';
 const dojo = require('../avatar/img/dojo.jpg');
 
@@ -15,7 +14,7 @@ export default factory(function Alert() {
 					content: <span>Content describing the alert.</span>,
 					actionButtons: (
 						<virtual>
-							<Button>Result Action</Button>
+							<Action>Result Action</Action>
 						</virtual>
 					)
 				}}

--- a/src/examples/src/widgets/result/Error.tsx
+++ b/src/examples/src/widgets/result/Error.tsx
@@ -1,6 +1,5 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Result from '@dojo/widgets/result';
-import Button from '@dojo/widgets/button';
+import Result, { Action } from '@dojo/widgets/result';
 import Example from '../../Example';
 
 const factory = create();
@@ -13,8 +12,8 @@ export default factory(function Error() {
 					content: <span>This is the error content.</span>,
 					actionButtons: (
 						<virtual>
-							<Button>Go Back</Button>
-							<Button>Try Again</Button>
+							<Action>Go Back</Action>
+							<Action>Try Again</Action>
 						</virtual>
 					)
 				}}

--- a/src/examples/src/widgets/result/Success.tsx
+++ b/src/examples/src/widgets/result/Success.tsx
@@ -1,6 +1,5 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Result from '@dojo/widgets/result';
-import Button from '@dojo/widgets/button';
+import Result, { Action } from '@dojo/widgets/result';
 import Example from '../../Example';
 
 const factory = create();
@@ -13,7 +12,7 @@ export default factory(function Error() {
 					content: <span>This is the success content.</span>,
 					actionButtons: (
 						<virtual>
-							<Button>OK</Button>
+							<Action>OK</Action>
 						</virtual>
 					)
 				}}

--- a/src/examples/src/widgets/snackbar/Stacked.tsx
+++ b/src/examples/src/widgets/snackbar/Stacked.tsx
@@ -1,7 +1,6 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import Snackbar from '@dojo/widgets/snackbar';
+import Snackbar, { Action } from '@dojo/widgets/snackbar';
 import Example from '../../Example';
-import ActionButton from '@dojo/widgets/action-button';
 
 const factory = create();
 
@@ -11,7 +10,7 @@ export default factory(function Stacked() {
 			<Snackbar stacked open={true}>
 				{{
 					message: 'Stacked Snackbar',
-					actions: <ActionButton>Some Action</ActionButton>
+					actions: <Action>Some Action</Action>
 				}}
 			</Snackbar>
 		</Example>

--- a/src/header/index.tsx
+++ b/src/header/index.tsx
@@ -2,23 +2,31 @@ import { RenderResult } from '@dojo/framework/core/interfaces';
 import { create, tsx } from '@dojo/framework/core/vdom';
 import { LinkProperties } from '@dojo/framework/routing/interfaces';
 import Link from '@dojo/framework/routing/Link';
+import ActionButton, { ActionButtonProperties } from '../action-button';
 import theme from '../middleware/theme';
 import * as css from '../theme/default/header.m.css';
 
-export interface ActionProperties extends LinkProperties {}
+export type ActionProperties = LinkProperties | ActionButtonProperties;
 
 const actionFactory = create({ theme }).properties<ActionProperties>();
 
+function IsLink(properties: ActionProperties): properties is LinkProperties {
+	return Boolean(properties && properties.hasOwnProperty('to'));
+}
+
 export const Action = actionFactory(({ properties, children, middleware: { theme } }) => {
 	const themedCss = theme.classes(css);
+	const props = properties();
 
-	const action = (
-		<Link {...properties()} classes={[theme.variant(), themedCss.action]}>
-			{children()}
-		</Link>
-	);
-
-	return action;
+	if (IsLink(props)) {
+		return (
+			<Link {...props} classes={[theme.variant(), themedCss.action]}>
+				{children()}
+			</Link>
+		);
+	} else {
+		return <ActionButton {...props}>{children()}</ActionButton>;
+	}
 });
 
 export interface HeaderProperties {

--- a/src/header/index.tsx
+++ b/src/header/index.tsx
@@ -1,7 +1,25 @@
-import * as css from '../theme/default/header.m.css';
-import theme from '../middleware/theme';
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import { create, tsx } from '@dojo/framework/core/vdom';
+import { LinkProperties } from '@dojo/framework/routing/interfaces';
+import Link from '@dojo/framework/routing/Link';
+import theme from '../middleware/theme';
+import * as css from '../theme/default/header.m.css';
+
+export interface ActionProperties extends LinkProperties {}
+
+const actionFactory = create({ theme }).properties<ActionProperties>();
+
+export const Action = actionFactory(({ properties, children, middleware: { theme } }) => {
+	const themedCss = theme.classes(css);
+
+	const action = (
+		<Link {...properties()} classes={themedCss.action}>
+			{children()}
+		</Link>
+	);
+
+	return action;
+});
 
 export interface HeaderProperties {
 	/** Determines if this header is fixed */
@@ -40,10 +58,7 @@ export const Header = factory(function Header({ children, properties, middleware
 					</div>
 					<div classes={classes.secondary} key="secondary">
 						<nav classes={classes.actions} key="actions">
-							{actions &&
-								(Array.isArray(actions) ? actions : [actions]).map((action) => (
-									<div classes={classes.action}>{action}</div>
-								))}
+							{actions}
 						</nav>
 						{trailing && <div classes={classes.trailing}>{trailing}</div>}
 					</div>

--- a/src/header/index.tsx
+++ b/src/header/index.tsx
@@ -13,7 +13,7 @@ export const Action = actionFactory(({ properties, children, middleware: { theme
 	const themedCss = theme.classes(css);
 
 	const action = (
-		<Link {...properties()} classes={themedCss.action}>
+		<Link {...properties()} classes={[theme.variant(), themedCss.action]}>
 			{children()}
 		</Link>
 	);

--- a/src/header/tests/unit/Header.spec.tsx
+++ b/src/header/tests/unit/Header.spec.tsx
@@ -4,6 +4,7 @@ import Link from '@dojo/framework/routing/Link';
 import assertionTemplate from '@dojo/framework/testing/harness/assertionTemplate';
 import harness from '@dojo/framework/testing/harness/harness';
 import Header, { Action } from '../..';
+import ActionButton from '../../../action-button';
 import * as classes from '../../../theme/default/header.m.css';
 
 const baseTemplate = assertionTemplate(() => (
@@ -116,6 +117,11 @@ describe('HeaderToolbar', () => {
 				</Link>
 			))
 		);
+	});
+
+	it('renders action as button', () => {
+		const h = harness(() => <Action name="testButton">test</Action>);
+		h.expect(assertionTemplate(() => <ActionButton name="testButton">test</ActionButton>));
 	});
 
 	it('Renders a sticky header', () => {

--- a/src/header/tests/unit/Header.spec.tsx
+++ b/src/header/tests/unit/Header.spec.tsx
@@ -1,9 +1,9 @@
 const { describe, it } = intern.getInterface('bdd');
-import * as classes from '../../../theme/default/header.m.css';
-import Header from '../..';
+import { tsx } from '@dojo/framework/core/vdom';
 import assertionTemplate from '@dojo/framework/testing/harness/assertionTemplate';
 import harness from '@dojo/framework/testing/harness/harness';
-import { tsx } from '@dojo/framework/core/vdom';
+import Header, { Action } from '../..';
+import * as classes from '../../../theme/default/header.m.css';
 
 const baseTemplate = assertionTemplate(() => (
 	<header key="header" classes={[undefined, undefined]}>
@@ -81,12 +81,12 @@ describe('HeaderToolbar', () => {
 			<Header>
 				{{
 					title: 'title',
-					actions: ['action']
+					actions: [<Action to="#foo">Action</Action>]
 				}}
 			</Header>
 		));
 		const testTemplate = baseTemplate.replaceChildren('@actions', () => [
-			<div classes={classes.action}>action</div>
+			<Action to="#foo">Action</Action>
 		]);
 		h.expect(testTemplate);
 	});
@@ -96,12 +96,12 @@ describe('HeaderToolbar', () => {
 			<Header>
 				{{
 					title: 'title',
-					actions: 'action'
+					actions: <Action to="#foo">Action</Action>
 				}}
 			</Header>
 		));
 		const testTemplate = baseTemplate.replaceChildren('@actions', () => [
-			<div classes={classes.action}>action</div>
+			<Action to="#foo">Action</Action>
 		]);
 		h.expect(testTemplate);
 	});

--- a/src/header/tests/unit/Header.spec.tsx
+++ b/src/header/tests/unit/Header.spec.tsx
@@ -1,5 +1,6 @@
 const { describe, it } = intern.getInterface('bdd');
 import { tsx } from '@dojo/framework/core/vdom';
+import Link from '@dojo/framework/routing/Link';
 import assertionTemplate from '@dojo/framework/testing/harness/assertionTemplate';
 import harness from '@dojo/framework/testing/harness/harness';
 import Header, { Action } from '../..';
@@ -104,6 +105,17 @@ describe('HeaderToolbar', () => {
 			<Action to="#foo">Action</Action>
 		]);
 		h.expect(testTemplate);
+	});
+
+	it('renders action as link', () => {
+		const h = harness(() => <Action to="#foo">test</Action>);
+		h.expect(
+			assertionTemplate(() => (
+				<Link to="#foo" classes={[undefined, classes.action]}>
+					test
+				</Link>
+			))
+		);
 	});
 
 	it('Renders a sticky header', () => {

--- a/src/result/index.tsx
+++ b/src/result/index.tsx
@@ -1,10 +1,20 @@
 import { RenderResult } from '@dojo/framework/core/interfaces';
 import { create, tsx } from '@dojo/framework/core/vdom';
-
-import theme from '../middleware/theme';
-import * as css from '../theme/default/result.m.css';
-import * as iconCss from '../theme/default/icon.m.css';
+import ActionButton, { ActionButtonProperties } from '../action-button';
 import Icon from '../icon';
+import theme from '../middleware/theme';
+import * as iconCss from '../theme/default/icon.m.css';
+import * as css from '../theme/default/result.m.css';
+
+export interface ActionProperties extends ActionButtonProperties {}
+
+const actionFactory = create().properties<ActionProperties>();
+
+export const Action = actionFactory(({ properties, children }) => {
+	const action = <ActionButton {...properties()}>{children()}</ActionButton>;
+
+	return action;
+});
 
 type ResultStatus = 'alert' | 'error' | 'info' | 'success';
 

--- a/src/result/tests/unit/Result.spec.tsx
+++ b/src/result/tests/unit/Result.spec.tsx
@@ -2,6 +2,7 @@ const { describe, it } = intern.getInterface('bdd');
 import { tsx } from '@dojo/framework/core/vdom';
 import assertionTemplate from '@dojo/framework/testing/harness/assertionTemplate';
 import harness from '@dojo/framework/testing/harness/harness';
+import ActionButton from '../../../action-button';
 import Icon from '../../../icon';
 import * as css from '../../../theme/default/result.m.css';
 import Result, { Action } from '../../index';
@@ -97,7 +98,7 @@ describe('Result', () => {
 			<div key="actions" classes={css.actions} />
 		]);
 
-		it('renders action buttons', () => {
+		it('renders actions', () => {
 			const h = harness(() => (
 				<Result>
 					{{
@@ -111,6 +112,11 @@ describe('Result', () => {
 				</div>
 			]);
 			h.expect(childrenTemplate);
+		});
+
+		it('renders action buttons', () => {
+			const h = harness(() => <Action name="testButton">test</Action>);
+			h.expect(assertionTemplate(() => <ActionButton name="testButton">test</ActionButton>));
 		});
 	});
 

--- a/src/result/tests/unit/Result.spec.tsx
+++ b/src/result/tests/unit/Result.spec.tsx
@@ -1,11 +1,10 @@
 const { describe, it } = intern.getInterface('bdd');
+import { tsx } from '@dojo/framework/core/vdom';
 import assertionTemplate from '@dojo/framework/testing/harness/assertionTemplate';
 import harness from '@dojo/framework/testing/harness/harness';
-import { tsx } from '@dojo/framework/core/vdom';
-import Result from '../../index';
-import Button from '../../../button/index';
 import Icon from '../../../icon';
 import * as css from '../../../theme/default/result.m.css';
+import Result, { Action } from '../../index';
 
 describe('Result', () => {
 	const template = assertionTemplate(() => <div key="root" classes={[undefined, css.root]} />);
@@ -102,13 +101,13 @@ describe('Result', () => {
 			const h = harness(() => (
 				<Result>
 					{{
-						actionButtons: <Button>test</Button>
+						actionButtons: <Action>test</Action>
 					}}
 				</Result>
 			));
 			const childrenTemplate = actionsTemplate.setChildren('@actions', () => [
 				<div classes={css.actionButtons}>
-					<Button>test</Button>
+					<Action>test</Action>
 				</div>
 			]);
 			h.expect(childrenTemplate);
@@ -121,7 +120,7 @@ describe('Result', () => {
 				{{
 					icon: <Icon type="clockIcon" />,
 					content: 'Result Content',
-					actionButtons: <Button>test</Button>
+					actionButtons: <Action>test</Action>
 				}}
 			</Result>
 		));
@@ -138,7 +137,7 @@ describe('Result', () => {
 				<div classes={css.contentWrapper}>Result Content</div>,
 				<div key="actions" classes={css.actions}>
 					<div classes={css.actionButtons}>
-						<Button>test</Button>
+						<Action>test</Action>
 					</div>
 				</div>
 			])

--- a/src/snackbar/index.tsx
+++ b/src/snackbar/index.tsx
@@ -1,8 +1,19 @@
 import { RenderResult } from '@dojo/framework/core/interfaces';
-import theme from '../middleware/theme';
 import { create, tsx } from '@dojo/framework/core/vdom';
+import ActionButton, { ActionButtonProperties } from '../action-button';
+import theme from '../middleware/theme';
 import * as css from '../theme/default/snackbar.m.css';
 import * as fixedCss from './styles/snackbar.m.css';
+
+export interface ActionProperties extends ActionButtonProperties {}
+
+const actionFactory = create().properties<ActionProperties>();
+
+export const Action = actionFactory(({ properties, children }) => {
+	const action = <ActionButton {...properties()}>{children()}</ActionButton>;
+
+	return action;
+});
 
 export interface SnackbarProperties {
 	/** If the snackbar is displayed */

--- a/src/snackbar/tests/unit/Snackbar.spec.tsx
+++ b/src/snackbar/tests/unit/Snackbar.spec.tsx
@@ -1,12 +1,11 @@
 const { describe, it } = intern.getInterface('bdd');
 
+import { tsx } from '@dojo/framework/core/vdom';
 import assertationTemplate from '@dojo/framework/testing/harness/assertionTemplate';
 import harness from '@dojo/framework/testing/harness/harness';
-import { tsx } from '@dojo/framework/core/vdom';
-import Snackbar from '../../index';
 import * as css from '../../../theme/default/snackbar.m.css';
+import Snackbar, { Action } from '../../index';
 import * as fixedCss from '../../styles/snackbar.m.css';
-import Button from '../../../button/index';
 
 describe('Snackbar', () => {
 	const template = assertationTemplate(() => {
@@ -173,13 +172,13 @@ describe('Snackbar', () => {
 			<Snackbar open={true}>
 				{{
 					message: 'test',
-					actions: <Button>Dismiss</Button>
+					actions: <Action>Dismiss</Action>
 				}}
 			</Snackbar>
 		));
 		const actionsTemplate = template.insertAfter('~label', () => [
 			<div key="actions" classes={css.actions}>
-				<Button>Dismiss</Button>
+				<Action>Dismiss</Action>
 			</div>
 		]);
 		h.expect(actionsTemplate);
@@ -190,14 +189,14 @@ describe('Snackbar', () => {
 			<Snackbar open={true}>
 				{{
 					message: 'test',
-					actions: [<Button>Retry</Button>, <Button>Close</Button>]
+					actions: [<Action>Retry</Action>, <Action>Close</Action>]
 				}}
 			</Snackbar>
 		));
 		const actionsTemplate = template.insertAfter('~label', () => [
 			<div key="actions" classes={css.actions}>
-				<Button>Retry</Button>
-				<Button>Close</Button>
+				<Action>Retry</Action>
+				<Action>Close</Action>
 			</div>
 		]);
 		h.expect(actionsTemplate);

--- a/src/snackbar/tests/unit/Snackbar.spec.tsx
+++ b/src/snackbar/tests/unit/Snackbar.spec.tsx
@@ -1,14 +1,15 @@
 const { describe, it } = intern.getInterface('bdd');
 
 import { tsx } from '@dojo/framework/core/vdom';
-import assertationTemplate from '@dojo/framework/testing/harness/assertionTemplate';
+import assertionTemplate from '@dojo/framework/testing/harness/assertionTemplate';
 import harness from '@dojo/framework/testing/harness/harness';
+import ActionButton from '../../../action-button';
 import * as css from '../../../theme/default/snackbar.m.css';
 import Snackbar, { Action } from '../../index';
 import * as fixedCss from '../../styles/snackbar.m.css';
 
 describe('Snackbar', () => {
-	const template = assertationTemplate(() => {
+	const template = assertionTemplate(() => {
 		return (
 			<div
 				key="root"
@@ -200,5 +201,10 @@ describe('Snackbar', () => {
 			</div>
 		]);
 		h.expect(actionsTemplate);
+	});
+
+	it('renders action buttons', () => {
+		const h = harness(() => <Action name="testButton">test</Action>);
+		h.expect(assertionTemplate(() => <ActionButton name="testButton">test</ActionButton>));
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

All widgets with "actions" have been switched to the same pattern established by Speed Dial, an internal action widget specialized to that widget. Most do not do anything beyond wrapping `ActionButton`, `Link` and `Icon` but create a basis for expanding upon later on.

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**

Resolves #1574 
