### PR TITLE
feat: wizard content configuration

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -268,7 +268,8 @@ import ErrorResult from './widgets/result/Error';
 import SuccessResult from './widgets/result/Success';
 import CustomIconResult from './widgets/result/CustomIcon';
 import BasicWizard from './widgets/wizard/Basic';
-import CustomWizard from './widgets/wizard/Custom';
+import StepRendererWizard from './widgets/wizard/StepRenderer';
+import StepContentWizard from './widgets/wizard/StepContent';
 import VerticalWizard from './widgets/wizard/Vertical';
 import ErrorWizard from './widgets/wizard/Error';
 import BasicTree from './widgets/tree/Basic';
@@ -2103,9 +2104,14 @@ export const config = {
 					title: 'Wizard with an error'
 				},
 				{
-					filename: 'Custom',
-					module: CustomWizard,
+					filename: 'StepRenderer',
+					module: StepRendererWizard,
 					title: 'Custom step renderer'
+				},
+				{
+					filename: 'StepContent',
+					module: StepContentWizard,
+					title: 'Step content'
 				}
 			]
 		}

--- a/src/examples/src/widgets/wizard/StepContent.tsx
+++ b/src/examples/src/widgets/wizard/StepContent.tsx
@@ -2,8 +2,12 @@ import { create, tsx } from '@dojo/framework/core/vdom';
 import Example from '../../Example';
 import Wizard from '@dojo/widgets/wizard';
 import Button from '@dojo/widgets/button';
+import icache from '@dojo/framework/core/middleware/icache';
 
-export default create()(function StepContent() {
+const factory = create({ icache });
+
+export default factory(function StepContent({ middleware: { icache } }) {
+	let activeStep = icache.getOrSet('activeStep', 1);
 	const steps = [
 		{
 			title: 'Select an app'
@@ -21,10 +25,16 @@ export default create()(function StepContent() {
 
 	return (
 		<Example>
-			<Wizard direction="vertical" steps={steps}>
+			<Wizard
+				direction="vertical"
+				steps={steps}
+				activeStep={activeStep}
+				onStep={(step) => icache.set('activeStep', step)}
+				clickable
+			>
 				<virtual />
 				<div>
-					<ExampleContent />
+					<ExampleContent onContinue={() => icache.set('activeStep', activeStep + 1)} />
 				</div>
 				<virtual />
 				<virtual />
@@ -33,12 +43,15 @@ export default create()(function StepContent() {
 	);
 });
 
-const ExampleContent = create()(() => (
+const exampleFactory = create().properties<{ onContinue: () => void }>();
+
+const ExampleContent = exampleFactory(({ properties }) => (
 	<div styles={{ paddingBottom: '16px' }}>
 		<div
 			styles={{ width: '300px', height: '150px', marginBottom: '8px', background: '#DDD' }}
 		/>
-		<Button kind="primary">Continue</Button>
-		<Button>Cancel</Button>
+		<Button kind="primary" onClick={properties().onContinue}>
+			Continue
+		</Button>
 	</div>
 ));

--- a/src/examples/src/widgets/wizard/StepContent.tsx
+++ b/src/examples/src/widgets/wizard/StepContent.tsx
@@ -1,0 +1,44 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import Example from '../../Example';
+import Wizard from '@dojo/widgets/wizard';
+import Button from '@dojo/widgets/button';
+
+export default create()(function StepContent() {
+	const steps = [
+		{
+			title: 'Select an app'
+		},
+		{
+			title: 'Configure analytics for this app'
+		},
+		{
+			title: 'Select an ad format and name ad unit'
+		},
+		{
+			title: 'View setup instructions'
+		}
+	];
+
+	return (
+		<Example>
+			<Wizard direction="vertical" steps={steps}>
+				<virtual />
+				<div>
+					<ExampleContent />
+				</div>
+				<virtual />
+				<virtual />
+			</Wizard>
+		</Example>
+	);
+});
+
+const ExampleContent = create()(() => (
+	<div styles={{ paddingBottom: '16px' }}>
+		<div
+			styles={{ width: '300px', height: '150px', marginBottom: '8px', background: '#DDD' }}
+		/>
+		<Button kind="primary">Continue</Button>
+		<Button>Cancel</Button>
+	</div>
+));

--- a/src/examples/src/widgets/wizard/StepRenderer.tsx
+++ b/src/examples/src/widgets/wizard/StepRenderer.tsx
@@ -5,7 +5,7 @@ import icache from '@dojo/framework/core/middleware/icache';
 
 const factory = create({ icache }).properties();
 
-export default factory(function Custom({ middleware: { icache } }) {
+export default factory(function StepRenderer({ middleware: { icache } }) {
 	const steps = [
 		{
 			title: 'Complete'

--- a/src/wizard/index.tsx
+++ b/src/wizard/index.tsx
@@ -1,5 +1,5 @@
 import { create, tsx } from '@dojo/framework/core/vdom';
-import { DNode, RenderResult } from '@dojo/framework/core/interfaces';
+import { RenderResult } from '@dojo/framework/core/interfaces';
 import theme from '../middleware/theme';
 import Icon from '../icon';
 import * as css from '../theme/default/wizard.m.css';
@@ -41,7 +41,7 @@ export type StepStatus = 'pending' | 'inProgress' | 'complete' | 'error';
 
 const factory = create({ theme })
 	.properties<WizardProperties>()
-	.children<WizardChildren | RenderResult | undefined>();
+	.children<WizardChildren | RenderResult | RenderResult[] | undefined>();
 
 export default factory(function Wizard({ properties, children, middleware: { theme } }) {
 	const themedCss = theme.classes(css);
@@ -57,13 +57,10 @@ export default factory(function Wizard({ properties, children, middleware: { the
 	} = properties();
 
 	let stepRenderer: StepRenderer | undefined;
-	let stepContent: DNode[] | undefined;
-	const body = children();
+	const [renderer] = children();
 
-	if (body && body[0] && !isRenderResult(body[0])) {
-		stepRenderer = body[0].step;
-	} else if (isRenderResult(body)) {
-		stepContent = body;
+	if (renderer && !isRenderResult(renderer)) {
+		stepRenderer = renderer.step;
 	}
 
 	const stepWrappers = steps.map((step, index) => {
@@ -133,7 +130,7 @@ export default factory(function Wizard({ properties, children, middleware: { the
 							<div classes={themedCss.stepSubTitle}>{subTitle}</div>
 						</div>
 						<div classes={themedCss.stepDescription}>{description}</div>
-						{stepContent && stepContent[index]}
+						{children()[index]}
 					</div>
 				</virtual>
 			),

--- a/src/wizard/tests/unit/Wizard.spec.tsx
+++ b/src/wizard/tests/unit/Wizard.spec.tsx
@@ -28,6 +28,9 @@ describe('Wizard', () => {
 	const WrappedStep1 = wrap('div');
 	const WrappedStep2 = wrap('div');
 	const WrappedStep3 = wrap('div');
+	const WrappedStepContent1 = wrap('div');
+	const WrappedStepContent2 = wrap('div');
+	const WrappedStepContent3 = wrap('div');
 	const WrappedAvatar = wrap(Avatar);
 	const baseAssertion = assertion(() => (
 		<WrappedRoot key="root" classes={[undefined, css.root, css.horizontal, false]}>
@@ -66,12 +69,12 @@ describe('Wizard', () => {
 							/>
 						</Avatar>
 					</div>
-					<div classes={[null, css.stepContent]}>
+					<WrappedStepContent1 classes={[null, css.stepContent]}>
 						<div classes={[css.stepTitle, false, css.noDescription]}>
 							Step 1<div classes={css.stepSubTitle}>{''}</div>
 						</div>
 						<div classes={css.stepDescription}>{''}</div>
-					</div>
+					</WrappedStepContent1>
 				</virtual>
 			</WrappedStep1>
 			<WrappedStep2 key="step2" classes={[css.step, false, false, false]} onclick={noop}>
@@ -100,12 +103,12 @@ describe('Wizard', () => {
 							2
 						</WrappedAvatar>
 					</div>
-					<div classes={[null, css.stepContent]}>
+					<WrappedStepContent2 classes={[null, css.stepContent]}>
 						<div classes={[css.stepTitle, false, css.noDescription]}>
 							Step 2<div classes={css.stepSubTitle}>{''}</div>
 						</div>
 						<div classes={css.stepDescription}>{''}</div>
-					</div>
+					</WrappedStepContent2>
 				</virtual>
 			</WrappedStep2>
 			<WrappedStep3
@@ -138,12 +141,12 @@ describe('Wizard', () => {
 							3
 						</Avatar>
 					</div>
-					<div classes={[null, css.stepContent]}>
+					<WrappedStepContent3 classes={[null, css.stepContent]}>
 						<div classes={[css.stepTitle, false, css.noDescription]}>
 							Step 3<div classes={css.stepSubTitle}>{''}</div>
 						</div>
 						<div classes={css.stepDescription}>{''}</div>
-					</div>
+					</WrappedStepContent3>
 				</virtual>
 			</WrappedStep3>
 		</WrappedRoot>
@@ -320,5 +323,25 @@ describe('Wizard', () => {
 				</div>
 			])
 		);
+	});
+
+	it('renders step content', () => {
+		const r = mockedRenderer(() => (
+			<Wizard
+				activeStep={1}
+				steps={[{ title: 'Step 1' }, { title: 'Step 2' }, { title: 'Step 3' }]}
+			>
+				<div>1</div>
+				<div>2</div>
+				<div>3</div>
+			</Wizard>
+		));
+
+		const contentAssertion = baseAssertion
+			.append(WrappedStepContent1, () => <div>1</div>)
+			.append(WrappedStepContent2, () => <div>2</div>)
+			.append(WrappedStepContent3, () => <div>3</div>);
+
+		r.expect(contentAssertion);
 	});
 });


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request adds custom content support to `Wizard` step configuration.

<img width="1404" alt="preview" src="https://user-images.githubusercontent.com/334586/113756612-995fd500-96df-11eb-85f7-1ddef1d80b88.png">

Resolves #1611 
