### PR TITLE
Bug: Check span value in diff property

### DIFF
--- a/src/stack/Spacer.tsx
+++ b/src/stack/Spacer.tsx
@@ -1,4 +1,4 @@
-import { create, diffProperty } from '@dojo/framework/core/vdom';
+import { create, diffProperty, invalidator } from '@dojo/framework/core/vdom';
 import './styles/spacer.m.css';
 
 interface SpacerProperties {
@@ -8,15 +8,18 @@ interface SpacerProperties {
 	spanCallback?: (span: number) => void;
 }
 
-const factory = create({ diffProperty }).properties<SpacerProperties>();
+const factory = create({ diffProperty, invalidator }).properties<SpacerProperties>();
 
 export const Spacer = factory(function Spacer({
 	children,
-	middleware: { diffProperty },
+	middleware: { diffProperty, invalidator },
 	properties
 }) {
-	diffProperty('span', properties, (_, next) => {
-		next.spanCallback && next.spanCallback(next.span || 1);
+	diffProperty('span', properties, (curr, next) => {
+		if (curr.span !== next.span || !curr.spanCallback) {
+			next.spanCallback && next.spanCallback(next.span || 1);
+			invalidator();
+		}
 	});
 	return children();
 });

--- a/src/stack/Spacer.tsx
+++ b/src/stack/Spacer.tsx
@@ -1,4 +1,4 @@
-import { create, diffProperty, invalidator } from '@dojo/framework/core/vdom';
+import { create, diffProperty } from '@dojo/framework/core/vdom';
 import './styles/spacer.m.css';
 
 interface SpacerProperties {
@@ -8,18 +8,15 @@ interface SpacerProperties {
 	spanCallback?: (span: number) => void;
 }
 
-const factory = create({ diffProperty, invalidator }).properties<SpacerProperties>();
+const factory = create({ diffProperty }).properties<SpacerProperties>();
 
 export const Spacer = factory(function Spacer({
 	children,
-	middleware: { diffProperty, invalidator },
+	middleware: { diffProperty },
 	properties
 }) {
-	diffProperty('span', properties, (curr, next) => {
-		if (curr.span !== next.span || !curr.spanCallback) {
-			next.spanCallback && next.spanCallback(next.span || 1);
-			invalidator();
-		}
+	diffProperty('span', properties, (_, next) => {
+		next.spanCallback && next.spanCallback(next.span || 1);
 	});
 	return children();
 });

--- a/src/stack/index.tsx
+++ b/src/stack/index.tsx
@@ -79,7 +79,10 @@ export const Stack = factory(function Stack({
 			// of the wrapping node of a spacer required for using the stacks
 			// as a custom element.
 			child.properties.spanCallback = (span: number) => {
-				icache.set(`span-${index}`, span);
+				const currentSpan = icache.get(`span-${index}`);
+				if (currentSpan !== span) {
+					icache.set(`span-${index}`, span);
+				}
 			};
 		}
 

--- a/src/stack/tests/Stack.spec.tsx
+++ b/src/stack/tests/Stack.spec.tsx
@@ -591,7 +591,7 @@ describe('Stack', () => {
 				<Stack direction="vertical" padding="large">
 					<Spacer />
 					VStack Child
-					<Spacer spanCallback={() => {}} />
+					<Spacer />
 				</Stack>
 			));
 			const baseAssertion = assertion(() => (


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [x] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

`diffProperty` needs to actually do the diff on the `span` property to determine if the callback needs to be called. Otherwise the the callback is called every time and ends up with causing an infinite render loop.
