### PR TITLE
Make Dialog material overrides styles more specific

### DIFF
--- a/src/theme/material/dialog.m.css
+++ b/src/theme/material/dialog.m.css
@@ -11,24 +11,24 @@
 /* Contains the dialog */
 .main {
 	composes: mdc-dialog__container, mdc-dialog__surface from '@material/dialog/dist/mdc.dialog.css';
-	outline: 0;
 }
 
 .root .main {
 	background-color: var(--mdc-raised-surface-background);
+	outline: 0;
 }
 
 /* Contains the title of the dialog */
 .title {
 	composes: mdc-dialog__title from '@material/dialog/dist/mdc.dialog.css';
-	padding-top: 20px;
 }
 
 .root .title {
 	color: var(--mdc-text-color);
+	padding-top: 20px;
 }
 
-.title:before {
+.root .title:before {
 	display: none;
 }
 


### PR DESCRIPTION
**Type:** bug

The following has been addressed in the PR:

* [ ] There is a related issue
* [ ] All code matches the [style guide](https://github.com/dojo/framework/blob/master/STYLE.md)
* [ ] Unit tests are included in the PR
* [ ] For new widgets, an entry has been added to the `.dojorc`
* [ ] For new widgets, `theme.variant()` is added to the root domnode
* [ ] Any widget variant uses `theme.compose` like [this](https://github.com/dojo/widgets/issues/847)
* [ ] WidgetProperties are exported

**Description:**

Makes the overriding styles for the material theme more specific than the composed styles
