### PR TITLE
1730 - Fix width of list item's primary span to expand to fill parent

### DIFF
--- a/src/theme/material/label.m.css.d.ts
+++ b/src/theme/material/label.m.css.d.ts
@@ -2,3 +2,4 @@ export const root: string;
 export const active: string;
 export const secondary: string;
 export const disabled: string;
+export const focused: string;

--- a/src/theme/material/list-item.m.css
+++ b/src/theme/material/list-item.m.css
@@ -59,6 +59,7 @@
 }
 
 .primary {
+	flex-grow: 1;
 	composes: mdc-list-item__text from '@material/list/dist/mdc.list.css';
 }
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

<!--
Our bots should ensure:

* [ ] All contributors have signed a CLA
* [ ] The PR passes CI testing
* [ ] Code coverage is maintained
* [ ] The PR has been reviewed and approved
-->

**Description:**
Fix width of list item's primary span to expand to fill parent, so loading indicators appear correctly.

![image](https://user-images.githubusercontent.com/1388138/114427477-1cbe7200-9b89-11eb-830c-b7558aba052d.png)

Resolves #1730
