### PR TITLE
fix: time picker formatting

### DIFF
--- a/src/time-picker/index.tsx
+++ b/src/time-picker/index.tsx
@@ -239,11 +239,16 @@ export const TimePicker = factory(function TimePicker({
 
 	const formatTime = (time: Date) => {
 		const { format = '24', step = 1800 } = properties();
-
 		const hideSeconds = step >= 60 && time.getSeconds() === 0;
 
+		// Use a new, local date so that display formatting does not offset based on timezone
+		const newTime = new Date();
+		newTime.setHours(time.getHours());
+		newTime.setMinutes(time.getMinutes());
+		newTime.setSeconds(time.getSeconds());
+
 		if (format === '24') {
-			return time
+			return newTime
 				.toLocaleTimeString(undefined, {
 					hour12: false,
 					hour: 'numeric',
@@ -252,7 +257,7 @@ export const TimePicker = factory(function TimePicker({
 				})
 				.replace(/[^a-zA-Z\d\s:.]/g, '');
 		} else {
-			return time
+			return newTime
 				.toLocaleTimeString(undefined, {
 					hour12: true,
 					hour: 'numeric',


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request fixes an issue when using the `TimePicker` in Safari wherein formatting was offsetting the chosen display value by the locale-specific timezone offset. This issue did not present itself in other browsers because `toLocaleTimeString` appears to respect the time that's passed to it in all browsers but Safari.

_Before:_

![before](https://i.gyazo.com/7e0e8c05ad0943c78c135a950b603b46.gif)

_After:_

![after](https://i.gyazo.com/9c46a6e90c8b1def3937f3591d452820.gif)

Resolves #1717
