### PR TITLE
Fix missing or incorrect widget names

### DIFF
--- a/src/checkbox-group/index.tsx
+++ b/src/checkbox-group/index.tsx
@@ -35,7 +35,7 @@ const factory = create({ checkboxGroup, theme })
 	.properties<CheckboxGroupProperties>()
 	.children<CheckboxGroupChildren | undefined>();
 
-export const CheckboxGroup = factory(function({
+export const CheckboxGroup = factory(function CheckboxGroup({
 	children,
 	properties,
 	middleware: { checkboxGroup, theme }

--- a/src/context-menu/index.tsx
+++ b/src/context-menu/index.tsx
@@ -16,7 +16,11 @@ const factory = create({
 	resource: createResourceMiddleware<ListOption>()
 }).properties<ContextMenuProperties>();
 
-export const ContextMenu = factory(function({ properties, children, middleware: { theme } }) {
+export const ContextMenu = factory(function ContextMenu({
+	properties,
+	children,
+	middleware: { theme }
+}) {
 	const { resource, onSelect, classes, variant } = properties();
 	return (
 		<ContextPopup>

--- a/src/email-input/index.tsx
+++ b/src/email-input/index.tsx
@@ -17,7 +17,7 @@ const factory = create({ icache, theme })
 	.properties<EmailInputProperties>()
 	.children<TextInputChildren | undefined>();
 
-export const EmailInput = factory(function({
+export const EmailInput = factory(function EmailInput({
 	properties,
 	children,
 	middleware: { icache, theme }

--- a/src/form/index.tsx
+++ b/src/form/index.tsx
@@ -116,7 +116,7 @@ const formGroupFactory = create({ theme })
 	.properties<FormGroupProperties>()
 	.children();
 
-export const FormGroup = formGroupFactory(function FormRow({
+export const FormGroup = formGroupFactory(function FormGroup({
 	properties,
 	children,
 	middleware: { theme }

--- a/src/radio-group/index.tsx
+++ b/src/radio-group/index.tsx
@@ -34,7 +34,7 @@ const factory = create({ radioGroup, theme })
 	.properties<RadioGroupProperties>()
 	.children<RadioGroupChildren | undefined>();
 
-export const RadioGroup = factory(function({
+export const RadioGroup = factory(function RadioGroup({
 	children,
 	properties,
 	middleware: { radioGroup, theme }

--- a/src/rate/index.tsx
+++ b/src/rate/index.tsx
@@ -46,7 +46,7 @@ const factory = create({ focus, theme, icache: createICacheMiddleware<RateIcache
 	.properties<RateProperties>()
 	.children<RateChildren | undefined>();
 
-export const Rate = factory(function Radio({
+export const Rate = factory(function Rate({
 	properties,
 	id,
 	children,

--- a/src/speed-dial/index.tsx
+++ b/src/speed-dial/index.tsx
@@ -37,7 +37,12 @@ const actionFactory = create({ theme })
 	.properties<ActionProperties>()
 	.children<ActionChildren | [ActionChildren] | RenderResult | RenderResult[]>();
 
-export const Action = actionFactory(({ properties, id, children, middleware: { theme } }) => {
+export const Action = actionFactory(function Action({
+	properties,
+	id,
+	children,
+	middleware: { theme }
+}) {
 	const {
 		labelOrientation = LabelOrientation.left,
 		onClick,

--- a/src/three-column-layout/index.tsx
+++ b/src/three-column-layout/index.tsx
@@ -31,7 +31,7 @@ const factory = create({ breakpoint, theme })
 	.properties<ThreeColumnLayoutProperties>()
 	.children<ThreeColumnLayoutChildren>();
 
-export const ThreeColumnLayout = factory(function({
+export const ThreeColumnLayout = factory(function ThreeColumnLayout({
 	properties,
 	children,
 	middleware: { breakpoint, theme }

--- a/src/two-column-layout/index.tsx
+++ b/src/two-column-layout/index.tsx
@@ -32,7 +32,7 @@ const factory = create({ theme, breakpoint, icache, resize, drag })
 	.properties<TwoColumnLayoutProperties>()
 	.children<TwoColumnLayoutChildren>();
 
-export const TwoColumnLayout = factory(function({
+export const TwoColumnLayout = factory(function TwoColumnLayout({
 	properties,
 	children,
 	middleware: { theme, breakpoint: breakpointMiddleware, icache, resize: resizeMiddleware, drag }


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Fixes a few missing or incorrect widget names across the library. Widget names are very useful as they are used by the test renderer to show diffs for failing tests.