### PR TITLE
fix: chip typeahead value placement

### DIFF
--- a/src/text-input/index.tsx
+++ b/src/text-input/index.tsx
@@ -8,7 +8,6 @@ import { formatAriaProperties } from '../common/util';
 import HelperText from '../helper-text/index';
 import Label from '../label/index';
 import * as css from '../theme/default/text-input.m.css';
-import { isArray } from 'util';
 
 export type TextInputType =
 	| 'text'
@@ -229,7 +228,7 @@ export const TextInput = factory(function TextInput({
 
 	let leadingElements;
 	if (leading) {
-		leadingElements = isArray(leading) ? leading : [leading];
+		leadingElements = Array.isArray(leading) ? leading : [leading];
 	}
 
 	return (

--- a/src/text-input/index.tsx
+++ b/src/text-input/index.tsx
@@ -275,10 +275,13 @@ export const TextInput = factory(function TextInput({
 					]}
 					role="presentation"
 				>
-					{leadingElements &&
-						leadingElements.map((leadingElement) => (
-							<span classes={themeCss.leading}>{leadingElement}</span>
-						))}
+					{leadingElements && (
+						<virtual>
+							{leadingElements.map((leadingElement) => (
+								<span classes={themeCss.leading}>{leadingElement}</span>
+							))}
+						</virtual>
+					)}
 					<input
 						{...formatAriaProperties(aria)}
 						aria-invalid={valid === false ? 'true' : undefined}

--- a/src/text-input/index.tsx
+++ b/src/text-input/index.tsx
@@ -8,6 +8,7 @@ import { formatAriaProperties } from '../common/util';
 import HelperText from '../helper-text/index';
 import Label from '../label/index';
 import * as css from '../theme/default/text-input.m.css';
+import { isArray } from 'util';
 
 export type TextInputType =
 	| 'text'
@@ -226,6 +227,11 @@ export const TextInput = factory(function TextInput({
 	const inputFocused = focus.isFocused('input');
 	const autofilled = Boolean(icache.get('autofilled'));
 
+	let leadingElements;
+	if (leading) {
+		leadingElements = isArray(leading) ? leading : [leading];
+	}
+
 	return (
 		<div key="root" classes={[theme.variant(), themeCss.root]} role="presentation">
 			<div
@@ -269,7 +275,10 @@ export const TextInput = factory(function TextInput({
 					]}
 					role="presentation"
 				>
-					{leading && <span classes={themeCss.leading}>{leading}</span>}
+					{leadingElements &&
+						leadingElements.map((leadingElement) => (
+							<span classes={themeCss.leading}>{leadingElement}</span>
+						))}
 					<input
 						{...formatAriaProperties(aria)}
 						aria-invalid={valid === false ? 'true' : undefined}

--- a/src/text-input/tests/unit/TextInput.spec.tsx
+++ b/src/text-input/tests/unit/TextInput.spec.tsx
@@ -591,7 +591,11 @@ registerSuite('TextInput', {
 		},
 
 		'leading property'() {
-			const leading = <span classes={css.leading}>A</span>;
+			const leading = (
+				<virtual>
+					<span classes={css.leading}>A</span>
+				</virtual>
+			);
 			const leadingTemplate = baseAssertion
 				.setProperty('@wrapper', 'classes', [
 					css.wrapper,

--- a/src/theme/dojo/chip-typeahead.m.css
+++ b/src/theme/dojo/chip-typeahead.m.css
@@ -17,11 +17,9 @@
 }
 
 .root .inputLeading {
-	display: block;
 	pointer-events: unset;
 	position: static;
 	transform: none;
-	max-width: 100%;
 }
 
 .root .inputWrapper {

--- a/src/theme/material/chip-typeahead.m.css
+++ b/src/theme/material/chip-typeahead.m.css
@@ -41,11 +41,9 @@
 }
 
 .root .inputLeading {
-	display: block;
 	pointer-events: unset;
 	position: static;
 	transform: none;
-	max-width: 100%;
 }
 
 .values .value {


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [x] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [x] Unit tests are included in the PR
* [x] For new widgets, an entry has been added to the `.dojorc`
* [x] For new widgets, `theme.variant()` is added to the root domnode
* [x] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [x] WidgetProperties are exported

**Description:**

This pull request fixes an issue where chip values were not wrapped inline with the input.

Resolves #1742 
