### PR TITLE
Add Button CSS Variables

### DIFF
--- a/src/examples/src/widgets/text/OverrideFont.tsx
+++ b/src/examples/src/widgets/text/OverrideFont.tsx
@@ -8,13 +8,11 @@ const factory = create({ icache });
 export default factory(function OverrideFont() {
 	return (
 		<Example>
-			<virtual>
-				<div style="--mdc-theme-font-family: 'Comic Sans MS', 'Comic Sans', cursive;">
-					<Text variant="inherit" size="x-large">
-						Override the variant font
-					</Text>
-				</div>
-			</virtual>
+			<div style="--mdc-theme-font-family: 'Comic Sans MS', 'Comic Sans', cursive;">
+				<Text variant="inherit" size="x-large">
+					Override the variant font
+				</Text>
+			</div>
 		</Example>
 	);
 });

--- a/src/theme/dojo/button.m.css
+++ b/src/theme/dojo/button.m.css
@@ -6,8 +6,8 @@
 }
 
 .text {
-	background-color: var(--color-background);
-	border: var(--border-width) solid var(--color-border);
+	background-color: var(--button-background);
+	border: var(--border-width) solid var(--button-border);
 	cursor: pointer;
 	display: inline-flex;
 	vertical-align: middle;
@@ -21,7 +21,7 @@
 
 .text:hover,
 .text:focus {
-	border-color: var(--color-highlight);
+	border-color: var(--button-border);
 	box-shadow: var(--box-shadow-dimensions-small) var(--color-box-shadow-highlight);
 	outline: none;
 }
@@ -37,17 +37,17 @@
 
 .text.disabled,
 .text.disabled:hover {
-	background-color: var(--color-background-faded);
-	border-color: var(--color-border);
+	background-color: var(--button-background-faded);
+	border-color: var(--button-border);
 	box-shadow: none;
-	color: var(--color-text-faded);
+	color: var(--button-text-faded);
 	cursor: default;
 }
 
 .outlined {
-	background-color: var(--color-background);
-	border: var(--border-width) solid var(--color-highlight);
-	color: var(--color-highlight);
+	background-color: var(--button-background);
+	border: var(--border-width) solid var(--button-border);
+	color: var(--button-text);
 	cursor: pointer;
 	display: inline-flex;
 	align-items: center;
@@ -67,25 +67,25 @@
 }
 
 .outlined:hover {
-	background-color: var(--color-highlight);
-	color: var(--color-text-inverted);
+	background-color: var(--button-background);
+	color: var(--button-text-inverted);
 	outline: none;
 }
 
 .outlined.root:hover .label {
-	color: var(--color-text-inverted);
+	color: var(--button-text-inverted);
 }
 
 .outlined.disabled,
 .outlined.disabled:hover {
 	background-color: initial;
-	border-color: var(--color-border);
-	color: var(--color-text-faded);
+	border-color: var(--button-border);
+	color: var(--button-text-faded);
 	cursor: default;
 }
 
 .outlined.disabled:hover .label {
-	color: var(--color-text-faded);
+	color: var(--button-text-faded);
 }
 
 .contained {
@@ -100,7 +100,7 @@
 	line-height: var(--line-height-base);
 	min-width: calc(var(--grid-base) * 20);
 	padding: var(--spacing-regular);
-	background-color: var(--color-background);
+	background-color: var(--button-background);
 }
 
 .contained:hover,
@@ -113,7 +113,7 @@
 }
 
 .label {
-	color: var(--color-highlight);
+	color: var(--button-text);
 	font-size: var(--font-size-base);
 	font-weight: bold;
 	line-height: var(--line-height-base);

--- a/src/theme/dojo/variants/dark.m.css
+++ b/src/theme/dojo/variants/dark.m.css
@@ -103,4 +103,11 @@
 	--hstack-spacing-small: var(--grid-base);
 	--hstack-spacing-medium: calc(var(--grid-base) * 1.5);
 	--hstack-spacing-large: calc(var(--grid-base) * 2);
+
+	--button-background: var(--color-background);
+	--button-background-faded: var(--color-background-faded);
+	--button-text: var(--color-highlight);
+	--button-text-faded: var(--color-text-faded);
+	--button-text-inverted: var(--color-text-inverted);
+	--button-border: var(--color-highlight);
 }

--- a/src/theme/dojo/variants/default.m.css
+++ b/src/theme/dojo/variants/default.m.css
@@ -114,4 +114,11 @@
 	--hstack-spacing-small: var(--grid-base);
 	--hstack-spacing-medium: calc(var(--grid-base) * 1.5);
 	--hstack-spacing-large: calc(var(--grid-base) * 2);
+
+	--button-background: var(--color-background);
+	--button-background-faded: var(--color-background-faded);
+	--button-text: var(--color-highlight);
+	--button-text-faded: var(--color-text-faded);
+	--button-text-inverted: var(--color-text-inverted);
+	--button-border: var(--color-highlight);
 }

--- a/src/theme/material/button.m.css
+++ b/src/theme/material/button.m.css
@@ -27,6 +27,20 @@
 	composes: mdc-button--raised from '@material/button/dist/mdc.button.css';
 }
 
+.root.contained {
+	background: var(--mdc-button-primary);
+	color: var(--mdc-button-text-on-primary);
+}
+
+.root.text {
+	color: var(--mdc-button-primary);
+}
+
+.root.outlined {
+	color: var(--mdc-button-primary);
+	border-color: var(--mdc-button-primary);
+}
+
 .root.disabled:disabled {
 	background-color: var(--mdc-disabled-text-color);
 }

--- a/src/theme/material/variants/dark.m.css
+++ b/src/theme/material/variants/dark.m.css
@@ -129,4 +129,7 @@
 	--mdc-hstack-spacing-small: var(--mdc-theme-grid-base);
 	--mdc-hstack-spacing-medium: calc(var(--mdc-theme-grid-base) * 1.5);
 	--mdc-hstack-spacing-large: calc(var(--mdc-theme-grid-base) * 2);
+
+	--mdc-button-primary: var(--mdc-theme-primary);
+	--mdc-button-text-on-primary: var(--mdc-theme-on-primary);
 }

--- a/src/theme/material/variants/default.m.css
+++ b/src/theme/material/variants/default.m.css
@@ -140,4 +140,7 @@
 	--mdc-hstack-spacing-small: var(--mdc-theme-grid-base);
 	--mdc-hstack-spacing-medium: calc(var(--mdc-theme-grid-base) * 1.5);
 	--mdc-hstack-spacing-large: calc(var(--mdc-theme-grid-base) * 2);
+
+	--mdc-button-primary: var(--mdc-theme-primary);
+	--mdc-button-text-on-primary: var(--mdc-theme-on-primary);
 }


### PR DESCRIPTION
**Type:** feature

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Add specific vars to customise button styling without needing to change the main CSS var
