### PR TITLE
Convert outlined property to kind 

### DIFF
--- a/src/card/index.tsx
+++ b/src/card/index.tsx
@@ -4,13 +4,20 @@ import * as css from '../theme/default/card.m.css';
 import theme from '../middleware/theme';
 
 export interface CardProperties {
+	/** Handler for events triggered by click of the card */
 	onClick?: () => void;
+	/** url source for media */
 	mediaSrc?: string;
+	/** The title description fo the media */
 	mediaTitle?: string;
+	/** to render a square card */
 	square?: boolean;
+	/** The title text for the card */
 	title?: string;
+	/** The subtitle text for the card */
 	subtitle?: string;
-	outlined?: boolean;
+	/** The kind of card */
+	kind?: 'elevated' | 'outlined';
 }
 
 export interface CardChildren {
@@ -33,12 +40,15 @@ export const Card = factory(function Card({ children, properties, middleware: { 
 		square,
 		title,
 		subtitle,
-		outlined = false
+		kind = 'elevated'
 	} = properties();
 	const { header, content, actionButtons, actionIcons } = children()[0] || ({} as CardChildren);
 
 	return (
-		<div key="root" classes={[theme.variant(), themeCss.root, outlined && themeCss.outlined]}>
+		<div
+			key="root"
+			classes={[theme.variant(), themeCss.root, kind === 'outlined' && themeCss.outlined]}
+		>
 			<div
 				key="content"
 				classes={[themeCss.content, onClick ? themeCss.primary : null]}

--- a/src/card/tests/unit/Card.spec.tsx
+++ b/src/card/tests/unit/Card.spec.tsx
@@ -26,7 +26,7 @@ describe('Card', () => {
 	});
 
 	it('renders outlined', () => {
-		const r = renderer(() => <Card outlined />);
+		const r = renderer(() => <Card kind="outlined" />);
 		const outlinedTemplate = template.setProperty(Root, 'classes', [
 			undefined,
 			css.root,

--- a/src/examples/src/widgets/card/Outlined.tsx
+++ b/src/examples/src/widgets/card/Outlined.tsx
@@ -8,7 +8,7 @@ export default factory(function Outlined() {
 	return (
 		<Example>
 			<div styles={{ maxWidth: '400px' }}>
-				<Card outlined title="Outlined Card">
+				<Card kind="outlined" title="Outlined Card">
 					{{
 						content: (
 							<span>

--- a/src/examples/src/widgets/header-card/Outlined.tsx
+++ b/src/examples/src/widgets/header-card/Outlined.tsx
@@ -9,7 +9,7 @@ export default factory(function Outlined() {
 	return (
 		<Example>
 			<div styles={{ maxWidth: '400px' }}>
-				<HeaderCard outlined title="Hello, World" subtitle="Lorem ipsum">
+				<HeaderCard kind="outlined" title="Hello, World" subtitle="Lorem ipsum">
 					{{
 						avatar: <Avatar>D</Avatar>,
 						content: <p styles={{ margin: '0' }}>Lorem ipsum</p>


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

`kind` is the property to used consistently across widgets to determine the type of widget, in this case the `outlined` and `elevated`  card types. This converts the existing `outlined` property to `kind`