### PR TITLE
1715 - Change label color on focus instead of on active for material theme

### DIFF
--- a/src/theme/material/label.m.css
+++ b/src/theme/material/label.m.css
@@ -10,11 +10,11 @@
 	position: relative;
 }
 
-.root:not(.disabled).active {
+.root:not(.disabled).focused {
 	color: var(--mdc-theme-primary) !important;
 }
 
-.root:not(.active) {
+.root:not(.focused) {
 	color: var(--mdc-secondary-text-color) !important;
 }
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Match label color behavior to material specs. Primary on `focus`, secondary on `blur`. Previously it was primary on `active` which resulted in the label staying the primary color once a value in the parent text input or select was set.

Resolves #1715
