### PR TITLE
1734 - Pass date input's required flag down to child text input

### DIFF
--- a/src/date-input/index.tsx
+++ b/src/date-input/index.tsx
@@ -202,6 +202,7 @@ export default factory(function DateInput({
 								<TextInput
 									key="input"
 									disabled={disabled}
+									required={required}
 									readOnly={readOnly}
 									focus={() => shouldFocus && focusNode === 'input'}
 									theme={theme.compose(

--- a/src/date-input/tests/unit/DateInput.spec.tsx
+++ b/src/date-input/tests/unit/DateInput.spec.tsx
@@ -71,6 +71,7 @@ const buttonTemplate = assertionTemplate(() => {
 			<TextInput
 				key="input"
 				disabled={false}
+				required={undefined}
 				readOnly={false}
 				focus={() => false}
 				theme={{}}
@@ -594,7 +595,7 @@ describe('DateInput', () => {
 			(node) => (node.children as any)[0].trigger,
 			toggleOpen
 		);
-		h.expect(buttonTemplate, () => triggerResult);
+		h.expect(buttonTemplate.setProperty('@input', 'required', true), () => triggerResult);
 
 		// Find the input widget and trigger it's value changed
 		const [input] = select('@input', triggerResult);

--- a/src/examples/src/widgets/date-input/Required.tsx
+++ b/src/examples/src/widgets/date-input/Required.tsx
@@ -18,7 +18,9 @@ export default factory(function Required({ middleware: { icache } }) {
 				}}
 				name="dateInput"
 				required={true}
-			/>
+			>
+				{{ label: 'Date: ' }}
+			</DateInput>
 		</Example>
 	);
 });


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Pass date input's required flag down to child text input

Resolves #1734
