### PR TITLE
The card content needs 100% sizing to work properly on safari

### DIFF
--- a/src/theme/default/card.m.css
+++ b/src/theme/default/card.m.css
@@ -23,6 +23,7 @@
 
 /* The wrapper around the main content section */
 .content {
+	height: 100%;
 	display: flex;
 	flex-direction: column;
 }

--- a/src/theme/dojo/card.m.css
+++ b/src/theme/dojo/card.m.css
@@ -39,6 +39,8 @@
 }
 
 .content {
+	width: 100%;
+	height: 100%;
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;

--- a/src/theme/material/card.m.css
+++ b/src/theme/material/card.m.css
@@ -26,6 +26,8 @@
 }
 
 .content {
+	width: 100%;
+	height: 100%;
 	display: flex;
 	flex-direction: column;
 	flex-grow: 1;


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Looks like the card content needs 100% width and height as in order to take up all the available space. It works properly in chrome but not in safari/ios.