### PR TITLE
Fix/chip typeahead styles

### DIFF
--- a/src/chip-typeahead/index.tsx
+++ b/src/chip-typeahead/index.tsx
@@ -257,7 +257,8 @@ export const ChipTypeahead = factory(function ChipTypeahead({
 					'@dojo/widgets/text-input': {
 						inputWrapper: [themeCss.inputWrapper],
 						input: [themeCss.input],
-						wrapper: [themeCss.wrapper]
+						wrapper: [themeCss.wrapper],
+						leading: [themeCss.inputLeading]
 					}
 				}}
 				itemDisabled={(item) => {

--- a/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
+++ b/src/chip-typeahead/tests/unit/ChipTypeahead.spec.tsx
@@ -53,7 +53,8 @@ const baseAssertion = assertionTemplate(() => (
 				'@dojo/widgets/text-input': {
 					inputWrapper: [themeCss.inputWrapper],
 					input: [themeCss.input],
-					wrapper: [themeCss.wrapper]
+					wrapper: [themeCss.wrapper],
+					leading: [themeCss.inputLeading]
 				}
 			}}
 		>

--- a/src/theme/default/chip-typeahead.m.css
+++ b/src/theme/default/chip-typeahead.m.css
@@ -57,3 +57,7 @@
 /* Added if the widget has a label */
 .hasLabel {
 }
+
+/* Added to the input's leading content containing chips */
+.inputLeading {
+}

--- a/src/theme/default/chip-typeahead.m.css.d.ts
+++ b/src/theme/default/chip-typeahead.m.css.d.ts
@@ -13,3 +13,4 @@ export const wrapper: string;
 export const hasValue: string;
 export const active: string;
 export const hasLabel: string;
+export const inputLeading: string;

--- a/src/theme/dojo/chip-typeahead.m.css
+++ b/src/theme/dojo/chip-typeahead.m.css
@@ -18,9 +18,10 @@
 
 .root .inputLeading {
 	display: block;
+	pointer-events: unset;
 	position: static;
 	transform: none;
-	width: 100%;
+	max-width: 100%;
 }
 
 .root .inputWrapper {

--- a/src/theme/dojo/chip-typeahead.m.css
+++ b/src/theme/dojo/chip-typeahead.m.css
@@ -16,6 +16,13 @@
 	width: 100px;
 }
 
+.root .inputLeading {
+	display: block;
+	position: static;
+	transform: none;
+	width: 100%;
+}
+
 .root .inputWrapper {
 	display: flex;
 	flex-wrap: wrap;

--- a/src/theme/material/chip-typeahead.m.css
+++ b/src/theme/material/chip-typeahead.m.css
@@ -42,9 +42,10 @@
 
 .root .inputLeading {
 	display: block;
+	pointer-events: unset;
 	position: static;
 	transform: none;
-	width: 100%;
+	max-width: 100%;
 }
 
 .values .value {

--- a/src/theme/material/chip-typeahead.m.css
+++ b/src/theme/material/chip-typeahead.m.css
@@ -40,6 +40,13 @@
 	padding-top: 20px;
 }
 
+.root .inputLeading {
+	display: block;
+	position: static;
+	transform: none;
+	width: 100%;
+}
+
 .values .value {
 	margin: 4px 4px 4px 0;
 }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request fixes issues with the `ChipTypeahead` that were introduced by changes to the `TextInput` leading content configuration.

Resolves #1728
