### PR TITLE
feat: easier list item theming

### DIFF
--- a/src/examples/src/config.tsx
+++ b/src/examples/src/config.tsx
@@ -110,6 +110,7 @@ import ListItemRenderer from './widgets/list/ListItemRenderer';
 import FetchedResource from './widgets/list/FetchedResource';
 import DisabledList from './widgets/list/Disabled';
 import DraggableList from './widgets/list/Draggable';
+import CustomThemeList from './widgets/list/CustomTheme';
 import Menu from './widgets/list/Menu';
 import CustomTransformer from './widgets/list/CustomTransformer';
 import BasicChipTypeahead from './widgets/chip-typeahead/Basic';
@@ -1145,6 +1146,12 @@ export const config = {
 					filename: 'Fill',
 					module: FillList,
 					title: 'Fill'
+				},
+				{
+					description: 'This example shows how list items can be easily themed',
+					filename: 'CustomTheme',
+					module: CustomThemeList,
+					title: 'CustomTheme'
 				}
 			],
 			overview: {

--- a/src/examples/src/widgets/list/CustomTheme.m.css
+++ b/src/examples/src/widgets/list/CustomTheme.m.css
@@ -1,0 +1,15 @@
+.exampleList {
+	--mdc-list-item-selected-background: #4fc3f7;
+	--mdc-list-item-selected-color: #eeeeee;
+	--mdc-list-item-active-background: #0093c4;
+	--mdc-list-item-active-color: #ffffff;
+	--mdc-list-item-hover-background: #4fc3f7;
+	--mdc-list-item-hover-color: #eeeeee;
+
+	--list-item-selected-background: #43a047;
+	--list-item-selected-color: #eeeeee;
+	--list-item-active-background: #00701a;
+	--list-item-active-color: #ffffff;
+	--list-item-hover-background: #43a047;
+	--list-item-hover-color: #eeeeee;
+}

--- a/src/examples/src/widgets/list/CustomTheme.m.css.d.ts
+++ b/src/examples/src/widgets/list/CustomTheme.m.css.d.ts
@@ -1,0 +1,1 @@
+export const exampleList: string;

--- a/src/examples/src/widgets/list/CustomTheme.tsx
+++ b/src/examples/src/widgets/list/CustomTheme.tsx
@@ -3,32 +3,34 @@ import List from '@dojo/widgets/list';
 import icache from '@dojo/framework/core/middleware/icache';
 import Example from '../../Example';
 import { listOptionTemplate } from '../../template';
+import * as css from './CustomTheme.m.css';
 
 const factory = create({ icache });
 
-const exampleStyles = `
-    .exampleList {
-        --mdc-list-item-selected-background: #4fc3f7;
-        --mdc-list-item-selected-color: #eeeeee;
-        --mdc-list-item-active-background: #0093c4;
-        --mdc-list-item-active-color: #ffffff;
-        --mdc-list-item-hover-background: #4fc3f7;
-        --mdc-list-item-hover-color: #eeeeee;
-
-        --list-item-selected-background: #43a047;
-        --list-item-selected-color: #eeeeee;
-        --list-item-active-background: #00701a;
-        --list-item-active-color: #ffffff;
-        --list-item-hover-background: #43a047;
-        --list-item-hover-color: #eeeeee;
-    }
-`;
+/**
+ * This code uses the custom CSS shown below:
+ *
+ * .exampleList {
+ *     --mdc-list-item-selected-background: #4fc3f7;
+ *     --mdc-list-item-selected-color: #eeeeee;
+ *     --mdc-list-item-active-background: #0093c4;
+ *     --mdc-list-item-active-color: #ffffff;
+ *     --mdc-list-item-hover-background: #4fc3f7;
+ *     --mdc-list-item-hover-color: #eeeeee;
+ *
+ *     --list-item-selected-background: #43a047;
+ *     --list-item-selected-color: #eeeeee;
+ *     --list-item-active-background: #00701a;
+ *     --list-item-active-color: #ffffff;
+ *     --list-item-hover-background: #43a047;
+ *     --list-item-hover-color: #eeeeee;
+ * }
+ */
 
 export default factory(function CustomTheme({ middleware: { icache } }) {
 	return (
 		<Example>
-			<style innerHTML={exampleStyles} />
-			<div classes="exampleList">
+			<div classes={css.exampleList}>
 				<List
 					variant="inherit"
 					resource={{ template: listOptionTemplate }}

--- a/src/examples/src/widgets/list/CustomTheme.tsx
+++ b/src/examples/src/widgets/list/CustomTheme.tsx
@@ -1,0 +1,43 @@
+import { create, tsx } from '@dojo/framework/core/vdom';
+import List from '@dojo/widgets/list';
+import icache from '@dojo/framework/core/middleware/icache';
+import Example from '../../Example';
+import { listOptionTemplate } from '../../template';
+
+const factory = create({ icache });
+
+const exampleStyles = `
+    .exampleList {
+        --mdc-list-item-selected-background: #4fc3f7;
+        --mdc-list-item-selected-color: #eeeeee;
+        --mdc-list-item-active-background: #0093c4;
+        --mdc-list-item-active-color: #ffffff;
+        --mdc-list-item-hover-background: #4fc3f7;
+        --mdc-list-item-hover-color: #eeeeee;
+
+        --list-item-selected-background: #43a047;
+        --list-item-selected-color: #eeeeee;
+        --list-item-active-background: #00701a;
+        --list-item-active-color: #ffffff;
+        --list-item-hover-background: #43a047;
+        --list-item-hover-color: #eeeeee;
+    }
+`;
+
+export default factory(function CustomTheme({ middleware: { icache } }) {
+	return (
+		<Example>
+			<style innerHTML={exampleStyles} />
+			<div classes="exampleList">
+				<List
+					variant="inherit"
+					resource={{ template: listOptionTemplate }}
+					onValue={(value) => {
+						icache.set('value', value);
+					}}
+				/>
+			</div>
+			<p>{`Clicked on: ${JSON.stringify(icache.getOrSet('value', ''))}`}</p>
+		</Example>
+	);
+});

--- a/src/theme/dojo/chip-typeahead.m.css.d.ts
+++ b/src/theme/dojo/chip-typeahead.m.css.d.ts
@@ -2,5 +2,6 @@ export const root: string;
 export const value: string;
 export const selectedIcon: string;
 export const input: string;
+export const inputLeading: string;
 export const inputWrapper: string;
 export const values: string;

--- a/src/theme/dojo/list-item.m.css
+++ b/src/theme/dojo/list-item.m.css
@@ -13,6 +13,11 @@
 	display: flex;
 }
 
+.root:hover {
+	color: var(--list-item-hover-color);
+	background: var(--list-hover-active-background);
+}
+
 .root.active {
 	border: 1px solid var(--color-highlight-border);
 	transition: none;

--- a/src/theme/dojo/list-item.m.css
+++ b/src/theme/dojo/list-item.m.css
@@ -16,14 +16,18 @@
 .root.active {
 	border: 1px solid var(--color-highlight-border);
 	transition: none;
+	background: var(--list-item-active-background);
+	color: var(--list-item-active-color);
 }
 
 .selected {
-	background: var(--color-background-faded);
+	background: var(--list-item-selected-background);
+	color: var(--list-item-selected-color);
 }
 
 .disabled {
-	color: var(--color-text-faded);
+	color: var(--list-item-disabled-color);
+	background: var(--list-item-disabled-background);
 	font-style: italic;
 }
 

--- a/src/theme/dojo/variants/dark.m.css
+++ b/src/theme/dojo/variants/dark.m.css
@@ -71,6 +71,13 @@
 	--tab-button-active-color: var(--color-highlight);
 	--tab-button-disabled-color: var(--color-border);
 
+	--list-item-selected-background: var(--color-background-faded);
+	--list-item-selected-color: var(--color-text-primary);
+	--list-item-disabled-background: inherit;
+	--list-item-disabled-color: var(--color-text-faded);
+	--list-item-active-background: inherit;
+	--list-item-active-color: var(--color-text-primary);
+
 	--loader-size-small: 24px;
 	--loader-size-medium: 36px;
 	--loader-size-large: 48px;

--- a/src/theme/dojo/variants/default.m.css
+++ b/src/theme/dojo/variants/default.m.css
@@ -76,6 +76,13 @@
 	--tab-button-active-color: var(--color-highlight);
 	--tab-button-disabled-color: var(--color-border);
 
+	--list-item-selected-background: var(--color-background-faded);
+	--list-item-selected-color: var(--color-text-primary);
+	--list-item-disabled-background: inherit;
+	--list-item-disabled-color: var(--color-text-faded);
+	--list-item-active-background: inherit;
+	--list-item-active-color: var(--color-text-primary);
+
 	--fab-background: var(--color-background);
 	--fab-color: inherit;
 

--- a/src/theme/material/chip-typeahead.m.css.d.ts
+++ b/src/theme/material/chip-typeahead.m.css.d.ts
@@ -7,6 +7,7 @@ export const wrapper: string;
 export const inputWrapper: string;
 export const input: string;
 export const selectedIcon: string;
+export const inputLeading: string;
 export const values: string;
 export const label: string;
 export const hasValue: string;

--- a/src/theme/material/list-item.m.css
+++ b/src/theme/material/list-item.m.css
@@ -16,12 +16,19 @@
 }
 
 .root.selected {
-	background: var(--mdc-theme-on-surface-hover);
+	background: var(--mdc-list-item-selected-background);
+	color: var(--mdc-list-item-selected-color);
+}
+
+.root.disabled {
+	background: var(--mdc-list-item-disabled-background);
+	color: var(--mdc-list-item-disabled-color);
 }
 
 .active {
 	border: none;
-	background: var(--mdc-theme-on-surface);
+	background: var(--mdc-list-item-active-background);
+	color: var(--mdc-list-item-active-color);
 	min-height: 48px;
 	height: 100%;
 	box-shadow: none;

--- a/src/theme/material/list-item.m.css
+++ b/src/theme/material/list-item.m.css
@@ -12,7 +12,8 @@
 }
 
 .root:hover {
-	background: var(--mdc-theme-on-surface);
+	background: var(--mdc-list-item-hover-background);
+	color: var(--mdc-list-item-hover-color);
 }
 
 .root.selected {

--- a/src/theme/material/list-item.m.css.d.ts
+++ b/src/theme/material/list-item.m.css.d.ts
@@ -1,6 +1,7 @@
 export const root: string;
 export const height: string;
 export const selected: string;
+export const disabled: string;
 export const active: string;
 export const collapsed: string;
 export const movedUp: string;

--- a/src/theme/material/variants/dark.m.css
+++ b/src/theme/material/variants/dark.m.css
@@ -103,4 +103,6 @@
 	--mdc-list-item-disabled-color: var(--mdc-text-color);
 	--mdc-list-item-active-background: var(--mdc-theme-on-surface);
 	--mdc-list-item-active-color: var(--mdc-text-color);
+	--mdc-list-item-hover-background: var(--mdc-theme-on-surface);
+	--mdc-list-item-hover-color: var(--mdc-text-color);
 }

--- a/src/theme/material/variants/dark.m.css
+++ b/src/theme/material/variants/dark.m.css
@@ -96,4 +96,11 @@
 	--loader-size-small: 24px;
 	--loader-size-medium: 36px;
 	--loader-size-large: 48px;
+
+	--mdc-list-item-selected-background: var(--mdc-theme-on-surface-hover);
+	--mdc-list-item-selected-color: var(--mdc-text-color);
+	--mdc-list-item-disabled-background: inherit;
+	--mdc-list-item-disabled-color: var(--mdc-text-color);
+	--mdc-list-item-active-background: var(--mdc-theme-on-surface);
+	--mdc-list-item-active-color: var(--mdc-text-color);
 }

--- a/src/theme/material/variants/default.m.css
+++ b/src/theme/material/variants/default.m.css
@@ -107,4 +107,11 @@
 	--loader-size-small: 24px;
 	--loader-size-medium: 36px;
 	--loader-size-large: 48px;
+
+	--mdc-list-item-selected-background: var(--mdc-theme-on-surface-hover);
+	--mdc-list-item-selected-color: var(--mdc-text-color);
+	--mdc-list-item-disabled-background: inherit;
+	--mdc-list-item-disabled-color: var(--mdc-text-color);
+	--mdc-list-item-active-background: var(--mdc-theme-on-surface);
+	--mdc-list-item-active-color: var(--mdc-text-color);
 }

--- a/src/theme/material/variants/default.m.css
+++ b/src/theme/material/variants/default.m.css
@@ -114,4 +114,6 @@
 	--mdc-list-item-disabled-color: var(--mdc-text-color);
 	--mdc-list-item-active-background: var(--mdc-theme-on-surface);
 	--mdc-list-item-active-color: var(--mdc-text-color);
+	--mdc-list-item-hover-background: var(--mdc-theme-on-surface);
+	--mdc-list-item-hover-color: var(--mdc-text-color);
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request updates the `ListItem` by adding background and color variables to applicable states (disabled, active, selected) so that it can be themed independently of other widgets.

Resolves #1726
