### PR TITLE
feat: add disabled prop to radio and checkbox groups

### DIFF
--- a/src/checkbox-group/index.tsx
+++ b/src/checkbox-group/index.tsx
@@ -18,6 +18,8 @@ export interface CheckboxGroupProperties {
 	initialValue?: string[];
 	/** A controlled value for the checkbox group */
 	value?: string[];
+	/** Disabled all inputs within this group */
+	disabled?: boolean;
 }
 
 export interface CheckboxGroupChildren {
@@ -48,7 +50,8 @@ export const CheckboxGroup = factory(function({
 		value,
 		classes,
 		theme: themeProp,
-		variant
+		variant,
+		disabled
 	} = properties();
 	const [{ checkboxes, label } = { checkboxes: undefined, label: undefined }] = children();
 
@@ -70,6 +73,7 @@ export const CheckboxGroup = factory(function({
 					classes={classes}
 					theme={themeProp}
 					variant={variant}
+					disabled={disabled}
 				>
 					{label || value}
 				</Checkbox>

--- a/src/checkbox-group/index.tsx
+++ b/src/checkbox-group/index.tsx
@@ -27,7 +27,8 @@ export interface CheckboxGroupChildren {
 	checkboxes?(
 		name: string,
 		middleware: ReturnType<ReturnType<typeof checkboxGroup>['api']>,
-		options: CheckboxOptions
+		options: CheckboxOptions,
+		disabled: boolean
 	): RenderResult;
 	/** A label for the checkbox group */
 	label?: RenderResult;
@@ -60,7 +61,7 @@ export const CheckboxGroup = factory(function({
 
 	function renderCheckboxes() {
 		if (checkboxes) {
-			return checkboxes(name, checkbox, options);
+			return checkboxes(name, checkbox, options, !!disabled);
 		}
 		return options.map(({ value, label }) => {
 			const { checked } = checkbox(value);

--- a/src/checkbox-group/tests/CheckboxGroup.spec.tsx
+++ b/src/checkbox-group/tests/CheckboxGroup.spec.tsx
@@ -234,6 +234,52 @@ describe('CheckboxGroup', () => {
 		h.expect(customTemplate);
 	});
 
+	it('renders with disabled custom renderer', () => {
+		const h = harness(() => (
+			<CheckboxGroup onValue={noop} name="test" options={[{ value: 'cat' }]} disabled>
+				{{
+					label: 'custom render label',
+					checkboxes: (_, __, ___, disabled) => {
+						return [
+							<span>custom label</span>,
+							<Checkbox
+								name="test"
+								value="cat"
+								checked={false}
+								onValue={noop}
+								theme={undefined}
+								classes={undefined}
+								variant={undefined}
+								disabled={disabled}
+							>
+								cat
+							</Checkbox>,
+							<hr />
+						];
+					}
+				}}
+			</CheckboxGroup>
+		));
+		const customTemplate = template.setChildren('@root', () => [
+			<legend classes={css.legend}>custom render label</legend>,
+			<span>custom label</span>,
+			<Checkbox
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+				disabled={true}
+			>
+				cat
+			</Checkbox>,
+			<hr />
+		]);
+		h.expect(customTemplate);
+	});
+
 	it('renders disabled inputs', () => {
 		const h = harness(() => (
 			<CheckboxGroup

--- a/src/checkbox-group/tests/CheckboxGroup.spec.tsx
+++ b/src/checkbox-group/tests/CheckboxGroup.spec.tsx
@@ -30,6 +30,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Checkbox>,
@@ -41,6 +42,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				fish
 			</Checkbox>,
@@ -52,6 +54,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				dog
 			</Checkbox>
@@ -77,6 +80,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Checkbox>
@@ -102,6 +106,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Checkbox>,
@@ -113,6 +118,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				fish
 			</Checkbox>,
@@ -124,6 +130,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				dog
 			</Checkbox>
@@ -149,6 +156,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Checkbox>,
@@ -160,6 +168,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				fish
 			</Checkbox>,
@@ -171,6 +180,7 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				dog
 			</Checkbox>
@@ -194,6 +204,7 @@ describe('CheckboxGroup', () => {
 								theme={undefined}
 								classes={undefined}
 								variant={undefined}
+								disabled={undefined}
 							>
 								cat
 							</Checkbox>,
@@ -214,11 +225,62 @@ describe('CheckboxGroup', () => {
 				theme={undefined}
 				classes={undefined}
 				variant={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Checkbox>,
 			<hr />
 		]);
 		h.expect(customTemplate);
+	});
+
+	it('renders disabled inputs', () => {
+		const h = harness(() => (
+			<CheckboxGroup
+				onValue={noop}
+				name="test"
+				options={[{ value: 'cat' }, { value: 'fish' }, { value: 'dog' }]}
+				disabled
+			/>
+		));
+		const optionTemplate = template.setChildren('@root', () => [
+			<Checkbox
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+				disabled
+			>
+				cat
+			</Checkbox>,
+			<Checkbox
+				name="test"
+				value="fish"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+				disabled
+			>
+				fish
+			</Checkbox>,
+			<Checkbox
+				name="test"
+				value="dog"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				classes={undefined}
+				variant={undefined}
+				disabled
+			>
+				dog
+			</Checkbox>
+		]);
+		h.expect(optionTemplate);
 	});
 });

--- a/src/radio-group/index.tsx
+++ b/src/radio-group/index.tsx
@@ -18,6 +18,8 @@ export interface RadioGroupProperties {
 	onValue(value: string): void;
 	/** Object containing the values / labels to create radios for */
 	options: RadioOptions;
+	/** Disabled all inputs within this group */
+	disabled?: boolean;
 }
 
 export interface RadioGroupChildren {
@@ -47,7 +49,8 @@ export const RadioGroup = factory(function({
 		initialValue,
 		theme: themeCss,
 		classes,
-		variant
+		variant,
+		disabled
 	} = properties();
 	const [{ radios, label } = { radios: undefined, label: undefined }] = children();
 	const radio = radioGroup(onValue, initialValue || '', value);
@@ -68,6 +71,7 @@ export const RadioGroup = factory(function({
 					theme={themeCss}
 					classes={classes}
 					variant={variant}
+					disabled={disabled}
 				>
 					{label || value}
 				</Radio>

--- a/src/radio-group/index.tsx
+++ b/src/radio-group/index.tsx
@@ -27,7 +27,8 @@ export interface RadioGroupChildren {
 	radios?(
 		name: string,
 		middleware: ReturnType<ReturnType<typeof radioGroup>['api']>,
-		options: RadioOptions
+		options: RadioOptions,
+		disabled: boolean
 	): RenderResult;
 	label?: RenderResult;
 }
@@ -58,7 +59,7 @@ export const RadioGroup = factory(function({
 
 	function renderRadios() {
 		if (radios) {
-			return radios(name, radio, options);
+			return radios(name, radio, options, !!disabled);
 		}
 		return options.map(({ value, label }) => {
 			const { checked } = radio(value);

--- a/src/radio-group/tests/RadioGroup.spec.tsx
+++ b/src/radio-group/tests/RadioGroup.spec.tsx
@@ -30,6 +30,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Radio>,
@@ -41,6 +42,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				fish
 			</Radio>,
@@ -52,6 +54,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				dog
 			</Radio>
@@ -77,6 +80,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Radio>
@@ -102,6 +106,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Radio>,
@@ -113,6 +118,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				fish
 			</Radio>,
@@ -124,6 +130,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				dog
 			</Radio>
@@ -150,6 +157,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Radio>,
@@ -161,6 +169,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				fish
 			</Radio>,
@@ -172,6 +181,7 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				dog
 			</Radio>
@@ -197,6 +207,7 @@ describe('RadioGroup', () => {
 								theme={undefined}
 								variant={undefined}
 								classes={undefined}
+								disabled={undefined}
 							>
 								cat
 							</Radio>,
@@ -217,11 +228,62 @@ describe('RadioGroup', () => {
 				theme={undefined}
 				variant={undefined}
 				classes={undefined}
+				disabled={undefined}
 			>
 				cat
 			</Radio>,
 			<hr />
 		]);
 		h.expect(customTemplate);
+	});
+
+	it('renders disabled inputs', () => {
+		const h = harness(() => (
+			<RadioGroup
+				name="test"
+				onValue={noop}
+				options={[{ value: 'cat' }, { value: 'fish' }, { value: 'dog' }]}
+				disabled
+			/>
+		));
+		const optionTemplate = template.setChildren('@root', () => [
+			<Radio
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+				disabled
+			>
+				cat
+			</Radio>,
+			<Radio
+				name="test"
+				value="fish"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+				disabled
+			>
+				fish
+			</Radio>,
+			<Radio
+				name="test"
+				value="dog"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+				disabled
+			>
+				dog
+			</Radio>
+		]);
+		h.expect(optionTemplate);
 	});
 });

--- a/src/radio-group/tests/RadioGroup.spec.tsx
+++ b/src/radio-group/tests/RadioGroup.spec.tsx
@@ -237,6 +237,52 @@ describe('RadioGroup', () => {
 		h.expect(customTemplate);
 	});
 
+	it('renders with disabled custom renderer', () => {
+		const h = harness(() => (
+			<RadioGroup name="test" onValue={noop} options={[{ value: 'cat' }]} disabled>
+				{{
+					label: 'custom render label',
+					radios: (_, __, ___, disabled) => {
+						return [
+							<span>custom label</span>,
+							<Radio
+								name="test"
+								value="cat"
+								checked={false}
+								onValue={noop}
+								theme={undefined}
+								variant={undefined}
+								classes={undefined}
+								disabled={true}
+							>
+								cat
+							</Radio>,
+							<hr />
+						];
+					}
+				}}
+			</RadioGroup>
+		));
+		const customTemplate = template.setChildren('@root', () => [
+			<legend classes={css.legend}>custom render label</legend>,
+			<span>custom label</span>,
+			<Radio
+				name="test"
+				value="cat"
+				checked={false}
+				onValue={noop}
+				theme={undefined}
+				variant={undefined}
+				classes={undefined}
+				disabled={true}
+			>
+				cat
+			</Radio>,
+			<hr />
+		]);
+		h.expect(customTemplate);
+	});
+
 	it('renders disabled inputs', () => {
 		const h = harness(() => (
 			<RadioGroup


### PR DESCRIPTION
**Type:** bug / feature

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request adds a top-level `disabled` prop to both `CheckboxGroup` and `RadioGroup` and updates tests accordingly.

Resolves #1698
Replaces #1711