### PR TITLE
fix: correctly validate required TimePicker

### DIFF
--- a/src/time-picker/index.tsx
+++ b/src/time-picker/index.tsx
@@ -335,7 +335,7 @@ export const TimePicker = factory(function TimePicker({
 				}
 			}
 
-			isValid = validationMessages.length === 0;
+			isValid = isValid === undefined ? validationMessages.length === 0 : isValid;
 			icache.set('isValid', isValid);
 		}
 
@@ -436,7 +436,10 @@ export const TimePicker = factory(function TimePicker({
 									onValidate={(valid, message) => {
 										if (valid !== icache.get('inputValid')) {
 											icache.set('inputValid', valid);
-											icache.set('inputValidMessage', message);
+											if (icache.get('dirty')) {
+												icache.set('inputValidMessage', message);
+											}
+											callOnValue();
 										}
 									}}
 									onKeyDown={(key) => {

--- a/src/time-picker/tests/unit/TimePicker.spec.tsx
+++ b/src/time-picker/tests/unit/TimePicker.spec.tsx
@@ -65,32 +65,33 @@ const baseTemplate = (date?: Date) =>
 		);
 	});
 
-const buttonTemplate = assertionTemplate(() => {
-	return (
-		<div classes={css.input}>
-			<TextInput
-				disabled={undefined}
-				key="input"
-				focus={() => false}
-				theme={{}}
-				onBlur={noop}
-				onFocus={noop}
-				onValue={noop}
-				initialValue={''}
-				onValidate={noop}
-				required={undefined}
-				valid={undefined}
-				helperText=""
-				onKeyDown={noop}
-				type="text"
-				variant={undefined}
-				classes={undefined}
-			>
-				{{ label: undefined, trailing: undefined }}
-			</TextInput>
-		</div>
-	);
-});
+const buttonTemplate = (required?: boolean) =>
+	assertionTemplate(() => {
+		return (
+			<div classes={css.input}>
+				<TextInput
+					disabled={undefined}
+					key="input"
+					focus={() => false}
+					theme={{}}
+					onBlur={noop}
+					onFocus={noop}
+					onValue={noop}
+					initialValue={''}
+					onValidate={noop}
+					required={required}
+					valid={undefined}
+					helperText=""
+					onKeyDown={noop}
+					type="text"
+					variant={undefined}
+					classes={undefined}
+				>
+					{{ label: undefined, trailing: undefined }}
+				</TextInput>
+			</div>
+		);
+	});
 
 function generateOptions(step: number, dateOptions: Intl.DateTimeFormatOptions = {}) {
 	const options: ListOption[] = [];
@@ -183,7 +184,7 @@ describe('TimePicker', () => {
 			(node) => (node.children as any)[0].trigger,
 			toggleOpen
 		);
-		h.expect(buttonTemplate, () => triggerResult);
+		h.expect(buttonTemplate(), () => triggerResult);
 
 		// Find the date icon & `click` it
 		const [dateIcon] = select(
@@ -212,7 +213,7 @@ describe('TimePicker', () => {
 			(node) => (node.children as any)[0].trigger,
 			() => {}
 		);
-		h.expect(buttonTemplate, () => triggerResult);
+		h.expect(buttonTemplate(), () => triggerResult);
 		assert.equal(
 			h.trigger('@popup', (node) => () =>
 				(node.children as any)[0].trigger().children[0].children[0].label
@@ -230,7 +231,7 @@ describe('TimePicker', () => {
 			(node) => (node.children as any)[0].trigger,
 			() => {}
 		);
-		h.expect(buttonTemplate, () => triggerResult);
+		h.expect(buttonTemplate(), () => triggerResult);
 		assert.equal(
 			h.trigger('@popup', (node) => () =>
 				(node.children as any)[0].trigger().children[0].children[0].label
@@ -249,7 +250,7 @@ describe('TimePicker', () => {
 			(node) => (node.children as any)[0].trigger,
 			toggleOpen
 		);
-		h.expect(buttonTemplate, () => triggerResult);
+		h.expect(buttonTemplate(), () => triggerResult);
 
 		// Find the input and simulate "enter"
 		const [input] = select('@input', triggerResult);
@@ -277,7 +278,7 @@ describe('TimePicker', () => {
 			(node) => (node.children as any)[0].trigger,
 			() => {}
 		);
-		h.expect(buttonTemplate, () => triggerResult);
+		h.expect(buttonTemplate(), () => triggerResult);
 		assert.equal(
 			h.trigger('@popup', (node) => () =>
 				(node.children as any)[0].trigger().children[0].children[0].label
@@ -317,7 +318,7 @@ describe('TimePicker', () => {
 			(node) => (node.children as any)[0].trigger,
 			toggleOpen
 		);
-		h.expect(buttonTemplate, () => triggerResult);
+		h.expect(buttonTemplate(), () => triggerResult);
 
 		// Find the input widget and trigger it's value changed
 		const [input] = select('@input', triggerResult);
@@ -553,5 +554,30 @@ describe('TimePicker', () => {
 			),
 			() => contentResult
 		);
+	});
+
+	it('required date input', () => {
+		const onValidate = sinon.stub();
+
+		const h = harness(() => (
+			<TimePicker
+				name="timeInput"
+				onValue={onValue}
+				onValidate={onValidate}
+				required={true}
+			/>
+		));
+
+		const triggerResult = h.trigger(
+			'@popup',
+			(node) => (node.children as any)[0].trigger,
+			noop
+		);
+
+		// Find the input widget and give it a bad value
+		let [input] = select('@input', triggerResult);
+		onValidate.resetHistory();
+		input.properties.onValidate(false);
+		sinon.assert.calledWith(onValidate, false);
 	});
 });

--- a/src/time-picker/tests/unit/TimePicker.spec.tsx
+++ b/src/time-picker/tests/unit/TimePicker.spec.tsx
@@ -65,33 +65,32 @@ const baseTemplate = (date?: Date) =>
 		);
 	});
 
-const buttonTemplate = (required?: boolean) =>
-	assertionTemplate(() => {
-		return (
-			<div classes={css.input}>
-				<TextInput
-					disabled={undefined}
-					key="input"
-					focus={() => false}
-					theme={{}}
-					onBlur={noop}
-					onFocus={noop}
-					onValue={noop}
-					initialValue={''}
-					onValidate={noop}
-					required={required}
-					valid={undefined}
-					helperText=""
-					onKeyDown={noop}
-					type="text"
-					variant={undefined}
-					classes={undefined}
-				>
-					{{ label: undefined, trailing: undefined }}
-				</TextInput>
-			</div>
-		);
-	});
+const buttonTemplate = assertionTemplate(() => {
+	return (
+		<div classes={css.input}>
+			<TextInput
+				disabled={undefined}
+				key="input"
+				focus={() => false}
+				theme={{}}
+				onBlur={noop}
+				onFocus={noop}
+				onValue={noop}
+				initialValue={''}
+				onValidate={noop}
+				required={undefined}
+				valid={undefined}
+				helperText=""
+				onKeyDown={noop}
+				type="text"
+				variant={undefined}
+				classes={undefined}
+			>
+				{{ label: undefined, trailing: undefined }}
+			</TextInput>
+		</div>
+	);
+});
 
 function generateOptions(step: number, dateOptions: Intl.DateTimeFormatOptions = {}) {
 	const options: ListOption[] = [];
@@ -184,7 +183,7 @@ describe('TimePicker', () => {
 			(node) => (node.children as any)[0].trigger,
 			toggleOpen
 		);
-		h.expect(buttonTemplate(), () => triggerResult);
+		h.expect(buttonTemplate, () => triggerResult);
 
 		// Find the date icon & `click` it
 		const [dateIcon] = select(
@@ -213,7 +212,7 @@ describe('TimePicker', () => {
 			(node) => (node.children as any)[0].trigger,
 			() => {}
 		);
-		h.expect(buttonTemplate(), () => triggerResult);
+		h.expect(buttonTemplate, () => triggerResult);
 		assert.equal(
 			h.trigger('@popup', (node) => () =>
 				(node.children as any)[0].trigger().children[0].children[0].label
@@ -231,7 +230,7 @@ describe('TimePicker', () => {
 			(node) => (node.children as any)[0].trigger,
 			() => {}
 		);
-		h.expect(buttonTemplate(), () => triggerResult);
+		h.expect(buttonTemplate, () => triggerResult);
 		assert.equal(
 			h.trigger('@popup', (node) => () =>
 				(node.children as any)[0].trigger().children[0].children[0].label
@@ -250,7 +249,7 @@ describe('TimePicker', () => {
 			(node) => (node.children as any)[0].trigger,
 			toggleOpen
 		);
-		h.expect(buttonTemplate(), () => triggerResult);
+		h.expect(buttonTemplate, () => triggerResult);
 
 		// Find the input and simulate "enter"
 		const [input] = select('@input', triggerResult);
@@ -278,7 +277,7 @@ describe('TimePicker', () => {
 			(node) => (node.children as any)[0].trigger,
 			() => {}
 		);
-		h.expect(buttonTemplate(), () => triggerResult);
+		h.expect(buttonTemplate, () => triggerResult);
 		assert.equal(
 			h.trigger('@popup', (node) => () =>
 				(node.children as any)[0].trigger().children[0].children[0].label
@@ -318,7 +317,7 @@ describe('TimePicker', () => {
 			(node) => (node.children as any)[0].trigger,
 			toggleOpen
 		);
-		h.expect(buttonTemplate(), () => triggerResult);
+		h.expect(buttonTemplate, () => triggerResult);
 
 		// Find the input widget and trigger it's value changed
 		const [input] = select('@input', triggerResult);


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request fixes an issue with `TimePicker` that prevented required instances from failing validation.

Resolves #1714
