### PR TITLE
1564 - Allow typeahead selection on tab

### DIFF
--- a/src/typeahead/index.tsx
+++ b/src/typeahead/index.tsx
@@ -204,6 +204,7 @@ export const Typeahead = factory(function Typeahead({
 					});
 				}
 				break;
+			case Keys.Tab:
 			case Keys.Enter:
 				preventDefault();
 				const activeIndex = icache.getOrSet('activeIndex', strict ? 0 : -1);

--- a/src/typeahead/tests/unit/Typeahead.spec.tsx
+++ b/src/typeahead/tests/unit/Typeahead.spec.tsx
@@ -422,6 +422,31 @@ describe('Typeahead', () => {
 		assert.strictEqual(onValueStub.callCount, 1);
 	});
 
+	it('Should select item on tab ', () => {
+		const r = renderer(() => (
+			<Typeahead resource={{ data, id: 'test', idKey: 'value' }} onValue={onValueStub} />
+		));
+		r.child(WrappedPopup, {
+			trigger: [() => {}]
+		});
+		r.expect(baseAssertion);
+		// open the drop down
+		r.property(WrappedTrigger, 'onClick');
+		// focus second item from the drop down, `cat`
+		r.property(WrappedTrigger, 'onKeyDown', Keys.Down, () => {});
+		// select second item from the drop down, `cat`
+		r.property(WrappedTrigger, 'onKeyDown', Keys.Tab, () => {});
+		r.expect(
+			baseAssertion.replaceChildren(WrappedPopup, () => ({
+				trigger: triggerAssertion.setProperty(WrappedTrigger, 'value', 'Cat'),
+				content: contentAssertion
+					.setProperty(WrappedList, 'initialValue', '2')
+					.setProperty(WrappedList, 'activeIndex', 1)
+			}))
+		);
+		assert.strictEqual(onValueStub.callCount, 1);
+	});
+
 	it('Should select value on blur in non-strict mode', () => {
 		const r = renderer(() => (
 			<Typeahead


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Allow typeahead selection on tab in addition to enter.

Resolves #1564
