### PR TITLE
1612 - Select rejects bad values

### DIFF
--- a/src/select/index.tsx
+++ b/src/select/index.tsx
@@ -148,6 +148,22 @@ export const Select = factory(function Select({
 		}
 	}
 
+	let valueOption: ListOption | undefined;
+	if (value && data) {
+		let found = find(data, (item) => {
+			return Boolean(item.value && item.value.value === value);
+		});
+		if (found) {
+			valueOption = found.value;
+		} else {
+			const items = get(options({ query: { value } }), { read });
+			if (items && items.length > 0 && items[0].value === value) {
+				valueOption = items[0];
+			}
+		}
+	}
+	value = valueOption ? valueOption.value : undefined;
+
 	return (
 		<div
 			classes={[
@@ -206,21 +222,6 @@ export const Select = factory(function Select({
 							}
 						}
 
-						let valueOption: ListOption | undefined;
-						if (value && data) {
-							let found = find(data, (item) => {
-								return Boolean(item.value && item.value.value === value);
-							});
-							if (found) {
-								valueOption = found.value;
-							} else {
-								const items = get(options({ query: { value } }), { read });
-								if (items) {
-									valueOption = items[0];
-								}
-							}
-						}
-
 						return (
 							<button
 								name={name}
@@ -251,7 +252,7 @@ export const Select = factory(function Select({
 								<span
 									classes={[themedCss.value, expanded && themedCss.valueExpanded]}
 								>
-									{(valueOption && valueOption.label) || value || (
+									{(valueOption && valueOption.label) || (
 										<span classes={themedCss.placeholder}>{placeholder}</span>
 									)}
 								</span>

--- a/src/select/tests/Select.spec.tsx
+++ b/src/select/tests/Select.spec.tsx
@@ -368,6 +368,42 @@ describe('Select', () => {
 		);
 	});
 
+	it('rejects bad values', () => {
+		const onValueStub = stub();
+		const toggleOpenStub = stub();
+
+		const h = harness(
+			() => (
+				<Select
+					onValue={onValueStub}
+					resource={{ data: options, idKey: 'value', id: 'test' }}
+					value="4"
+				/>
+			),
+			[compareAriaControls, compareId]
+		);
+
+		const triggerRenderResult = h.trigger(
+			'@popup',
+			(node) => (node.children as any)[0].trigger,
+			toggleOpenStub
+		);
+
+		h.expect(
+			buttonTemplate
+				.setProperty('@trigger', 'value', undefined)
+				.setChildren('@trigger', () => [
+					<span classes={[css.value, undefined]}>
+						<span classes={css.placeholder} />
+					</span>,
+					<span classes={css.arrow}>
+						<Icon type="downIcon" theme={{}} classes={undefined} variant={undefined} />
+					</span>
+				]),
+			() => triggerRenderResult
+		);
+	});
+
 	it('invalidates correctly', () => {
 		const onValidate = stub();
 		const h = harness(() => (

--- a/src/select/tests/Select.spec.tsx
+++ b/src/select/tests/Select.spec.tsx
@@ -298,7 +298,7 @@ describe('Select', () => {
 		assert.isTrue(onValueStub.calledOnceWith('cat'));
 	});
 
-	it('displays an optional label when available', async () => {
+	it('displays values label when available', async () => {
 		const onValueStub = stub();
 		const toggleOpenStub = stub();
 
@@ -319,6 +319,17 @@ describe('Select', () => {
 			[compareAriaControls, compareId]
 		);
 		h.trigger('@popup', (node) => (node.children as any)[0].trigger, toggleOpenStub);
+		h.expect(
+			baseTemplate.setProperty('@root', 'classes', [
+				undefined,
+				css.root,
+				undefined,
+				false,
+				false,
+				false,
+				false
+			])
+		);
 		await res();
 		const triggerRenderResult = h.trigger(
 			'@popup',
@@ -400,6 +411,46 @@ describe('Select', () => {
 						<Icon type="downIcon" theme={{}} classes={undefined} variant={undefined} />
 					</span>
 				]),
+			() => triggerRenderResult
+		);
+	});
+
+	it('queries for matching value if not found', () => {
+		const onValueStub = stub();
+		const toggleOpenStub = stub();
+
+		const readSub = stub();
+		readSub.callsFake((req, { put }) => {
+			if (req.query.value === '4') {
+				put({ data: [{ value: '4', label: 'Frog' }], total: 1 }, req);
+			} else {
+				put({ data: [...options], total: options.length }, req);
+			}
+		});
+
+		const template = createResourceTemplate<any>({
+			idKey: 'value',
+			read: readSub
+		});
+
+		const h = harness(
+			() => <Select onValue={onValueStub} resource={{ template }} value="4" />,
+			[compareAriaControls, compareId]
+		);
+
+		const triggerRenderResult = h.trigger(
+			'@popup',
+			(node) => (node.children as any)[0].trigger,
+			toggleOpenStub
+		);
+
+		h.expect(
+			buttonTemplate.setProperty('@trigger', 'value', '4').setChildren('@trigger', () => [
+				<span classes={[css.value, undefined]}>Frog</span>,
+				<span classes={css.arrow}>
+					<Icon type="downIcon" theme={{}} classes={undefined} variant={undefined} />
+				</span>
+			]),
 			() => triggerRenderResult
 		);
 	});


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
- If no item can be queried from the resource with the given `value`:
  - `Select` will no longer display `value`
  - `Select` will style itself as it empty
- Returned query results will be checked against the given `value` to ensure it matches

Resolves #1612