### PR TITLE
fix: select placeholder z-index

### DIFF
--- a/src/theme/material/select.m.css
+++ b/src/theme/material/select.m.css
@@ -75,7 +75,7 @@
 .labelRoot {
 	composes: root from './label.m.css';
 	composes: mdc-floating-label from '@material/select/dist/mdc.select.css';
-	z-index: 10;
+	z-index: 1;
 }
 
 .labelActive {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request fixes `Select` placeholder `z-index` styling using the Material theme.

<img width="589" alt="preview" src="https://user-images.githubusercontent.com/334586/114394385-23d58800-9b69-11eb-8b6c-aa570618426a.png">

Resolves #1729 
